### PR TITLE
Print CLI errors with Display so multi-line messages render

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -308,7 +308,14 @@ enum ChatCommands {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() {
+    if let Err(err) = run().await {
+        eprintln!("Error: {err}");
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
     let env = CliEnvironment::load(cli.env_file_if_exists.as_deref(), cli.env_file.as_deref())?;
     let runtime_config = env.braintrust_runtime_config(


### PR DESCRIPTION
Noticed while running the repl: with no model registered, the setup hint prints with the newlines escaped and the whole message quoted, because `main` returns `Result` and the runtime prints the error with `Debug`.

Before:
```
Error: "no model is registered; set one up first:\n  exo secret set openai --env OPENAI_API_KEY\n  exo model register gpt-5.5 --secret openai"
```

After:
```
Error: no model is registered; set one up first:
  exo secret set openai --env OPENAI_API_KEY
  exo model register gpt-5.5 --secret openai
```

Moved the body into `run()` and have `main` print the error with `Display` and exit non-zero, so multi-line error messages render properly.