### PR TITLE
Linux support for exoharness

### DIFF
--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -18,7 +18,7 @@ use crate::sandbox::{
     SandboxSpec,
 };
 use crate::secrets::{
-    AppleKeychainSecretKeyProvider, EncryptedSecret, SecretCipher, StaticSecretKeyProvider,
+    EncryptedSecret, SecretCipher, StaticSecretKeyProvider, default_secret_cipher,
 };
 use crate::storage::BasicObjectStore;
 use crate::{
@@ -50,9 +50,7 @@ impl BasicExoHarness {
     pub async fn new(root: impl Into<PathBuf>) -> Result<Self> {
         let root = root.into();
         let storage = BasicObjectStore::local_filesystem(&root).await?;
-        let secret_cipher = SecretCipher::new(Arc::new(AppleKeychainSecretKeyProvider::new(
-            root.to_string_lossy().to_string(),
-        )));
+        let secret_cipher = default_secret_cipher(root.to_string_lossy().to_string())?;
         Self::new_with_components(
             storage,
             secret_cipher,
@@ -73,10 +71,7 @@ impl BasicExoHarness {
     }
 
     pub async fn new_with_object_store(store: Arc<dyn object_store::ObjectStore>) -> Result<Self> {
-        let keychain_account = store.to_string();
-        let secret_cipher = SecretCipher::new(Arc::new(AppleKeychainSecretKeyProvider::new(
-            keychain_account,
-        )));
+        let secret_cipher = default_secret_cipher(store.to_string())?;
         Self::new_with_components(
             BasicObjectStore::new(store),
             secret_cipher,
@@ -89,10 +84,7 @@ impl BasicExoHarness {
         store: Arc<dyn object_store::ObjectStore>,
         sandbox_backend: Arc<dyn ManagedSandboxBackend>,
     ) -> Result<Self> {
-        let keychain_account = store.to_string();
-        let secret_cipher = SecretCipher::new(Arc::new(AppleKeychainSecretKeyProvider::new(
-            keychain_account,
-        )));
+        let secret_cipher = default_secret_cipher(store.to_string())?;
         Self::new_with_components(BasicObjectStore::new(store), secret_cipher, sandbox_backend)
             .await
     }

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -12,10 +12,10 @@ use tokio::sync::{Mutex as AsyncMutex, mpsc};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use crate::sandbox::{
-    AppleContainerSandboxBackend, LocalProcessSandboxBackend, ManagedSandboxBackend,
-    ManagedSandboxHandle, SANDBOX_MAIN_MOUNT_DIR, SandboxCommand, SandboxKey,
-    SandboxLifecycleConfig, SandboxMount, SandboxMountAccess, SandboxNetworkPolicy, SandboxRequest,
-    SandboxSpec,
+    LocalProcessSandboxBackend, ManagedSandboxBackend, ManagedSandboxHandle,
+    SANDBOX_MAIN_MOUNT_DIR, SandboxCommand, SandboxKey, SandboxLifecycleConfig, SandboxMount,
+    SandboxMountAccess, SandboxNetworkPolicy, SandboxRequest, SandboxSpec,
+    default_sandbox_backend,
 };
 use crate::secrets::{
     EncryptedSecret, SecretCipher, StaticSecretKeyProvider, default_secret_cipher,
@@ -54,7 +54,7 @@ impl BasicExoHarness {
         Self::new_with_components(
             storage,
             secret_cipher,
-            Arc::new(AppleContainerSandboxBackend::new()),
+            default_sandbox_backend(),
         )
         .await
     }
@@ -75,7 +75,7 @@ impl BasicExoHarness {
         Self::new_with_components(
             BasicObjectStore::new(store),
             secret_cipher,
-            Arc::new(AppleContainerSandboxBackend::new()),
+            default_sandbox_backend(),
         )
         .await
     }

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -114,6 +114,25 @@ pub const DEFAULT_SANDBOX_IMAGE: &str = "docker.io/library/debian:bookworm";
 pub const SANDBOX_HOME_DIR: &str = "/home/exo";
 pub const SANDBOX_MAIN_MOUNT_DIR: &str = "/home/exo/workspace";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContainerCliFlavor {
+    AppleContainer,
+    Docker,
+}
+
+impl ContainerCliFlavor {
+    fn default_binary(self) -> &'static str {
+        match self {
+            Self::AppleContainer => "container",
+            Self::Docker => "docker",
+        }
+    }
+
+    fn requires_system_start(self) -> bool {
+        matches!(self, Self::AppleContainer)
+    }
+}
+
 const DEFAULT_ENABLED_NETWORK_NAME: &str = "exo-default";
 const WARM_SANDBOX_KEEPALIVE_ARGV: &[&str] = &["sleep", "infinity"];
 const WARM_SANDBOX_HEALTHCHECK_TIMEOUT: Duration = Duration::from_secs(3);
@@ -147,17 +166,27 @@ struct ContainerListConfiguration {
 }
 
 #[derive(Debug)]
-pub struct AppleContainerSandboxBackend {
+pub struct CliContainerSandboxBackend {
+    cli: ContainerCliFlavor,
     container_bin: PathBuf,
     system_started: Mutex<bool>,
     network_created: Mutex<bool>,
     warm_sandboxes: Arc<Mutex<HashMap<SandboxKey, WarmSandboxEntry>>>,
 }
 
-impl AppleContainerSandboxBackend {
-    pub fn new() -> Self {
+impl CliContainerSandboxBackend {
+    pub fn apple_container() -> Self {
+        Self::new(ContainerCliFlavor::AppleContainer)
+    }
+
+    pub fn docker() -> Self {
+        Self::new(ContainerCliFlavor::Docker)
+    }
+
+    fn new(cli: ContainerCliFlavor) -> Self {
         Self {
-            container_bin: PathBuf::from("container"),
+            cli,
+            container_bin: PathBuf::from(cli.default_binary()),
             system_started: Mutex::new(false),
             network_created: Mutex::new(false),
             warm_sandboxes: Arc::new(Mutex::new(HashMap::new())),
@@ -165,6 +194,9 @@ impl AppleContainerSandboxBackend {
     }
 
     async fn ensure_system_started(&self) -> Result<()> {
+        if !self.cli.requires_system_start() {
+            return Ok(());
+        }
         let mut started = self.system_started.lock().await;
         if *started {
             return Ok(());
@@ -273,20 +305,14 @@ impl AppleContainerSandboxBackend {
         };
 
         for entry in expired {
-            cleanup_named_container(&self.container_bin, &entry.name).await?;
+            cleanup_named_container(&self.container_bin, self.cli, &entry.name).await?;
         }
 
         Ok(())
     }
 }
 
-impl Default for AppleContainerSandboxBackend {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Drop for AppleContainerSandboxBackend {
+impl Drop for CliContainerSandboxBackend {
     fn drop(&mut self) {
         let Ok(mut warm_sandboxes) = self.warm_sandboxes.try_lock() else {
             return;
@@ -296,18 +322,18 @@ impl Drop for AppleContainerSandboxBackend {
             .map(|(_, entry)| entry.name)
             .collect::<Vec<_>>();
         for name in names {
-            cleanup_named_container_blocking(&self.container_bin, &name);
+            cleanup_named_container_blocking(&self.container_bin, self.cli, &name);
         }
     }
 }
 
 #[async_trait]
-impl ManagedSandboxBackend for AppleContainerSandboxBackend {
+impl ManagedSandboxBackend for CliContainerSandboxBackend {
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
         let request = self.prepare_request(request).await?;
 
         if request.lifecycle.idle_ttl.is_none() {
-            return Ok(Arc::new(AppleOneShotSandboxHandle {
+            return Ok(Arc::new(OneShotSandboxHandle {
                 id: format!("oneshot:{}", request.key),
                 container_bin: self.container_bin.clone(),
                 request,
@@ -320,8 +346,9 @@ impl ManagedSandboxBackend for AppleContainerSandboxBackend {
             let mut warm_sandboxes = self.warm_sandboxes.lock().await;
             match warm_sandboxes.get(&request.key) {
                 Some(entry) if entry.request.spec == request.spec => {
-                    return Ok(Arc::new(AppleWarmSandboxHandle {
+                    return Ok(Arc::new(WarmSandboxHandle {
                         id: format!("warm:{}", request.key),
+                        cli: self.cli,
                         container_bin: self.container_bin.clone(),
                         request,
                         warm_sandboxes: Arc::clone(&self.warm_sandboxes),
@@ -332,7 +359,7 @@ impl ManagedSandboxBackend for AppleContainerSandboxBackend {
             }
         };
         if let Some(entry) = replaced {
-            schedule_cleanup_named_container(self.container_bin.clone(), entry.name);
+            schedule_cleanup_named_container(self.container_bin.clone(), self.cli, entry.name);
         }
 
         let name = create_unique_warm_sandbox(&self.container_bin, &request).await?;
@@ -349,8 +376,9 @@ impl ManagedSandboxBackend for AppleContainerSandboxBackend {
             );
         }
 
-        Ok(Arc::new(AppleWarmSandboxHandle {
+        Ok(Arc::new(WarmSandboxHandle {
             id: format!("warm:{}", request.key),
+            cli: self.cli,
             container_bin: self.container_bin.clone(),
             request,
             warm_sandboxes: Arc::clone(&self.warm_sandboxes),
@@ -358,14 +386,14 @@ impl ManagedSandboxBackend for AppleContainerSandboxBackend {
     }
 }
 
-struct AppleOneShotSandboxHandle {
+struct OneShotSandboxHandle {
     id: String,
     container_bin: PathBuf,
     request: SandboxRequest,
 }
 
 #[async_trait]
-impl ManagedSandboxHandle for AppleOneShotSandboxHandle {
+impl ManagedSandboxHandle for OneShotSandboxHandle {
     fn id(&self) -> &str {
         &self.id
     }
@@ -395,22 +423,23 @@ impl ManagedSandboxHandle for AppleOneShotSandboxHandle {
     }
 }
 
-struct AppleWarmSandboxHandle {
+struct WarmSandboxHandle {
     id: String,
+    cli: ContainerCliFlavor,
     container_bin: PathBuf,
     request: SandboxRequest,
     warm_sandboxes: Arc<Mutex<HashMap<SandboxKey, WarmSandboxEntry>>>,
 }
 
 #[async_trait]
-impl ManagedSandboxHandle for AppleWarmSandboxHandle {
+impl ManagedSandboxHandle for WarmSandboxHandle {
     fn id(&self) -> &str {
         &self.id
     }
 
     async fn exec(&self, command: &SandboxCommand) -> Result<SandboxCommandOutput> {
         let name =
-            ensure_warm_sandbox_ready(&self.container_bin, &self.request, &self.warm_sandboxes)
+            ensure_warm_sandbox_ready(&self.container_bin, self.cli, &self.request, &self.warm_sandboxes)
                 .await?;
         touch_warm_sandbox(&self.warm_sandboxes, &self.request.key).await;
         let output = exec_warm(&self.container_bin, &name, &self.request.spec, command).await;
@@ -420,7 +449,7 @@ impl ManagedSandboxHandle for AppleWarmSandboxHandle {
 
     async fn start_process(&self, command: &SandboxCommand) -> Result<crate::SandboxProcessParts> {
         let name =
-            ensure_warm_sandbox_ready(&self.container_bin, &self.request, &self.warm_sandboxes)
+            ensure_warm_sandbox_ready(&self.container_bin, self.cli, &self.request, &self.warm_sandboxes)
                 .await?;
         touch_warm_sandbox(&self.warm_sandboxes, &self.request.key).await;
         start_warm_process(&self.container_bin, &name, &self.request.spec, command).await
@@ -433,11 +462,21 @@ impl ManagedSandboxHandle for AppleWarmSandboxHandle {
         };
 
         if let Some(entry) = removed {
-            cleanup_named_container(&self.container_bin, &entry.name).await
+            cleanup_named_container(&self.container_bin, self.cli, &entry.name).await
         } else {
             Ok(())
         }
     }
+}
+
+#[cfg(target_os = "macos")]
+pub fn default_sandbox_backend() -> Arc<dyn ManagedSandboxBackend> {
+    Arc::new(CliContainerSandboxBackend::apple_container())
+}
+
+#[cfg(target_os = "linux")]
+pub fn default_sandbox_backend() -> Arc<dyn ManagedSandboxBackend> {
+    Arc::new(CliContainerSandboxBackend::docker())
 }
 
 #[derive(Debug, Default)]
@@ -603,6 +642,7 @@ async fn create_unique_warm_sandbox(
 
 async fn ensure_warm_sandbox_ready(
     container_bin: &Path,
+    cli: ContainerCliFlavor,
     request: &SandboxRequest,
     warm_sandboxes: &Arc<Mutex<HashMap<SandboxKey, WarmSandboxEntry>>>,
 ) -> Result<String> {
@@ -624,7 +664,7 @@ async fn ensure_warm_sandbox_ready(
             let stale = warm_sandboxes
                 .remove(&request.key)
                 .expect("entry disappeared while locked");
-            schedule_cleanup_named_container(container_bin.to_path_buf(), stale.name);
+            schedule_cleanup_named_container(container_bin.to_path_buf(), cli, stale.name);
             let name = create_unique_warm_sandbox(container_bin, request).await?;
             warm_sandboxes.insert(
                 request.key.clone(),
@@ -668,7 +708,7 @@ async fn ensure_warm_sandbox_ready(
         },
     );
     drop(warm_sandboxes);
-    schedule_cleanup_named_container(container_bin.to_path_buf(), current_name);
+    schedule_cleanup_named_container(container_bin.to_path_buf(), cli, current_name);
     Ok(replacement_name)
 }
 
@@ -900,31 +940,63 @@ fn configure_env_args(process: &mut Command, env: &HashMap<String, String>) {
     }
 }
 
-async fn cleanup_named_container(container_bin: &Path, name: &str) -> Result<()> {
-    let stop =
-        run_container_admin_command(container_bin, WARM_SANDBOX_CLEANUP_TIMEOUT, ["stop", name])
+async fn cleanup_named_container(
+    container_bin: &Path,
+    cli: ContainerCliFlavor,
+    name: &str,
+) -> Result<()> {
+    match cli {
+        ContainerCliFlavor::AppleContainer => {
+            let stop = run_container_admin_command(
+                container_bin,
+                WARM_SANDBOX_CLEANUP_TIMEOUT,
+                ["stop", name],
+            )
             .await?;
-    if !stop.status.success() {
-        let stderr = String::from_utf8_lossy(&stop.stderr).trim().to_string();
-        if !is_missing_container_error(&stderr) {
-            return Err(anyhow!("failed to stop warm sandbox {}: {}", name, stderr));
-        }
-    }
+            if !stop.status.success() {
+                let stderr = String::from_utf8_lossy(&stop.stderr).trim().to_string();
+                if !is_missing_container_error(&stderr) {
+                    return Err(anyhow!("failed to stop warm sandbox {}: {}", name, stderr));
+                }
+            }
 
-    let delete = run_container_admin_command(
-        container_bin,
-        WARM_SANDBOX_CLEANUP_TIMEOUT,
-        ["delete", name],
-    )
-    .await?;
-    if !delete.status.success() {
-        let stderr = String::from_utf8_lossy(&delete.stderr).trim().to_string();
-        if !is_missing_container_error(&stderr) {
-            return Err(anyhow!(
-                "failed to delete warm sandbox {}: {}",
-                name,
-                stderr
-            ));
+            let delete = run_container_admin_command(
+                container_bin,
+                WARM_SANDBOX_CLEANUP_TIMEOUT,
+                ["delete", name],
+            )
+            .await?;
+            if !delete.status.success() {
+                let stderr = String::from_utf8_lossy(&delete.stderr).trim().to_string();
+                if !is_missing_container_error(&stderr) {
+                    return Err(anyhow!(
+                        "failed to delete warm sandbox {}: {}",
+                        name,
+                        stderr
+                    ));
+                }
+            }
+        }
+        ContainerCliFlavor::Docker => {
+            // `docker rm -f` is SIGKILL + remove in one shot. Avoids racing
+            // the daemon's default 10s SIGTERM grace against our cleanup
+            // timeout, which otherwise leaves Exited containers behind.
+            let rm = run_container_admin_command(
+                container_bin,
+                WARM_SANDBOX_CLEANUP_TIMEOUT,
+                ["rm", "-f", name],
+            )
+            .await?;
+            if !rm.status.success() {
+                let stderr = String::from_utf8_lossy(&rm.stderr).trim().to_string();
+                if !is_missing_container_error(&stderr) {
+                    return Err(anyhow!(
+                        "failed to delete warm sandbox {}: {}",
+                        name,
+                        stderr
+                    ));
+                }
+            }
         }
     }
 
@@ -972,8 +1044,12 @@ async fn reap_orphaned_warm_sandboxes(container_bin: &Path) -> Result<()> {
         if now - started_date < ORPHANED_WARM_SANDBOX_MIN_AGE.as_secs_f64() {
             continue;
         }
-        if let Err(error) =
-            cleanup_named_container(container_bin, &container.configuration.id).await
+        if let Err(error) = cleanup_named_container(
+            container_bin,
+            ContainerCliFlavor::AppleContainer,
+            &container.configuration.id,
+        )
+        .await
         {
             eprintln!(
                 "failed to clean up orphaned warm sandbox {}: {error}",
@@ -1005,14 +1081,25 @@ fn owner_pid_is_alive(pid: &str) -> bool {
         .is_ok_and(|status| status.success())
 }
 
-fn cleanup_named_container_blocking(container_bin: &Path, name: &str) {
-    run_container_admin_command_blocking(container_bin, ["stop", name]);
-    run_container_admin_command_blocking(container_bin, ["delete", name]);
+fn cleanup_named_container_blocking(
+    container_bin: &Path,
+    cli: ContainerCliFlavor,
+    name: &str,
+) {
+    match cli {
+        ContainerCliFlavor::AppleContainer => {
+            run_container_admin_command_blocking(container_bin, ["stop", name]);
+            run_container_admin_command_blocking(container_bin, ["delete", name]);
+        }
+        ContainerCliFlavor::Docker => {
+            run_container_admin_command_blocking(container_bin, ["rm", "-f", name]);
+        }
+    }
 }
 
-fn schedule_cleanup_named_container(container_bin: PathBuf, name: String) {
+fn schedule_cleanup_named_container(container_bin: PathBuf, cli: ContainerCliFlavor, name: String) {
     tokio::spawn(async move {
-        if let Err(error) = cleanup_named_container(&container_bin, &name).await {
+        if let Err(error) = cleanup_named_container(&container_bin, cli, &name).await {
             eprintln!("failed to clean up warm sandbox {name}: {error}");
         }
     });

--- a/crates/exoharness/src/secrets.rs
+++ b/crates/exoharness/src/secrets.rs
@@ -1,9 +1,13 @@
+#[cfg(target_os = "macos")]
 use std::collections::HashMap;
+#[cfg(target_os = "linux")]
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
 use aes_gcm::aead::{Aead, KeyInit};
 use aes_gcm::{Aes256Gcm, Nonce};
 use anyhow::{Context, anyhow, bail};
+#[cfg(target_os = "macos")]
 use keyring_core::{Entry, Error as KeyringError};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -12,7 +16,12 @@ use crate::{Result, Secret};
 
 const MASTER_KEY_LEN: usize = 32;
 const NONCE_LEN: usize = 12;
+#[cfg(target_os = "macos")]
 const KEYCHAIN_SERVICE: &str = "exo-exoharness-master-key";
+#[cfg(target_os = "linux")]
+const MASTER_KEY_FILE_PERMS: u32 = 0o600;
+#[cfg(target_os = "linux")]
+const MASTER_KEY_DIR_PERMS: u32 = 0o700;
 
 #[derive(Clone)]
 pub(crate) struct SecretCipher {
@@ -83,11 +92,13 @@ impl SecretKeyProvider for StaticSecretKeyProvider {
     }
 }
 
+#[cfg(target_os = "macos")]
 pub(crate) struct AppleKeychainSecretKeyProvider {
     account: String,
     key: OnceLock<[u8; MASTER_KEY_LEN]>,
 }
 
+#[cfg(target_os = "macos")]
 impl AppleKeychainSecretKeyProvider {
     pub(crate) fn new(account: String) -> Self {
         Self {
@@ -97,6 +108,7 @@ impl AppleKeychainSecretKeyProvider {
     }
 }
 
+#[cfg(target_os = "macos")]
 impl SecretKeyProvider for AppleKeychainSecretKeyProvider {
     fn get_or_create_key(&self) -> Result<[u8; MASTER_KEY_LEN]> {
         if let Some(key) = self.key.get() {
@@ -122,6 +134,47 @@ impl SecretKeyProvider for AppleKeychainSecretKeyProvider {
     }
 }
 
+#[cfg(target_os = "linux")]
+pub(crate) struct FileBackedSecretKeyProvider {
+    path: PathBuf,
+    key: OnceLock<[u8; MASTER_KEY_LEN]>,
+}
+
+#[cfg(target_os = "linux")]
+impl FileBackedSecretKeyProvider {
+    pub(crate) fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            key: OnceLock::new(),
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl SecretKeyProvider for FileBackedSecretKeyProvider {
+    fn get_or_create_key(&self) -> Result<[u8; MASTER_KEY_LEN]> {
+        if let Some(key) = self.key.get() {
+            return Ok(*key);
+        }
+        let key = match std::fs::read(&self.path) {
+            Ok(bytes) => parse_master_key_bytes(&bytes).with_context(|| {
+                format!("reading master key at {}", self.path.display())
+            })?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let key = random_master_key();
+                write_master_key_file(&self.path, &key)?;
+                key
+            }
+            Err(error) => {
+                return Err(anyhow::Error::from(error)
+                    .context(format!("reading master key at {}", self.path.display())));
+            }
+        };
+        let _ = self.key.set(key);
+        Ok(key)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct EncryptedSecret {
     pub(crate) algorithm: SecretEncryptionAlgorithm,
@@ -135,6 +188,7 @@ pub(crate) enum SecretEncryptionAlgorithm {
     Aes256Gcm,
 }
 
+#[cfg(target_os = "macos")]
 fn deserialize_key(serialized: &str) -> Result<[u8; MASTER_KEY_LEN]> {
     let bytes: Vec<u8> = serde_json::from_str(serialized)?;
     if bytes.len() != MASTER_KEY_LEN {
@@ -158,6 +212,7 @@ fn random_nonce() -> [u8; NONCE_LEN] {
     nonce
 }
 
+#[cfg(target_os = "macos")]
 fn ensure_apple_keychain_store() -> Result<()> {
     static INIT: OnceLock<std::result::Result<(), String>> = OnceLock::new();
     let result = INIT.get_or_init(|| {
@@ -168,4 +223,78 @@ fn ensure_apple_keychain_store() -> Result<()> {
         Ok(()) => Ok(()),
         Err(message) => Err(anyhow!(message.clone())),
     }
+}
+
+#[cfg(target_os = "linux")]
+fn parse_master_key_bytes(bytes: &[u8]) -> Result<[u8; MASTER_KEY_LEN]> {
+    if bytes.len() != MASTER_KEY_LEN {
+        bail!(
+            "invalid master key length: expected {MASTER_KEY_LEN}, got {}",
+            bytes.len()
+        );
+    }
+    let mut key = [0u8; MASTER_KEY_LEN];
+    key.copy_from_slice(bytes);
+    Ok(key)
+}
+
+#[cfg(target_os = "linux")]
+fn write_master_key_file(path: &Path, key: &[u8; MASTER_KEY_LEN]) -> Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating master key directory {}", parent.display()))?;
+        std::fs::set_permissions(parent, std::fs::Permissions::from_mode(MASTER_KEY_DIR_PERMS))
+            .with_context(|| format!("setting permissions on {}", parent.display()))?;
+    }
+
+    let tmp_path = path.with_extension("tmp");
+    let _ = std::fs::remove_file(&tmp_path);
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(MASTER_KEY_FILE_PERMS)
+        .open(&tmp_path)
+        .with_context(|| format!("creating master key file {}", tmp_path.display()))?;
+    file.write_all(key)
+        .with_context(|| format!("writing master key file {}", tmp_path.display()))?;
+    file.sync_all()
+        .with_context(|| format!("syncing master key file {}", tmp_path.display()))?;
+    drop(file);
+    std::fs::rename(&tmp_path, path)
+        .with_context(|| format!("renaming master key into place at {}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn default_master_key_path() -> Result<PathBuf> {
+    if let Some(value) = std::env::var_os("XDG_CONFIG_HOME") {
+        let path = PathBuf::from(value);
+        if !path.as_os_str().is_empty() {
+            return Ok(path.join("exo").join("master.key"));
+        }
+    }
+    if let Some(value) = std::env::var_os("HOME") {
+        let path = PathBuf::from(value);
+        if !path.as_os_str().is_empty() {
+            return Ok(path.join(".config").join("exo").join("master.key"));
+        }
+    }
+    bail!("could not determine config directory: set XDG_CONFIG_HOME or HOME")
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn default_secret_cipher(keychain_account: String) -> Result<SecretCipher> {
+    Ok(SecretCipher::new(Arc::new(
+        AppleKeychainSecretKeyProvider::new(keychain_account),
+    )))
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn default_secret_cipher(_keychain_account: String) -> Result<SecretCipher> {
+    Ok(SecretCipher::new(Arc::new(
+        FileBackedSecretKeyProvider::new(default_master_key_path()?),
+    )))
 }


### PR DESCRIPTION
## Summary

Makes exoharness work on Linux. Previously the harness hardcoded macOS-only dependencies (Apple Keychain for secret encryption, Apple's `container` CLI for sandboxes), so `exo secret set` failed immediately on any non-macOS host and the chat REPL couldn't get past harness construction.


updated the approach here to be static (gated by `cfg(target_os = "..."). 

### `exoharness: file-backed master key provider for Linux`

Adds `FileBackedSecretKeyProvider` mirroring the shape of `AppleKeychainSecretKeyProvider`: lazy `OnceLock` cache, read existing key on first access, or generate a random 32-byte key and persist it. The key file lives at `$XDG_CONFIG_HOME/exo/master.key` (or `$HOME/.config/exo/master.key`), written atomically via tmp+rename with file mode `0600` and parent directory `0700`. A cfg-gated `default_secret_cipher` is what the harness constructors call.

Noting the threat model here: this does not give us real encryption-at-rest, because an attacker with access to this machine can find the key and decrepyt the encrypted secrets. I looked at what some other tools do (aws cli, gh, etc.) and this seems to be acceptable to them. The one thing we do to provide some slight safety is we store the key in a different, global directory than the local secrets. so it is harder to accidentally leak. 

I structured the architecture this way on: swapping in a real keystore (1Password Connect, Vault, AWS Secrets Manager) later is a new `SecretKeyProvider` impl, no other code changes.

### `exoharness: docker sandbox backend for Linux`

Generalizes the Apple-only sandbox backend into `CliContainerSandboxBackend` parameterized by `ContainerCliFlavor`, with `apple_container()` and `docker()` constructors. The Apple flavor keeps every shell invocation byte-for-byte; the Docker flavor uses the same `run`/`exec` shape and substitutes `docker rm -f` for the Apple `stop`+`delete` two-step.

The `rm -f` substitution isn't cosmetic: `docker stop` defaults to a 10s SIGTERM grace, which races the harness's 5s `WARM_SANDBOX_CLEANUP_TIMEOUT` and leaves `Exited` containers behind that the subsequent `docker rm` can't remove. `rm -f` is SIGKILL + remove in one command; for sleep-infinity warm sandboxes there is no graceful state to preserve.

Apple-specific bits (system-start, orphan reaper, Apple-absolute-time deserializer) stay confined to the apple_container arm via `cli.requires_system_start()` and `match cli`. A cfg-gated `default_sandbox_backend` returns `apple_container()` on macOS and `docker()` on Linux. Adding a Podman backend later is a new `ContainerCliFlavor` variant + a new constructor.

## End-to-end verified on Linux

- `exo secret set <name> --env <ENV>` succeeds (previously failed at keychain init).
- `master.key` file written 0600, parent dir 0700, 32 bytes.
- Secrets round-trip across separate `exo` invocations (multi-process master-key read works).
- On-disk secret blobs are AES-256-GCM ciphertext with per-secret nonces (verified by inspecting `<root>/exoharness/secrets/<uuid>.json`).
- `exo chat repl <agent> <conversation>` against `gpt-4o-mini` completes turns successfully — secret decrypts via file-backed master key, sandbox container starts via Docker, streaming response arrives token-by-token.
- `docker rm -f` cleanup in `Drop for CliContainerSandboxBackend` leaves zero containers behind after the harness drops (previously each chat invocation would leak one `Exited` container under a `stop` + `rm` two-step).

## macOS verification

Not directly verified on macOS hardware. The macOS code paths are **structurally preserved**: every macOS-flavor invocation produces byte-identical shell commands to before this PR, and the cfg gates mean the macOS-specific code is identical to what's on `main`.

I'm going to look at adding some ci testing to make sure stuff works on both macos and linux. 

## Test plan

- [x] Linux end-to-end (chat repl, multi-turn, parallel tool calls — all work)
- [x] `cargo test -p exoharness --features basic-backend` (10/10 pass)
- [x] `cargo clippy -p exoharness --all-targets --features basic-backend` (no warnings)
- [ ] macOS verification via follow-up CI PR
