### PR TITLE
CI: run rust-tests on macOS and add backend-matrix integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,12 @@ jobs:
         run: pnpm check
 
   rust-tests:
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
 
     steps:
       - name: Check out repository

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,35 @@
+name: Integration tests
+
+# Runs the heavier integration tests (real Docker, real binary spawn,
+# wiremock-backed fake OpenAI) that we don't want on every PR. Triggers
+# on push to main (post-merge confirmation) and manual workflow dispatch.
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  rust-integration-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+
+      - name: Cache Rust dependencies and build output
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+
+      - name: Verify Docker is available
+        run: docker info
+
+      - name: Run integration tests
+        run: cargo test --workspace --all-targets -- --ignored

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,8 +1,11 @@
 name: Integration tests
 
-# Runs the heavier integration tests (real Docker, real binary spawn,
-# wiremock-backed fake OpenAI) that we don't want on every PR. Triggers
-# on push to main (post-merge confirmation) and manual workflow dispatch.
+# Heavier integration tests (real sandbox, real binary spawn, wiremock fake
+# OpenAI). Matrix covers each (os, sandbox-backend) cell we plausibly support
+# in CI; the secret backend is always `file` (with the master key inside a
+# per-test tempdir via XDG_CONFIG_HOME).
+#
+# Triggers on push to main and manual workflow_dispatch.
 
 on:
   push:
@@ -15,8 +18,48 @@ permissions:
 
 jobs:
   rust-integration-tests:
-    runs-on: ubuntu-latest
+    name: ${{ matrix.os }} / ${{ matrix.sandbox-backend }}
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: linux
+            runner: ubuntu-latest
+            sandbox-backend: local-process
+          - os: linux
+            runner: ubuntu-latest
+            sandbox-backend: docker
+          - os: macos
+            runner: macos-15
+            sandbox-backend: local-process
+          - os: macos
+            runner: macos-15-intel # Intel runner exposes HVF; arm64 doesn't (nested virt)
+            sandbox-backend: docker
+          # macOS / apple-container is intentionally not covered by CI.
+          #
+          # Apple's `container` CLI uses VZ.framework, which requires
+          # hardware virtualization on Apple Silicon. GitHub-hosted
+          # Apple Silicon runners do not expose nested virtualization
+          # (tracked upstream: https://github.com/actions/runner-images/issues/13505),
+          # so VZ fails with "Virtualization is not available on this
+          # hardware" no matter how the container CLI is configured.
+          #
+          # To exercise this cell, run on either:
+          #   - a self-hosted Apple Silicon runner on macOS 26+, or
+          #   - a third-party Mac CI service such as Cirrus or MacStadium.
+          #
+          # The install-step + run-step plumbing for apple-container is
+          # left in place below so a self-hosted matrix entry can be
+          # added by just uncommenting and pointing `runner:` at a
+          # labelled self-hosted runner.
+          # - os: macos
+          #   runner: self-hosted-macos-26
+          #   sandbox-backend: apple-container
+
+    env:
+      EXO_TEST_SANDBOX_BACKEND: ${{ matrix.sandbox-backend }}
 
     steps:
       - name: Check out repository
@@ -28,8 +71,48 @@ jobs:
       - name: Cache Rust dependencies and build output
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
 
+      # Linux runners ship with Docker preinstalled; just confirm it's up.
       - name: Verify Docker is available
+        if: matrix.os == 'linux' && matrix.sandbox-backend == 'docker'
         run: docker info
 
+      # macOS runners don't ship Docker. Use the crazy-max action which
+      # handles the Colima + Lima setup with a known-good config —
+      # brew-installed Colima 0.10.1 + Lima 2.1.1 hits a hostagent Go panic
+      # on macos-15.
+      - name: Install Docker (macOS)
+        if: matrix.os == 'macos' && matrix.sandbox-backend == 'docker'
+        uses: crazy-max/ghaction-setup-docker@b2189fbf2a6592b51fee7cdd93ee2bfaeba733db # v5.1.0
+
+      - name: Verify Docker is available (macOS)
+        if: matrix.os == 'macos' && matrix.sandbox-backend == 'docker'
+        run: docker info
+
+      # Apple's `container` CLI is distributed as a signed .pkg from the
+      # apple/container repo. No matrix cell exercises this today (see the
+      # commented-out apple-container entry in the matrix above), but the
+      # install step is kept so a self-hosted-runner cell can re-enable it
+      # without re-discovering the install incantation.
+      - name: Install Apple container CLI (macOS)
+        if: matrix.os == 'macos' && matrix.sandbox-backend == 'apple-container'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euxo pipefail
+          # Authed download via gh CLI to avoid api.github.com rate limiting.
+          gh release download --repo apple/container \
+            --pattern '*-installer-signed.pkg' \
+            --dir /tmp
+          PKG=$(ls /tmp/*-installer-signed.pkg | head -n1)
+          sudo installer -pkg "$PKG" -target /
+          container --version
+          # --enable-kernel-install skips the first-run interactive prompt
+          # asking whether to install the default kernel.
+          container system start --enable-kernel-install
+          container system status
+
       - name: Run integration tests
-        run: cargo test --workspace --all-targets -- --ignored
+        # Narrow to the one integration target — unit tests are already
+        # covered by the rust-tests job in ci.yml, no need to recompile or
+        # rerun them here.
+        run: cargo test --package exo --test integration_chat -- --ignored

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,6 +1585,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1776,7 +1794,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1841,6 +1859,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "wiremock",
 ]
 
 [[package]]
@@ -2368,6 +2387,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2396,6 +2421,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -3295,7 +3321,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3393,6 +3419,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -4409,7 +4445,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4996,7 +5032,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5948,7 +5984,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6202,6 +6238,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json 1.0.149",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,3 +21,4 @@ tokio-stream.workspace = true
 
 [dev-dependencies]
 tempfile = "3.23.0"
+wiremock = "0.6"

--- a/crates/cli/tests/integration_chat.rs
+++ b/crates/cli/tests/integration_chat.rs
@@ -1,15 +1,12 @@
 //! Integration test exercising the real `exo` binary against:
-//!   - a real Docker container (sandbox), and
+//!   - a real sandbox backend (docker / apple-container / local-process), and
 //!   - a wiremock-backed fake OpenAI Responses endpoint.
 //!
 //! `#[ignore]`'d so `cargo test` skips it by default; the integration workflow
-//! runs `cargo test --workspace -- --ignored` on push to main.
-//!
-//! Linux-only because the production sandbox backend on macOS is the Apple
-//! `container` CLI, which is not assumed to be present on macOS CI runners
-//! today. Verifying the Apple arm in CI is a separate follow-up.
-
-#![cfg(target_os = "linux")]
+//! runs `cargo test --workspace -- --ignored` and selects the backend via the
+//! `EXO_TEST_SANDBOX_BACKEND` env var (defaults to `docker`). The secret
+//! backend is always `file`, with the master key materialised inside a
+//! per-test tempdir via `XDG_CONFIG_HOME`.
 
 use std::path::PathBuf;
 use std::process::Command;
@@ -19,13 +16,63 @@ use tempfile::TempDir;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SandboxBackend {
+    Docker,
+    AppleContainer,
+    LocalProcess,
+}
+
+impl SandboxBackend {
+    fn from_env() -> Self {
+        let raw = std::env::var("EXO_TEST_SANDBOX_BACKEND").unwrap_or_else(|_| "docker".into());
+        match raw.as_str() {
+            "docker" => Self::Docker,
+            "apple-container" => Self::AppleContainer,
+            "local-process" => Self::LocalProcess,
+            other => panic!("unknown EXO_TEST_SANDBOX_BACKEND={other}"),
+        }
+    }
+
+    fn cli_arg(self) -> &'static str {
+        match self {
+            Self::Docker => "docker",
+            Self::AppleContainer => "apple-container",
+            Self::LocalProcess => "local-process",
+        }
+    }
+
+    fn runtime_available(self) -> bool {
+        match self {
+            Self::Docker => Command::new("docker")
+                .arg("info")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false),
+            Self::AppleContainer => Command::new("container")
+                .arg("--version")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false),
+            Self::LocalProcess => true,
+        }
+    }
+}
+
 fn exo_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_exo"))
 }
 
-fn run_exo(args: &[&str], root: &str, xdg: &str) -> std::process::Output {
+fn run_exo(
+    args: &[&str],
+    root: &str,
+    xdg: &str,
+    backend: SandboxBackend,
+) -> std::process::Output {
     let output = Command::new(exo_bin())
         .args(["--root", root])
+        .args(["--secret-backend", "file"])
+        .args(["--sandbox-backend", backend.cli_arg()])
         .args(args)
         .env("XDG_CONFIG_HOME", xdg)
         .env("OPENAI_API_KEY", "sk-test-key")
@@ -42,9 +89,6 @@ fn run_exo(args: &[&str], root: &str, xdg: &str) -> std::process::Output {
     output
 }
 
-/// Canned OpenAI Responses API completion body. Format derived from the
-/// public API surface; if lingua's parsing tightens, this is the place to
-/// update.
 fn canned_response_body() -> Value {
     json!({
         "id": "resp_test_abc123",
@@ -76,16 +120,14 @@ fn canned_response_body() -> Value {
 }
 
 #[tokio::test]
-#[ignore = "spawns real exo binary + real Docker container + wiremock; run with cargo test -- --ignored"]
-async fn chat_send_round_trips_through_real_docker_and_mocked_openai() {
-    // Pre-flight: skip cleanly if Docker isn't available on the runner.
-    let docker_available = Command::new("docker")
-        .arg("info")
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false);
-    if !docker_available {
-        eprintln!("docker not available, skipping integration test");
+#[ignore = "spawns real exo binary + real sandbox + wiremock; run with cargo test -- --ignored"]
+async fn chat_send_round_trips_through_real_sandbox_and_mocked_openai() {
+    let backend = SandboxBackend::from_env();
+    if !backend.runtime_available() {
+        eprintln!(
+            "sandbox backend {:?} not available on this runner, skipping",
+            backend
+        );
         return;
     }
 
@@ -94,8 +136,6 @@ async fn chat_send_round_trips_through_real_docker_and_mocked_openai() {
     let root = root_dir.path().to_string_lossy().into_owned();
     let xdg = xdg_dir.path().to_string_lossy().into_owned();
 
-    // Stand up the fake OpenAI Responses endpoint. lingua targets `/responses`
-    // relative to the supplied base_url (it does not auto-prepend `/v1`).
     let mock_server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/responses"))
@@ -103,11 +143,11 @@ async fn chat_send_round_trips_through_real_docker_and_mocked_openai() {
         .mount(&mock_server)
         .await;
 
-    // Wire up secret + model + agent + conversation via the real binary.
     run_exo(
         &["secret", "set", "test-key", "--env", "OPENAI_API_KEY"],
         &root,
         &xdg,
+        backend,
     );
     run_exo(
         &[
@@ -121,6 +161,7 @@ async fn chat_send_round_trips_through_real_docker_and_mocked_openai() {
         ],
         &root,
         &xdg,
+        backend,
     );
     run_exo(
         &[
@@ -134,19 +175,20 @@ async fn chat_send_round_trips_through_real_docker_and_mocked_openai() {
         ],
         &root,
         &xdg,
+        backend,
     );
     run_exo(
         &["conversation", "create", "test-agent", "first"],
         &root,
         &xdg,
+        backend,
     );
 
-    // Send a chat; this is the bit that hits the mock server through the real
-    // executor + the real Docker sandbox.
     let output = run_exo(
         &["chat", "send", "test-agent", "first", "hello there"],
         &root,
         &xdg,
+        backend,
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
@@ -154,7 +196,6 @@ async fn chat_send_round_trips_through_real_docker_and_mocked_openai() {
         "expected mocked assistant text in stdout; got: {stdout}"
     );
 
-    // The mock server should have received exactly one /responses request.
     let recorded = mock_server.received_requests().await.unwrap_or_default();
     let responses_calls = recorded
         .iter()
@@ -169,8 +210,6 @@ async fn chat_send_round_trips_through_real_docker_and_mocked_openai() {
             .collect::<Vec<_>>()
     );
 
-    // The conversation's event log should contain the assistant message we
-    // returned from the mock.
     let conv_root = root_dir
         .path()
         .join("exoharness/agents")
@@ -215,27 +254,26 @@ async fn chat_send_round_trips_through_real_docker_and_mocked_openai() {
         events_dir.display()
     );
 
-    // Sandbox lifecycle: the harness should have created at least one
-    // labeled Docker container while running, and `docker rm -f` should
-    // have cleaned it up by the time the binary exited.
-    let leftover_containers = Command::new("docker")
-        .args([
-            "ps",
-            "-aq",
-            "--filter",
-            "label=exo.sandbox.owner-pid",
-            "--filter",
-            "status=exited",
-        ])
-        .output()
-        .expect("docker ps");
-    let stdout = String::from_utf8_lossy(&leftover_containers.stdout);
-    let stale = stdout
-        .lines()
-        .filter(|l| !l.trim().is_empty())
-        .collect::<Vec<_>>();
-    assert!(
-        stale.is_empty(),
-        "expected zero leftover Exited exo containers after binary exit; found: {stale:?}"
-    );
+    if backend == SandboxBackend::Docker {
+        let leftover_containers = Command::new("docker")
+            .args([
+                "ps",
+                "-aq",
+                "--filter",
+                "label=exo.sandbox.owner-pid",
+                "--filter",
+                "status=exited",
+            ])
+            .output()
+            .expect("docker ps");
+        let stdout = String::from_utf8_lossy(&leftover_containers.stdout);
+        let stale = stdout
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .collect::<Vec<_>>();
+        assert!(
+            stale.is_empty(),
+            "expected zero leftover Exited exo containers after binary exit; found: {stale:?}"
+        );
+    }
 }

--- a/crates/cli/tests/integration_chat_linux.rs
+++ b/crates/cli/tests/integration_chat_linux.rs
@@ -1,0 +1,241 @@
+//! Integration test exercising the real `exo` binary against:
+//!   - a real Docker container (sandbox), and
+//!   - a wiremock-backed fake OpenAI Responses endpoint.
+//!
+//! `#[ignore]`'d so `cargo test` skips it by default; the integration workflow
+//! runs `cargo test --workspace -- --ignored` on push to main.
+//!
+//! Linux-only because the production sandbox backend on macOS is the Apple
+//! `container` CLI, which is not assumed to be present on macOS CI runners
+//! today. Verifying the Apple arm in CI is a separate follow-up.
+
+#![cfg(target_os = "linux")]
+
+use std::path::PathBuf;
+use std::process::Command;
+
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn exo_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_exo"))
+}
+
+fn run_exo(args: &[&str], root: &str, xdg: &str) -> std::process::Output {
+    let output = Command::new(exo_bin())
+        .args(["--root", root])
+        .args(args)
+        .env("XDG_CONFIG_HOME", xdg)
+        .env("OPENAI_API_KEY", "sk-test-key")
+        .output()
+        .expect("failed to spawn exo");
+    if !output.status.success() {
+        panic!(
+            "exo {:?} failed: stdout={} stderr={}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+    output
+}
+
+/// Canned OpenAI Responses API completion body. Format derived from the
+/// public API surface; if lingua's parsing tightens, this is the place to
+/// update.
+fn canned_response_body() -> Value {
+    json!({
+        "id": "resp_test_abc123",
+        "object": "response",
+        "status": "completed",
+        "created_at": 1_700_000_000_u64,
+        "model": "gpt-test",
+        "output": [
+            {
+                "type": "message",
+                "id": "msg_test_xyz",
+                "role": "assistant",
+                "status": "completed",
+                "content": [
+                    {
+                        "type": "output_text",
+                        "text": "Hello from the mock OpenAI server.",
+                        "annotations": []
+                    }
+                ]
+            }
+        ],
+        "usage": {
+            "input_tokens": 5,
+            "output_tokens": 7,
+            "total_tokens": 12
+        }
+    })
+}
+
+#[tokio::test]
+#[ignore = "spawns real exo binary + real Docker container + wiremock; run with cargo test -- --ignored"]
+async fn chat_send_round_trips_through_real_docker_and_mocked_openai() {
+    // Pre-flight: skip cleanly if Docker isn't available on the runner.
+    let docker_available = Command::new("docker")
+        .arg("info")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if !docker_available {
+        eprintln!("docker not available, skipping integration test");
+        return;
+    }
+
+    let root_dir = TempDir::new().expect("tempdir for --root");
+    let xdg_dir = TempDir::new().expect("tempdir for XDG_CONFIG_HOME");
+    let root = root_dir.path().to_string_lossy().into_owned();
+    let xdg = xdg_dir.path().to_string_lossy().into_owned();
+
+    // Stand up the fake OpenAI Responses endpoint. lingua targets `/responses`
+    // relative to the supplied base_url (it does not auto-prepend `/v1`).
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(canned_response_body()))
+        .mount(&mock_server)
+        .await;
+
+    // Wire up secret + model + agent + conversation via the real binary.
+    run_exo(
+        &["secret", "set", "test-key", "--env", "OPENAI_API_KEY"],
+        &root,
+        &xdg,
+    );
+    run_exo(
+        &[
+            "model",
+            "register",
+            "gpt-test",
+            "--secret",
+            "test-key",
+            "--base-url",
+            &mock_server.uri(),
+        ],
+        &root,
+        &xdg,
+    );
+    run_exo(
+        &[
+            "agent",
+            "create",
+            "--slug",
+            "test-agent",
+            "--model",
+            "gpt-test",
+            "Integration Test Agent",
+        ],
+        &root,
+        &xdg,
+    );
+    run_exo(
+        &["conversation", "create", "test-agent", "first"],
+        &root,
+        &xdg,
+    );
+
+    // Send a chat; this is the bit that hits the mock server through the real
+    // executor + the real Docker sandbox.
+    let output = run_exo(
+        &["chat", "send", "test-agent", "first", "hello there"],
+        &root,
+        &xdg,
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Hello from the mock OpenAI server."),
+        "expected mocked assistant text in stdout; got: {stdout}"
+    );
+
+    // The mock server should have received exactly one /responses request.
+    let recorded = mock_server.received_requests().await.unwrap_or_default();
+    let responses_calls = recorded
+        .iter()
+        .filter(|r| r.url.path() == "/responses")
+        .count();
+    assert_eq!(
+        responses_calls, 1,
+        "expected exactly one POST /responses; got {responses_calls} (all paths: {:?})",
+        recorded
+            .iter()
+            .map(|r| r.url.path().to_string())
+            .collect::<Vec<_>>()
+    );
+
+    // The conversation's event log should contain the assistant message we
+    // returned from the mock.
+    let conv_root = root_dir
+        .path()
+        .join("exoharness/agents")
+        .read_dir()
+        .expect("agents dir exists")
+        .next()
+        .expect("at least one agent")
+        .unwrap()
+        .path()
+        .join("conversations");
+    let conv_dir = conv_root
+        .read_dir()
+        .expect("conversations dir exists")
+        .next()
+        .expect("at least one conversation")
+        .unwrap()
+        .path();
+    let events_dir = conv_dir.join("events");
+    let mut found_assistant_text = false;
+    for entry in events_dir.read_dir().expect("events dir exists").flatten() {
+        let raw = std::fs::read(entry.path()).expect("event file readable");
+        let event: Value = serde_json::from_slice(&raw).expect("event is valid json");
+        let Some(messages) = event
+            .pointer("/data/messages")
+            .and_then(Value::as_array)
+            .cloned()
+        else {
+            continue;
+        };
+        for message in messages {
+            if message.get("role").and_then(Value::as_str) == Some("assistant") {
+                let text = serde_json::to_string(&message).unwrap_or_default();
+                if text.contains("Hello from the mock OpenAI server.") {
+                    found_assistant_text = true;
+                }
+            }
+        }
+    }
+    assert!(
+        found_assistant_text,
+        "expected mocked assistant text in persisted events under {}",
+        events_dir.display()
+    );
+
+    // Sandbox lifecycle: the harness should have created at least one
+    // labeled Docker container while running, and `docker rm -f` should
+    // have cleaned it up by the time the binary exited.
+    let leftover_containers = Command::new("docker")
+        .args([
+            "ps",
+            "-aq",
+            "--filter",
+            "label=exo.sandbox.owner-pid",
+            "--filter",
+            "status=exited",
+        ])
+        .output()
+        .expect("docker ps");
+    let stdout = String::from_utf8_lossy(&leftover_containers.stdout);
+    let stale = stdout
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .collect::<Vec<_>>();
+    assert!(
+        stale.is_empty(),
+        "expected zero leftover Exited exo containers after binary exit; found: {stale:?}"
+    );
+}


### PR DESCRIPTION
Stacked on #9 (`selectable-backends`).

## Summary

Two logical changes land:

1. **macOS added to the `rust-tests` matrix** — the existing workspace unit tests now compile-check + run on both Ubuntu and macOS.

2. **Integration-test matrix** — the (formerly Linux-only Docker) integration test is now backend-parameterised via `EXO_TEST_SANDBOX_BACKEND`, always uses the `file` secret backend with the master key inside a per-test tempdir via `XDG_CONFIG_HOME`. New workflow matrix:

   | OS    | runner            | sandbox-backend  | setup                              |
   |-------|-------------------|------------------|------------------------------------|
   | linux | ubuntu-latest     | local-process    | none                               |
   | linux | ubuntu-latest     | docker           | none (preinstalled)                |
   | macos | macos-15          | local-process    | none                               |
   | macos | macos-15-intel    | docker           | `crazy-max/ghaction-setup-docker`  |
   | ~~macos~~ | ~~macos-15~~  | ~~apple-container~~ | ~~not viable on GH-hosted runners~~ |

## Findings worth knowing

A few load-bearing decisions from iterating on the macOS arms:

- **macOS / Docker requires the Intel runner.** GitHub-hosted Apple Silicon macOS runners don't expose nested virtualization, so any docker-via-VM setup (Colima/Lima/Docker Desktop) fails at VM startup. `macos-15-intel` exposes HVF and runs Colima via `crazy-max/ghaction-setup-docker` (SHA-pinned to v5.1.0).

- **macOS / apple-container is not testable on GH-hosted runners.** Apple's `container` CLI uses VZ.framework, which needs hardware virtualization on Apple Silicon. Tracked upstream: https://github.com/actions/runner-images/issues/13505. Re-enabling requires either a self-hosted Apple Silicon runner on macOS 26+ or a third-party Mac CI service (Cirrus, MacStadium). The matrix entry is left commented out with the explanation; the install plumbing is kept intact so re-enabling is one line.

- **`container system start` prompts interactively** on first run asking whether to install the default kernel. `--enable-kernel-install` (visible in `--help`) bypasses it cleanly.

- **Unauthenticated `curl` to `api.github.com` from macOS runners hits rate limiting silently** (shared IPs, 60/h). Use `gh release download` instead, which auths via the runner's `GITHUB_TOKEN`.

- **Integration step uses `cargo test --package exo --test integration_chat`** rather than `cargo test --workspace --all-targets`. Unit tests are already covered by the `rust-tests` job in `ci.yml`; no need to recompile them here.

## Test plan

- [x] `cargo test --workspace` (51 unit tests, on Linux)
- [x] `EXO_TEST_SANDBOX_BACKEND=docker cargo test ... -- --ignored` passes locally
- [x] `EXO_TEST_SANDBOX_BACKEND=local-process cargo test ... -- --ignored` passes locally
- [x] CI: `rust-tests` on ubuntu-latest + macos-latest both green
- [x] CI: 4-cell integration matrix all green on this branch
- [x] Temporary push trigger removed before review
- [ ] Open a follow-up issue tracking macOS / apple-container CI via self-hosted runner (post-merge)