### PR TITLE
executor: drop phantom tool-call slots from streaming accumulator

### DIFF
--- a/crates/executor/src/harness_runtime.rs
+++ b/crates/executor/src/harness_runtime.rs
@@ -310,6 +310,57 @@ mod tests {
             [Message::Assistant { id: None, .. }]
         ));
     }
+
+    #[test]
+    fn stream_accumulator_drops_tool_call_slots_without_id_and_name() {
+        let mut accumulator = UniversalResponseAccumulator::default();
+        accumulator.push(&UniversalStreamChunk::new(
+            Some("resp_123".to_string()),
+            Some("gpt-5.4".to_string()),
+            vec![lingua::UniversalStreamChoice {
+                index: 0,
+                delta: Some(lingua_json::json!({
+                    "role": "assistant",
+                    "tool_calls": [
+                        { "index": 0 },
+                        {
+                            "index": 1,
+                            "id": "call_real",
+                            "function": { "name": "shell", "arguments": "{}" }
+                        }
+                    ]
+                })),
+                finish_reason: None,
+            }],
+            None,
+            None,
+        ));
+
+        let response = accumulator.finalize();
+
+        let Some(Message::Assistant {
+            content: AssistantContent::Array(parts),
+            ..
+        }) = response.messages.first()
+        else {
+            panic!("expected a single Assistant message with array content");
+        };
+        let tool_calls: Vec<&AssistantContentPart> = parts
+            .iter()
+            .filter(|part| matches!(part, AssistantContentPart::ToolCall { .. }))
+            .collect();
+        assert_eq!(tool_calls.len(), 1);
+        let AssistantContentPart::ToolCall {
+            tool_call_id,
+            tool_name,
+            ..
+        } = tool_calls[0]
+        else {
+            unreachable!();
+        };
+        assert_eq!(tool_call_id, "call_real");
+        assert_eq!(tool_name, "shell");
+    }
 }
 
 fn serialize_request(format: ProviderFormat, request: &UniversalRequest) -> Result<Bytes> {
@@ -483,13 +534,16 @@ impl UniversalResponseAccumulator {
         }
 
         for tool_call in &self.tool_calls {
+            let Some(id) = tool_call.id.clone() else {
+                continue;
+            };
             let function = tool_call.function.clone().unwrap_or_default();
+            let Some(name) = function.name else {
+                continue;
+            };
             content_parts.push(AssistantContentPart::ToolCall {
-                tool_call_id: tool_call
-                    .id
-                    .clone()
-                    .unwrap_or_else(|| format!("tool-call-{}", content_parts.len())),
-                tool_name: function.name.unwrap_or_else(|| "unknown".to_string()),
+                tool_call_id: id,
+                tool_name: name,
                 arguments: ToolCallArguments::from(function.arguments.unwrap_or_default()),
                 encrypted_content: None,
                 provider_options: None,


### PR DESCRIPTION
## Summary

Follow-up to #5 in the same accumulator. `UniversalResponseAccumulator::finalize` was synthesizing `tool_call_id = \"tool-call-N\"` and `tool_name = \"unknown\"` for slots in `self.tool_calls` that came back from lingua's streaming parser without an id or function name. Lingua emits one such phantom slot during OpenAI Responses streaming of parallel function calls (a \`delta.tool_calls\` entry with neither id nor name nor arguments), and the synthetic record was then persisted into the event log.

On the next turn, lingua's \`universal_to_responses_input\` serializes that record as a \`function_call\` item with \`call_id: \"tool-call-N\"\`, which the Responses API rejects because there's no matching \`function_call_output\`:

\`\`\`
Error: provider 'openai' error: HTTP 400 Bad Request:
  {\"error\":{\"message\":\"No tool output found for function call tool-call-1.\",...}}
\`\`\`

## Repro

In \`chat repl\`, ask: "do three things in parallel: print the date, print the python version, and ls /tmp"

The model emits 3 parallel \`function_call\`s; one slot comes through phantom. The first turn completes successfully (model issues calls, exec returns results), but the next assistant turn fails because the phantom record has no matching output.

## Fix

Skip slots that don't carry both a real id and a real function name, instead of inventing synthetic fallbacks. A valid tool call must have both; if either is missing it's a lingua artifact, not a tool the model actually called.

## Test

Adds \`stream_accumulator_drops_tool_call_slots_without_id_and_name\` next to the existing accumulator tests from #5. Feeds a chunk with one phantom delta and one real tool_call, asserts only the real one persists. Mirrors the pattern of the \`stream_accumulator_does_not_treat_chunk_id_as_assistant_message_id\` test.

## Test plan

- [x] \`cargo test -p executor\` (23/23 pass — 22 existing + 1 new)
- [x] Reproduced the original failure with a parallel-tool-call prompt on \`chat repl\` against \`gpt-4o-mini\`; confirmed the fix resolves it (multi-turn completes cleanly).