### PR TITLE
Configure exoharness backends via config; add Linux support with file secrets + Docker

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -42,6 +42,12 @@ struct Cli {
     root: PathBuf,
     #[arg(long, global = true, value_enum)]
     harness: Option<HarnessKind>,
+    #[arg(long, global = true, value_enum, env = "EXO_SECRET_BACKEND")]
+    secret_backend: Option<SecretBackendArg>,
+    #[arg(long, global = true, value_enum, env = "EXO_SANDBOX_BACKEND")]
+    sandbox_backend: Option<SandboxBackendArg>,
+    #[arg(long, global = true, env = "EXO_MASTER_KEY_PATH")]
+    master_key_path: Option<PathBuf>,
     #[arg(long, global = true)]
     env_file: Option<PathBuf>,
     #[arg(long, global = true)]
@@ -64,12 +70,59 @@ enum HarnessKind {
     TypeScript,
 }
 
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum SecretBackendArg {
+    #[value(name = "apple-keychain")]
+    AppleKeychain,
+    File,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum SandboxBackendArg {
+    #[value(name = "apple-container")]
+    AppleContainer,
+    Docker,
+    #[value(name = "local-process")]
+    LocalProcess,
+}
+
 fn build_exo_config(cli: &Cli) -> Result<BasicExoHarnessConfig, Box<dyn std::error::Error>> {
+    let secret_backend = match cli.secret_backend.unwrap_or_else(default_secret_backend) {
+        SecretBackendArg::AppleKeychain => SecretBackendChoice::AppleKeychain,
+        SecretBackendArg::File => SecretBackendChoice::File {
+            path: cli.master_key_path.clone(),
+        },
+    };
+    let sandbox_backend = match cli.sandbox_backend.unwrap_or_else(default_sandbox_backend) {
+        SandboxBackendArg::AppleContainer => SandboxBackendChoice::AppleContainer,
+        SandboxBackendArg::Docker => SandboxBackendChoice::Docker,
+        SandboxBackendArg::LocalProcess => SandboxBackendChoice::LocalProcess,
+    };
     Ok(BasicExoHarnessConfig {
         root: cli.root.join("exoharness"),
-        secret_backend: SecretBackendChoice::AppleKeychain,
-        sandbox_backend: SandboxBackendChoice::AppleContainer,
+        secret_backend,
+        sandbox_backend,
     })
+}
+
+#[cfg(target_os = "macos")]
+fn default_secret_backend() -> SecretBackendArg {
+    SecretBackendArg::AppleKeychain
+}
+
+#[cfg(not(target_os = "macos"))]
+fn default_secret_backend() -> SecretBackendArg {
+    SecretBackendArg::File
+}
+
+#[cfg(target_os = "macos")]
+fn default_sandbox_backend() -> SandboxBackendArg {
+    SandboxBackendArg::AppleContainer
+}
+
+#[cfg(not(target_os = "macos"))]
+fn default_sandbox_backend() -> SandboxBackendArg {
+    SandboxBackendArg::Docker
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -17,11 +17,12 @@ use std::sync::Arc;
 
 use clap::{Parser, Subcommand, ValueEnum};
 use executor::{
-    AgentHarnessKind, BasicExoHarness, BasicHarness, Binding, BraintrustProject,
-    BraintrustRuntimeConfig, BraintrustTracingConfig, ConversationModelConfig, CreateAgentRequest,
-    CreateConversationRequest, EventQuery, EventQueryDirection, ExoHarness, FileSystemMount,
-    FileSystemMountMode, ForkConversationRequest, Harness, HarnessAgent, HarnessConversation,
-    PutSecretRequest, RlmHarness, SANDBOX_MAIN_MOUNT_DIR, Secret, SendRequest, TypeScriptHarness,
+    AgentHarnessKind, BasicExoHarness, BasicExoHarnessConfig, BasicHarness, Binding,
+    BraintrustProject, BraintrustRuntimeConfig, BraintrustTracingConfig, ConversationModelConfig,
+    CreateAgentRequest, CreateConversationRequest, EventQuery, EventQueryDirection, ExoHarness,
+    FileSystemMount, FileSystemMountMode, ForkConversationRequest, Harness, HarnessAgent,
+    HarnessConversation, PutSecretRequest, RlmHarness, SANDBOX_MAIN_MOUNT_DIR,
+    SandboxBackendChoice, Secret, SecretBackendChoice, SendRequest, TypeScriptHarness,
     TypeScriptHarnessConfig, Uuid7, load_agent_config,
 };
 use lingua::Message;
@@ -61,6 +62,14 @@ enum HarnessKind {
     Rlm,
     #[value(name = "typescript")]
     TypeScript,
+}
+
+fn build_exo_config(cli: &Cli) -> Result<BasicExoHarnessConfig, Box<dyn std::error::Error>> {
+    Ok(BasicExoHarnessConfig {
+        root: cli.root.join("exoharness"),
+        secret_backend: SecretBackendChoice::AppleKeychain,
+        sandbox_backend: SandboxBackendChoice::AppleContainer,
+    })
 }
 
 #[derive(Debug, Clone, Copy, ValueEnum)]
@@ -310,6 +319,7 @@ enum ChatCommands {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
+    let exo_config = build_exo_config(&cli)?;
     let env = CliEnvironment::load(cli.env_file_if_exists.as_deref(), cli.env_file.as_deref())?;
     let runtime_config = env.braintrust_runtime_config(
         cli.braintrust_api_key,
@@ -317,9 +327,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         cli.braintrust_api_url,
     );
     let env_vars = env.into_vars();
-    let harness_kind = determine_harness_kind(&cli.root, cli.harness, &cli.command).await?;
+    let harness_kind = determine_harness_kind(&exo_config, cli.harness, &cli.command).await?;
     let harness = instantiate_harness(
-        &cli.root,
+        &exo_config,
         harness_kind,
         runtime_config.clone(),
         env_vars.clone(),
@@ -1102,7 +1112,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 async fn determine_harness_kind(
-    root: &Path,
+    exo_config: &BasicExoHarnessConfig,
     override_kind: Option<HarnessKind>,
     command: &Commands,
 ) -> Result<HarnessKind, Box<dyn std::error::Error>> {
@@ -1114,7 +1124,7 @@ async fn determine_harness_kind(
         return Ok(HarnessKind::Basic);
     };
 
-    Ok(infer_agent_harness_kind(root, agent_ref)
+    Ok(infer_agent_harness_kind(exo_config, agent_ref)
         .await?
         .unwrap_or(HarnessKind::Basic))
 }
@@ -1152,10 +1162,10 @@ fn command_agent_ref(command: &Commands) -> Option<&str> {
 }
 
 async fn infer_agent_harness_kind(
-    root: &Path,
+    exo_config: &BasicExoHarnessConfig,
     agent_ref: &str,
 ) -> Result<Option<HarnessKind>, Box<dyn std::error::Error>> {
-    let exoharness = BasicExoHarness::new(root.join("exoharness")).await?;
+    let exoharness = BasicExoHarness::new(exo_config.clone()).await?;
     let agent = if let Ok(agent_id) = agent_ref.parse::<Uuid7>() {
         exoharness.get_agent(&agent_id).await?
     } else {
@@ -1174,19 +1184,21 @@ async fn infer_agent_harness_kind(
 }
 
 async fn instantiate_harness(
-    root: &Path,
+    exo_config: &BasicExoHarnessConfig,
     kind: HarnessKind,
     runtime_config: Option<BraintrustRuntimeConfig>,
     env_vars: HashMap<String, String>,
 ) -> Result<Arc<dyn Harness>, Box<dyn std::error::Error>> {
     let harness: Arc<dyn Harness> = match kind {
-        HarnessKind::Basic => {
-            Arc::new(BasicHarness::from_root(root, runtime_config, env_vars).await?)
+        HarnessKind::Basic => Arc::new(
+            BasicHarness::from_config(exo_config.clone(), runtime_config, env_vars).await?,
+        ),
+        HarnessKind::Rlm => {
+            Arc::new(RlmHarness::from_config(exo_config.clone(), runtime_config, env_vars).await?)
         }
-        HarnessKind::Rlm => Arc::new(RlmHarness::from_root(root, runtime_config, env_vars).await?),
-        HarnessKind::TypeScript => {
-            Arc::new(TypeScriptHarness::from_root(root, runtime_config, env_vars).await?)
-        }
+        HarnessKind::TypeScript => Arc::new(
+            TypeScriptHarness::from_config(exo_config.clone(), runtime_config, env_vars).await?,
+        ),
     };
     Ok(harness)
 }

--- a/crates/executor/src/harness_basic.rs
+++ b/crates/executor/src/harness_basic.rs
@@ -1,9 +1,8 @@
 use std::collections::HashMap;
-use std::path::Path;
 use std::sync::Arc;
 
 use crate::{BasicExecutor, BraintrustRuntimeConfig, ModelClient, ToolRuntime};
-use exoharness::{BasicExoHarness, ExoHarness, Result};
+use exoharness::{BasicExoHarness, BasicExoHarnessConfig, ExoHarness, Result};
 
 use crate::harness_executor::ExecutorHarnessRuntime;
 use crate::harness_facade::{SharedHarness, SharedHarnessBacked};
@@ -28,13 +27,12 @@ impl<M, T> BasicHarness<M, T> {
 }
 
 impl BasicHarness<RouterModelClient, BasicToolRuntime> {
-    pub async fn from_root(
-        root: impl AsRef<Path>,
+    pub async fn from_config(
+        exo_config: BasicExoHarnessConfig,
         runtime_config: Option<BraintrustRuntimeConfig>,
         env: HashMap<String, String>,
     ) -> Result<Self> {
-        let root = root.as_ref();
-        let exoharness = Arc::new(BasicExoHarness::new(root.join("exoharness")).await?);
+        let exoharness = Arc::new(BasicExoHarness::new(exo_config).await?);
         let model = Arc::new(RouterModelClient::new(env));
         let tools = Arc::new(BasicToolRuntime);
         let runtime = ExecutorHarnessRuntime::new(BasicExecutor::new(model, tools), runtime_config);

--- a/crates/executor/src/harness_basic_tests.rs
+++ b/crates/executor/src/harness_basic_tests.rs
@@ -7,9 +7,18 @@ use crate::{
 use anyhow::anyhow;
 use async_trait::async_trait;
 use exoharness::{
-    BasicExoHarness, Binding, EventData, EventQuery, EventQueryDirection, ExoHarness,
-    FileSystemMount, FileSystemMountMode, PutSecretRequest, Result, Secret, ToolRequest, Uuid7,
+    BasicExoHarness, BasicExoHarnessConfig, Binding, EventData, EventQuery, EventQueryDirection,
+    ExoHarness, FileSystemMount, FileSystemMountMode, PutSecretRequest, Result,
+    SandboxBackendChoice, Secret, SecretBackendChoice, ToolRequest, Uuid7,
 };
+
+fn local_test_config(root: impl Into<std::path::PathBuf>) -> BasicExoHarnessConfig {
+    BasicExoHarnessConfig {
+        root: root.into(),
+        secret_backend: SecretBackendChoice::Static([7u8; 32]),
+        sandbox_backend: SandboxBackendChoice::LocalProcess,
+    }
+}
 use lingua::universal::{AssistantContent, UserContent};
 use lingua::{Message, UniversalStreamChunk};
 use serde_json::{Map, Value};
@@ -24,7 +33,7 @@ use crate::{
 async fn creates_agents_and_conversations_with_persisted_config() {
     let tempdir = TempDir::new().expect("tempdir should exist");
     let exoharness = Arc::new(
-        BasicExoHarness::new_with_local_process_sandbox(tempdir.path().join("exoharness"))
+        BasicExoHarness::new(local_test_config(tempdir.path().join("exoharness")))
             .await
             .expect("basic exoharness should initialize"),
     ) as Arc<dyn ExoHarness>;
@@ -89,7 +98,7 @@ async fn creates_agents_and_conversations_with_persisted_config() {
 async fn send_persists_messages_through_harness() {
     let tempdir = TempDir::new().expect("tempdir should exist");
     let exoharness = Arc::new(
-        BasicExoHarness::new_with_local_process_sandbox(tempdir.path().join("exoharness"))
+        BasicExoHarness::new(local_test_config(tempdir.path().join("exoharness")))
             .await
             .expect("basic exoharness should initialize"),
     ) as Arc<dyn ExoHarness>;
@@ -143,7 +152,7 @@ async fn send_persists_messages_through_harness() {
 async fn close_session_appends_session_ended_event() {
     let tempdir = TempDir::new().expect("tempdir should exist");
     let exoharness: Arc<dyn ExoHarness> = Arc::new(
-        BasicExoHarness::new_with_local_process_sandbox(tempdir.path().join("exoharness"))
+        BasicExoHarness::new(local_test_config(tempdir.path().join("exoharness")))
             .await
             .expect("basic exoharness should initialize"),
     );
@@ -217,7 +226,7 @@ async fn close_session_appends_session_ended_event() {
 async fn updating_agent_config_refreshes_executor_cache() {
     let tempdir = TempDir::new().expect("tempdir should exist");
     let exoharness = Arc::new(
-        BasicExoHarness::new_with_local_process_sandbox(tempdir.path().join("exoharness"))
+        BasicExoHarness::new(local_test_config(tempdir.path().join("exoharness")))
             .await
             .expect("basic exoharness should initialize"),
     );
@@ -295,7 +304,7 @@ async fn updating_agent_config_refreshes_executor_cache() {
 async fn send_executes_shell_tool_when_enabled() {
     let tempdir = TempDir::new().expect("tempdir should exist");
     let exoharness = Arc::new(
-        BasicExoHarness::new_with_local_process_sandbox(tempdir.path().join("exoharness"))
+        BasicExoHarness::new(local_test_config(tempdir.path().join("exoharness")))
             .await
             .expect("basic exoharness should initialize"),
     );
@@ -399,7 +408,7 @@ async fn send_executes_shell_tool_when_enabled() {
 async fn harness_exposes_raw_exoharness_handles() {
     let tempdir = TempDir::new().expect("tempdir should exist");
     let exoharness = Arc::new(
-        BasicExoHarness::new_with_local_process_sandbox(tempdir.path().join("exoharness"))
+        BasicExoHarness::new(local_test_config(tempdir.path().join("exoharness")))
             .await
             .expect("basic exoharness should initialize"),
     );
@@ -468,7 +477,7 @@ async fn updating_mounts_recreates_shell_sandbox() {
     std::fs::create_dir_all(&mount_dir).expect("mount dir should exist");
 
     let exoharness = Arc::new(
-        BasicExoHarness::new_with_local_process_sandbox(tempdir.path().join("exoharness"))
+        BasicExoHarness::new(local_test_config(tempdir.path().join("exoharness")))
             .await
             .expect("basic exoharness should initialize"),
     );
@@ -589,7 +598,7 @@ async fn updating_mounts_recreates_shell_sandbox() {
 async fn conversation_model_override_changes_effective_model() {
     let tempdir = TempDir::new().expect("tempdir should exist");
     let exoharness: Arc<dyn ExoHarness> = Arc::new(
-        BasicExoHarness::new_with_local_process_sandbox(tempdir.path().join("exoharness"))
+        BasicExoHarness::new(local_test_config(tempdir.path().join("exoharness")))
             .await
             .expect("basic exoharness should initialize"),
     );

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -31,9 +31,10 @@ pub use executor_types::{
     TypeScriptHarnessConfig,
 };
 pub use exoharness::{
-    AgentHandle, BasicExoHarness, Binding, BindingMetadata, ConversationHandle, EventData, EventId,
-    EventQuery, EventQueryDirection, ExoHarness, FileSystemMount, FileSystemMountMode,
-    ForkConversationRequest, PutSecretRequest, SANDBOX_MAIN_MOUNT_DIR, Secret, SecretMetadata,
+    AgentHandle, BasicExoHarness, BasicExoHarnessConfig, Binding, BindingMetadata,
+    ConversationHandle, EventData, EventId, EventQuery, EventQueryDirection, ExoHarness,
+    FileSystemMount, FileSystemMountMode, ForkConversationRequest, PutSecretRequest,
+    SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, Secret, SecretBackendChoice, SecretMetadata,
     SessionId, Uuid7,
 };
 pub use harness_basic::BasicHarness;

--- a/crates/executor/src/rlm.rs
+++ b/crates/executor/src/rlm.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::path::Path;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -11,8 +10,8 @@ use crate::{
 };
 use anyhow::{Context as AnyhowContext, anyhow, bail};
 use exoharness::{
-    AgentHandle, BasicExoHarness, ConversationHandle, EventData, EventId, ExoHarness,
-    FileSystemMountMode, Result, ToolCallId, ToolRequest, ToolResult, TurnHandle,
+    AgentHandle, BasicExoHarness, BasicExoHarnessConfig, ConversationHandle, EventData, EventId,
+    ExoHarness, FileSystemMountMode, Result, ToolCallId, ToolRequest, ToolResult, TurnHandle,
 };
 use lingua::Message;
 use lingua::universal::{ToolContentPart, ToolResultContentPart};
@@ -772,13 +771,12 @@ impl<M> RlmHarness<M> {
 }
 
 impl RlmHarness<RouterModelClient> {
-    pub async fn from_root(
-        root: impl AsRef<Path>,
+    pub async fn from_config(
+        exo_config: BasicExoHarnessConfig,
         runtime_config: Option<BraintrustRuntimeConfig>,
         env: HashMap<String, String>,
     ) -> Result<Self> {
-        let root = root.as_ref();
-        let exoharness = Arc::new(BasicExoHarness::new(root.join("exoharness")).await?);
+        let exoharness = Arc::new(BasicExoHarness::new(exo_config).await?);
         let model = Arc::new(RouterModelClient::new(env));
         let runtime = ExecutorHarnessRuntime::new(RlmExecutor::new(model), runtime_config);
 

--- a/crates/executor/src/rlm_tests.rs
+++ b/crates/executor/src/rlm_tests.rs
@@ -8,9 +8,18 @@ use crate::{
 use anyhow::{anyhow, bail};
 use async_trait::async_trait;
 use exoharness::{
-    BasicExoHarness, Binding, EventData, EventQuery, EventQueryDirection, ExoHarness,
-    PutSecretRequest, Secret, ToolRequest, Uuid7,
+    BasicExoHarness, BasicExoHarnessConfig, Binding, EventData, EventQuery, EventQueryDirection,
+    ExoHarness, PutSecretRequest, SandboxBackendChoice, Secret, SecretBackendChoice, ToolRequest,
+    Uuid7,
 };
+
+fn local_test_config(root: impl Into<std::path::PathBuf>) -> BasicExoHarnessConfig {
+    BasicExoHarnessConfig {
+        root: root.into(),
+        secret_backend: SecretBackendChoice::Static([7u8; 32]),
+        sandbox_backend: SandboxBackendChoice::LocalProcess,
+    }
+}
 use lingua::universal::{AssistantContent, UserContent};
 use lingua::{Message, UniversalStreamChunk};
 use serde_json::{Map, Value};
@@ -23,7 +32,7 @@ use crate::{CreateAgentRequest, CreateConversationRequest, Harness, RlmHarness};
 async fn rlm_send_executes_repl_steps_and_persists_final_answer() {
     let tempdir = TempDir::new().expect("tempdir should exist");
     let exoharness = Arc::new(
-        BasicExoHarness::new_with_local_process_sandbox(tempdir.path().join("exoharness"))
+        BasicExoHarness::new(local_test_config(tempdir.path().join("exoharness")))
             .await
             .expect("basic exoharness should initialize"),
     ) as Arc<dyn ExoHarness>;
@@ -121,7 +130,7 @@ async fn rlm_send_executes_repl_steps_and_persists_final_answer() {
 async fn rlm_subquery_variable_can_store_final_answer() {
     let tempdir = TempDir::new().expect("tempdir should exist");
     let exoharness = Arc::new(
-        BasicExoHarness::new_with_local_process_sandbox(tempdir.path().join("exoharness"))
+        BasicExoHarness::new(local_test_config(tempdir.path().join("exoharness")))
             .await
             .expect("basic exoharness should initialize"),
     ) as Arc<dyn ExoHarness>;
@@ -225,7 +234,7 @@ async fn rlm_subquery_variable_can_store_final_answer() {
 async fn rlm_send_stream_suppresses_internal_control_text() {
     let tempdir = TempDir::new().expect("tempdir should exist");
     let exoharness = Arc::new(
-        BasicExoHarness::new_with_local_process_sandbox(tempdir.path().join("exoharness"))
+        BasicExoHarness::new(local_test_config(tempdir.path().join("exoharness")))
             .await
             .expect("basic exoharness should initialize"),
     ) as Arc<dyn ExoHarness>;
@@ -298,7 +307,7 @@ async fn rlm_send_stream_suppresses_internal_control_text() {
 async fn rlm_exposes_history_via_get_messages() {
     let tempdir = TempDir::new().expect("tempdir should exist");
     let exoharness = Arc::new(
-        BasicExoHarness::new_with_local_process_sandbox(tempdir.path().join("exoharness"))
+        BasicExoHarness::new(local_test_config(tempdir.path().join("exoharness")))
             .await
             .expect("basic exoharness should initialize"),
     ) as Arc<dyn ExoHarness>;
@@ -394,7 +403,7 @@ globalThis.answer = String(\n\
 async fn rlm_can_finish_by_setting_final_in_repl() {
     let tempdir = TempDir::new().expect("tempdir should exist");
     let exoharness = Arc::new(
-        BasicExoHarness::new_with_local_process_sandbox(tempdir.path().join("exoharness"))
+        BasicExoHarness::new(local_test_config(tempdir.path().join("exoharness")))
             .await
             .expect("basic exoharness should initialize"),
     ) as Arc<dyn ExoHarness>;

--- a/crates/executor/src/typescript.rs
+++ b/crates/executor/src/typescript.rs
@@ -7,8 +7,9 @@ use std::time::Duration;
 use anyhow::{Context as AnyhowContext, anyhow, bail};
 use async_trait::async_trait;
 use exoharness::{
-    AgentHandle, BasicExoHarness, BoxAsyncRead, BoxAsyncWrite, ConversationHandle, ExoHarness,
-    Result, RunInSandboxRequest, ToolArguments, ToolRequest, ToolResult, TurnHandle,
+    AgentHandle, BasicExoHarness, BasicExoHarnessConfig, BoxAsyncRead, BoxAsyncWrite,
+    ConversationHandle, ExoHarness, Result, RunInSandboxRequest, ToolArguments, ToolRequest,
+    ToolResult, TurnHandle,
     protocol::{
         ConversationHandleInfo, Request as ExoRequest, Response as ExoResponse, TurnHandleInfo,
     },
@@ -586,16 +587,14 @@ impl<T> TypeScriptHarness<T> {
 }
 
 impl TypeScriptHarness<BasicToolRuntime> {
-    pub async fn from_root(
-        root: impl AsRef<Path>,
+    pub async fn from_config(
+        exo_config: BasicExoHarnessConfig,
         runtime_config: Option<BraintrustRuntimeConfig>,
         env: HashMap<String, String>,
     ) -> Result<Self> {
         let workspace_root = std::env::current_dir()
             .context("failed to resolve current directory for TypeScript harness")?;
-        let root = root.as_ref();
-        let exoharness: Arc<dyn ExoHarness> =
-            Arc::new(BasicExoHarness::new(root.join("exoharness")).await?);
+        let exoharness: Arc<dyn ExoHarness> = Arc::new(BasicExoHarness::new(exo_config).await?);
         let tools = Arc::new(BasicToolRuntime);
         let runtime = ExecutorHarnessRuntime::new(
             TypeScriptExecutor::new(Arc::clone(&exoharness), workspace_root, env, tools),

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -12,14 +12,14 @@ use tokio::sync::{Mutex as AsyncMutex, mpsc};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use crate::sandbox::{
-    AppleContainerSandboxBackend, LocalProcessSandboxBackend, ManagedSandboxBackend,
+    CliContainerSandboxBackend, LocalProcessSandboxBackend, ManagedSandboxBackend,
     ManagedSandboxHandle, SANDBOX_MAIN_MOUNT_DIR, SandboxCommand, SandboxKey,
     SandboxLifecycleConfig, SandboxMount, SandboxMountAccess, SandboxNetworkPolicy, SandboxRequest,
     SandboxSpec,
 };
 use crate::secrets::{
-    AppleKeychainSecretKeyProvider, EncryptedSecret, SecretCipher, SecretKeyProvider,
-    StaticSecretKeyProvider,
+    AppleKeychainSecretKeyProvider, EncryptedSecret, FileBackedSecretKeyProvider, SecretCipher,
+    SecretKeyProvider, StaticSecretKeyProvider, default_master_key_path,
 };
 use crate::storage::BasicObjectStore;
 use crate::{
@@ -36,12 +36,14 @@ use crate::{
 #[derive(Debug, Clone)]
 pub enum SecretBackendChoice {
     AppleKeychain,
+    File { path: Option<PathBuf> },
     Static([u8; 32]),
 }
 
 #[derive(Debug, Clone, Copy)]
 pub enum SandboxBackendChoice {
     AppleContainer,
+    Docker,
     LocalProcess,
 }
 
@@ -1777,6 +1779,13 @@ fn build_secret_cipher(
         SecretBackendChoice::AppleKeychain => {
             Arc::new(AppleKeychainSecretKeyProvider::new(keychain_account))
         }
+        SecretBackendChoice::File { path } => {
+            let path = match path {
+                Some(path) => path,
+                None => default_master_key_path()?,
+            };
+            Arc::new(FileBackedSecretKeyProvider::new(path))
+        }
         SecretBackendChoice::Static(key) => Arc::new(StaticSecretKeyProvider::new(key)),
     };
     Ok(SecretCipher::new(provider))
@@ -1784,7 +1793,10 @@ fn build_secret_cipher(
 
 fn build_sandbox_backend(choice: SandboxBackendChoice) -> Arc<dyn ManagedSandboxBackend> {
     match choice {
-        SandboxBackendChoice::AppleContainer => Arc::new(AppleContainerSandboxBackend::new()),
+        SandboxBackendChoice::AppleContainer => {
+            Arc::new(CliContainerSandboxBackend::apple_container())
+        }
+        SandboxBackendChoice::Docker => Arc::new(CliContainerSandboxBackend::docker()),
         SandboxBackendChoice::LocalProcess => Arc::new(LocalProcessSandboxBackend::new()),
     }
 }

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -18,7 +18,8 @@ use crate::sandbox::{
     SandboxSpec,
 };
 use crate::secrets::{
-    AppleKeychainSecretKeyProvider, EncryptedSecret, SecretCipher, StaticSecretKeyProvider,
+    AppleKeychainSecretKeyProvider, EncryptedSecret, SecretCipher, SecretKeyProvider,
+    StaticSecretKeyProvider,
 };
 use crate::storage::BasicObjectStore;
 use crate::{
@@ -31,6 +32,26 @@ use crate::{
     SandboxProcessParts, Secret, SecretId, SecretMetadata, SecretType, SessionId, SnapshotId,
     StartSandboxRequest, TurnHandle, TurnId, TurnRecord, Uuid7, WriteArtifactRequest,
 };
+
+#[derive(Debug, Clone)]
+pub enum SecretBackendChoice {
+    AppleKeychain,
+    Static([u8; 32]),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum SandboxBackendChoice {
+    AppleContainer,
+    LocalProcess,
+}
+
+// TODO: as more knobs land here, swap to a builder pattern.
+#[derive(Debug, Clone)]
+pub struct BasicExoHarnessConfig {
+    pub root: PathBuf,
+    pub secret_backend: SecretBackendChoice,
+    pub sandbox_backend: SandboxBackendChoice,
+}
 
 #[derive(Clone)]
 pub struct BasicExoHarness {
@@ -47,61 +68,16 @@ struct BasicExoHarnessInner {
 }
 
 impl BasicExoHarness {
-    pub async fn new(root: impl Into<PathBuf>) -> Result<Self> {
-        let root = root.into();
+    pub async fn new(config: BasicExoHarnessConfig) -> Result<Self> {
+        let BasicExoHarnessConfig {
+            root,
+            secret_backend,
+            sandbox_backend,
+        } = config;
         let storage = BasicObjectStore::local_filesystem(&root).await?;
-        let secret_cipher = SecretCipher::new(Arc::new(AppleKeychainSecretKeyProvider::new(
-            root.to_string_lossy().to_string(),
-        )));
-        Self::new_with_components(
-            storage,
-            secret_cipher,
-            Arc::new(AppleContainerSandboxBackend::new()),
-        )
-        .await
-    }
-
-    pub async fn new_with_local_process_sandbox(root: impl Into<PathBuf>) -> Result<Self> {
-        let storage = BasicObjectStore::local_filesystem(root).await?;
-        let secret_cipher = SecretCipher::new(Arc::new(StaticSecretKeyProvider::new([7u8; 32])));
-        Self::new_with_components(
-            storage,
-            secret_cipher,
-            Arc::new(LocalProcessSandboxBackend::new()),
-        )
-        .await
-    }
-
-    pub async fn new_with_object_store(store: Arc<dyn object_store::ObjectStore>) -> Result<Self> {
-        let keychain_account = store.to_string();
-        let secret_cipher = SecretCipher::new(Arc::new(AppleKeychainSecretKeyProvider::new(
-            keychain_account,
-        )));
-        Self::new_with_components(
-            BasicObjectStore::new(store),
-            secret_cipher,
-            Arc::new(AppleContainerSandboxBackend::new()),
-        )
-        .await
-    }
-
-    pub async fn new_with_object_store_and_sandbox_backend(
-        store: Arc<dyn object_store::ObjectStore>,
-        sandbox_backend: Arc<dyn ManagedSandboxBackend>,
-    ) -> Result<Self> {
-        let keychain_account = store.to_string();
-        let secret_cipher = SecretCipher::new(Arc::new(AppleKeychainSecretKeyProvider::new(
-            keychain_account,
-        )));
-        Self::new_with_components(BasicObjectStore::new(store), secret_cipher, sandbox_backend)
-            .await
-    }
-
-    async fn new_with_components(
-        storage: BasicObjectStore,
-        secret_cipher: SecretCipher,
-        sandbox_backend: Arc<dyn ManagedSandboxBackend>,
-    ) -> Result<Self> {
+        let secret_cipher =
+            build_secret_cipher(secret_backend, root.to_string_lossy().to_string())?;
+        let sandbox_backend = build_sandbox_backend(sandbox_backend);
         Ok(Self {
             inner: Arc::new(BasicExoHarnessInner {
                 storage,
@@ -1791,4 +1767,24 @@ fn agent_secrets_dir(harness: &BasicExoHarness, agent_id: AgentId) -> PathBuf {
         .agents_dir()
         .join(agent_id.to_string())
         .join("secrets")
+}
+
+fn build_secret_cipher(
+    choice: SecretBackendChoice,
+    keychain_account: String,
+) -> Result<SecretCipher> {
+    let provider: Arc<dyn SecretKeyProvider> = match choice {
+        SecretBackendChoice::AppleKeychain => {
+            Arc::new(AppleKeychainSecretKeyProvider::new(keychain_account))
+        }
+        SecretBackendChoice::Static(key) => Arc::new(StaticSecretKeyProvider::new(key)),
+    };
+    Ok(SecretCipher::new(provider))
+}
+
+fn build_sandbox_backend(choice: SandboxBackendChoice) -> Arc<dyn ManagedSandboxBackend> {
+    match choice {
+        SandboxBackendChoice::AppleContainer => Arc::new(AppleContainerSandboxBackend::new()),
+        SandboxBackendChoice::LocalProcess => Arc::new(LocalProcessSandboxBackend::new()),
+    }
 }

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -5,15 +5,24 @@ use tempfile::TempDir;
 use tokio::fs;
 
 use crate::{
-    Artifact, ArtifactVersion, BasicExoHarness, BeginTurnRequest, Binding, CreateSandboxRequest,
-    EventData, EventQuery, EventQueryDirection, ExoHarness, ForkConversationRequest,
-    NewAgentRequest, NewConversationRequest, PutSecretRequest, RunInSandboxRequest, Secret,
+    Artifact, ArtifactVersion, BasicExoHarness, BasicExoHarnessConfig, BeginTurnRequest, Binding,
+    CreateSandboxRequest, EventData, EventQuery, EventQueryDirection, ExoHarness,
+    ForkConversationRequest, NewAgentRequest, NewConversationRequest, PutSecretRequest,
+    RunInSandboxRequest, SandboxBackendChoice, Secret, SecretBackendChoice,
 };
+
+fn local_test_config(root: impl Into<std::path::PathBuf>) -> BasicExoHarnessConfig {
+    BasicExoHarnessConfig {
+        root: root.into(),
+        secret_backend: SecretBackendChoice::Static([7u8; 32]),
+        sandbox_backend: SandboxBackendChoice::LocalProcess,
+    }
+}
 
 #[tokio::test(flavor = "current_thread")]
 async fn basic_backend_supports_agent_and_conversation_crud() {
     let tempdir = TempDir::new().expect("tempdir");
-    let harness = BasicExoHarness::new_with_local_process_sandbox(tempdir.path())
+    let harness = BasicExoHarness::new(local_test_config(tempdir.path()))
         .await
         .expect("harness should initialize");
 
@@ -59,7 +68,7 @@ async fn basic_backend_supports_agent_and_conversation_crud() {
 #[tokio::test(flavor = "current_thread")]
 async fn begin_turn_tracks_events_through_finish() {
     let tempdir = TempDir::new().expect("tempdir");
-    let harness = BasicExoHarness::new_with_local_process_sandbox(tempdir.path())
+    let harness = BasicExoHarness::new(local_test_config(tempdir.path()))
         .await
         .expect("harness should initialize");
     let agent = harness
@@ -113,7 +122,7 @@ async fn begin_turn_tracks_events_through_finish() {
 #[tokio::test(flavor = "current_thread")]
 async fn artifacts_are_versioned_by_path() {
     let tempdir = TempDir::new().expect("tempdir");
-    let harness = BasicExoHarness::new_with_local_process_sandbox(tempdir.path())
+    let harness = BasicExoHarness::new(local_test_config(tempdir.path()))
         .await
         .expect("harness should initialize");
     let agent = harness
@@ -151,7 +160,7 @@ async fn artifacts_are_versioned_by_path() {
 #[tokio::test(flavor = "current_thread")]
 async fn artifacts_store_metadata_and_raw_contents_separately() {
     let tempdir = TempDir::new().expect("tempdir");
-    let harness = BasicExoHarness::new_with_local_process_sandbox(tempdir.path())
+    let harness = BasicExoHarness::new(local_test_config(tempdir.path()))
         .await
         .expect("harness should initialize");
     let agent = harness
@@ -192,7 +201,7 @@ async fn artifacts_store_metadata_and_raw_contents_separately() {
 #[tokio::test(flavor = "current_thread")]
 async fn legacy_json_artifacts_are_still_readable() {
     let tempdir = TempDir::new().expect("tempdir");
-    let harness = BasicExoHarness::new_with_local_process_sandbox(tempdir.path())
+    let harness = BasicExoHarness::new(local_test_config(tempdir.path()))
         .await
         .expect("harness should initialize");
     let agent = harness
@@ -244,7 +253,7 @@ async fn legacy_json_artifacts_are_still_readable() {
 #[tokio::test(flavor = "current_thread")]
 async fn conversation_scope_overrides_agent_scope_and_fork_copies_local_state() {
     let tempdir = TempDir::new().expect("tempdir");
-    let harness = BasicExoHarness::new_with_local_process_sandbox(tempdir.path())
+    let harness = BasicExoHarness::new(local_test_config(tempdir.path()))
         .await
         .expect("harness should initialize");
     let agent = harness
@@ -344,7 +353,7 @@ async fn conversation_scope_overrides_agent_scope_and_fork_copies_local_state() 
 #[tokio::test(flavor = "current_thread")]
 async fn secrets_are_encrypted_at_rest() {
     let tempdir = TempDir::new().expect("tempdir");
-    let harness = BasicExoHarness::new_with_local_process_sandbox(tempdir.path())
+    let harness = BasicExoHarness::new(local_test_config(tempdir.path()))
         .await
         .expect("harness should initialize");
     let agent = harness
@@ -384,7 +393,7 @@ async fn secrets_are_encrypted_at_rest() {
 #[tokio::test(flavor = "current_thread")]
 async fn basic_backend_runs_commands_in_created_sandbox() {
     let tempdir = TempDir::new().expect("tempdir");
-    let harness = BasicExoHarness::new_with_local_process_sandbox(tempdir.path())
+    let harness = BasicExoHarness::new(local_test_config(tempdir.path()))
         .await
         .expect("harness should initialize");
     let agent = harness

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -114,6 +114,25 @@ pub const DEFAULT_SANDBOX_IMAGE: &str = "docker.io/library/debian:bookworm";
 pub const SANDBOX_HOME_DIR: &str = "/home/exo";
 pub const SANDBOX_MAIN_MOUNT_DIR: &str = "/home/exo/workspace";
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContainerCliFlavor {
+    AppleContainer,
+    Docker,
+}
+
+impl ContainerCliFlavor {
+    fn default_binary(self) -> &'static str {
+        match self {
+            Self::AppleContainer => "container",
+            Self::Docker => "docker",
+        }
+    }
+
+    fn requires_system_start(self) -> bool {
+        matches!(self, Self::AppleContainer)
+    }
+}
+
 const DEFAULT_ENABLED_NETWORK_NAME: &str = "exo-default";
 const WARM_SANDBOX_KEEPALIVE_ARGV: &[&str] = &["sleep", "infinity"];
 const WARM_SANDBOX_HEALTHCHECK_TIMEOUT: Duration = Duration::from_secs(3);
@@ -147,17 +166,27 @@ struct ContainerListConfiguration {
 }
 
 #[derive(Debug)]
-pub struct AppleContainerSandboxBackend {
+pub struct CliContainerSandboxBackend {
+    cli: ContainerCliFlavor,
     container_bin: PathBuf,
     system_started: Mutex<bool>,
     network_created: Mutex<bool>,
     warm_sandboxes: Arc<Mutex<HashMap<SandboxKey, WarmSandboxEntry>>>,
 }
 
-impl AppleContainerSandboxBackend {
-    pub fn new() -> Self {
+impl CliContainerSandboxBackend {
+    pub fn apple_container() -> Self {
+        Self::new(ContainerCliFlavor::AppleContainer)
+    }
+
+    pub fn docker() -> Self {
+        Self::new(ContainerCliFlavor::Docker)
+    }
+
+    fn new(cli: ContainerCliFlavor) -> Self {
         Self {
-            container_bin: PathBuf::from("container"),
+            cli,
+            container_bin: PathBuf::from(cli.default_binary()),
             system_started: Mutex::new(false),
             network_created: Mutex::new(false),
             warm_sandboxes: Arc::new(Mutex::new(HashMap::new())),
@@ -165,6 +194,9 @@ impl AppleContainerSandboxBackend {
     }
 
     async fn ensure_system_started(&self) -> Result<()> {
+        if !self.cli.requires_system_start() {
+            return Ok(());
+        }
         let mut started = self.system_started.lock().await;
         if *started {
             return Ok(());
@@ -273,20 +305,14 @@ impl AppleContainerSandboxBackend {
         };
 
         for entry in expired {
-            cleanup_named_container(&self.container_bin, &entry.name).await?;
+            cleanup_named_container(&self.container_bin, self.cli, &entry.name).await?;
         }
 
         Ok(())
     }
 }
 
-impl Default for AppleContainerSandboxBackend {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Drop for AppleContainerSandboxBackend {
+impl Drop for CliContainerSandboxBackend {
     fn drop(&mut self) {
         let Ok(mut warm_sandboxes) = self.warm_sandboxes.try_lock() else {
             return;
@@ -296,18 +322,18 @@ impl Drop for AppleContainerSandboxBackend {
             .map(|(_, entry)| entry.name)
             .collect::<Vec<_>>();
         for name in names {
-            cleanup_named_container_blocking(&self.container_bin, &name);
+            cleanup_named_container_blocking(&self.container_bin, self.cli, &name);
         }
     }
 }
 
 #[async_trait]
-impl ManagedSandboxBackend for AppleContainerSandboxBackend {
+impl ManagedSandboxBackend for CliContainerSandboxBackend {
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
         let request = self.prepare_request(request).await?;
 
         if request.lifecycle.idle_ttl.is_none() {
-            return Ok(Arc::new(AppleOneShotSandboxHandle {
+            return Ok(Arc::new(OneShotSandboxHandle {
                 id: format!("oneshot:{}", request.key),
                 container_bin: self.container_bin.clone(),
                 request,
@@ -320,8 +346,9 @@ impl ManagedSandboxBackend for AppleContainerSandboxBackend {
             let mut warm_sandboxes = self.warm_sandboxes.lock().await;
             match warm_sandboxes.get(&request.key) {
                 Some(entry) if entry.request.spec == request.spec => {
-                    return Ok(Arc::new(AppleWarmSandboxHandle {
+                    return Ok(Arc::new(WarmSandboxHandle {
                         id: format!("warm:{}", request.key),
+                        cli: self.cli,
                         container_bin: self.container_bin.clone(),
                         request,
                         warm_sandboxes: Arc::clone(&self.warm_sandboxes),
@@ -332,7 +359,7 @@ impl ManagedSandboxBackend for AppleContainerSandboxBackend {
             }
         };
         if let Some(entry) = replaced {
-            schedule_cleanup_named_container(self.container_bin.clone(), entry.name);
+            schedule_cleanup_named_container(self.container_bin.clone(), self.cli, entry.name);
         }
 
         let name = create_unique_warm_sandbox(&self.container_bin, &request).await?;
@@ -349,8 +376,9 @@ impl ManagedSandboxBackend for AppleContainerSandboxBackend {
             );
         }
 
-        Ok(Arc::new(AppleWarmSandboxHandle {
+        Ok(Arc::new(WarmSandboxHandle {
             id: format!("warm:{}", request.key),
+            cli: self.cli,
             container_bin: self.container_bin.clone(),
             request,
             warm_sandboxes: Arc::clone(&self.warm_sandboxes),
@@ -358,14 +386,14 @@ impl ManagedSandboxBackend for AppleContainerSandboxBackend {
     }
 }
 
-struct AppleOneShotSandboxHandle {
+struct OneShotSandboxHandle {
     id: String,
     container_bin: PathBuf,
     request: SandboxRequest,
 }
 
 #[async_trait]
-impl ManagedSandboxHandle for AppleOneShotSandboxHandle {
+impl ManagedSandboxHandle for OneShotSandboxHandle {
     fn id(&self) -> &str {
         &self.id
     }
@@ -395,22 +423,23 @@ impl ManagedSandboxHandle for AppleOneShotSandboxHandle {
     }
 }
 
-struct AppleWarmSandboxHandle {
+struct WarmSandboxHandle {
     id: String,
+    cli: ContainerCliFlavor,
     container_bin: PathBuf,
     request: SandboxRequest,
     warm_sandboxes: Arc<Mutex<HashMap<SandboxKey, WarmSandboxEntry>>>,
 }
 
 #[async_trait]
-impl ManagedSandboxHandle for AppleWarmSandboxHandle {
+impl ManagedSandboxHandle for WarmSandboxHandle {
     fn id(&self) -> &str {
         &self.id
     }
 
     async fn exec(&self, command: &SandboxCommand) -> Result<SandboxCommandOutput> {
         let name =
-            ensure_warm_sandbox_ready(&self.container_bin, &self.request, &self.warm_sandboxes)
+            ensure_warm_sandbox_ready(&self.container_bin, self.cli, &self.request, &self.warm_sandboxes)
                 .await?;
         touch_warm_sandbox(&self.warm_sandboxes, &self.request.key).await;
         let output = exec_warm(&self.container_bin, &name, &self.request.spec, command).await;
@@ -420,7 +449,7 @@ impl ManagedSandboxHandle for AppleWarmSandboxHandle {
 
     async fn start_process(&self, command: &SandboxCommand) -> Result<crate::SandboxProcessParts> {
         let name =
-            ensure_warm_sandbox_ready(&self.container_bin, &self.request, &self.warm_sandboxes)
+            ensure_warm_sandbox_ready(&self.container_bin, self.cli, &self.request, &self.warm_sandboxes)
                 .await?;
         touch_warm_sandbox(&self.warm_sandboxes, &self.request.key).await;
         start_warm_process(&self.container_bin, &name, &self.request.spec, command).await
@@ -433,7 +462,7 @@ impl ManagedSandboxHandle for AppleWarmSandboxHandle {
         };
 
         if let Some(entry) = removed {
-            cleanup_named_container(&self.container_bin, &entry.name).await
+            cleanup_named_container(&self.container_bin, self.cli, &entry.name).await
         } else {
             Ok(())
         }
@@ -603,6 +632,7 @@ async fn create_unique_warm_sandbox(
 
 async fn ensure_warm_sandbox_ready(
     container_bin: &Path,
+    cli: ContainerCliFlavor,
     request: &SandboxRequest,
     warm_sandboxes: &Arc<Mutex<HashMap<SandboxKey, WarmSandboxEntry>>>,
 ) -> Result<String> {
@@ -624,7 +654,7 @@ async fn ensure_warm_sandbox_ready(
             let stale = warm_sandboxes
                 .remove(&request.key)
                 .expect("entry disappeared while locked");
-            schedule_cleanup_named_container(container_bin.to_path_buf(), stale.name);
+            schedule_cleanup_named_container(container_bin.to_path_buf(), cli, stale.name);
             let name = create_unique_warm_sandbox(container_bin, request).await?;
             warm_sandboxes.insert(
                 request.key.clone(),
@@ -668,7 +698,7 @@ async fn ensure_warm_sandbox_ready(
         },
     );
     drop(warm_sandboxes);
-    schedule_cleanup_named_container(container_bin.to_path_buf(), current_name);
+    schedule_cleanup_named_container(container_bin.to_path_buf(), cli, current_name);
     Ok(replacement_name)
 }
 
@@ -900,31 +930,63 @@ fn configure_env_args(process: &mut Command, env: &HashMap<String, String>) {
     }
 }
 
-async fn cleanup_named_container(container_bin: &Path, name: &str) -> Result<()> {
-    let stop =
-        run_container_admin_command(container_bin, WARM_SANDBOX_CLEANUP_TIMEOUT, ["stop", name])
+async fn cleanup_named_container(
+    container_bin: &Path,
+    cli: ContainerCliFlavor,
+    name: &str,
+) -> Result<()> {
+    match cli {
+        ContainerCliFlavor::AppleContainer => {
+            let stop = run_container_admin_command(
+                container_bin,
+                WARM_SANDBOX_CLEANUP_TIMEOUT,
+                ["stop", name],
+            )
             .await?;
-    if !stop.status.success() {
-        let stderr = String::from_utf8_lossy(&stop.stderr).trim().to_string();
-        if !is_missing_container_error(&stderr) {
-            return Err(anyhow!("failed to stop warm sandbox {}: {}", name, stderr));
-        }
-    }
+            if !stop.status.success() {
+                let stderr = String::from_utf8_lossy(&stop.stderr).trim().to_string();
+                if !is_missing_container_error(&stderr) {
+                    return Err(anyhow!("failed to stop warm sandbox {}: {}", name, stderr));
+                }
+            }
 
-    let delete = run_container_admin_command(
-        container_bin,
-        WARM_SANDBOX_CLEANUP_TIMEOUT,
-        ["delete", name],
-    )
-    .await?;
-    if !delete.status.success() {
-        let stderr = String::from_utf8_lossy(&delete.stderr).trim().to_string();
-        if !is_missing_container_error(&stderr) {
-            return Err(anyhow!(
-                "failed to delete warm sandbox {}: {}",
-                name,
-                stderr
-            ));
+            let delete = run_container_admin_command(
+                container_bin,
+                WARM_SANDBOX_CLEANUP_TIMEOUT,
+                ["delete", name],
+            )
+            .await?;
+            if !delete.status.success() {
+                let stderr = String::from_utf8_lossy(&delete.stderr).trim().to_string();
+                if !is_missing_container_error(&stderr) {
+                    return Err(anyhow!(
+                        "failed to delete warm sandbox {}: {}",
+                        name,
+                        stderr
+                    ));
+                }
+            }
+        }
+        ContainerCliFlavor::Docker => {
+            // `docker rm -f` is SIGKILL + remove in one shot. Avoids racing
+            // the daemon's default 10s SIGTERM grace against our cleanup
+            // timeout, which otherwise leaves Exited containers behind.
+            let rm = run_container_admin_command(
+                container_bin,
+                WARM_SANDBOX_CLEANUP_TIMEOUT,
+                ["rm", "-f", name],
+            )
+            .await?;
+            if !rm.status.success() {
+                let stderr = String::from_utf8_lossy(&rm.stderr).trim().to_string();
+                if !is_missing_container_error(&stderr) {
+                    return Err(anyhow!(
+                        "failed to delete warm sandbox {}: {}",
+                        name,
+                        stderr
+                    ));
+                }
+            }
         }
     }
 
@@ -972,8 +1034,12 @@ async fn reap_orphaned_warm_sandboxes(container_bin: &Path) -> Result<()> {
         if now - started_date < ORPHANED_WARM_SANDBOX_MIN_AGE.as_secs_f64() {
             continue;
         }
-        if let Err(error) =
-            cleanup_named_container(container_bin, &container.configuration.id).await
+        if let Err(error) = cleanup_named_container(
+            container_bin,
+            ContainerCliFlavor::AppleContainer,
+            &container.configuration.id,
+        )
+        .await
         {
             eprintln!(
                 "failed to clean up orphaned warm sandbox {}: {error}",
@@ -1005,14 +1071,25 @@ fn owner_pid_is_alive(pid: &str) -> bool {
         .is_ok_and(|status| status.success())
 }
 
-fn cleanup_named_container_blocking(container_bin: &Path, name: &str) {
-    run_container_admin_command_blocking(container_bin, ["stop", name]);
-    run_container_admin_command_blocking(container_bin, ["delete", name]);
+fn cleanup_named_container_blocking(
+    container_bin: &Path,
+    cli: ContainerCliFlavor,
+    name: &str,
+) {
+    match cli {
+        ContainerCliFlavor::AppleContainer => {
+            run_container_admin_command_blocking(container_bin, ["stop", name]);
+            run_container_admin_command_blocking(container_bin, ["delete", name]);
+        }
+        ContainerCliFlavor::Docker => {
+            run_container_admin_command_blocking(container_bin, ["rm", "-f", name]);
+        }
+    }
 }
 
-fn schedule_cleanup_named_container(container_bin: PathBuf, name: String) {
+fn schedule_cleanup_named_container(container_bin: PathBuf, cli: ContainerCliFlavor, name: String) {
     tokio::spawn(async move {
-        if let Err(error) = cleanup_named_container(&container_bin, &name).await {
+        if let Err(error) = cleanup_named_container(&container_bin, cli, &name).await {
             eprintln!("failed to clean up warm sandbox {name}: {error}");
         }
     });

--- a/crates/exoharness/src/secrets.rs
+++ b/crates/exoharness/src/secrets.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 
 use aes_gcm::aead::{Aead, KeyInit};
@@ -13,6 +14,8 @@ use crate::{Result, Secret};
 const MASTER_KEY_LEN: usize = 32;
 const NONCE_LEN: usize = 12;
 const KEYCHAIN_SERVICE: &str = "exo-exoharness-master-key";
+const MASTER_KEY_FILE_PERMS: u32 = 0o600;
+const MASTER_KEY_DIR_PERMS: u32 = 0o700;
 
 #[derive(Clone)]
 pub(crate) struct SecretCipher {
@@ -122,6 +125,44 @@ impl SecretKeyProvider for AppleKeychainSecretKeyProvider {
     }
 }
 
+pub(crate) struct FileBackedSecretKeyProvider {
+    path: PathBuf,
+    key: OnceLock<[u8; MASTER_KEY_LEN]>,
+}
+
+impl FileBackedSecretKeyProvider {
+    pub(crate) fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            key: OnceLock::new(),
+        }
+    }
+}
+
+impl SecretKeyProvider for FileBackedSecretKeyProvider {
+    fn get_or_create_key(&self) -> Result<[u8; MASTER_KEY_LEN]> {
+        if let Some(key) = self.key.get() {
+            return Ok(*key);
+        }
+        let key = match std::fs::read(&self.path) {
+            Ok(bytes) => parse_master_key_bytes(&bytes).with_context(|| {
+                format!("reading master key at {}", self.path.display())
+            })?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let key = random_master_key();
+                write_master_key_file(&self.path, &key)?;
+                key
+            }
+            Err(error) => {
+                return Err(anyhow::Error::from(error)
+                    .context(format!("reading master key at {}", self.path.display())));
+            }
+        };
+        let _ = self.key.set(key);
+        Ok(key)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct EncryptedSecret {
     pub(crate) algorithm: SecretEncryptionAlgorithm,
@@ -169,3 +210,61 @@ fn ensure_apple_keychain_store() -> Result<()> {
         Err(message) => Err(anyhow!(message.clone())),
     }
 }
+
+fn parse_master_key_bytes(bytes: &[u8]) -> Result<[u8; MASTER_KEY_LEN]> {
+    if bytes.len() != MASTER_KEY_LEN {
+        bail!(
+            "invalid master key length: expected {MASTER_KEY_LEN}, got {}",
+            bytes.len()
+        );
+    }
+    let mut key = [0u8; MASTER_KEY_LEN];
+    key.copy_from_slice(bytes);
+    Ok(key)
+}
+
+fn write_master_key_file(path: &Path, key: &[u8; MASTER_KEY_LEN]) -> Result<()> {
+    use std::io::Write;
+    use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating master key directory {}", parent.display()))?;
+        std::fs::set_permissions(parent, std::fs::Permissions::from_mode(MASTER_KEY_DIR_PERMS))
+            .with_context(|| format!("setting permissions on {}", parent.display()))?;
+    }
+
+    let tmp_path = path.with_extension("tmp");
+    let _ = std::fs::remove_file(&tmp_path);
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(MASTER_KEY_FILE_PERMS)
+        .open(&tmp_path)
+        .with_context(|| format!("creating master key file {}", tmp_path.display()))?;
+    file.write_all(key)
+        .with_context(|| format!("writing master key file {}", tmp_path.display()))?;
+    file.sync_all()
+        .with_context(|| format!("syncing master key file {}", tmp_path.display()))?;
+    drop(file);
+    std::fs::rename(&tmp_path, path)
+        .with_context(|| format!("renaming master key into place at {}", path.display()))?;
+    Ok(())
+}
+
+pub(crate) fn default_master_key_path() -> Result<PathBuf> {
+    if let Some(value) = std::env::var_os("XDG_CONFIG_HOME") {
+        let path = PathBuf::from(value);
+        if !path.as_os_str().is_empty() {
+            return Ok(path.join("exo").join("master.key"));
+        }
+    }
+    if let Some(value) = std::env::var_os("HOME") {
+        let path = PathBuf::from(value);
+        if !path.as_os_str().is_empty() {
+            return Ok(path.join(".config").join("exo").join("master.key"));
+        }
+    }
+    bail!("could not determine config directory: set XDG_CONFIG_HOME or HOME")
+}
+


### PR DESCRIPTION
## Summary

Supersedes #2. Reshapes how a `BasicExoHarness` is constructed so the secret backend and sandbox backend are user-selectable at runtime, and adds the backends needed to actually run on Linux.

Three commits:

1. **`exoharness: replace constructors with BasicExoHarnessConfig API`** — library refactor. `BasicExoHarness::from_root(root)` is replaced by `BasicExoHarness::new(BasicExoHarnessConfig { root, secret_backend, sandbox_backend })`. No new backends yet — `SecretBackendChoice` exposes `AppleKeychain` / `Static`, `SandboxBackendChoice` exposes `AppleContainer` / `LocalProcess`. Tests gain a per-file `local_test_config` helper instead of a library-level `for_test` constructor.
2. **`Add file-backed secret and Docker sandbox backends`** — adds `SecretBackendChoice::File { path: Option<PathBuf> }` (encrypts with a master key on disk at `$XDG_CONFIG_HOME/exo/master.key` or `~/.config/exo/master.key`, perms 0700/0600) and `SandboxBackendChoice::Docker`. The two CLI-driven sandbox backends now share a `CliContainerSandboxBackend` parameterised by `ContainerCliFlavor`. Both backends compile on every platform — selection is purely runtime.
3. **`Add CLI flags for selecting secret and sandbox backends`** — three global flags with env-var fallbacks: `--secret-backend [apple-keychain|file]` (`EXO_SECRET_BACKEND`), `--sandbox-backend [apple-container|docker|local-process]` (`EXO_SANDBOX_BACKEND`), `--master-key-path` (`EXO_MASTER_KEY_PATH`). Cfg-based defaults preserve macOS UX (apple-keychain / apple-container) and give Linux users a working pair out of the box (file / docker).

Linux support is the motivating use case — `apple-keychain` and `apple-container` aren't available there — but the library API is platform-agnostic, so the CLI is where defaults get applied.

## Test plan

- [x] `cargo test --workspace` (51/51 pass on Linux)
- [x] `cargo build --workspace` clean on Linux
- [x] Each of the 3 commits builds + tests independently
- [x] End-to-end run on Linux with `--secret-backend file --sandbox-backend docker`: secret set, model register, agent create, conversation create, chat completes with shell tool call inside a docker sandbox
- [x] End-to-end run on Linux with no backend flags: cfg defaults pick file + docker, auto-creates `~/.config/exo/master.key`, chat completes
- [ ] macOS smoke test (defaults should pick apple-keychain + apple-container — unchanged from main)