### PR TITLE
Remove unnecessary trait code 

### DIFF
--- a/crates/executor/src/basic_tests.rs
+++ b/crates/executor/src/basic_tests.rs
@@ -66,7 +66,7 @@ async fn send_appends_user_and_assistant_messages() {
         )
         .await
         .expect("prepare conversation should succeed");
-    HarnessExecutor::execute_turn(
+    HarnessExecutor::run_turn(
         &executor,
         agent.as_ref(),
         conversation.as_ref(),
@@ -74,6 +74,7 @@ async fn send_appends_user_and_assistant_messages() {
         &default_agent_config(),
         &ConversationConfig::default(),
         &(),
+        ExecutorStreamMode::Disabled,
         None,
     )
     .await
@@ -161,7 +162,7 @@ async fn send_executes_tool_round_trip() {
         .await
         .expect("begin turn should succeed");
 
-    HarnessExecutor::execute_turn(
+    HarnessExecutor::run_turn(
         &executor,
         agent.as_ref(),
         conversation.as_ref(),
@@ -169,6 +170,7 @@ async fn send_executes_tool_round_trip() {
         &agent_config,
         &conversation_config,
         &(),
+        ExecutorStreamMode::Disabled,
         None,
     )
     .await
@@ -265,7 +267,7 @@ async fn send_stream_emits_chunks_and_persists_final_response() {
         )
         .await
         .expect("prepare conversation should succeed");
-    HarnessExecutor::execute_turn_stream(
+    HarnessExecutor::run_turn(
         &executor,
         agent.as_ref(),
         conversation.as_ref(),
@@ -273,7 +275,7 @@ async fn send_stream_emits_chunks_and_persists_final_response() {
         &default_agent_config(),
         &ConversationConfig::default(),
         &(),
-        &event_tx,
+        ExecutorStreamMode::Enabled(&event_tx),
         None,
     )
     .await

--- a/crates/executor/src/basic_tests.rs
+++ b/crates/executor/src/basic_tests.rs
@@ -23,7 +23,7 @@ use serde_json::{Map, Value};
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
-use crate::harness_executor::HarnessExecutor;
+use crate::harness_executor::{ExecutorStreamMode, HarnessExecutor};
 use crate::*;
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/executor/src/harness_executor.rs
+++ b/crates/executor/src/harness_executor.rs
@@ -54,53 +54,6 @@ pub(crate) trait HarnessExecutor: Send + Sync + Clone + 'static {
         stream_mode: ExecutorStreamMode<'_>,
         turn_trace: Option<&dyn TurnExecutionTrace>,
     ) -> Result<()>;
-
-    async fn execute_turn(
-        &self,
-        agent: &dyn AgentHandle,
-        conversation: &dyn ConversationHandle,
-        turn: Arc<dyn TurnHandle>,
-        agent_config: &AgentConfig,
-        conversation_config: &ConversationConfig,
-        prepared: &Self::Prepared,
-        turn_trace: Option<&dyn TurnExecutionTrace>,
-    ) -> Result<()> {
-        self.run_turn(
-            agent,
-            conversation,
-            turn,
-            agent_config,
-            conversation_config,
-            prepared,
-            ExecutorStreamMode::Disabled,
-            turn_trace,
-        )
-        .await
-    }
-
-    async fn execute_turn_stream(
-        &self,
-        agent: &dyn AgentHandle,
-        conversation: &dyn ConversationHandle,
-        turn: Arc<dyn TurnHandle>,
-        agent_config: &AgentConfig,
-        conversation_config: &ConversationConfig,
-        prepared: &Self::Prepared,
-        event_tx: &mpsc::UnboundedSender<Result<ExecutionStreamEvent>>,
-        turn_trace: Option<&dyn TurnExecutionTrace>,
-    ) -> Result<()> {
-        self.run_turn(
-            agent,
-            conversation,
-            turn,
-            agent_config,
-            conversation_config,
-            prepared,
-            ExecutorStreamMode::Enabled(event_tx),
-            turn_trace,
-        )
-        .await
-    }
 }
 
 pub(crate) struct ExecutorHarnessRuntime<E> {
@@ -231,13 +184,14 @@ where
             |turn_trace| {
                 Box::pin(async move {
                     executor
-                        .execute_turn(
+                        .run_turn(
                             run_agent.as_ref(),
                             run_conversation.as_ref(),
                             Arc::clone(&run_turn),
                             &agent_config,
                             &conversation_config,
                             &prepared,
+                            ExecutorStreamMode::Disabled,
                             turn_trace,
                         )
                         .await
@@ -284,14 +238,14 @@ where
             move |turn_trace, event_tx| {
                 Box::pin(async move {
                     executor
-                        .execute_turn_stream(
+                        .run_turn(
                             run_agent.as_ref(),
                             run_conversation.as_ref(),
                             Arc::clone(&run_turn),
                             &agent_config,
                             &conversation_config,
                             &prepared,
-                            event_tx,
+                            ExecutorStreamMode::Enabled(event_tx),
                             turn_trace,
                         )
                         .await


### PR DESCRIPTION
We don't need `execute_turn` and `execute_turn_stream`