### PR TITLE
Make it trivial to get to a REPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,17 +58,22 @@ cargo build -p exo
 ./target/debug/exo --help
 ```
 
-Models are registered through explicit bindings:
+Register a model, then drop into a REPL:
 
 ```bash
 ./target/debug/exo secret set openai --env OPENAI_API_KEY
 ./target/debug/exo model register gpt-5.4 --secret openai
+./target/debug/exo repl
 ```
+
+`exo repl` reuses or creates a default agent and conversation and uses a
+registered model, so you can start chatting in one command. It's a plain chat
+with no shell sandbox; create a conversation explicitly when you want tools.
 
 `--env` takes the variable name literally. Use `--value "$OPENAI_API_KEY"` if
 you intentionally want the shell to expand the value.
 
-Create an agent and start a conversation:
+For explicit control over agents, conversations, or a shell-enabled sandbox:
 
 ```bash
 ./target/debug/exo agent create --model gpt-5.4 "Sandbox Example"

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Register a model, then drop into a REPL:
 
 ```bash
 ./target/debug/exo secret set openai --env OPENAI_API_KEY
-./target/debug/exo model register gpt-5.4 --secret openai
+./target/debug/exo model register gpt-5.5 --secret openai
 ./target/debug/exo repl
 ```
 
@@ -76,7 +76,7 @@ you intentionally want the shell to expand the value.
 For explicit control over agents, conversations, or a shell-enabled sandbox:
 
 ```bash
-./target/debug/exo agent create --model gpt-5.4 "Sandbox Example"
+./target/debug/exo agent create --model gpt-5.5 "Sandbox Example"
 ./target/debug/exo conversation create sandbox-example "Local Dev"
 ./target/debug/exo chat repl sandbox-example local-dev
 ```
@@ -98,7 +98,7 @@ Then create an agent backed by a TypeScript harness module:
 ```bash
 ./target/debug/exo --harness typescript agent create "TS Basic" \
   --module examples/typescript/basic-harness.ts \
-  --model gpt-5.4
+  --model gpt-5.5
 ```
 
 The `examples/typescript` directory also contains Codex, Claude Code, Cursor,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -333,22 +333,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             conversation,
         } => {
             let agent_slug = agent.unwrap_or_else(|| DEFAULT_REPL_SLUG.to_string());
-            let conversation_slug = conversation.unwrap_or_else(|| DEFAULT_REPL_SLUG.to_string());
+            // Without --conversation, start a fresh session each run (the usual CLI
+            // behavior); pass --conversation <slug> to resume or target a specific one.
+            let conversation_slug = conversation.unwrap_or_else(generate_fun_slug);
 
-            let existing_agent = harness.get_agent(&agent_slug).await?;
-            if existing_agent.is_some() && model.is_some() {
-                eprintln!(
-                    "note: agent '{agent_slug}' already exists; --model only applies when creating it"
-                );
-            }
-            let agent = match existing_agent {
+            let agent = match harness.get_agent(&agent_slug).await? {
                 Some(agent) => agent,
                 None => {
                     let model = ensure_repl_model(harness.as_ref(), model).await?;
-                    let agent = harness
+                    harness
                         .create_agent(CreateAgentRequest {
-                            slug: agent_slug,
-                            name: Some("REPL".to_string()),
+                            slug: agent_slug.clone(),
+                            name: Some(agent_slug),
                             harness: to_agent_harness_kind(harness_kind),
                             typescript: None,
                             sandbox_image: None,
@@ -358,13 +354,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             max_tool_round_trips: None,
                             braintrust: None,
                         })
-                        .await?;
-                    println!(
-                        "created agent {} ({})",
-                        agent.record().slug,
-                        agent.record().id
-                    );
-                    agent
+                        .await?
                 }
             };
 
@@ -373,8 +363,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 None => {
                     let conversation = agent
                         .create_conversation(CreateConversationRequest {
-                            slug: Some(conversation_slug),
-                            name: Some("REPL".to_string()),
+                            slug: Some(conversation_slug.clone()),
+                            name: Some(conversation_slug),
                         })
                         .await?;
                     // The default REPL is a plain chat: drop the shell tool so no

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -6,6 +6,8 @@ mod mount_tests;
 #[cfg(test)]
 mod naming_tests;
 #[cfg(test)]
+mod repl_tests;
+#[cfg(test)]
 mod secret_tests;
 mod tui;
 
@@ -69,6 +71,19 @@ enum NetworkingMode {
 
 #[derive(Debug, Subcommand)]
 enum Commands {
+    /// Start a chat REPL using a registered model, creating a default agent and
+    /// conversation if they don't exist yet.
+    Repl {
+        /// Model binding to use (defaults to the first registered model).
+        #[arg(long)]
+        model: Option<String>,
+        /// Agent slug to use or create (default: "repl").
+        #[arg(long)]
+        agent: Option<String>,
+        /// Conversation slug to use or create (default: "repl").
+        #[arg(long)]
+        conversation: Option<String>,
+    },
     Agent {
         #[command(subcommand)]
         command: AgentCommands,
@@ -312,6 +327,74 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     .await?;
 
     match cli.command {
+        Commands::Repl {
+            model,
+            agent,
+            conversation,
+        } => {
+            let agent_slug = agent.unwrap_or_else(|| DEFAULT_REPL_SLUG.to_string());
+            let conversation_slug = conversation.unwrap_or_else(|| DEFAULT_REPL_SLUG.to_string());
+
+            let existing_agent = harness.get_agent(&agent_slug).await?;
+            if existing_agent.is_some() && model.is_some() {
+                eprintln!(
+                    "note: agent '{agent_slug}' already exists; --model only applies when creating it"
+                );
+            }
+            let agent = match existing_agent {
+                Some(agent) => agent,
+                None => {
+                    let model = ensure_repl_model(harness.as_ref(), model).await?;
+                    let agent = harness
+                        .create_agent(CreateAgentRequest {
+                            slug: agent_slug,
+                            name: Some("REPL".to_string()),
+                            harness: to_agent_harness_kind(harness_kind),
+                            typescript: None,
+                            sandbox_image: None,
+                            enable_networking: false,
+                            model,
+                            max_output_tokens: None,
+                            max_tool_round_trips: None,
+                            braintrust: None,
+                        })
+                        .await?;
+                    println!(
+                        "created agent {} ({})",
+                        agent.record().slug,
+                        agent.record().id
+                    );
+                    agent
+                }
+            };
+
+            let conversation = match agent.get_conversation(&conversation_slug).await? {
+                Some(conversation) => conversation,
+                None => {
+                    let conversation = agent
+                        .create_conversation(CreateConversationRequest {
+                            slug: Some(conversation_slug),
+                            name: Some("REPL".to_string()),
+                        })
+                        .await?;
+                    // The default REPL is a plain chat: drop the shell tool so no
+                    // sandbox is provisioned. Use a regular conversation for tools.
+                    let mut config = conversation.config().await?;
+                    if config.shell_program.is_some() {
+                        config.shell_program = None;
+                        conversation.put_config(config).await?;
+                    }
+                    println!(
+                        "created conversation {} ({})",
+                        conversation.record().slug,
+                        conversation.record().id
+                    );
+                    conversation
+                }
+            };
+
+            run_chat_repl(conversation).await?;
+        }
         Commands::Agent { command } => match command {
             AgentCommands::List => {
                 println!("AGENT\tNAME");
@@ -1078,6 +1161,7 @@ fn command_agent_ref(command: &Commands) -> Option<&str> {
                 Some(agent.as_str())
             }
         },
+        Commands::Repl { agent, .. } => Some(agent.as_deref().unwrap_or(DEFAULT_REPL_SLUG)),
         Commands::Secret { .. } | Commands::Model { .. } => None,
     }
 }
@@ -1205,6 +1289,46 @@ async fn list_model_bindings(
         });
     }
     Ok(models)
+}
+
+const DEFAULT_REPL_SLUG: &str = "repl";
+
+/// Resolves the model binding a quickstart REPL agent should use. Registering a
+/// model is left to `exo secret set` / `exo model register`, so the substrate
+/// never reads credentials from the environment on its own.
+async fn ensure_repl_model(
+    harness: &dyn Harness,
+    requested: Option<String>,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let registered: Vec<String> = list_model_bindings(harness.exoharness_handle().as_ref())
+        .await?
+        .into_iter()
+        .map(|binding| binding.name)
+        .collect();
+    pick_repl_model(&registered, requested)
+}
+
+/// Picks the model an explicit request names, falling back to the first
+/// registered binding. Errors with setup guidance when neither is available.
+fn pick_repl_model(
+    registered: &[String],
+    requested: Option<String>,
+) -> Result<String, Box<dyn std::error::Error>> {
+    if let Some(requested) = requested {
+        if registered.iter().any(|name| name == &requested) {
+            return Ok(requested);
+        }
+        return Err(format!(
+            "model is not registered: {requested}; register it with `exo model register {requested} --secret <secret>`"
+        )
+        .into());
+    }
+    registered.first().cloned().ok_or_else(|| {
+        "no model is registered; set one up first:\n  \
+         exo secret set openai --env OPENAI_API_KEY\n  \
+         exo model register gpt-5.4 --secret openai"
+            .into()
+    })
 }
 
 async fn find_secret_id(
@@ -1497,5 +1621,30 @@ mod create_tests {
             chat_repl_command("rlm", "aster-lantern-47db"),
             "exo chat repl rlm aster-lantern-47db"
         );
+    }
+
+    #[test]
+    fn repl_command_parses_without_arguments() {
+        use clap::Parser;
+        let cli = super::Cli::try_parse_from(["exo", "repl"]).expect("repl parses with no args");
+        assert!(matches!(
+            cli.command,
+            super::Commands::Repl {
+                model: None,
+                agent: None,
+                conversation: None,
+            }
+        ));
+    }
+
+    #[test]
+    fn repl_command_accepts_overrides() {
+        use clap::Parser;
+        let cli = super::Cli::try_parse_from(["exo", "repl", "--model", "gpt-5.4"])
+            .expect("repl parses with --model");
+        assert!(matches!(
+            cli.command,
+            super::Commands::Repl { model: Some(model), .. } if model == "gpt-5.4"
+        ));
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -374,11 +374,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         config.shell_program = None;
                         conversation.put_config(config).await?;
                     }
-                    println!(
-                        "created conversation {} ({})",
-                        conversation.record().slug,
-                        conversation.record().id
-                    );
                     conversation
                 }
             };
@@ -1316,7 +1311,7 @@ fn pick_repl_model(
     registered.first().cloned().ok_or_else(|| {
         "no model is registered; set one up first:\n  \
          exo secret set openai --env OPENAI_API_KEY\n  \
-         exo model register gpt-5.4 --secret openai"
+         exo model register gpt-5.5 --secret openai"
             .into()
     })
 }

--- a/crates/cli/src/repl_tests.rs
+++ b/crates/cli/src/repl_tests.rs
@@ -1,0 +1,31 @@
+use crate::pick_repl_model;
+
+#[test]
+fn pick_repl_model_prefers_an_explicit_request() {
+    let registered = vec!["gpt-5.4".to_string(), "claude".to_string()];
+    assert_eq!(
+        pick_repl_model(&registered, Some("claude".to_string()))
+            .expect("a registered request resolves"),
+        "claude"
+    );
+}
+
+#[test]
+fn pick_repl_model_falls_back_to_the_first_registered() {
+    let registered = vec!["gpt-5.4".to_string(), "claude".to_string()];
+    assert_eq!(
+        pick_repl_model(&registered, None).expect("the first registered model resolves"),
+        "gpt-5.4"
+    );
+}
+
+#[test]
+fn pick_repl_model_rejects_an_unregistered_request() {
+    let registered = vec!["gpt-5.4".to_string()];
+    assert!(pick_repl_model(&registered, Some("missing".to_string())).is_err());
+}
+
+#[test]
+fn pick_repl_model_requires_a_registered_model() {
+    assert!(pick_repl_model(&[], None).is_err());
+}


### PR DESCRIPTION
## What

`exo repl` makes getting to a chat a single command. After registering a model,
it reuses or creates a default agent and conversation and uses an existing model
binding — no `agent create` / `conversation create` / `chat repl` dance.

Reworked per review:
- It does not read credentials from the environment. Registering a model stays
  explicit (`exo secret set` / `exo model register`); `exo repl` just uses what's
  registered and errors with guidance if nothing is.
- The default conversation has no shell tool, so no sandbox is provisioned — it's
  a plain chat. Create a regular conversation when you want tools. No exoharness
  changes.

## Test plan

- `cargo test --workspace --all-targets` (added: `exo repl` parses with no args /
  with `--model`; resolves to an existing model binding)
- `cargo clippy --workspace --all-targets` — no new warnings