### PR TITLE
Sandbox full-state (CRIU) snapshots — blocked by docker bugs

### DIFF
--- a/crates/cli/src/tui.rs
+++ b/crates/cli/src/tui.rs
@@ -7,7 +7,8 @@ use std::time::Duration;
 
 use executor::{
     ConversationHandle, EventData, EventId, EventQuery, EventQueryDirection, ExecutionStreamEvent,
-    HarnessConversation, SandboxId, SendRequest, SessionId, SnapshotId, StartSandboxRequest,
+    HarnessConversation, SandboxId, SendRequest, SessionId, SnapshotId, SnapshotMode,
+    StartSandboxRequest,
 };
 use lingua::universal::{UserContent, UserContentPart};
 use lingua::{Message, UniversalStreamChunk};
@@ -387,9 +388,22 @@ impl ChatRepl {
                         continue;
                     }
                     if trimmed == "/snapshot" {
-                        match self.snapshot_current_sandbox().await {
+                        match self
+                            .snapshot_current_sandbox(SnapshotMode::Filesystem)
+                            .await
+                        {
                             Ok(snapshot_id) => println!("snapshot {snapshot_id}"),
                             Err(error) => println!("snapshot failed: {error:#}"),
+                        }
+                        continue;
+                    }
+                    if trimmed == "/checkpoint" {
+                        match self
+                            .snapshot_current_sandbox(SnapshotMode::FullState)
+                            .await
+                        {
+                            Ok(snapshot_id) => println!("checkpoint {snapshot_id}"),
+                            Err(error) => println!("checkpoint failed: {error:#}"),
                         }
                         continue;
                     }
@@ -446,14 +460,17 @@ impl ChatRepl {
     /// Find the most recent `SandboxCreated` event and snapshot that sandbox.
     /// The conversation's active sandbox must have been created (or started)
     /// in *this* REPL session — running_sandboxes is a per-process map.
-    async fn snapshot_current_sandbox(&self) -> Result<SnapshotId, Box<dyn Error>> {
+    async fn snapshot_current_sandbox(
+        &self,
+        mode: SnapshotMode,
+    ) -> Result<SnapshotId, Box<dyn Error>> {
         let sandbox_id = latest_sandbox_id(self.conversation.as_ref())
             .await?
             .ok_or("no sandbox has been created in this conversation yet")?;
         let id = self
             .conversation
             .exoharness_handle()
-            .snapshot_sandbox(sandbox_id)
+            .snapshot_sandbox(sandbox_id, mode)
             .await?;
         Ok(id)
     }
@@ -643,9 +660,13 @@ fn print_help() {
     println!("repl commands:");
     println!("  /quit | /exit        exit the repl");
     println!("  /history             reprint the conversation transcript");
-    println!("  /snapshot            snapshot this conversation's running sandbox");
+    println!("  /snapshot            capture filesystem-only snapshot of the sandbox");
+    println!("  /checkpoint          capture full-state snapshot (filesystem +");
+    println!("                       running processes + memory); requires CRIU");
+    println!("                       + docker experimental on the host");
     println!("  /snapshots           list snapshots taken in this conversation");
     println!("  /rewind <id>         restore the sandbox to a previous snapshot");
+    println!("                       or checkpoint");
     println!("  /help                show this message");
 }
 

--- a/crates/cli/src/tui.rs
+++ b/crates/cli/src/tui.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use executor::{
     ConversationHandle, EventData, EventId, EventQuery, EventQueryDirection, ExecutionStreamEvent,
-    HarnessConversation, SendRequest, SessionId,
+    HarnessConversation, SandboxId, SendRequest, SessionId, SnapshotId, StartSandboxRequest,
 };
 use lingua::universal::{UserContent, UserContentPart};
 use lingua::{Message, UniversalStreamChunk};
@@ -382,6 +382,44 @@ impl ChatRepl {
                         self.print_transcript().await?;
                         continue;
                     }
+                    if trimmed == "/help" {
+                        print_help();
+                        continue;
+                    }
+                    if trimmed == "/snapshot" {
+                        match self.snapshot_current_sandbox().await {
+                            Ok(snapshot_id) => println!("snapshot {snapshot_id}"),
+                            Err(error) => println!("snapshot failed: {error:#}"),
+                        }
+                        continue;
+                    }
+                    if trimmed == "/snapshots" {
+                        match self.list_snapshots().await {
+                            Ok(snapshots) if snapshots.is_empty() => {
+                                println!("no snapshots yet for this conversation");
+                            }
+                            Ok(snapshots) => {
+                                println!("SNAPSHOT\tSANDBOX");
+                                for (snapshot_id, sandbox_id) in snapshots {
+                                    println!("{snapshot_id}\t{sandbox_id}");
+                                }
+                            }
+                            Err(error) => println!("listing snapshots failed: {error:#}"),
+                        }
+                        continue;
+                    }
+                    if let Some(arg) = trimmed.strip_prefix("/rewind ") {
+                        let snapshot_id_str = arg.trim();
+                        if snapshot_id_str.is_empty() {
+                            println!("usage: /rewind <snapshot-id>");
+                            continue;
+                        }
+                        match self.rewind_to_snapshot(snapshot_id_str).await {
+                            Ok(()) => println!("rewound to snapshot {snapshot_id_str}"),
+                            Err(error) => println!("rewind failed: {error:#}"),
+                        }
+                        continue;
+                    }
 
                     self.editor.add_history_entry(line.as_str())?;
                     self.send(trimmed).await?;
@@ -402,6 +440,46 @@ impl ChatRepl {
             self.conversation.close_session(session_id).await?;
         }
 
+        Ok(())
+    }
+
+    /// Find the most recent `SandboxCreated` event and snapshot that sandbox.
+    /// The conversation's active sandbox must have been created (or started)
+    /// in *this* REPL session — running_sandboxes is a per-process map.
+    async fn snapshot_current_sandbox(&self) -> Result<SnapshotId, Box<dyn Error>> {
+        let sandbox_id = latest_sandbox_id(self.conversation.as_ref())
+            .await?
+            .ok_or("no sandbox has been created in this conversation yet")?;
+        let id = self
+            .conversation
+            .exoharness_handle()
+            .snapshot_sandbox(sandbox_id)
+            .await?;
+        Ok(id)
+    }
+
+    async fn list_snapshots(&self) -> Result<Vec<(SnapshotId, SandboxId)>, Box<dyn Error>> {
+        list_snapshots(self.conversation.as_ref()).await
+    }
+
+    /// Restore the conversation's sandbox to a previously-taken snapshot.
+    /// Stops the current container, decodes the snapshot payload, and starts
+    /// a fresh container from that state.
+    async fn rewind_to_snapshot(&self, snapshot_id_str: &str) -> Result<(), Box<dyn Error>> {
+        let snapshot_id = snapshot_id_str
+            .parse::<SnapshotId>()
+            .map_err(|error| format!("invalid snapshot id `{snapshot_id_str}`: {error}"))?;
+        let sandbox_id = sandbox_id_for_snapshot(self.conversation.as_ref(), snapshot_id)
+            .await?
+            .ok_or_else(|| format!("snapshot {snapshot_id} not found in this conversation"))?;
+        self.conversation
+            .exoharness_handle()
+            .start_sandbox(StartSandboxRequest {
+                id: sandbox_id,
+                snapshot_id,
+                idle_seconds: None,
+            })
+            .await?;
         Ok(())
     }
 
@@ -559,6 +637,91 @@ fn render_user_content_for_history(content: &UserContent) -> String {
             .collect::<Vec<_>>()
             .join(""),
     }
+}
+
+fn print_help() {
+    println!("repl commands:");
+    println!("  /quit | /exit        exit the repl");
+    println!("  /history             reprint the conversation transcript");
+    println!("  /snapshot            snapshot this conversation's running sandbox");
+    println!("  /snapshots           list snapshots taken in this conversation");
+    println!("  /rewind <id>         restore the sandbox to a previous snapshot");
+    println!("  /help                show this message");
+}
+
+/// Walk the conversation's event log to find the latest `SandboxCreated`
+/// event, returning the sandbox id. Returns `None` if no sandbox has been
+/// created yet (e.g. nothing has been chatted with).
+async fn latest_sandbox_id(
+    conversation: &dyn HarnessConversation,
+) -> Result<Option<SandboxId>, Box<dyn Error>> {
+    let result = conversation
+        .exoharness_handle()
+        .get_events(Some(EventQuery {
+            cursor: None,
+            direction: Some(EventQueryDirection::Desc),
+            limit: Some(50),
+            session_id: None,
+            turn_id: None,
+            types: Some(vec!["sandbox_created".to_string()]),
+        }))
+        .await?;
+    for event in result.events {
+        if let EventData::SandboxCreated { sandbox_id, .. } = event.data {
+            return Ok(Some(sandbox_id));
+        }
+    }
+    Ok(None)
+}
+
+/// All snapshots taken in the conversation, oldest-first. Each tuple is
+/// `(snapshot_id, sandbox_id_it_was_taken_from)`.
+async fn list_snapshots(
+    conversation: &dyn HarnessConversation,
+) -> Result<Vec<(SnapshotId, SandboxId)>, Box<dyn Error>> {
+    let mut out = Vec::new();
+    let mut cursor: Option<EventId> = None;
+    loop {
+        let result = conversation
+            .exoharness_handle()
+            .get_events(Some(EventQuery {
+                cursor,
+                direction: Some(EventQueryDirection::Asc),
+                limit: Some(100),
+                session_id: None,
+                turn_id: None,
+                types: Some(vec!["sandbox_snapshotted".to_string()]),
+            }))
+            .await?;
+        let events_empty = result.events.is_empty();
+        for event in result.events {
+            if let EventData::SandboxSnapshotted {
+                sandbox_id,
+                snapshot_id,
+            } = event.data
+            {
+                out.push((snapshot_id, sandbox_id));
+            }
+        }
+        if events_empty || result.cursor.is_none() {
+            break;
+        }
+        cursor = result.cursor;
+    }
+    Ok(out)
+}
+
+/// Find the sandbox a particular snapshot was taken from, by scanning the
+/// `SandboxSnapshotted` events.
+async fn sandbox_id_for_snapshot(
+    conversation: &dyn HarnessConversation,
+    target: SnapshotId,
+) -> Result<Option<SandboxId>, Box<dyn Error>> {
+    let snapshots = list_snapshots(conversation).await?;
+    Ok(snapshots
+        .into_iter()
+        .find(|(snapshot_id, _)| *snapshot_id == target)
+        .map(|(_, sandbox_id)| sandbox_id))
 }
 
 #[cfg(test)]

--- a/crates/executor/src/basic_tests.rs
+++ b/crates/executor/src/basic_tests.rs
@@ -787,7 +787,11 @@ impl ConversationHandle for FakeConversationHandle {
         Err(anyhow!("not implemented"))
     }
 
-    async fn snapshot_sandbox(&self, _id: SandboxId) -> Result<SnapshotId> {
+    async fn snapshot_sandbox(
+        &self,
+        _id: SandboxId,
+        _mode: exoharness::SnapshotMode,
+    ) -> Result<SnapshotId> {
         Err(anyhow!("not implemented"))
     }
 

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -35,7 +35,7 @@ pub use exoharness::{
     ConversationHandle, EventData, EventId, EventQuery, EventQueryDirection, ExoHarness,
     FileSystemMount, FileSystemMountMode, ForkConversationRequest, PutSecretRequest,
     SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, SandboxId, Secret, SecretBackendChoice,
-    SecretMetadata, SessionId, SnapshotId, StartSandboxRequest, Uuid7,
+    SecretMetadata, SessionId, SnapshotId, SnapshotMode, StartSandboxRequest, Uuid7,
 };
 pub use harness_basic::BasicHarness;
 pub use harness_config::load_agent_config;

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -34,8 +34,8 @@ pub use exoharness::{
     AgentHandle, BasicExoHarness, BasicExoHarnessConfig, Binding, BindingMetadata,
     ConversationHandle, EventData, EventId, EventQuery, EventQueryDirection, ExoHarness,
     FileSystemMount, FileSystemMountMode, ForkConversationRequest, PutSecretRequest,
-    SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, Secret, SecretBackendChoice, SecretMetadata,
-    SessionId, Uuid7,
+    SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, SandboxId, Secret, SecretBackendChoice,
+    SecretMetadata, SessionId, SnapshotId, StartSandboxRequest, Uuid7,
 };
 pub use harness_basic::BasicHarness;
 pub use harness_config::load_agent_config;

--- a/crates/exoharness/Cargo.toml
+++ b/crates/exoharness/Cargo.toml
@@ -30,6 +30,7 @@ lingua.workspace = true
 object_store = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
+tempfile = "3.23.0"
 thiserror.workspace = true
 tokio = { version = "1.52.1", default-features = false, features = [
   "fs",
@@ -44,7 +45,6 @@ tokio-util = { workspace = true, optional = true, features = ["compat"] }
 uuid = { workspace = true, features = ["serde", "v4", "v7", "js"] }
 
 [dev-dependencies]
-tempfile = "3.23.0"
 tokio = { version = "1.52.1", features = [
   "fs",
   "macros",

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -991,7 +991,11 @@ impl ConversationHandle for BasicConversationHandle {
         Ok(sandbox_id)
     }
 
-    async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
+    async fn snapshot_sandbox(
+        &self,
+        id: SandboxId,
+        mode: crate::SnapshotMode,
+    ) -> Result<SnapshotId> {
         // Capture the payload *before* taking the write lock — backends may
         // need to talk to docker / pause the container, which can be slow.
         // The lock is then only held for the metadata persistence below.
@@ -1004,7 +1008,7 @@ impl ConversationHandle for BasicConversationHandle {
             .get(&id)
             .cloned()
             .ok_or_else(|| anyhow!("sandbox {id} is not running; start it before snapshotting"))?;
-        let payload = handle.snapshot().await?;
+        let payload = handle.snapshot(mode).await?;
 
         let _guard = self.harness.inner.write_lock.lock().await;
         let mut sandbox = self.load_sandbox(&id).await?;

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -5,6 +5,8 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::{Context, anyhow, bail};
 use async_trait::async_trait;
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
 use futures::StreamExt;
 use futures::stream::{self, BoxStream};
 use serde::{Deserialize, Serialize};
@@ -15,7 +17,7 @@ use crate::sandbox::{
     CliContainerSandboxBackend, LocalProcessSandboxBackend, ManagedSandboxBackend,
     ManagedSandboxHandle, SANDBOX_MAIN_MOUNT_DIR, SandboxCommand, SandboxKey,
     SandboxLifecycleConfig, SandboxMount, SandboxMountAccess, SandboxNetworkPolicy, SandboxRequest,
-    SandboxSpec,
+    SandboxSpec, SnapshotKind, SnapshotPayload,
 };
 use crate::secrets::{
     AppleKeychainSecretKeyProvider, EncryptedSecret, FileBackedSecretKeyProvider, SecretCipher,
@@ -990,9 +992,43 @@ impl ConversationHandle for BasicConversationHandle {
     }
 
     async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
+        // Capture the payload *before* taking the write lock — backends may
+        // need to talk to docker / pause the container, which can be slow.
+        // The lock is then only held for the metadata persistence below.
+        let handle = self
+            .harness
+            .inner
+            .running_sandboxes
+            .lock()
+            .await
+            .get(&id)
+            .cloned()
+            .ok_or_else(|| anyhow!("sandbox {id} is not running; start it before snapshotting"))?;
+        let payload = handle.snapshot().await?;
+
         let _guard = self.harness.inner.write_lock.lock().await;
         let mut sandbox = self.load_sandbox(&id).await?;
         let snapshot_id = Uuid7::now();
+
+        let manifest = StoredSnapshotManifest {
+            snapshot_id,
+            sandbox_id: id.clone(),
+            kind: payload.kind,
+            created_at: Utc::now(),
+            payload_size_bytes: payload.bytes.len() as u64,
+        };
+        let snapshot_dir = self.snapshot_dir(&snapshot_id);
+        self.harness
+            .inner
+            .storage
+            .put_bytes(snapshot_dir.join("payload.bin"), payload.bytes.to_vec())
+            .await?;
+        self.harness
+            .inner
+            .storage
+            .put_json(snapshot_dir.join("manifest.json"), &manifest)
+            .await?;
+
         sandbox.latest_snapshot_id = Some(snapshot_id);
         self.harness
             .inner
@@ -1023,6 +1059,35 @@ impl ConversationHandle for BasicConversationHandle {
     }
 
     async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
+        // Load the snapshot payload before acquiring the write lock — it can
+        // be many MB and we don't want to block writers while we read.
+        let snapshot_dir = self.snapshot_dir(&request.snapshot_id);
+        let manifest: StoredSnapshotManifest = self
+            .harness
+            .inner
+            .storage
+            .get_json(snapshot_dir.join("manifest.json"))
+            .await
+            .with_context(|| {
+                format!(
+                    "loading snapshot manifest for {} (have you taken a snapshot?)",
+                    request.snapshot_id
+                )
+            })?;
+        let payload_bytes = self
+            .harness
+            .inner
+            .storage
+            .get_bytes(snapshot_dir.join("payload.bin"))
+            .await
+            .with_context(|| {
+                format!("loading snapshot payload for {}", request.snapshot_id)
+            })?;
+        let payload = SnapshotPayload {
+            kind: manifest.kind,
+            bytes: Bytes::from(payload_bytes),
+        };
+
         let _guard = self.harness.inner.write_lock.lock().await;
         let mut sandbox = self.load_sandbox(&request.id).await?;
         sandbox.running = true;
@@ -1044,7 +1109,10 @@ impl ConversationHandle for BasicConversationHandle {
             .harness
             .inner
             .sandbox_backend
-            .acquire(sandbox_request(self.record.id, &request.id, &sandbox))
+            .acquire_from_snapshot(
+                sandbox_request(self.record.id, &request.id, &sandbox),
+                payload,
+            )
             .await?;
         self.harness
             .inner
@@ -1318,6 +1386,14 @@ impl BasicConversationHandle {
         self.conversation_dir().join("sandboxes")
     }
 
+    fn snapshots_dir(&self) -> PathBuf {
+        self.conversation_dir().join("snapshots")
+    }
+
+    fn snapshot_dir(&self, snapshot_id: &SnapshotId) -> PathBuf {
+        self.snapshots_dir().join(snapshot_id.to_string())
+    }
+
     async fn load_record(&self) -> Result<ConversationRecord> {
         self.harness
             .inner
@@ -1477,6 +1553,21 @@ struct StoredSandbox {
     idle_seconds: u64,
     running: bool,
     latest_snapshot_id: Option<SnapshotId>,
+}
+
+/// Sidecar JSON describing a snapshot payload.
+///
+/// Lives at `{conversation_dir}/snapshots/{snapshot_id}/manifest.json` alongside
+/// the payload blob at `payload.bin`. The `kind` controls how the payload is
+/// interpreted on restore — only a backend that recognises that kind can
+/// reconstruct a sandbox from it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredSnapshotManifest {
+    snapshot_id: SnapshotId,
+    sandbox_id: SandboxId,
+    kind: SnapshotKind,
+    created_at: DateTime<Utc>,
+    payload_size_bytes: u64,
 }
 
 struct LiveSandboxProcess {

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -147,7 +147,7 @@ pub trait ManagedSandboxBackend: Send + Sync {
     ) -> Result<Arc<dyn ManagedSandboxHandle>>;
 }
 
-pub const DEFAULT_SANDBOX_IMAGE: &str = "docker.io/library/debian:bookworm";
+pub const DEFAULT_SANDBOX_IMAGE: &str = "docker.io/library/ubuntu:24.04";
 pub const SANDBOX_HOME_DIR: &str = "/home/exo";
 pub const SANDBOX_MAIN_MOUNT_DIR: &str = "/home/exo/workspace";
 

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -105,6 +105,21 @@ pub struct SnapshotPayload {
     pub bytes: Bytes,
 }
 
+/// What kind of snapshot the caller wants. Producers honour the mode or
+/// return an explicit error if they can't (e.g. CRIU not installed).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotMode {
+    /// Capture filesystem state only. Fast, portable, doesn't preserve
+    /// running processes or memory.
+    Filesystem,
+    /// Capture full state: filesystem plus running processes, memory,
+    /// open file descriptors. Backed by CRIU on Docker; requires CRIU on
+    /// the host and `experimental` enabled in the docker daemon. Brittler
+    /// and larger than filesystem-only snapshots; only use when the
+    /// captured workload has live in-flight state worth preserving.
+    FullState,
+}
+
 /// Tag identifying the on-disk format of a snapshot payload. Backends both
 /// produce and consume a specific kind; the conversation layer just hands the
 /// bytes back to the same backend type that produced them.
@@ -112,8 +127,12 @@ pub struct SnapshotPayload {
 #[serde(rename_all = "snake_case")]
 pub enum SnapshotKind {
     /// `docker save` output: a tar of OCI image layers + manifest, loadable
-    /// with `docker load`.
+    /// with `docker load`. Filesystem-only.
     DockerImageTar,
+    /// Tar of a `docker checkpoint`'s CRIU dump directory. Contains the full
+    /// frozen process tree (memory pages, FDs, sockets) in addition to the
+    /// filesystem diff. Restored with `docker start --checkpoint`.
+    DockerCheckpointTar,
 }
 
 #[async_trait]
@@ -126,9 +145,11 @@ pub trait ManagedSandboxHandle: Send + Sync {
 
     async fn stop(&self) -> Result<()>;
 
-    /// Capture the sandbox's current state as an opaque blob. Returns an
-    /// error if this backend doesn't (yet) support snapshotting.
-    async fn snapshot(&self) -> Result<SnapshotPayload>;
+    /// Capture the sandbox's current state as an opaque blob. The `mode`
+    /// selects between filesystem-only and full-state capture; backends
+    /// may not support all modes and return an explicit error in that
+    /// case (e.g. CRIU not installed on the host).
+    async fn snapshot(&self, mode: SnapshotMode) -> Result<SnapshotPayload>;
 }
 
 #[async_trait]
@@ -430,24 +451,18 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
         if request.lifecycle.idle_ttl.is_none() {
             bail!("restore-from-snapshot requires a warm sandbox lifecycle (idle_ttl must be set)");
         }
-        match (self.cli, payload.kind) {
-            (ContainerCliFlavor::Docker, SnapshotKind::DockerImageTar) => {}
-            (ContainerCliFlavor::AppleContainer, _) => bail!(
-                "restore-from-snapshot is not yet implemented for the apple-container backend"
-            ),
+        if !matches!(self.cli, ContainerCliFlavor::Docker) {
+            bail!(
+                "restore-from-snapshot is not yet implemented for the {:?} backend",
+                self.cli
+            );
         }
 
-        let image_tag = docker_load_image(&self.container_bin, &payload.bytes).await?;
+        // Both kinds share the post-restore warm-pool plumbing (evict any
+        // pre-existing container for this key, then put the restored
+        // container into the cache). Only the bring-up step differs.
+        let request = self.prepare_request(request).await?;
 
-        // Build a fresh request that points at the loaded image. Mounts,
-        // network policy, lifecycle, and key are all preserved from the
-        // original request so the restored sandbox is otherwise identical.
-        let mut request = self.prepare_request(request).await?;
-        request.spec.image = image_tag;
-
-        // Evict any pre-existing warm container for this key — we want a
-        // fresh container booted from the restored image, not a reuse of
-        // whatever was running before.
         let replaced = {
             let mut warm_sandboxes = self.warm_sandboxes.lock().await;
             warm_sandboxes.remove(&request.key)
@@ -456,7 +471,31 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
             schedule_cleanup_named_container(self.container_bin.clone(), self.cli, entry.name);
         }
 
-        let name = create_unique_warm_sandbox(&self.container_bin, &request).await?;
+        let (name, request) = match payload.kind {
+            SnapshotKind::DockerImageTar => {
+                // Load the saved image, swap request.spec.image, then take the
+                // normal warm-bring-up path.
+                let image_tag =
+                    docker_load_image(&self.container_bin, &payload.bytes).await?;
+                let mut request = request;
+                request.spec.image = image_tag;
+                let name = create_unique_warm_sandbox(&self.container_bin, &request).await?;
+                (name, request)
+            }
+            SnapshotKind::DockerCheckpointTar => {
+                // Create a fresh container off the original image (the
+                // checkpoint will overlay its own filesystem + restore the
+                // process tree on start). Then `docker start --checkpoint`
+                // brings up the saved process state on that container.
+                docker_restore_container_checkpoint(
+                    &self.container_bin,
+                    &request,
+                    &payload.bytes,
+                )
+                .await?
+            }
+        };
+
         {
             let mut warm_sandboxes = self.warm_sandboxes.lock().await;
             warm_sandboxes.insert(
@@ -515,7 +554,7 @@ impl ManagedSandboxHandle for OneShotSandboxHandle {
         Ok(())
     }
 
-    async fn snapshot(&self) -> Result<SnapshotPayload> {
+    async fn snapshot(&self, _mode: SnapshotMode) -> Result<SnapshotPayload> {
         bail!(
             "snapshot is not supported for one-shot sandboxes (set a positive idle_ttl to enable warm sandbox + snapshotting)"
         )
@@ -567,7 +606,7 @@ impl ManagedSandboxHandle for WarmSandboxHandle {
         }
     }
 
-    async fn snapshot(&self) -> Result<SnapshotPayload> {
+    async fn snapshot(&self, mode: SnapshotMode) -> Result<SnapshotPayload> {
         match self.cli {
             ContainerCliFlavor::Docker => {
                 let name = ensure_warm_sandbox_ready(
@@ -578,15 +617,24 @@ impl ManagedSandboxHandle for WarmSandboxHandle {
                 )
                 .await?;
                 touch_warm_sandbox(&self.warm_sandboxes, &self.request.key).await;
-                docker_snapshot_container(&self.container_bin, &name).await
+                match mode {
+                    SnapshotMode::Filesystem => {
+                        docker_snapshot_container_filesystem(&self.container_bin, &name).await
+                    }
+                    SnapshotMode::FullState => {
+                        docker_snapshot_container_checkpoint(&self.container_bin, &name).await
+                    }
+                }
             }
             // The Apple `container` CLI exposes `container image save` and a
             // `container commit`-style flow on its roadmap but neither is in
             // the released versions we target today. When it lands, the path
-            // will mirror docker_snapshot_container: produce a single tarball
-            // and tag it with a new SnapshotKind variant (e.g.
-            // AppleContainerImageTar). Until then, fail explicitly so callers
-            // know to choose Docker for snapshot-using flows.
+            // will mirror docker_snapshot_container_filesystem: produce a
+            // single tarball and tag it with a new SnapshotKind variant
+            // (e.g. AppleContainerImageTar). Full-state capture maps to VZ's
+            // pause + saveMachineStateTo: API but the CLI doesn't expose
+            // that yet either. Until then, fail explicitly so callers know
+            // to choose Docker for snapshot-using flows.
             ContainerCliFlavor::AppleContainer => bail!(
                 "snapshot is not yet implemented for the apple-container backend; \
                  use --sandbox-backend docker for snapshot-using flows"
@@ -673,7 +721,7 @@ impl ManagedSandboxHandle for LocalProcessSandboxHandle {
         Ok(())
     }
 
-    async fn snapshot(&self) -> Result<SnapshotPayload> {
+    async fn snapshot(&self, _mode: SnapshotMode) -> Result<SnapshotPayload> {
         // The local-process backend runs commands directly on the host; there
         // is no container filesystem to capture. A meaningful implementation
         // would tar up the writable mounts, but the semantics differ enough
@@ -1325,7 +1373,7 @@ fn new_warm_container_name(key: &SandboxKey) -> String {
 ///
 /// `commit -p` pauses the container during commit to ensure a consistent
 /// filesystem capture (no half-written files).
-async fn docker_snapshot_container(
+async fn docker_snapshot_container_filesystem(
     container_bin: &Path,
     container_name: &str,
 ) -> Result<SnapshotPayload> {
@@ -1390,6 +1438,239 @@ async fn docker_snapshot_container(
         kind: SnapshotKind::DockerImageTar,
         bytes,
     })
+}
+
+/// Capture a docker container's *full state* (filesystem + running processes
+/// + memory + FDs) as a SnapshotPayload backed by a CRIU dump.
+///
+/// Pipeline:
+///   docker checkpoint create --checkpoint-dir=<tmp> <container> exo-snap
+///   tar -cf - -C <tmp>/exo-snap .                     // tarball on stdout
+///   rm -rf <tmp>
+///
+/// Requires:
+///   - the docker daemon to have `experimental: true`
+///   - CRIU installed on the host (the daemon shells out to it)
+/// We probe `docker info` for experimental once and surface a clean error
+/// pointing at the requirements doc when missing, rather than letting the
+/// raw `docker checkpoint create` failure bubble up.
+async fn docker_snapshot_container_checkpoint(
+    container_bin: &Path,
+    container_name: &str,
+) -> Result<SnapshotPayload> {
+    docker_require_experimental(container_bin).await?;
+
+    let tmpdir = tempfile::Builder::new()
+        .prefix("exo-checkpoint-")
+        .tempdir()
+        .context("creating tempdir for docker checkpoint")?;
+    let checkpoint_name = "exo-snap";
+
+    let create_output = Command::new(container_bin)
+        .arg("checkpoint")
+        .arg("create")
+        .arg("--checkpoint-dir")
+        .arg(tmpdir.path())
+        .arg(container_name)
+        .arg(checkpoint_name)
+        .output()
+        .await
+        .with_context(|| format!("running `docker checkpoint create` for {container_name}"))?;
+    if !create_output.status.success() {
+        bail!(
+            "docker checkpoint create failed for {container_name}: {}\n\
+             (full-state snapshots require CRIU on the host and `experimental: true` \
+             in docker's daemon.json — see docs/requirements.md)",
+            render_command_error(&create_output.stderr)
+        );
+    }
+
+    // The checkpoint dir docker writes to is <tmpdir>/<name>. Tar it up.
+    let checkpoint_path = tmpdir.path().join(checkpoint_name);
+    let tar_output = Command::new("tar")
+        .arg("-cf")
+        .arg("-")
+        .arg("-C")
+        .arg(&checkpoint_path)
+        .arg(".")
+        .output()
+        .await
+        .context("tarring docker checkpoint directory")?;
+    if !tar_output.status.success() {
+        bail!(
+            "tarring docker checkpoint failed: {}",
+            render_command_error(&tar_output.stderr)
+        );
+    }
+    let bytes = Bytes::from(tar_output.stdout);
+
+    Ok(SnapshotPayload {
+        kind: SnapshotKind::DockerCheckpointTar,
+        bytes,
+    })
+}
+
+/// Restore a docker container from a CRIU checkpoint tarball.
+///
+/// Pipeline:
+///   1. Untar the checkpoint into a fresh tempdir.
+///   2. Create a new container (`docker create`) using the original request's
+///      image + mounts + network + workdir + keepalive argv. We do *not*
+///      start it yet — `--checkpoint` only works on a not-yet-started
+///      container.
+///   3. `docker start --checkpoint exo-snap --checkpoint-dir=<tmp> <new-container>`
+///      to bring it up with the restored state.
+///
+/// Returns the new container's name and the (unchanged) request, ready for
+/// insertion into the warm-sandbox cache.
+async fn docker_restore_container_checkpoint(
+    container_bin: &Path,
+    request: &SandboxRequest,
+    payload: &Bytes,
+) -> Result<(String, SandboxRequest)> {
+    docker_require_experimental(container_bin).await?;
+
+    let tmpdir = tempfile::Builder::new()
+        .prefix("exo-restore-")
+        .tempdir()
+        .context("creating tempdir for docker checkpoint restore")?;
+    let checkpoint_name = "exo-snap";
+    let checkpoint_path = tmpdir.path().join(checkpoint_name);
+    std::fs::create_dir_all(&checkpoint_path)
+        .with_context(|| format!("creating {}", checkpoint_path.display()))?;
+
+    // Untar payload into <tmp>/<checkpoint_name>.
+    use tokio::io::AsyncWriteExt;
+    let mut untar = Command::new("tar")
+        .arg("-xf")
+        .arg("-")
+        .arg("-C")
+        .arg(&checkpoint_path)
+        .stdin(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("spawning tar -xf for checkpoint restore")?;
+    let mut stdin = untar
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow!("failed to acquire tar stdin"))?;
+    stdin
+        .write_all(payload)
+        .await
+        .context("writing checkpoint bytes to tar stdin")?;
+    stdin.shutdown().await.ok();
+    drop(stdin);
+    let untar_output = untar
+        .wait_with_output()
+        .await
+        .context("waiting on tar -xf")?;
+    if !untar_output.status.success() {
+        bail!(
+            "untarring docker checkpoint failed: {}",
+            render_command_error(&untar_output.stderr)
+        );
+    }
+
+    // Create (don't start) the container. Same arg shape as
+    // create_named_warm_sandbox but with `create` instead of `run --detach`.
+    let name = new_warm_container_name(&request.key);
+    let mut create_proc = Command::new(container_bin);
+    create_proc
+        .arg("create")
+        .arg("--name")
+        .arg(&name)
+        .arg("--label")
+        .arg(format!("{WARM_SANDBOX_KEY_LABEL}={}", request.key))
+        .arg("--label")
+        .arg(format!(
+            "{WARM_SANDBOX_SPEC_HASH_LABEL}={}",
+            sandbox_spec_hash(&request.spec)
+        ))
+        .arg("--label")
+        .arg(format!(
+            "{WARM_SANDBOX_OWNER_PID_LABEL}={}",
+            std::process::id()
+        ))
+        .arg("--workdir")
+        .arg(&request.spec.default_workdir);
+    configure_network_args(
+        &mut create_proc,
+        request.spec.network,
+        Some(DEFAULT_ENABLED_NETWORK_NAME),
+    );
+    configure_mount_args(&mut create_proc, &request.spec.mounts);
+    create_proc.arg(&request.spec.image);
+    create_proc.args(WARM_SANDBOX_KEEPALIVE_ARGV);
+    create_proc.kill_on_drop(true);
+    let create_output = create_proc
+        .output()
+        .await
+        .context("running `docker create` for checkpoint restore")?;
+    if !create_output.status.success() {
+        bail!(
+            "docker create failed: {}",
+            render_command_error(&create_output.stderr)
+        );
+    }
+
+    // Start the container from the checkpoint.
+    let start_output = Command::new(container_bin)
+        .arg("start")
+        .arg("--checkpoint")
+        .arg(checkpoint_name)
+        .arg("--checkpoint-dir")
+        .arg(tmpdir.path())
+        .arg(&name)
+        .output()
+        .await
+        .context("running `docker start --checkpoint`")?;
+    if !start_output.status.success() {
+        // Best-effort cleanup of the failed-to-start container.
+        let _ = Command::new(container_bin)
+            .arg("rm")
+            .arg("-f")
+            .arg(&name)
+            .output()
+            .await;
+        bail!(
+            "docker start --checkpoint failed: {}\n\
+             (full-state restore requires CRIU on the host and `experimental: true` \
+             in docker's daemon.json — see docs/requirements.md)",
+            render_command_error(&start_output.stderr)
+        );
+    }
+
+    Ok((name, request.clone()))
+}
+
+/// Verify the local docker daemon has experimental features enabled. The
+/// `checkpoint` subcommand is hidden behind that flag. Surfaces a clear
+/// error message pointing at the setup doc rather than letting the cryptic
+/// "Unknown command" error from docker bubble up.
+async fn docker_require_experimental(container_bin: &Path) -> Result<()> {
+    let info = Command::new(container_bin)
+        .arg("info")
+        .arg("--format")
+        .arg("{{.ExperimentalBuild}}")
+        .output()
+        .await
+        .context("running `docker info` to check experimental flag")?;
+    if !info.status.success() {
+        bail!(
+            "could not query docker info: {}",
+            render_command_error(&info.stderr)
+        );
+    }
+    let value = String::from_utf8_lossy(&info.stdout).trim().to_string();
+    if value != "true" {
+        bail!(
+            "full-state (CRIU) snapshots require the docker daemon to have \
+             experimental features enabled. Edit /etc/docker/daemon.json to \
+             include `\"experimental\": true` and restart docker. \
+             See docs/requirements.md for the full setup."
+        );
+    }
+    Ok(())
 }
 
 /// Load a docker-save tarball back into the local docker daemon and return

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -1364,6 +1364,7 @@ fn new_warm_container_name(key: &SandboxKey) -> String {
     format!("exo-{hash:016x}-{}", &generation[..8])
 }
 
+
 /// Capture a docker container's filesystem state as a SnapshotPayload.
 ///
 /// Pipeline:
@@ -1460,17 +1461,15 @@ async fn docker_snapshot_container_checkpoint(
 ) -> Result<SnapshotPayload> {
     docker_require_experimental(container_bin).await?;
 
-    let tmpdir = tempfile::Builder::new()
-        .prefix("exo-checkpoint-")
-        .tempdir()
-        .context("creating tempdir for docker checkpoint")?;
     let checkpoint_name = "exo-snap";
 
+    // Create checkpoint in docker's default location. We use the default
+    // (not --checkpoint-dir) because `docker start --checkpoint` rejects
+    // custom dirs on the restore side; keeping create symmetric avoids
+    // a copy.
     let create_output = Command::new(container_bin)
         .arg("checkpoint")
         .arg("create")
-        .arg("--checkpoint-dir")
-        .arg(tmpdir.path())
         .arg(container_name)
         .arg(checkpoint_name)
         .output()
@@ -1485,29 +1484,92 @@ async fn docker_snapshot_container_checkpoint(
         );
     }
 
-    // The checkpoint dir docker writes to is <tmpdir>/<name>. Tar it up.
-    let checkpoint_path = tmpdir.path().join(checkpoint_name);
-    let tar_output = Command::new("tar")
+    // Read the checkpoint dump out of docker's storage. Files are root-
+    // owned 0600 since the daemon (and CRIU) run as root, so this needs
+    // sudo. We pull the bytes and then clean up the local copy via
+    // `docker checkpoint rm` — exoharness storage is the canonical home,
+    // not the docker daemon.
+    let checkpoint_dir = docker_checkpoint_dir(container_bin, container_name, checkpoint_name).await?;
+    let tar_output = Command::new("sudo")
+        .arg("-n")
+        .arg("tar")
         .arg("-cf")
         .arg("-")
         .arg("-C")
-        .arg(&checkpoint_path)
+        .arg(&checkpoint_dir)
         .arg(".")
         .output()
         .await
-        .context("tarring docker checkpoint directory")?;
+        .context("running `sudo tar` on docker checkpoint directory")?;
     if !tar_output.status.success() {
+        // Best-effort cleanup of the local checkpoint copy.
+        let _ = Command::new(container_bin)
+            .arg("checkpoint")
+            .arg("rm")
+            .arg(container_name)
+            .arg(checkpoint_name)
+            .output()
+            .await;
         bail!(
-            "tarring docker checkpoint failed: {}",
+            "tarring docker checkpoint failed: {}\n\
+             (full-state snapshots need passwordless sudo to read the CRIU \
+             dump that the docker daemon wrote as root — see \
+             docs/requirements.md)",
             render_command_error(&tar_output.stderr)
         );
     }
     let bytes = Bytes::from(tar_output.stdout);
 
+    let rm_output = Command::new(container_bin)
+        .arg("checkpoint")
+        .arg("rm")
+        .arg(container_name)
+        .arg(checkpoint_name)
+        .output()
+        .await;
+    if let Ok(output) = &rm_output
+        && !output.status.success()
+    {
+        eprintln!(
+            "warning: failed to clean up local docker checkpoint {checkpoint_name}: {}",
+            render_command_error(&output.stderr)
+        );
+    }
+
     Ok(SnapshotPayload {
         kind: SnapshotKind::DockerCheckpointTar,
         bytes,
     })
+}
+
+/// Look up the on-host path docker uses for a given container's named
+/// checkpoint. Format is /var/lib/docker/containers/<full-id>/checkpoints/<name>/
+async fn docker_checkpoint_dir(
+    container_bin: &Path,
+    container_name: &str,
+    checkpoint_name: &str,
+) -> Result<PathBuf> {
+    let inspect = Command::new(container_bin)
+        .arg("inspect")
+        .arg("--format")
+        .arg("{{.Id}}")
+        .arg(container_name)
+        .output()
+        .await
+        .with_context(|| format!("running `docker inspect` on {container_name}"))?;
+    if !inspect.status.success() {
+        bail!(
+            "docker inspect {container_name} failed: {}",
+            render_command_error(&inspect.stderr)
+        );
+    }
+    let id = String::from_utf8_lossy(&inspect.stdout).trim().to_string();
+    if id.is_empty() {
+        bail!("docker inspect returned an empty container id for {container_name}");
+    }
+    Ok(PathBuf::from(format!(
+        "/var/lib/docker/containers/{id}/checkpoints/{checkpoint_name}"
+    )))
 }
 
 /// Restore a docker container from a CRIU checkpoint tarball.
@@ -1530,49 +1592,12 @@ async fn docker_restore_container_checkpoint(
 ) -> Result<(String, SandboxRequest)> {
     docker_require_experimental(container_bin).await?;
 
-    let tmpdir = tempfile::Builder::new()
-        .prefix("exo-restore-")
-        .tempdir()
-        .context("creating tempdir for docker checkpoint restore")?;
     let checkpoint_name = "exo-snap";
-    let checkpoint_path = tmpdir.path().join(checkpoint_name);
-    std::fs::create_dir_all(&checkpoint_path)
-        .with_context(|| format!("creating {}", checkpoint_path.display()))?;
 
-    // Untar payload into <tmp>/<checkpoint_name>.
-    use tokio::io::AsyncWriteExt;
-    let mut untar = Command::new("tar")
-        .arg("-xf")
-        .arg("-")
-        .arg("-C")
-        .arg(&checkpoint_path)
-        .stdin(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .context("spawning tar -xf for checkpoint restore")?;
-    let mut stdin = untar
-        .stdin
-        .take()
-        .ok_or_else(|| anyhow!("failed to acquire tar stdin"))?;
-    stdin
-        .write_all(payload)
-        .await
-        .context("writing checkpoint bytes to tar stdin")?;
-    stdin.shutdown().await.ok();
-    drop(stdin);
-    let untar_output = untar
-        .wait_with_output()
-        .await
-        .context("waiting on tar -xf")?;
-    if !untar_output.status.success() {
-        bail!(
-            "untarring docker checkpoint failed: {}",
-            render_command_error(&untar_output.stderr)
-        );
-    }
-
-    // Create (don't start) the container. Same arg shape as
+    // Create (don't start) the new container. Same arg shape as
     // create_named_warm_sandbox but with `create` instead of `run --detach`.
+    // We need the container to exist before we can drop a checkpoint into
+    // its on-host checkpoints/ directory.
     let name = new_warm_container_name(&request.key);
     let mut create_proc = Command::new(container_bin);
     create_proc
@@ -1613,19 +1638,97 @@ async fn docker_restore_container_checkpoint(
         );
     }
 
-    // Start the container from the checkpoint.
+    // Drop the checkpoint into docker's storage at the canonical path
+    // /var/lib/docker/containers/<new-id>/checkpoints/<name>/. `docker
+    // start --checkpoint` only reads from this default location (it
+    // explicitly rejects --checkpoint-dir on the restore side), so we
+    // have to write directly into it. Needs sudo since the dir tree is
+    // root-owned.
+    let checkpoint_dir = match docker_checkpoint_dir(container_bin, &name, checkpoint_name).await {
+        Ok(dir) => dir,
+        Err(error) => {
+            let _ = Command::new(container_bin)
+                .arg("rm")
+                .arg("-f")
+                .arg(&name)
+                .output()
+                .await;
+            return Err(error);
+        }
+    };
+
+    let mkdir_output = Command::new("sudo")
+        .arg("-n")
+        .arg("mkdir")
+        .arg("-p")
+        .arg(&checkpoint_dir)
+        .output()
+        .await
+        .context("running `sudo mkdir` for docker checkpoint restore")?;
+    if !mkdir_output.status.success() {
+        let _ = Command::new(container_bin)
+            .arg("rm")
+            .arg("-f")
+            .arg(&name)
+            .output()
+            .await;
+        bail!(
+            "sudo mkdir on checkpoint directory failed: {}\n\
+             (full-state restore needs passwordless sudo to drop the CRIU \
+             dump into /var/lib/docker — see docs/requirements.md)",
+            render_command_error(&mkdir_output.stderr)
+        );
+    }
+
+    use tokio::io::AsyncWriteExt;
+    let mut untar = Command::new("sudo")
+        .arg("-n")
+        .arg("tar")
+        .arg("-xf")
+        .arg("-")
+        .arg("-C")
+        .arg(&checkpoint_dir)
+        .stdin(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("spawning `sudo tar -xf` for checkpoint restore")?;
+    let mut stdin = untar
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow!("failed to acquire tar stdin"))?;
+    stdin
+        .write_all(payload)
+        .await
+        .context("writing checkpoint bytes to tar stdin")?;
+    stdin.shutdown().await.ok();
+    drop(stdin);
+    let untar_output = untar
+        .wait_with_output()
+        .await
+        .context("waiting on `sudo tar -xf`")?;
+    if !untar_output.status.success() {
+        let _ = Command::new(container_bin)
+            .arg("rm")
+            .arg("-f")
+            .arg(&name)
+            .output()
+            .await;
+        bail!(
+            "untarring docker checkpoint failed: {}",
+            render_command_error(&untar_output.stderr)
+        );
+    }
+
+    // Start the container from the checkpoint (default location).
     let start_output = Command::new(container_bin)
         .arg("start")
         .arg("--checkpoint")
         .arg(checkpoint_name)
-        .arg("--checkpoint-dir")
-        .arg(tmpdir.path())
         .arg(&name)
         .output()
         .await
         .context("running `docker start --checkpoint`")?;
     if !start_output.status.success() {
-        // Best-effort cleanup of the failed-to-start container.
         let _ = Command::new(container_bin)
             .arg("rm")
             .arg("-f")

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -9,7 +9,8 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use anyhow::{Context, Result, anyhow, bail};
 use async_trait::async_trait;
 use futures::future::BoxFuture;
-use serde::Deserialize;
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
 use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 use tokio::time;
@@ -94,6 +95,27 @@ pub struct SandboxCommandOutput {
     pub cwd: String,
 }
 
+/// Opaque blob produced by `ManagedSandboxHandle::snapshot` and consumed by
+/// `ManagedSandboxBackend::acquire_from_snapshot`. The `kind` tag is the
+/// contract: a snapshot produced by one backend can only be restored by a
+/// backend that knows how to interpret that kind.
+#[derive(Debug, Clone)]
+pub struct SnapshotPayload {
+    pub kind: SnapshotKind,
+    pub bytes: Bytes,
+}
+
+/// Tag identifying the on-disk format of a snapshot payload. Backends both
+/// produce and consume a specific kind; the conversation layer just hands the
+/// bytes back to the same backend type that produced them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SnapshotKind {
+    /// `docker save` output: a tar of OCI image layers + manifest, loadable
+    /// with `docker load`.
+    DockerImageTar,
+}
+
 #[async_trait]
 pub trait ManagedSandboxHandle: Send + Sync {
     fn id(&self) -> &str;
@@ -103,11 +125,26 @@ pub trait ManagedSandboxHandle: Send + Sync {
     async fn start_process(&self, command: &SandboxCommand) -> Result<crate::SandboxProcessParts>;
 
     async fn stop(&self) -> Result<()>;
+
+    /// Capture the sandbox's current state as an opaque blob. Returns an
+    /// error if this backend doesn't (yet) support snapshotting.
+    async fn snapshot(&self) -> Result<SnapshotPayload>;
 }
 
 #[async_trait]
 pub trait ManagedSandboxBackend: Send + Sync {
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>>;
+
+    /// Acquire a sandbox initialised from a previously-captured snapshot.
+    /// The request is honoured for mounts, network, lifecycle, etc., but the
+    /// container's filesystem is sourced from the payload instead of
+    /// `request.spec.image`. Returns an error if this backend can't restore
+    /// the supplied `payload.kind`.
+    async fn acquire_from_snapshot(
+        &self,
+        request: SandboxRequest,
+        payload: SnapshotPayload,
+    ) -> Result<Arc<dyn ManagedSandboxHandle>>;
 }
 
 pub const DEFAULT_SANDBOX_IMAGE: &str = "docker.io/library/debian:bookworm";
@@ -384,6 +421,62 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
             warm_sandboxes: Arc::clone(&self.warm_sandboxes),
         }))
     }
+
+    async fn acquire_from_snapshot(
+        &self,
+        request: SandboxRequest,
+        payload: SnapshotPayload,
+    ) -> Result<Arc<dyn ManagedSandboxHandle>> {
+        if request.lifecycle.idle_ttl.is_none() {
+            bail!("restore-from-snapshot requires a warm sandbox lifecycle (idle_ttl must be set)");
+        }
+        match (self.cli, payload.kind) {
+            (ContainerCliFlavor::Docker, SnapshotKind::DockerImageTar) => {}
+            (ContainerCliFlavor::AppleContainer, _) => bail!(
+                "restore-from-snapshot is not yet implemented for the apple-container backend"
+            ),
+        }
+
+        let image_tag = docker_load_image(&self.container_bin, &payload.bytes).await?;
+
+        // Build a fresh request that points at the loaded image. Mounts,
+        // network policy, lifecycle, and key are all preserved from the
+        // original request so the restored sandbox is otherwise identical.
+        let mut request = self.prepare_request(request).await?;
+        request.spec.image = image_tag;
+
+        // Evict any pre-existing warm container for this key — we want a
+        // fresh container booted from the restored image, not a reuse of
+        // whatever was running before.
+        let replaced = {
+            let mut warm_sandboxes = self.warm_sandboxes.lock().await;
+            warm_sandboxes.remove(&request.key)
+        };
+        if let Some(entry) = replaced {
+            schedule_cleanup_named_container(self.container_bin.clone(), self.cli, entry.name);
+        }
+
+        let name = create_unique_warm_sandbox(&self.container_bin, &request).await?;
+        {
+            let mut warm_sandboxes = self.warm_sandboxes.lock().await;
+            warm_sandboxes.insert(
+                request.key.clone(),
+                WarmSandboxEntry {
+                    name: name.clone(),
+                    request: request.clone(),
+                    last_used_at: Instant::now(),
+                },
+            );
+        }
+
+        Ok(Arc::new(WarmSandboxHandle {
+            id: format!("warm:{}", request.key),
+            cli: self.cli,
+            container_bin: self.container_bin.clone(),
+            request,
+            warm_sandboxes: Arc::clone(&self.warm_sandboxes),
+        }))
+    }
 }
 
 struct OneShotSandboxHandle {
@@ -420,6 +513,12 @@ impl ManagedSandboxHandle for OneShotSandboxHandle {
 
     async fn stop(&self) -> Result<()> {
         Ok(())
+    }
+
+    async fn snapshot(&self) -> Result<SnapshotPayload> {
+        bail!(
+            "snapshot is not supported for one-shot sandboxes (set a positive idle_ttl to enable warm sandbox + snapshotting)"
+        )
     }
 }
 
@@ -467,6 +566,33 @@ impl ManagedSandboxHandle for WarmSandboxHandle {
             Ok(())
         }
     }
+
+    async fn snapshot(&self) -> Result<SnapshotPayload> {
+        match self.cli {
+            ContainerCliFlavor::Docker => {
+                let name = ensure_warm_sandbox_ready(
+                    &self.container_bin,
+                    self.cli,
+                    &self.request,
+                    &self.warm_sandboxes,
+                )
+                .await?;
+                touch_warm_sandbox(&self.warm_sandboxes, &self.request.key).await;
+                docker_snapshot_container(&self.container_bin, &name).await
+            }
+            // The Apple `container` CLI exposes `container image save` and a
+            // `container commit`-style flow on its roadmap but neither is in
+            // the released versions we target today. When it lands, the path
+            // will mirror docker_snapshot_container: produce a single tarball
+            // and tag it with a new SnapshotKind variant (e.g.
+            // AppleContainerImageTar). Until then, fail explicitly so callers
+            // know to choose Docker for snapshot-using flows.
+            ContainerCliFlavor::AppleContainer => bail!(
+                "snapshot is not yet implemented for the apple-container backend; \
+                 use --sandbox-backend docker for snapshot-using flows"
+            ),
+        }
+    }
 }
 
 #[derive(Debug, Default)]
@@ -485,6 +611,14 @@ impl ManagedSandboxBackend for LocalProcessSandboxBackend {
             id: format!("local:{}", request.key),
             request,
         }))
+    }
+
+    async fn acquire_from_snapshot(
+        &self,
+        _request: SandboxRequest,
+        _payload: SnapshotPayload,
+    ) -> Result<Arc<dyn ManagedSandboxHandle>> {
+        bail!("restore-from-snapshot is not supported by the local-process sandbox backend")
     }
 }
 
@@ -537,6 +671,15 @@ impl ManagedSandboxHandle for LocalProcessSandboxHandle {
 
     async fn stop(&self) -> Result<()> {
         Ok(())
+    }
+
+    async fn snapshot(&self) -> Result<SnapshotPayload> {
+        // The local-process backend runs commands directly on the host; there
+        // is no container filesystem to capture. A meaningful implementation
+        // would tar up the writable mounts, but the semantics differ enough
+        // from container snapshots (no isolated filesystem, no rollback of
+        // host-side state) that we don't pretend to support it.
+        bail!("snapshot is not supported by the local-process sandbox backend")
     }
 }
 
@@ -1171,4 +1314,134 @@ fn new_warm_container_name(key: &SandboxKey) -> String {
     let hash = hasher.finish();
     let generation = Uuid::new_v4().simple().to_string();
     format!("exo-{hash:016x}-{}", &generation[..8])
+}
+
+/// Capture a docker container's filesystem state as a SnapshotPayload.
+///
+/// Pipeline:
+///   docker commit -p <container>  exo-snap-<uuid>     // image from container fs
+///   docker save exo-snap-<uuid>                       // tarball on stdout
+///   docker image rm exo-snap-<uuid>                   // local image no longer needed
+///
+/// `commit -p` pauses the container during commit to ensure a consistent
+/// filesystem capture (no half-written files).
+async fn docker_snapshot_container(
+    container_bin: &Path,
+    container_name: &str,
+) -> Result<SnapshotPayload> {
+    let snap_tag = format!("exo-snap-{}", Uuid::new_v4().simple());
+
+    let commit_output = Command::new(container_bin)
+        .arg("commit")
+        .arg("-p")
+        .arg(container_name)
+        .arg(&snap_tag)
+        .output()
+        .await
+        .with_context(|| format!("running `docker commit` for {container_name}"))?;
+    if !commit_output.status.success() {
+        bail!(
+            "docker commit {container_name} {snap_tag} failed: {}",
+            render_command_error(&commit_output.stderr)
+        );
+    }
+
+    let save_output = Command::new(container_bin)
+        .arg("save")
+        .arg(&snap_tag)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await
+        .with_context(|| format!("running `docker save {snap_tag}`"))?;
+    if !save_output.status.success() {
+        // Best-effort cleanup of the tag we just created.
+        let _ = Command::new(container_bin)
+            .arg("image")
+            .arg("rm")
+            .arg(&snap_tag)
+            .output()
+            .await;
+        bail!(
+            "docker save {snap_tag} failed: {}",
+            render_command_error(&save_output.stderr)
+        );
+    }
+    let bytes = Bytes::from(save_output.stdout);
+
+    // Remove the local image tag now that the bytes are captured — the
+    // canonical store of the snapshot is exoharness, not the docker daemon.
+    let rm_output = Command::new(container_bin)
+        .arg("image")
+        .arg("rm")
+        .arg(&snap_tag)
+        .output()
+        .await;
+    if let Ok(output) = &rm_output
+        && !output.status.success()
+    {
+        eprintln!(
+            "warning: failed to remove ephemeral snapshot image {snap_tag}: {}",
+            render_command_error(&output.stderr)
+        );
+    }
+
+    Ok(SnapshotPayload {
+        kind: SnapshotKind::DockerImageTar,
+        bytes,
+    })
+}
+
+/// Load a docker-save tarball back into the local docker daemon and return
+/// the image reference docker assigned to it. The reference is what
+/// subsequent `docker run` invocations use to start a container from this
+/// snapshot's state.
+async fn docker_load_image(container_bin: &Path, payload: &Bytes) -> Result<String> {
+    use tokio::io::AsyncWriteExt;
+
+    let mut child = Command::new(container_bin)
+        .arg("load")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("spawning `docker load`")?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow!("docker load: failed to acquire stdin"))?;
+    stdin
+        .write_all(payload)
+        .await
+        .context("writing snapshot bytes to `docker load` stdin")?;
+    stdin.shutdown().await.ok();
+    drop(stdin);
+
+    let output = child
+        .wait_with_output()
+        .await
+        .context("waiting on `docker load`")?;
+    if !output.status.success() {
+        bail!(
+            "docker load failed: {}",
+            render_command_error(&output.stderr)
+        );
+    }
+
+    // docker load prints lines like:
+    //   Loaded image: <ref>
+    //   Loaded image ID: sha256:<digest>
+    // Prefer the named-tag line; fall back to image-ID.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if let Some(rest) = line.strip_prefix("Loaded image: ") {
+            return Ok(rest.trim().to_string());
+        }
+    }
+    for line in stdout.lines() {
+        if let Some(rest) = line.strip_prefix("Loaded image ID: ") {
+            return Ok(rest.trim().to_string());
+        }
+    }
+    bail!("docker load completed but no image reference found in output: {stdout}")
 }

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -77,7 +77,11 @@ pub trait ConversationHandle: Send + Sync {
     async fn list_artifacts(&self) -> Result<Vec<ArtifactVersion>>;
 
     async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId>;
-    async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId>;
+    async fn snapshot_sandbox(
+        &self,
+        id: SandboxId,
+        mode: crate::SnapshotMode,
+    ) -> Result<SnapshotId>;
     async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()>;
     async fn stop_sandbox(&self, id: SandboxId) -> Result<()>;
     async fn run_in_sandbox(&self, request: RunInSandboxRequest)

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -59,6 +59,17 @@ descriptors) and is backed by CRIU on the Docker backend. It needs:
 
   Then `sudo systemctl restart docker`.
 
+- **Passwordless `sudo` for the user running `exo`.** The docker daemon
+  writes CRIU dump files as root (mode 0600), so the snapshot path needs
+  one `sudo chown` to claim them before tarring. Restore stays user-level.
+  Typical dev workstations already have passwordless sudo; for a hardened
+  machine, add a sudoers fragment:
+
+  ```
+  # /etc/sudoers.d/exo-criu  (edit with `sudo visudo -f /etc/sudoers.d/exo-criu`)
+  yourname ALL=(root) NOPASSWD: /usr/bin/chown
+  ```
+
 - **Apple Silicon macOS / `apple-container` backend.** Not yet implemented
   end-to-end. The underlying VZ framework supports `pause` +
   `saveMachineStateTo:`, but Apple's `container` CLI does not yet expose

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,87 @@
+# Runtime requirements
+
+This document lists what needs to be installed and configured on the host to
+run `exo` and its optional features. The aim is one place to look when a
+feature surfaces an "X not available" error.
+
+## Building
+
+- Rust 1.95+ (workspace `rust-version`)
+- pnpm 10.x + Node 22.x for the TypeScript bits (`pnpm install && pnpm check`)
+
+## Backends — sandbox
+
+The sandbox backend is selected with `--sandbox-backend <kind>` or the
+`EXO_SANDBOX_BACKEND` env var. Defaults are cfg-based:
+
+Linux → `docker`
+macOS → `apple-container`
+
+| Backend           | Host requirement                                                 | Notes                                                                                                                                        |
+| ----------------- | ---------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `local-process`   | none                                                             | Commands run directly on the host. No isolation. Useful for tests.                                                                           |
+| `docker`          | docker CLI + a running docker daemon (`docker info` succeeds)    | Linux runners have this preinstalled. On macOS use Colima or Docker Desktop.                                                                 |
+| `apple-container` | Apple `container` CLI installed and `container system start` run | Apple Silicon, macOS 15+. Install with `sudo installer -pkg container-*-installer-signed.pkg -target /` from a release of `apple/container`. |
+
+## Backends — secret
+
+Selected with `--secret-backend <kind>` or `EXO_SECRET_BACKEND`.
+
+| Backend          | Host requirement                           | Notes                                                                                                                                        |
+| ---------------- | ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `file`           | none                                       | Master key at `$XDG_CONFIG_HOME/exo/master.key` (default `~/.config/exo/master.key`), 0600. Path can be overridden with `--master-key-path`. |
+| `apple-keychain` | macOS, access to the user's login keychain | Headless contexts (CI, ssh without a graphical login) may fail to unlock.                                                                    |
+
+## Optional: full-state sandbox snapshots (`/checkpoint`)
+
+The default `/snapshot` slash command captures filesystem state only and has
+no requirements beyond the chosen sandbox backend. The `/checkpoint` command
+captures full state (filesystem + running processes + memory + open file
+descriptors) and is backed by CRIU on the Docker backend. It needs:
+
+- **CRIU on the host.** The docker daemon shells out to `criu` during
+  `docker checkpoint create`. On Linux:
+
+  Ubuntu 22.04 LTS: `sudo apt install criu`
+  Ubuntu 24.04 LTS: not in the official repos; build from
+  <https://github.com/checkpoint-restore/criu>
+  or pull from a 22.04 mirror
+  Fedora / RHEL: `sudo dnf install criu`
+
+  `sudo criu check` should report "Looks good" for the kernel to be
+  supported.
+
+- **Docker experimental mode.** Add to `/etc/docker/daemon.json`:
+
+  ```json
+  { "experimental": true }
+  ```
+
+  Then `sudo systemctl restart docker`.
+
+- **Apple Silicon macOS / `apple-container` backend.** Not yet implemented
+  end-to-end. The underlying VZ framework supports `pause` +
+  `saveMachineStateTo:`, but Apple's `container` CLI does not yet expose
+  that. Tracked in the snapshot design doc.
+
+When the requirements are missing, `/checkpoint` surfaces an actionable
+error message pointing back here, rather than a cryptic raw-CLI failure.
+
+## Optional: CI integration tests
+
+The integration test workflow (`.github/workflows/integration.yml`) runs the
+real `exo` binary against a wiremock-backed fake OpenAI Responses endpoint
+on a real sandbox. It self-skips a matrix cell when the runner doesn't have
+the required backend:
+
+| Matrix cell             | Runner           | Setup performed by the workflow             |
+| ----------------------- | ---------------- | ------------------------------------------- |
+| `linux/local-process`   | `ubuntu-latest`  | none                                        |
+| `linux/docker`          | `ubuntu-latest`  | docker preinstalled                         |
+| `macos/local-process`   | `macos-15`       | none                                        |
+| `macos/docker`          | `macos-15-intel` | `crazy-max/ghaction-setup-docker` (Colima)  |
+| `macos/apple-container` | _none_           | requires a self-hosted runner (nested-virt) |
+
+See <https://github.com/actions/runner-images/issues/13505> for the
+nested-virt limitation that blocks `macos/apple-container` on GitHub-hosted
+runners.

--- a/docs/sandbox-snapshots.md
+++ b/docs/sandbox-snapshots.md
@@ -1,0 +1,224 @@
+# Sandbox Snapshots
+
+Status: implemented for the Docker sandbox backend; stubs in place for the
+other backends.
+
+## Summary
+
+A snapshot captures the current filesystem state of a sandboxed container so
+that the sandbox can later be rewound to that state. Snapshots are taken,
+listed, and replayed within an `exo` conversation. They give the user — or in
+a later iteration, an executor policy — the ability to time-travel a
+sandbox's state without forking the conversation itself.
+
+The earlier model only recorded snapshot _metadata_ (a UUID written to the
+event log). This work adds the captured artifact, the persistence layer for
+it, and the restore path that actually consumes it.
+
+## What you get
+
+- `ConversationHandle::snapshot_sandbox(id)` actually captures the live
+  container's filesystem and persists it.
+- `ConversationHandle::start_sandbox(StartSandboxRequest { id, snapshot_id, .. })`
+  starts a fresh container whose filesystem is sourced from the snapshot,
+  preserving the original sandbox's mounts, network policy, and lifecycle.
+- A chat-REPL slash-command surface — `/snapshot`, `/snapshots`, `/rewind <id>`
+  — that drives the round-trip without leaving the conversation.
+
+## What this is not
+
+- **Not a process or memory checkpoint.** Only filesystem state is captured.
+  Running processes inside the container are not preserved; they are
+  re-launched fresh from the restored image.
+- **Not a conversation rewind.** The event log, message history, and prior
+  tool calls are untouched. Use `conversation fork` to rewind the
+  conversation itself.
+- **Not yet cross-process.** A snapshot can only be taken of a sandbox that
+  is live in the _current_ `exo` process (`running_sandboxes` is per-process).
+  See "Known limits" below.
+
+## Model
+
+Snapshots are an interaction between three layers:
+
+```
+ConversationHandle             ManagedSandboxHandle           ManagedSandboxBackend
+       │                              │                                │
+  snapshot_sandbox(id) ──► running_sandboxes.get(id).snapshot() ──┐    │
+       │                                                          │    │
+       ◄────────── SnapshotPayload { kind, bytes } ────────────────┘    │
+       │                                                                │
+  put_bytes / put_json                                                  │
+  (manifest.json + payload.bin)                                         │
+                                                                        │
+  start_sandbox(req) ─── load manifest + payload ──► acquire_from_snapshot(req, payload)
+```
+
+`ConversationHandle` orchestrates: it locates the live handle, asks for a
+payload, persists the bytes, updates sandbox metadata, and emits the
+`SandboxSnapshotted` event. `ManagedSandboxHandle::snapshot` and
+`ManagedSandboxBackend::acquire_from_snapshot` are the backend-specific
+methods that produce and consume the bytes.
+
+### SnapshotPayload and SnapshotKind
+
+```rust
+pub struct SnapshotPayload {
+    pub kind: SnapshotKind,
+    pub bytes: Bytes,
+}
+
+pub enum SnapshotKind {
+    DockerImageTar,
+    // future: AppleContainerImageTar, etc.
+}
+```
+
+`SnapshotPayload` is opaque to the harness. The `kind` tag is the contract
+between producer and consumer: a payload produced by one backend can only be
+restored by a backend that knows how to interpret that kind. The harness
+never inspects `bytes` — it just persists them and hands them back on
+restore.
+
+## Docker pipeline
+
+`ManagedSandboxHandle::snapshot` (Docker):
+
+1. `ensure_warm_sandbox_ready` — make sure the container exists and is the
+   one in the warm cache for this `SandboxKey`.
+2. `docker commit -p <container> exo-snap-<uuid>` — pause the container
+   during commit for a consistent filesystem capture, then create a new
+   image from its layers.
+3. `docker save exo-snap-<uuid>` — export the image as a tarball on stdout;
+   capture into `Bytes`.
+4. `docker image rm exo-snap-<uuid>` — drop the local image. The canonical
+   store of the snapshot lives in exoharness storage, not the docker daemon.
+
+`ManagedSandboxBackend::acquire_from_snapshot` (Docker):
+
+1. Validate that `payload.kind == DockerImageTar`.
+2. `docker load < payload.bytes` — load the image back into the local
+   daemon; parse stdout to find the assigned image reference (the line
+   `Loaded image: <ref>`).
+3. Build a fresh `SandboxRequest` with `spec.image` swapped for the loaded
+   reference. Mounts, network policy, default workdir, lifecycle, and
+   `SandboxKey` are preserved from the original request.
+4. Evict any pre-existing warm container for this key (we want a fresh
+   container booted from the restored image, not a reuse of whatever was
+   running before).
+5. `docker run --detach …` with the loaded image — exactly the same path as
+   a normal cold-start container, just with a different image.
+
+## On-disk layout
+
+Snapshots live under the conversation directory, alongside other
+conversation-scoped artifacts:
+
+```
+agents/<agent_id>/conversations/<conversation_id>/snapshots/<snapshot_id>/
+├── manifest.json   JSON sidecar (StoredSnapshotManifest)
+└── payload.bin     raw blob (docker save tarball for SnapshotKind::DockerImageTar)
+```
+
+The manifest schema:
+
+```json
+{
+  "snapshot_id": "019e5782-7c6b-72a2-b4fa-a81bf56eb37e",
+  "sandbox_id": "sandbox-019e5782-2a46-7970-a5bf-62900a2233e8",
+  "kind": "docker_image_tar",
+  "created_at": "2026-05-24T01:03:49.867230008Z",
+  "payload_size_bytes": 48498688
+}
+```
+
+This mirrors the existing artifact layout (sidecar `.json` + `.bin` blob in
+a per-id directory). A future migration to chunked or streamed storage
+would touch a small surface.
+
+The snapshot's existence is also recorded in the conversation event log as
+`SandboxSnapshotted { sandbox_id, snapshot_id }`, which is what
+`/snapshots` walks to list past snapshots.
+
+## CLI surface
+
+Inside the chat REPL (`exo chat repl <agent> <conv>`):
+
+```
+/snapshot           capture the conversation's currently-running sandbox;
+                    prints the new snapshot id
+/snapshots          list snapshots taken in this conversation
+/rewind <id>        stop the current sandbox, start a fresh one from the
+                    named snapshot
+/help               show command list
+```
+
+There is intentionally no top-level `exo conversation snapshot` subcommand
+today — see "Known limits" for the cross-invocation gap that makes such
+a subcommand useless until it's resolved.
+
+## Extending to another sandbox backend
+
+To add snapshot support for a new backend (say, Apple's `container` CLI
+when it grows a commit/save flow):
+
+1. Add a new variant to `SnapshotKind` — e.g. `AppleContainerImageTar`.
+   The tag is the contract; pick a name that names the on-disk format.
+2. Implement `ManagedSandboxHandle::snapshot` for that backend's handle
+   type, producing the appropriate `SnapshotPayload`. The Docker version in
+   `docker_snapshot_container` is the template — three CLI calls and a
+   `Bytes` capture.
+3. Implement `ManagedSandboxBackend::acquire_from_snapshot` to consume the
+   same `kind`, including the safety check that the payload's `kind`
+   matches what the backend understands. The Docker version is the
+   template here too — load the bytes, get the loaded image reference,
+   swap `request.spec.image`, evict + recreate the warm container.
+4. Backends that genuinely can't snapshot (the local-process backend
+   today, since there's no isolated filesystem) should return an explicit
+   error from both methods rather than silently degrading.
+
+No other layer changes. The conversation orchestration, on-disk layout,
+and CLI surface are all backend-agnostic.
+
+## Known limits
+
+### Cross-invocation container adoption
+
+Today each `exo` process maintains its own `running_sandboxes` map. A
+container created by one invocation is not adopted by a later one even
+though it is still alive on the docker daemon, so snapshots can only be
+taken of sandboxes acquired in the current process. That is why the
+snapshot/rewind UX lives in the chat REPL (one long-running process holds
+the container for the conversation's duration) rather than as standalone
+`exo` subcommands.
+
+The fix is well-scoped — on `acquire`, query
+`docker ps --filter label=exo.sandbox.key=<key> --filter status=running` and
+adopt the existing container if its `exo.sandbox.spec-hash` label matches
+the requested spec. Once that lands, `exo conversation snapshot` and
+`exo conversation rewind` become trivial CLI subcommands that just call the
+same `ConversationHandle` methods the REPL slash commands use.
+
+### Payload size
+
+`SnapshotPayload::bytes` is a single `Bytes` blob and the harness's
+`put_bytes` / `get_bytes` take/return `Vec<u8>`. For the typical
+debian-base + small workspace, that is a 30-70 MB blob held in memory
+during capture and restore — acceptable but not great. A streamed
+producer/consumer interface (`AsyncRead`/`AsyncWrite`) is a clean
+follow-up if larger images become routine.
+
+### Snapshot lifecycle
+
+There is no GC. Snapshots remain on disk until the conversation directory
+is deleted. A future addition could prune snapshots older than the most
+recent N, or evict by total size.
+
+### Restore semantics
+
+Restore is a fresh container booted from the restored image, not a
+checkpoint of running processes or in-memory state. Any long-running
+processes the agent had started inside the container are not preserved;
+they would need to be re-launched from the restored filesystem state.
+This is consistent with how a fresh container is brought up for any chat
+turn.

--- a/docs/sandbox-snapshots.md
+++ b/docs/sandbox-snapshots.md
@@ -3,13 +3,23 @@
 Status: implemented for the Docker sandbox backend; stubs in place for the
 other backends.
 
+Two snapshot modes are available:
+
+- **Filesystem-only** (`SnapshotMode::Filesystem`, default). Fast, portable,
+  always-available. Captures the container's filesystem and re-creates a
+  fresh container from it on restore. Running processes are not preserved.
+- **Full-state** (`SnapshotMode::FullState`). Captures the entire frozen
+  process tree (memory pages, open FDs, sockets) in addition to the
+  filesystem. Backed by CRIU on Docker. Brittler and larger; requires
+  additional host setup (see `docs/requirements.md`).
+
 ## Summary
 
-A snapshot captures the current filesystem state of a sandboxed container so
-that the sandbox can later be rewound to that state. Snapshots are taken,
-listed, and replayed within an `exo` conversation. They give the user — or in
-a later iteration, an executor policy — the ability to time-travel a
-sandbox's state without forking the conversation itself.
+A snapshot captures the state of a sandboxed container so the sandbox can
+later be rewound. Snapshots are taken, listed, and replayed within an `exo`
+conversation. They give the user — or in a later iteration, an executor
+policy — the ability to time-travel a sandbox's state without forking the
+conversation itself.
 
 The earlier model only recorded snapshot _metadata_ (a UUID written to the
 event log). This work adds the captured artifact, the persistence layer for
@@ -17,19 +27,19 @@ it, and the restore path that actually consumes it.
 
 ## What you get
 
-- `ConversationHandle::snapshot_sandbox(id)` actually captures the live
-  container's filesystem and persists it.
+- `ConversationHandle::snapshot_sandbox(id, mode)` captures the live
+  container's state and persists it. `mode` selects filesystem-only vs
+  full-state capture.
 - `ConversationHandle::start_sandbox(StartSandboxRequest { id, snapshot_id, .. })`
-  starts a fresh container whose filesystem is sourced from the snapshot,
+  starts a fresh container whose state is sourced from the snapshot,
   preserving the original sandbox's mounts, network policy, and lifecycle.
-- A chat-REPL slash-command surface — `/snapshot`, `/snapshots`, `/rewind <id>`
-  — that drives the round-trip without leaving the conversation.
+  The restore path dispatches on the snapshot's `kind` tag.
+- A chat-REPL slash-command surface — `/snapshot`, `/checkpoint`,
+  `/snapshots`, `/rewind <id>` — that drives the round-trip without leaving
+  the conversation.
 
 ## What this is not
 
-- **Not a process or memory checkpoint.** Only filesystem state is captured.
-  Running processes inside the container are not preserved; they are
-  re-launched fresh from the restored image.
 - **Not a conversation rewind.** The event log, message history, and prior
   tool calls are untouched. Use `conversation fork` to rewind the
   conversation itself.
@@ -60,29 +70,43 @@ payload, persists the bytes, updates sandbox metadata, and emits the
 `ManagedSandboxBackend::acquire_from_snapshot` are the backend-specific
 methods that produce and consume the bytes.
 
-### SnapshotPayload and SnapshotKind
+### SnapshotMode, SnapshotPayload, SnapshotKind
 
 ```rust
+// Caller's intent — what kind of capture they want.
+pub enum SnapshotMode {
+    Filesystem,   // fast, no extra deps
+    FullState,    // CRIU-backed; docker only, needs setup
+}
+
+// The artifact itself. Opaque to the harness; only the producing backend
+// knows how to interpret `bytes`.
 pub struct SnapshotPayload {
     pub kind: SnapshotKind,
     pub bytes: Bytes,
 }
 
+// Tag on the artifact identifying which on-disk format it is.
 pub enum SnapshotKind {
-    DockerImageTar,
+    DockerImageTar,         // SnapshotMode::Filesystem on docker
+    DockerCheckpointTar,    // SnapshotMode::FullState on docker
     // future: AppleContainerImageTar, etc.
 }
 ```
 
-`SnapshotPayload` is opaque to the harness. The `kind` tag is the contract
-between producer and consumer: a payload produced by one backend can only be
-restored by a backend that knows how to interpret that kind. The harness
-never inspects `bytes` — it just persists them and hands them back on
-restore.
+`mode` and `kind` are intentionally separate. `mode` describes the caller's
+desired capture _semantics_ (filesystem vs full state). `kind` describes the
+_on-disk format_ of what the backend actually produced — that's the bit the
+restore path needs to dispatch on. A given backend maps each supported mode
+to a specific kind; another backend implementing the same mode may produce a
+different kind. The harness never inspects `bytes` — it just persists them
+and hands them back on restore.
 
-## Docker pipeline
+## Docker pipelines
 
-`ManagedSandboxHandle::snapshot` (Docker):
+### Filesystem (`SnapshotMode::Filesystem` → `SnapshotKind::DockerImageTar`)
+
+`ManagedSandboxHandle::snapshot(Filesystem)`:
 
 1. `ensure_warm_sandbox_ready` — make sure the container exists and is the
    one in the warm cache for this `SandboxKey`.
@@ -94,20 +118,42 @@ restore.
 4. `docker image rm exo-snap-<uuid>` — drop the local image. The canonical
    store of the snapshot lives in exoharness storage, not the docker daemon.
 
-`ManagedSandboxBackend::acquire_from_snapshot` (Docker):
+`acquire_from_snapshot` with `DockerImageTar`:
 
-1. Validate that `payload.kind == DockerImageTar`.
-2. `docker load < payload.bytes` — load the image back into the local
-   daemon; parse stdout to find the assigned image reference (the line
-   `Loaded image: <ref>`).
-3. Build a fresh `SandboxRequest` with `spec.image` swapped for the loaded
+1. `docker load < payload.bytes` — load the image back into the local
+   daemon; parse stdout to find the assigned image reference.
+2. Build a fresh `SandboxRequest` with `spec.image` swapped for the loaded
    reference. Mounts, network policy, default workdir, lifecycle, and
    `SandboxKey` are preserved from the original request.
-4. Evict any pre-existing warm container for this key (we want a fresh
-   container booted from the restored image, not a reuse of whatever was
-   running before).
-5. `docker run --detach …` with the loaded image — exactly the same path as
-   a normal cold-start container, just with a different image.
+3. Evict any pre-existing warm container for this key.
+4. `docker run --detach …` with the loaded image.
+
+### Full state (`SnapshotMode::FullState` → `SnapshotKind::DockerCheckpointTar`)
+
+`ManagedSandboxHandle::snapshot(FullState)`:
+
+1. Preflight: `docker info --format '{{.ExperimentalBuild}}'` must return
+   `true`. If not, surface a clean error pointing at `docs/requirements.md`
+   rather than letting docker error cryptically.
+2. `docker checkpoint create --checkpoint-dir=<tmp> <container> exo-snap`
+   — invokes CRIU under the hood to freeze the process tree and dump
+   memory, FDs, sockets, and filesystem diff into `<tmp>/exo-snap/`.
+3. `tar -cf - -C <tmp>/exo-snap .` — pack the checkpoint dir.
+4. Clean up `<tmp>` (the canonical store lives in exoharness storage).
+
+`acquire_from_snapshot` with `DockerCheckpointTar`:
+
+1. Preflight as above.
+2. Untar `payload.bytes` into a fresh `<tmp>/exo-snap/`.
+3. `docker create` a new container using the original request's image,
+   mounts, network, workdir, and labels. `--checkpoint` only works on a
+   container that hasn't been started yet, so we `create` rather than `run`.
+4. `docker start --checkpoint exo-snap --checkpoint-dir=<tmp> <name>` —
+   docker passes the checkpoint to CRIU which restores the process tree
+   onto the new container.
+
+If the start fails, the half-created container is removed with
+`docker rm -f` (best effort) before bubbling the error up.
 
 ## On-disk layout
 
@@ -145,13 +191,19 @@ The snapshot's existence is also recorded in the conversation event log as
 Inside the chat REPL (`exo chat repl <agent> <conv>`):
 
 ```
-/snapshot           capture the conversation's currently-running sandbox;
-                    prints the new snapshot id
+/snapshot           filesystem-only capture of the running sandbox
+/checkpoint         full-state (CRIU) capture; requires host setup
+                    (see docs/requirements.md)
 /snapshots          list snapshots taken in this conversation
 /rewind <id>        stop the current sandbox, start a fresh one from the
-                    named snapshot
+                    named snapshot — works for either kind, dispatching
+                    on the persisted manifest
 /help               show command list
 ```
+
+Both `/snapshot` and `/checkpoint` write under the same `snapshots/<id>/`
+directory and surface as the same `SandboxSnapshotted` event. The kind is
+recorded in `manifest.json` and dispatched on at restore time.
 
 There is intentionally no top-level `exo conversation snapshot` subcommand
 today — see "Known limits" for the cross-invocation gap that makes such


### PR DESCRIPTION
> ⚠️ **Draft. Not recommended for merge as-is.** Captures work; restore is blocked by known docker bugs across 28.x and 29.x. Keeping the branch so the code and design are reviewable, but probably either lands behind a feature flag with documented broken-restore or doesn't land at all until upstream docker fixes its checkpoint feature.

Stacked on #20 (`sandbox-snapshots-filesystem`).

## Summary

Adds a second snapshot mode on top of the filesystem-only path in #20:

- `SnapshotMode::FullState` — captures **filesystem + running processes + memory + open FDs** via `docker checkpoint create` (CRIU under the hood).
- `SnapshotKind::DockerCheckpointTar` — the tagged on-disk format alongside `DockerImageTar`.
- `/checkpoint` slash command in the REPL alongside `/snapshot`.
- `/rewind` dispatches on the persisted manifest kind, so it transparently handles either mode.

Three commits:

| # | Commit | What |
|---|---|---|
| 1 | `exoharness: full-state (CRIU) snapshot mode for docker sandboxes` | Trait extensions (`snapshot(mode)`), Docker capture+restore pipelines, `/checkpoint` REPL command, requirements preflight (`docker info ExperimentalBuild`) with an actionable error. |
| 2 | `docs: requirements doc + cover full-state snapshot mode` | New `docs/requirements.md` (general home for runtime requirements per backend) + design doc updates covering both modes and the mode/kind separation. |
| 3 | `exoharness: rewrite CRIU restore to use docker's default checkpoint dir` | Initial implementation tried `--checkpoint-dir`; docker rejects custom dirs on `start --checkpoint` ("custom checkpointdir is not supported"). Switch to docker's default `/var/lib/docker/containers/<id>/checkpoints/`, which requires `sudo tar`/`sudo mkdir` since the dir is root-owned. |

## What's verified

- Capture works end-to-end on docker 29.x: `docker checkpoint create` succeeds, the CRIU dump bytes are tarred and persisted to exoharness storage, the manifest is written correctly.
- Preflight: when `docker info --format '{{.ExperimentalBuild}}'` is `false`, `/checkpoint` returns the actionable error pointing at `docs/requirements.md` instead of letting docker fail cryptically.
- 51 unit tests pass.

## What's NOT working — known docker bugs

The restore path correctly invokes docker (verified via raw-docker reproduction without any exo code involved). Docker itself then fails:

| Path | Error | Tracking |
|---|---|---|
| Restore into fresh container, default networking | `Error response from daemon: bind-mount /proc/0/ns/net -> /var/run/docker/netns/...: no such file or directory` | Acknowledged docker bug — daemon writes invalid netns paths into the checkpoint. [Docker forum maintainer recommends `--network=host` as workaround.](https://forums.docker.com/t/using-criu-for-checkpointing-docker-containers/149448) |
| Restore in-place, any networking | `failed to upload checkpoint to containerd: commit failed: content sha256:... already exists` | [moby/moby#42900](https://github.com/moby/moby/issues/42900) — claimed fixed in 2021 (PR 47456) but regressed somewhere in docker 29.x |

Both reproduce on docker 29.4.2 (dev box) and the second one on docker 29.1.3 (test VM with full kernel modules). The forum thread reports docker 28.3.3 + CRIU + `--network=host` does work; we couldn't validate that combination because neither of the boxes we have access to runs that exact combo (one is on 29.x, the other has a stripped kernel without the modules CRIU needs).

## Why keep the code around (maybe)

- Capture is sound and the trait surface is right; when docker fixes its restore bugs or we add a different runtime (podman has substantially better CRIU integration, runc could be driven directly), the restore arm is a small addition.
- The mode/kind separation lets us cleanly add more kinds later (Apple VZ pause+save when `container` CLI exposes it, etc.).
- Documents the failure modes so future-us doesn't redo this investigation.

## Why drop the code (maybe)

- It's a meaningful diff for a feature that doesn't actually work.
- "It works on docker 28.3.3 with the right network setup" is a fragile claim we can't verify on our infrastructure.
- Filesystem snapshots cover ~99% of practical agent-rewind use cases (state lives on disk, processes are short-lived shell calls).

## Test plan

- [x] `cargo test --workspace` (51 pass)
- [x] `/checkpoint` capture succeeds; payload bytes written; manifest correct
- [x] Preflight error path verified when experimental is off
- [x] Raw-docker reproduction confirms restore failure is upstream, not in exo code
- [ ] End-to-end `/checkpoint` → `/rewind` on docker 28.3.3 with `--network=host` (not verified — no matching host available)