### PR TITLE
Sandbox filesystem snapshots and rewind (Docker)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -112,7 +112,13 @@ jobs:
           container system status
 
       - name: Run integration tests
-        # Narrow to the one integration target — unit tests are already
-        # covered by the rust-tests job in ci.yml, no need to recompile or
-        # rerun them here.
-        run: cargo test --package exo --test integration_chat -- --ignored
+        # List each integration-test target explicitly. Each scenario lives
+        # in its own file under crates/cli/tests/ and self-skips when its
+        # required backend isn't available on the current matrix cell.
+        # Adding a new scenario in a future PR means appending another
+        # `--test <name>` flag here.
+        run: |
+          cargo test --package exo \
+            --test integration_chat \
+            --test snapshot_round_trip \
+            -- --ignored

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -112,13 +112,6 @@ jobs:
           container system status
 
       - name: Run integration tests
-        # List each integration-test target explicitly. Each scenario lives
-        # in its own file under crates/cli/tests/ and self-skips when its
-        # required backend isn't available on the current matrix cell.
-        # Adding a new scenario in a future PR means appending another
-        # `--test <name>` flag here.
-        run: |
-          cargo test --package exo \
-            --test integration_chat \
-            --test snapshot_round_trip \
-            -- --ignored
+        # `--tests` auto-picks-up new test files; each self-skips on
+        # cells that don't have its required backend.
+        run: cargo test --package exo --tests -- --ignored

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1853,6 +1853,8 @@ dependencies = [
  "anyhow",
  "clap",
  "executor",
+ "exoharness",
+ "futures",
  "lingua",
  "rustyline",
  "serde",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,5 +21,7 @@ tokio.workspace = true
 tokio-stream.workspace = true
 
 [dev-dependencies]
+exoharness = { path = "../exoharness", features = ["basic-backend"] }
+futures.workspace = true
 tempfile = "3.23.0"
 wiremock = "0.6"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -21,9 +21,9 @@ use clap::{Parser, Subcommand, ValueEnum};
 use executor::{
     AgentHarnessKind, BasicExoHarness, BasicExoHarnessConfig, BasicHarness, Binding,
     BraintrustProject, BraintrustRuntimeConfig, BraintrustTracingConfig, ConversationModelConfig,
-    CreateAgentRequest, CreateConversationRequest, EventQuery, EventQueryDirection, ExoHarness,
-    FileSystemMount, FileSystemMountMode, ForkConversationRequest, Harness, HarnessAgent,
-    HarnessConversation, PutSecretRequest, RlmHarness, SANDBOX_MAIN_MOUNT_DIR,
+    CreateAgentRequest, CreateConversationRequest, EventKind, EventQuery, EventQueryDirection,
+    ExoHarness, FileSystemMount, FileSystemMountMode, ForkConversationRequest, Harness,
+    HarnessAgent, HarnessConversation, PutSecretRequest, RlmHarness, SANDBOX_MAIN_MOUNT_DIR,
     SandboxBackendChoice, Secret, SecretBackendChoice, SendRequest, TypeScriptHarness,
     TypeScriptHarnessConfig, Uuid7, load_agent_config,
 };
@@ -1257,7 +1257,13 @@ async fn main() -> Result<()> {
                         limit,
                         session_id: parse_optional_uuid7(session_id.as_deref(), "session_id")?,
                         turn_id: parse_optional_uuid7(turn_id.as_deref(), "turn_id")?,
-                        types: if types.is_empty() { None } else { Some(types) },
+                        types: if types.is_empty() {
+                            None
+                        } else {
+                            // User-supplied strings; `EventKind::custom` matches
+                            // both known kinds (by name) and Custom events.
+                            Some(types.into_iter().map(EventKind::custom).collect())
+                        },
                     }))
                     .await?;
                 println!("{}", serde_json::to_string_pretty(&result)?);

--- a/crates/cli/src/tui.rs
+++ b/crates/cli/src/tui.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 use anyhow::Result;
 use executor::{
     ConversationHandle, EventData, EventId, EventQuery, EventQueryDirection, ExecutionStreamEvent,
-    HarnessConversation, SendRequest, SessionId,
+    HarnessConversation, SandboxId, SendRequest, SessionId, SnapshotId, StartSandboxRequest,
 };
 use lingua::universal::{UserContent, UserContentPart};
 use lingua::{Message, UniversalStreamChunk};
@@ -380,6 +380,44 @@ impl ChatRepl {
                         self.print_transcript().await?;
                         continue;
                     }
+                    if trimmed == "/help" {
+                        print_help();
+                        continue;
+                    }
+                    if trimmed == "/snapshot" {
+                        match self.snapshot_current_sandbox().await {
+                            Ok(snapshot_id) => println!("snapshot {snapshot_id}"),
+                            Err(error) => println!("snapshot failed: {error:#}"),
+                        }
+                        continue;
+                    }
+                    if trimmed == "/snapshots" {
+                        match self.list_snapshots().await {
+                            Ok(snapshots) if snapshots.is_empty() => {
+                                println!("no snapshots yet for this conversation");
+                            }
+                            Ok(snapshots) => {
+                                println!("SNAPSHOT\tSANDBOX");
+                                for (snapshot_id, sandbox_id) in snapshots {
+                                    println!("{snapshot_id}\t{sandbox_id}");
+                                }
+                            }
+                            Err(error) => println!("listing snapshots failed: {error:#}"),
+                        }
+                        continue;
+                    }
+                    if let Some(arg) = trimmed.strip_prefix("/rewind ") {
+                        let snapshot_id_str = arg.trim();
+                        if snapshot_id_str.is_empty() {
+                            println!("usage: /rewind <snapshot-id>");
+                            continue;
+                        }
+                        match self.rewind_to_snapshot(snapshot_id_str).await {
+                            Ok(()) => println!("rewound to snapshot {snapshot_id_str}"),
+                            Err(error) => println!("rewind failed: {error:#}"),
+                        }
+                        continue;
+                    }
 
                     self.editor.add_history_entry(line.as_str())?;
                     self.send(trimmed).await?;
@@ -400,6 +438,50 @@ impl ChatRepl {
             self.conversation.close_session(session_id).await?;
         }
 
+        Ok(())
+    }
+
+    /// Find the most recent `SandboxCreated` event and snapshot that sandbox.
+    /// The conversation's active sandbox must have been created (or started)
+    /// in *this* REPL session — running_sandboxes is a per-process map.
+    async fn snapshot_current_sandbox(&self) -> Result<SnapshotId> {
+        let sandbox_id = latest_sandbox_id(self.conversation.as_ref())
+            .await?
+            .ok_or_else(|| {
+                anyhow::anyhow!("no sandbox has been created in this conversation yet")
+            })?;
+        let id = self
+            .conversation
+            .exoharness_handle()
+            .snapshot_sandbox(sandbox_id)
+            .await?;
+        Ok(id)
+    }
+
+    async fn list_snapshots(&self) -> Result<Vec<(SnapshotId, SandboxId)>> {
+        list_snapshots(self.conversation.as_ref()).await
+    }
+
+    /// Restore the conversation's sandbox to a previously-taken snapshot.
+    /// Stops the current container, decodes the snapshot payload, and starts
+    /// a fresh container from that state.
+    async fn rewind_to_snapshot(&self, snapshot_id_str: &str) -> Result<()> {
+        let snapshot_id = snapshot_id_str
+            .parse::<SnapshotId>()
+            .map_err(|error| anyhow::anyhow!("invalid snapshot id `{snapshot_id_str}`: {error}"))?;
+        let sandbox_id = sandbox_id_for_snapshot(self.conversation.as_ref(), snapshot_id)
+            .await?
+            .ok_or_else(|| {
+                anyhow::anyhow!("snapshot {snapshot_id} not found in this conversation")
+            })?;
+        self.conversation
+            .exoharness_handle()
+            .start_sandbox(StartSandboxRequest {
+                id: sandbox_id,
+                snapshot_id,
+                idle_seconds: None,
+            })
+            .await?;
         Ok(())
     }
 
@@ -557,6 +639,91 @@ fn render_user_content_for_history(content: &UserContent) -> String {
             .collect::<Vec<_>>()
             .join(""),
     }
+}
+
+fn print_help() {
+    println!("repl commands:");
+    println!("  /quit | /exit        exit the repl");
+    println!("  /history             reprint the conversation transcript");
+    println!("  /snapshot            snapshot this conversation's running sandbox");
+    println!("  /snapshots           list snapshots taken in this conversation");
+    println!("  /rewind <id>         restore the sandbox to a previous snapshot");
+    println!("  /help                show this message");
+}
+
+/// Walk the conversation's event log to find the latest `SandboxCreated`
+/// event, returning the sandbox id. Returns `None` if no sandbox has been
+/// created yet (e.g. nothing has been chatted with).
+async fn latest_sandbox_id(
+    conversation: &dyn HarnessConversation,
+) -> Result<Option<SandboxId>> {
+    let result = conversation
+        .exoharness_handle()
+        .get_events(Some(EventQuery {
+            cursor: None,
+            direction: Some(EventQueryDirection::Desc),
+            limit: Some(50),
+            session_id: None,
+            turn_id: None,
+            types: Some(vec!["sandbox_created".to_string()]),
+        }))
+        .await?;
+    for event in result.events {
+        if let EventData::SandboxCreated { sandbox_id, .. } = event.data {
+            return Ok(Some(sandbox_id));
+        }
+    }
+    Ok(None)
+}
+
+/// All snapshots taken in the conversation, oldest-first. Each tuple is
+/// `(snapshot_id, sandbox_id_it_was_taken_from)`.
+async fn list_snapshots(
+    conversation: &dyn HarnessConversation,
+) -> Result<Vec<(SnapshotId, SandboxId)>> {
+    let mut out = Vec::new();
+    let mut cursor: Option<EventId> = None;
+    loop {
+        let result = conversation
+            .exoharness_handle()
+            .get_events(Some(EventQuery {
+                cursor,
+                direction: Some(EventQueryDirection::Asc),
+                limit: Some(100),
+                session_id: None,
+                turn_id: None,
+                types: Some(vec!["sandbox_snapshotted".to_string()]),
+            }))
+            .await?;
+        let events_empty = result.events.is_empty();
+        for event in result.events {
+            if let EventData::SandboxSnapshotted {
+                sandbox_id,
+                snapshot_id,
+            } = event.data
+            {
+                out.push((snapshot_id, sandbox_id));
+            }
+        }
+        if events_empty || result.cursor.is_none() {
+            break;
+        }
+        cursor = result.cursor;
+    }
+    Ok(out)
+}
+
+/// Find the sandbox a particular snapshot was taken from, by scanning the
+/// `SandboxSnapshotted` events.
+async fn sandbox_id_for_snapshot(
+    conversation: &dyn HarnessConversation,
+    target: SnapshotId,
+) -> Result<Option<SandboxId>> {
+    let snapshots = list_snapshots(conversation).await?;
+    Ok(snapshots
+        .into_iter()
+        .find(|(snapshot_id, _)| *snapshot_id == target)
+        .map(|(_, sandbox_id)| sandbox_id))
 }
 
 #[cfg(test)]

--- a/crates/cli/src/tui.rs
+++ b/crates/cli/src/tui.rs
@@ -6,8 +6,9 @@ use std::time::Duration;
 
 use anyhow::Result;
 use executor::{
-    ConversationHandle, EventData, EventId, EventQuery, EventQueryDirection, ExecutionStreamEvent,
-    HarnessConversation, SandboxId, SendRequest, SessionId, SnapshotId, StartSandboxRequest,
+    ConversationHandle, EventData, EventId, EventKind, EventQuery, EventQueryDirection,
+    ExecutionStreamEvent, HarnessConversation, SandboxId, SendRequest, SessionId, SnapshotId,
+    StartSandboxRequest,
 };
 use lingua::universal::{UserContent, UserContentPart};
 use lingua::{Message, UniversalStreamChunk};
@@ -373,26 +374,28 @@ impl ChatRepl {
                     if trimmed.is_empty() {
                         continue;
                     }
-                    if trimmed == "/quit" || trimmed == "/exit" {
-                        break;
-                    }
-                    if trimmed == "/history" {
-                        self.print_transcript().await?;
-                        continue;
-                    }
-                    if trimmed == "/help" {
-                        print_help();
-                        continue;
-                    }
-                    if trimmed == "/snapshot" {
-                        match self.snapshot_current_sandbox().await {
+                    match trimmed {
+                        "/quit" | "/exit" => break,
+                        "/history" => self.print_transcript().await?,
+                        "/help" => print_help(),
+                        "/snapshot" => match self.snapshot_sandbox(None).await {
                             Ok(snapshot_id) => println!("snapshot {snapshot_id}"),
                             Err(error) => println!("snapshot failed: {error:#}"),
+                        },
+                        other if let Some(arg) = other.strip_prefix("/snapshot ") => {
+                            let arg = arg.trim();
+                            if arg.is_empty() {
+                                println!("usage: /snapshot [<sandbox-id>]");
+                            } else if arg.contains(char::is_whitespace) {
+                                println!("/snapshot takes at most one sandbox id; got: {arg:?}");
+                            } else {
+                                match self.snapshot_sandbox(Some(arg.to_string())).await {
+                                    Ok(snapshot_id) => println!("snapshot {snapshot_id}"),
+                                    Err(error) => println!("snapshot failed: {error:#}"),
+                                }
+                            }
                         }
-                        continue;
-                    }
-                    if trimmed == "/snapshots" {
-                        match self.list_snapshots().await {
+                        "/snapshots" => match self.list_snapshots().await {
                             Ok(snapshots) if snapshots.is_empty() => {
                                 println!("no snapshots yet for this conversation");
                             }
@@ -403,24 +406,25 @@ impl ChatRepl {
                                 }
                             }
                             Err(error) => println!("listing snapshots failed: {error:#}"),
+                        },
+                        other if let Some(arg) = other.strip_prefix("/rewind ") => {
+                            let arg = arg.trim();
+                            if arg.is_empty() {
+                                println!("usage: /rewind <snapshot-id>");
+                            } else if arg.contains(char::is_whitespace) {
+                                println!("/rewind takes exactly one snapshot id; got: {arg:?}");
+                            } else {
+                                match self.rewind_to_snapshot(arg).await {
+                                    Ok(()) => println!("rewound to snapshot {arg}"),
+                                    Err(error) => println!("rewind failed: {error:#}"),
+                                }
+                            }
                         }
-                        continue;
+                        _ => {
+                            self.editor.add_history_entry(line.as_str())?;
+                            self.send(trimmed).await?;
+                        }
                     }
-                    if let Some(arg) = trimmed.strip_prefix("/rewind ") {
-                        let snapshot_id_str = arg.trim();
-                        if snapshot_id_str.is_empty() {
-                            println!("usage: /rewind <snapshot-id>");
-                            continue;
-                        }
-                        match self.rewind_to_snapshot(snapshot_id_str).await {
-                            Ok(()) => println!("rewound to snapshot {snapshot_id_str}"),
-                            Err(error) => println!("rewind failed: {error:#}"),
-                        }
-                        continue;
-                    }
-
-                    self.editor.add_history_entry(line.as_str())?;
-                    self.send(trimmed).await?;
                 }
                 Err(ReadlineError::Interrupted) => {
                     println!();
@@ -441,15 +445,15 @@ impl ChatRepl {
         Ok(())
     }
 
-    /// Find the most recent `SandboxCreated` event and snapshot that sandbox.
-    /// The conversation's active sandbox must have been created (or started)
-    /// in *this* REPL session — running_sandboxes is a per-process map.
-    async fn snapshot_current_sandbox(&self) -> Result<SnapshotId> {
-        let sandbox_id = latest_sandbox_id(self.conversation.as_ref())
-            .await?
-            .ok_or_else(|| {
-                anyhow::anyhow!("no sandbox has been created in this conversation yet")
-            })?;
+    async fn snapshot_sandbox(&self, explicit_id: Option<SandboxId>) -> Result<SnapshotId> {
+        let sandbox_id = match explicit_id {
+            Some(id) => id,
+            None => latest_sandbox_id(self.conversation.as_ref())
+                .await?
+                .ok_or_else(|| {
+                    anyhow::anyhow!("no sandbox has been created in this conversation yet")
+                })?,
+        };
         let id = self
             .conversation
             .exoharness_handle()
@@ -645,7 +649,8 @@ fn print_help() {
     println!("repl commands:");
     println!("  /quit | /exit        exit the repl");
     println!("  /history             reprint the conversation transcript");
-    println!("  /snapshot            snapshot this conversation's running sandbox");
+    println!("  /snapshot [<id>]     snapshot a sandbox in this conversation");
+    println!("                       (defaults to the latest one if no id is given)");
     println!("  /snapshots           list snapshots taken in this conversation");
     println!("  /rewind <id>         restore the sandbox to a previous snapshot");
     println!("  /help                show this message");
@@ -654,26 +659,29 @@ fn print_help() {
 /// Walk the conversation's event log to find the latest `SandboxCreated`
 /// event, returning the sandbox id. Returns `None` if no sandbox has been
 /// created yet (e.g. nothing has been chatted with).
-async fn latest_sandbox_id(
-    conversation: &dyn HarnessConversation,
-) -> Result<Option<SandboxId>> {
+async fn latest_sandbox_id(conversation: &dyn HarnessConversation) -> Result<Option<SandboxId>> {
     let result = conversation
         .exoharness_handle()
         .get_events(Some(EventQuery {
             cursor: None,
             direction: Some(EventQueryDirection::Desc),
-            limit: Some(50),
+            limit: Some(1),
             session_id: None,
             turn_id: None,
-            types: Some(vec!["sandbox_created".to_string()]),
+            types: Some(vec![EventKind::SANDBOX_CREATED]),
         }))
         .await?;
-    for event in result.events {
-        if let EventData::SandboxCreated { sandbox_id, .. } = event.data {
-            return Ok(Some(sandbox_id));
-        }
+    let Some(event) = result.events.into_iter().next() else {
+        return Ok(None);
+    };
+    match event.data {
+        EventData::SandboxCreated { sandbox_id, .. } => Ok(Some(sandbox_id)),
+        other => anyhow::bail!(
+            "type-filtered query for {} returned unexpected variant {}",
+            EventKind::SANDBOX_CREATED.as_str(),
+            other.kind().as_str(),
+        ),
     }
-    Ok(None)
 }
 
 /// All snapshots taken in the conversation, oldest-first. Each tuple is
@@ -692,17 +700,23 @@ async fn list_snapshots(
                 limit: Some(100),
                 session_id: None,
                 turn_id: None,
-                types: Some(vec!["sandbox_snapshotted".to_string()]),
+                types: Some(vec![EventKind::SANDBOX_SNAPSHOTTED]),
             }))
             .await?;
         let events_empty = result.events.is_empty();
         for event in result.events {
-            if let EventData::SandboxSnapshotted {
-                sandbox_id,
-                snapshot_id,
-            } = event.data
-            {
-                out.push((snapshot_id, sandbox_id));
+            match event.data {
+                EventData::SandboxSnapshotted {
+                    sandbox_id,
+                    snapshot_id,
+                } => out.push((snapshot_id, sandbox_id)),
+                other => {
+                    anyhow::bail!(
+                        "type-filtered query for {} returned unexpected variant {}",
+                        EventKind::SANDBOX_SNAPSHOTTED.as_str(),
+                        other.kind().as_str(),
+                    );
+                }
             }
         }
         if events_empty || result.cursor.is_none() {

--- a/crates/cli/tests/snapshot_round_trip.rs
+++ b/crates/cli/tests/snapshot_round_trip.rs
@@ -1,0 +1,267 @@
+//! End-to-end snapshot + rewind round-trip for the Docker sandbox backend.
+//!
+//! This test is the canonical reference for how filesystem snapshots are
+//! used. It drives the harness API directly (no binary spawn, no LLM mock)
+//! and exercises the same lifecycle the manual REPL demo does:
+//!
+//!   1. create a sandbox
+//!   2. write `version 1` to a file via a real shell tool call
+//!   3. `snapshot_sandbox` — capture filesystem state
+//!   4. overwrite the file to `version 2` and create a sibling file
+//!   5. `start_sandbox` with the captured snapshot id — rewind
+//!   6. read the file back: it reads `version 1`, the sibling file is gone
+//!
+//! Linux + Docker only. `#[ignore]`'d so the regular `cargo test` skips it;
+//! CI runs it via `cargo test -- --ignored`. Self-skips when
+//! `EXO_TEST_SANDBOX_BACKEND` is set to anything other than `docker` so the
+//! matrix cells for other backends don't false-fail.
+
+#![cfg(target_os = "linux")]
+
+use std::process::Command;
+
+use exoharness::{
+    BasicExoHarness, BasicExoHarnessConfig, ConversationHandle, CreateSandboxRequest, ExoHarness,
+    NewAgentRequest, NewConversationRequest, RunInSandboxRequest, SandboxBackendChoice, SandboxId,
+    SecretBackendChoice, StartSandboxRequest,
+};
+use futures::io::AsyncReadExt;
+use tempfile::TempDir;
+
+/// Default sandbox image. We pin explicitly here rather than relying on
+/// `DEFAULT_SANDBOX_IMAGE` so a future change to the default doesn't
+/// silently affect what this test exercises.
+const SANDBOX_IMAGE: &str = "docker.io/library/ubuntu:24.04";
+
+#[tokio::test]
+#[ignore = "spawns a real docker container; run with `cargo test -- --ignored`"]
+async fn filesystem_snapshot_and_rewind_round_trip() {
+    if !preflight() {
+        return;
+    }
+
+    let root_dir = TempDir::new().expect("tempdir for harness root");
+    let harness = BasicExoHarness::new(BasicExoHarnessConfig {
+        root: root_dir.path().to_path_buf(),
+        // Static cipher key keeps the test off the filesystem for secret state;
+        // it's orthogonal to what we're testing (sandbox snapshots).
+        secret_backend: SecretBackendChoice::Static([7u8; 32]),
+        sandbox_backend: SandboxBackendChoice::Docker,
+    })
+    .await
+    .expect("BasicExoHarness::new should succeed");
+
+    let agent = harness
+        .new_agent(NewAgentRequest {
+            slug: "snap-test-agent".into(),
+            name: "snap-test agent".into(),
+        })
+        .await
+        .expect("new_agent");
+    let conversation = agent
+        .new_conversation(NewConversationRequest {
+            slug: Some("snap-test-conv".into()),
+            name: Some("snap-test conversation".into()),
+        })
+        .await
+        .expect("new_conversation");
+
+    // ───── Phase 1: create a docker sandbox and write the initial state ─────
+    let sandbox_id = conversation
+        .create_sandbox(CreateSandboxRequest {
+            image: SANDBOX_IMAGE.into(),
+            default_workdir: Some("/".into()),
+            file_system_mounts: None,
+            enable_networking: Some(false),
+            idle_seconds: Some(60),
+        })
+        .await
+        .expect("create_sandbox");
+
+    let (rc, _, _) = exec_shell(
+        conversation.as_ref(),
+        &sandbox_id,
+        "echo 'version 1' > /tmp/demo.txt",
+    )
+    .await;
+    assert_eq!(rc, 0, "writing v1 should succeed");
+
+    let (rc, stdout, _) = exec_shell(conversation.as_ref(), &sandbox_id, "cat /tmp/demo.txt").await;
+    assert_eq!(rc, 0);
+    assert_eq!(stdout.trim(), "version 1");
+
+    // ───── Phase 2: capture a snapshot of the sandbox at v1 ─────
+    let snapshot_id = conversation
+        .snapshot_sandbox(sandbox_id.clone())
+        .await
+        .expect("snapshot_sandbox should succeed");
+
+    // Verify the on-disk artefacts. Snapshots are stored under
+    //   <root>/agents/<agent>/conversations/<conv>/snapshots/<snapshot-id>/
+    // as a `manifest.json` + `payload.bin` pair. Using read_dir() here means
+    // the assertions document the layout without hard-coding the
+    // (test-generated) agent/conversation UUIDs.
+    let snapshot_dir = find_single_subdir(
+        &find_single_subdir(&root_dir.path().join("agents"))
+            .join("conversations"),
+    )
+    .join("snapshots")
+    .join(snapshot_id.to_string());
+    assert!(
+        snapshot_dir.exists(),
+        "snapshot directory should exist at {}",
+        snapshot_dir.display()
+    );
+    assert!(
+        snapshot_dir.join("manifest.json").exists(),
+        "snapshot manifest.json should exist"
+    );
+    let payload = snapshot_dir.join("payload.bin");
+    assert!(payload.exists(), "snapshot payload.bin should exist");
+    assert!(
+        payload.metadata().unwrap().len() > 0,
+        "snapshot payload.bin should not be empty"
+    );
+
+    // ───── Phase 3: mutate the sandbox after the snapshot ─────
+    //
+    // Two distinct mutations so the rewind correctness check has two
+    // independent signals:
+    //   (a) /tmp/demo.txt is overwritten — rewind must roll its content back
+    //   (b) /tmp/post-snapshot.txt is created — rewind must make it disappear
+    let (rc, _, _) = exec_shell(
+        conversation.as_ref(),
+        &sandbox_id,
+        "echo 'version 2' > /tmp/demo.txt && touch /tmp/post-snapshot.txt",
+    )
+    .await;
+    assert_eq!(rc, 0);
+
+    let (_, stdout, _) = exec_shell(conversation.as_ref(), &sandbox_id, "cat /tmp/demo.txt").await;
+    assert_eq!(stdout.trim(), "version 2", "before rewind, file should be v2");
+
+    let (rc, _, _) = exec_shell(
+        conversation.as_ref(),
+        &sandbox_id,
+        "test -f /tmp/post-snapshot.txt",
+    )
+    .await;
+    assert_eq!(rc, 0, "post-snapshot file should exist before rewind");
+
+    // ───── Phase 4: rewind to the snapshot ─────
+    conversation
+        .start_sandbox(StartSandboxRequest {
+            id: sandbox_id.clone(),
+            snapshot_id,
+            idle_seconds: None,
+        })
+        .await
+        .expect("start_sandbox (rewind) should succeed");
+
+    // ───── Phase 5: prove the rewind landed ─────
+    let (_, stdout, _) = exec_shell(conversation.as_ref(), &sandbox_id, "cat /tmp/demo.txt").await;
+    assert_eq!(
+        stdout.trim(),
+        "version 1",
+        "after rewind, /tmp/demo.txt should be 'version 1' again"
+    );
+
+    let (rc, _, _) = exec_shell(
+        conversation.as_ref(),
+        &sandbox_id,
+        "test -f /tmp/post-snapshot.txt",
+    )
+    .await;
+    assert_ne!(
+        rc, 0,
+        "after rewind, the post-snapshot file should be gone"
+    );
+
+    // ───── Cleanup ─────
+    //
+    // Explicitly stop the sandbox so the docker container is removed instead
+    // of leaking past the test's lifetime. TempDir handles the on-disk side.
+    let _ = conversation.stop_sandbox(sandbox_id).await;
+}
+
+/// Run a shell command in the conversation's sandbox and collect everything.
+/// Drives the streaming `SandboxProcess` to completion and returns the exit
+/// code along with full stdout/stderr.
+async fn exec_shell(
+    conversation: &dyn ConversationHandle,
+    sandbox_id: &SandboxId,
+    cmd: &str,
+) -> (i32, String, String) {
+    let process = conversation
+        .run_in_sandbox(RunInSandboxRequest {
+            id: sandbox_id.clone(),
+            command: vec!["/bin/bash".into(), "-c".into(), cmd.into()],
+            env: Default::default(),
+        })
+        .await
+        .unwrap_or_else(|error| panic!("run_in_sandbox({cmd:?}) failed: {error:#}"));
+
+    let mut parts = process.into_parts();
+    drop(parts.stdin);
+
+    let mut stdout_bytes = Vec::new();
+    let mut stderr_bytes = Vec::new();
+    let (stdout_result, stderr_result, wait_result) = tokio::join!(
+        parts.stdout.read_to_end(&mut stdout_bytes),
+        parts.stderr.read_to_end(&mut stderr_bytes),
+        parts.wait,
+    );
+    stdout_result.expect("read stdout");
+    stderr_result.expect("read stderr");
+    let exit_code = wait_result.expect("wait on sandbox process");
+    (
+        exit_code,
+        String::from_utf8_lossy(&stdout_bytes).into_owned(),
+        String::from_utf8_lossy(&stderr_bytes).into_owned(),
+    )
+}
+
+fn preflight() -> bool {
+    // Bail early if docker isn't usable.
+    let docker_ok = Command::new("docker")
+        .arg("info")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if !docker_ok {
+        eprintln!("docker not available, skipping filesystem-snapshot round-trip test");
+        return false;
+    }
+
+    // The integration workflow runs this test on every (os, sandbox-backend)
+    // matrix cell. Skip cleanly for cells that aren't testing the docker
+    // backend instead of failing them.
+    let backend = std::env::var("EXO_TEST_SANDBOX_BACKEND").unwrap_or_else(|_| "docker".into());
+    if backend != "docker" {
+        eprintln!(
+            "filesystem-snapshot round-trip test is docker-only; skipping \
+             (EXO_TEST_SANDBOX_BACKEND={backend})"
+        );
+        return false;
+    }
+
+    true
+}
+
+/// Read a directory expected to contain exactly one entry and return that
+/// entry's path. Used to walk into the per-agent / per-conversation directories
+/// without hardcoding the test-generated UUIDs.
+fn find_single_subdir(parent: &std::path::Path) -> std::path::PathBuf {
+    let mut entries: Vec<_> = std::fs::read_dir(parent)
+        .unwrap_or_else(|error| panic!("read_dir({}) failed: {error:#}", parent.display()))
+        .filter_map(Result::ok)
+        .collect();
+    assert_eq!(
+        entries.len(),
+        1,
+        "expected exactly one entry under {}, found {}",
+        parent.display(),
+        entries.len()
+    );
+    entries.pop().unwrap().path()
+}

--- a/crates/cli/tests/snapshot_round_trip.rs
+++ b/crates/cli/tests/snapshot_round_trip.rs
@@ -11,12 +11,12 @@
 //!   5. `start_sandbox` with the captured snapshot id — rewind
 //!   6. read the file back: it reads `version 1`, the sibling file is gone
 //!
-//! Linux + Docker only. `#[ignore]`'d so the regular `cargo test` skips it;
-//! CI runs it via `cargo test -- --ignored`. Self-skips when
-//! `EXO_TEST_SANDBOX_BACKEND` is set to anything other than `docker` so the
-//! matrix cells for other backends don't false-fail.
-
-#![cfg(target_os = "linux")]
+//! Backend-agnostic at the source level: docker works the same on Linux and
+//! macOS (Docker Desktop / Colima). `#[ignore]`'d so the regular `cargo test`
+//! skips it; CI runs it via `cargo test -- --ignored`. Self-skips when
+//! `EXO_TEST_SANDBOX_BACKEND` is set to anything other than `docker` (so the
+//! local-process matrix cells don't false-fail), and when `docker info` is
+//! unhappy on the runner.
 
 use std::process::Command;
 
@@ -234,8 +234,10 @@ fn preflight() -> bool {
     }
 
     // The integration workflow runs this test on every (os, sandbox-backend)
-    // matrix cell. Skip cleanly for cells that aren't testing the docker
-    // backend instead of failing them.
+    // matrix cell — including `*/local-process`. Skip cleanly for cells that
+    // aren't testing the docker backend instead of failing them. macOS+docker
+    // cells (Colima via the Intel runner) exercise this test exactly like
+    // Linux+docker cells.
     let backend = std::env::var("EXO_TEST_SANDBOX_BACKEND").unwrap_or_else(|_| "docker".into());
     if backend != "docker" {
         eprintln!(

--- a/crates/cli/tests/snapshot_round_trip.rs
+++ b/crates/cli/tests/snapshot_round_trip.rs
@@ -102,8 +102,7 @@ async fn filesystem_snapshot_and_rewind_round_trip() {
     // the assertions document the layout without hard-coding the
     // (test-generated) agent/conversation UUIDs.
     let snapshot_dir = find_single_subdir(
-        &find_single_subdir(&root_dir.path().join("agents"))
-            .join("conversations"),
+        &find_single_subdir(&root_dir.path().join("agents")).join("conversations"),
     )
     .join("snapshots")
     .join(snapshot_id.to_string());
@@ -138,7 +137,11 @@ async fn filesystem_snapshot_and_rewind_round_trip() {
     assert_eq!(rc, 0);
 
     let (_, stdout, _) = exec_shell(conversation.as_ref(), &sandbox_id, "cat /tmp/demo.txt").await;
-    assert_eq!(stdout.trim(), "version 2", "before rewind, file should be v2");
+    assert_eq!(
+        stdout.trim(),
+        "version 2",
+        "before rewind, file should be v2"
+    );
 
     let (rc, _, _) = exec_shell(
         conversation.as_ref(),
@@ -172,10 +175,7 @@ async fn filesystem_snapshot_and_rewind_round_trip() {
         "test -f /tmp/post-snapshot.txt",
     )
     .await;
-    assert_ne!(
-        rc, 0,
-        "after rewind, the post-snapshot file should be gone"
-    );
+    assert_ne!(rc, 0, "after rewind, the post-snapshot file should be gone");
 
     // ───── Cleanup ─────
     //

--- a/crates/executor/src/basic.rs
+++ b/crates/executor/src/basic.rs
@@ -4,7 +4,7 @@ use std::time::Instant;
 
 use async_trait::async_trait;
 use exoharness::{
-    AgentHandle, ConversationHandle, ConversationId, EventData, EventId, EventQuery,
+    AgentHandle, ConversationHandle, ConversationId, EventData, EventId, EventKind, EventQuery,
     EventQueryDirection, Result, ToolCallId, ToolRequest, TurnHandle,
 };
 use lingua::Message;
@@ -70,9 +70,9 @@ where
                 session_id: None,
                 turn_id: None,
                 types: Some(vec![
-                    "messages".to_string(),
-                    "tool_requested".to_string(),
-                    "tool_result".to_string(),
+                    EventKind::MESSAGES,
+                    EventKind::TOOL_REQUESTED,
+                    EventKind::TOOL_RESULT,
                 ]),
             }))
             .await?;

--- a/crates/executor/src/harness_basic_tests.rs
+++ b/crates/executor/src/harness_basic_tests.rs
@@ -7,9 +7,9 @@ use crate::{
 use anyhow::anyhow;
 use async_trait::async_trait;
 use exoharness::{
-    BasicExoHarness, BasicExoHarnessConfig, Binding, EventData, EventQuery, EventQueryDirection,
-    ExoHarness, FileSystemMount, FileSystemMountMode, PutSecretRequest, Result,
-    SandboxBackendChoice, Secret, SecretBackendChoice, ToolRequest, Uuid7,
+    BasicExoHarness, BasicExoHarnessConfig, Binding, EventData, EventKind, EventQuery,
+    EventQueryDirection, ExoHarness, FileSystemMount, FileSystemMountMode, PutSecretRequest,
+    Result, SandboxBackendChoice, Secret, SecretBackendChoice, ToolRequest, Uuid7,
 };
 
 fn local_test_config(root: impl Into<std::path::PathBuf>) -> BasicExoHarnessConfig {
@@ -391,7 +391,7 @@ async fn send_executes_shell_tool_when_enabled() {
             limit: None,
             session_id: None,
             turn_id: None,
-            types: Some(vec!["sandbox_created".to_string()]),
+            types: Some(vec![EventKind::SANDBOX_CREATED]),
         }))
         .await
         .expect("sandbox events should load")
@@ -547,7 +547,7 @@ async fn updating_mounts_recreates_shell_sandbox() {
             limit: None,
             session_id: None,
             turn_id: None,
-            types: Some(vec!["sandbox_created".to_string()]),
+            types: Some(vec![EventKind::SANDBOX_CREATED]),
         }))
         .await
         .expect("get sandbox events")
@@ -589,7 +589,7 @@ async fn updating_mounts_recreates_shell_sandbox() {
             limit: None,
             session_id: None,
             turn_id: None,
-            types: Some(vec!["sandbox_created".to_string()]),
+            types: Some(vec![EventKind::SANDBOX_CREATED]),
         }))
         .await
         .expect("get sandbox events after mount change")

--- a/crates/executor/src/harness_helpers.rs
+++ b/crates/executor/src/harness_helpers.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use exoharness::{
-    AddEventsRequest, AgentHandle, Binding, ConversationHandle, EventData, EventQuery,
+    AddEventsRequest, AgentHandle, Binding, ConversationHandle, EventData, EventKind, EventQuery,
     EventQueryDirection, ExoHarness, Result, Secret, ToolCallId, Uuid7,
 };
 use lingua::Message;
@@ -138,7 +138,9 @@ pub(crate) async fn get_conversation_model_override(
             limit: Some(1),
             session_id: None,
             turn_id: None,
-            types: Some(vec![CONVERSATION_MODEL_CONFIG_EVENT_TYPE.to_string()]),
+            types: Some(vec![EventKind::custom(
+                CONVERSATION_MODEL_CONFIG_EVENT_TYPE,
+            )]),
         }))
         .await?
         .events;

--- a/crates/executor/src/harness_tool.rs
+++ b/crates/executor/src/harness_tool.rs
@@ -1,9 +1,9 @@
 use crate::{AgentConfig, ConversationConfig, ToolRuntime};
 use async_trait::async_trait;
 use exoharness::{
-    ConversationHandle, CreateSandboxRequest, DEFAULT_SANDBOX_IMAGE, EventData, EventQuery,
-    EventQueryDirection, FileSystemMount, FileSystemMountMode, Result, RunInSandboxRequest,
-    ToolRequest, ToolResult,
+    ConversationHandle, CreateSandboxRequest, DEFAULT_SANDBOX_IMAGE, EventData, EventKind,
+    EventQuery, EventQueryDirection, FileSystemMount, FileSystemMountMode, Result,
+    RunInSandboxRequest, ToolRequest, ToolResult,
 };
 use futures::io::AsyncReadExt;
 use serde::{Deserialize, Serialize};
@@ -186,31 +186,34 @@ async fn latest_shell_sandbox(
             limit: Some(50),
             session_id: None,
             turn_id: None,
-            types: Some(vec!["sandbox_created".to_string()]),
+            types: Some(vec![EventKind::SANDBOX_CREATED]),
         }))
         .await?
         .events;
 
-    for event in events {
-        if let EventData::SandboxCreated {
+    let Some(event) = events.into_iter().next() else {
+        return Ok(None);
+    };
+    match event.data {
+        EventData::SandboxCreated {
             sandbox_id,
             image,
             default_workdir,
             file_system_mounts,
             enable_networking,
             idle_seconds,
-        } = event.data
-        {
-            return Ok(Some(ShellSandboxInfo {
-                id: sandbox_id,
-                image,
-                default_workdir,
-                file_system_mounts,
-                enable_networking,
-                idle_seconds,
-            }));
-        }
+        } => Ok(Some(ShellSandboxInfo {
+            id: sandbox_id,
+            image,
+            default_workdir,
+            file_system_mounts,
+            enable_networking,
+            idle_seconds,
+        })),
+        other => Err(anyhow::anyhow!(
+            "type-filtered query for {} returned unexpected variant {}",
+            EventKind::SANDBOX_CREATED.as_str(),
+            other.kind().as_str(),
+        )),
     }
-
-    Ok(None)
 }

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -32,7 +32,7 @@ pub use executor_types::{
 };
 pub use exoharness::{
     AgentHandle, BasicExoHarness, BasicExoHarnessConfig, Binding, BindingMetadata,
-    ConversationHandle, EventData, EventId, EventQuery, EventQueryDirection, ExoHarness,
+    ConversationHandle, EventData, EventId, EventKind, EventQuery, EventQueryDirection, ExoHarness,
     FileSystemMount, FileSystemMountMode, ForkConversationRequest, PutSecretRequest,
     SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, SandboxId, Secret, SecretBackendChoice,
     SecretMetadata, SessionId, SnapshotId, StartSandboxRequest, Uuid7,

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -34,8 +34,8 @@ pub use exoharness::{
     AgentHandle, BasicExoHarness, BasicExoHarnessConfig, Binding, BindingMetadata,
     ConversationHandle, EventData, EventId, EventQuery, EventQueryDirection, ExoHarness,
     FileSystemMount, FileSystemMountMode, ForkConversationRequest, PutSecretRequest,
-    SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, Secret, SecretBackendChoice, SecretMetadata,
-    SessionId, Uuid7,
+    SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, SandboxId, Secret, SecretBackendChoice,
+    SecretMetadata, SessionId, SnapshotId, StartSandboxRequest, Uuid7,
 };
 pub use harness_basic::BasicHarness;
 pub use harness_config::load_agent_config;

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -6,6 +6,8 @@ use std::sync::{Arc, Mutex};
 
 use anyhow::{Context, anyhow, bail};
 use async_trait::async_trait;
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
 use futures::StreamExt;
 use futures::stream::{self, BoxStream};
 use serde::{Deserialize, Serialize};
@@ -16,7 +18,7 @@ use crate::sandbox::{
     CliContainerSandboxBackend, LocalProcessSandboxBackend, ManagedSandboxBackend,
     ManagedSandboxHandle, SANDBOX_MAIN_MOUNT_DIR, SandboxCommand, SandboxKey,
     SandboxLifecycleConfig, SandboxMount, SandboxMountAccess, SandboxNetworkPolicy, SandboxRequest,
-    SandboxSpec,
+    SandboxSpec, SnapshotKind, SnapshotPayload,
 };
 use crate::secrets::{
     AppleKeychainSecretKeyProvider, EncryptedSecret, FileBackedSecretKeyProvider, SecretCipher,
@@ -921,9 +923,43 @@ impl ConversationHandle for BasicConversationHandle {
     }
 
     async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
+        // Capture the payload *before* taking the write lock — backends may
+        // need to talk to docker / pause the container, which can be slow.
+        // The lock is then only held for the metadata persistence below.
+        let handle = self
+            .harness
+            .inner
+            .running_sandboxes
+            .lock()
+            .await
+            .get(&id)
+            .cloned()
+            .ok_or_else(|| anyhow!("sandbox {id} is not running; start it before snapshotting"))?;
+        let payload = handle.snapshot().await?;
+
         let _guard = self.harness.inner.write_lock.lock().await;
         let mut sandbox = self.load_sandbox(&id).await?;
         let snapshot_id = Uuid7::now();
+
+        let manifest = StoredSnapshotManifest {
+            snapshot_id,
+            sandbox_id: id.clone(),
+            kind: payload.kind,
+            created_at: Utc::now(),
+            payload_size_bytes: payload.bytes.len() as u64,
+        };
+        let snapshot_dir = self.snapshot_dir(&snapshot_id);
+        self.harness
+            .inner
+            .storage
+            .put_bytes(snapshot_dir.join("payload.bin"), payload.bytes.to_vec())
+            .await?;
+        self.harness
+            .inner
+            .storage
+            .put_json(snapshot_dir.join("manifest.json"), &manifest)
+            .await?;
+
         sandbox.latest_snapshot_id = Some(snapshot_id);
         self.harness
             .inner
@@ -954,6 +990,35 @@ impl ConversationHandle for BasicConversationHandle {
     }
 
     async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
+        // Load the snapshot payload before acquiring the write lock — it can
+        // be many MB and we don't want to block writers while we read.
+        let snapshot_dir = self.snapshot_dir(&request.snapshot_id);
+        let manifest: StoredSnapshotManifest = self
+            .harness
+            .inner
+            .storage
+            .get_json(snapshot_dir.join("manifest.json"))
+            .await
+            .with_context(|| {
+                format!(
+                    "loading snapshot manifest for {} (have you taken a snapshot?)",
+                    request.snapshot_id
+                )
+            })?;
+        let payload_bytes = self
+            .harness
+            .inner
+            .storage
+            .get_bytes(snapshot_dir.join("payload.bin"))
+            .await
+            .with_context(|| {
+                format!("loading snapshot payload for {}", request.snapshot_id)
+            })?;
+        let payload = SnapshotPayload {
+            kind: manifest.kind,
+            bytes: Bytes::from(payload_bytes),
+        };
+
         let _guard = self.harness.inner.write_lock.lock().await;
         let mut sandbox = self.load_sandbox(&request.id).await?;
         sandbox.running = true;
@@ -975,7 +1040,10 @@ impl ConversationHandle for BasicConversationHandle {
             .harness
             .inner
             .sandbox_backend
-            .acquire(sandbox_request(self.record.id, &request.id, &sandbox))
+            .acquire_from_snapshot(
+                sandbox_request(self.record.id, &request.id, &sandbox),
+                payload,
+            )
             .await?;
         self.harness
             .inner
@@ -1249,6 +1317,14 @@ impl BasicConversationHandle {
         self.conversation_dir().join("sandboxes")
     }
 
+    fn snapshots_dir(&self) -> PathBuf {
+        self.conversation_dir().join("snapshots")
+    }
+
+    fn snapshot_dir(&self, snapshot_id: &SnapshotId) -> PathBuf {
+        self.snapshots_dir().join(snapshot_id.to_string())
+    }
+
     async fn load_record(&self) -> Result<ConversationRecord> {
         self.harness
             .inner
@@ -1471,6 +1547,21 @@ struct StoredSandbox {
     idle_seconds: u64,
     running: bool,
     latest_snapshot_id: Option<SnapshotId>,
+}
+
+/// Sidecar JSON describing a snapshot payload.
+///
+/// Lives at `{conversation_dir}/snapshots/{snapshot_id}/manifest.json` alongside
+/// the payload blob at `payload.bin`. The `kind` controls how the payload is
+/// interpreted on restore — only a backend that recognises that kind can
+/// reconstruct a sandbox from it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredSnapshotManifest {
+    snapshot_id: SnapshotId,
+    sandbox_id: SandboxId,
+    kind: SnapshotKind,
+    created_at: DateTime<Utc>,
+    payload_size_bytes: u64,
 }
 
 struct LiveSandboxProcess {

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -629,7 +629,7 @@ impl ConversationHandle for BasicConversationHandle {
                 events.retain(|event| event.turn_id == Some(turn_id));
             }
             if let Some(types) = query.types {
-                events.retain(|event| types.iter().any(|ty| event_type(&event.data) == *ty));
+                events.retain(|event| types.contains(&event.data.kind()));
             }
             match query.direction.unwrap_or(EventQueryDirection::Asc) {
                 EventQueryDirection::Asc => {
@@ -949,16 +949,11 @@ impl ConversationHandle for BasicConversationHandle {
             payload_size_bytes: payload.bytes.len() as u64,
         };
         let snapshot_dir = self.snapshot_dir(&snapshot_id);
-        self.harness
-            .inner
-            .storage
-            .put_bytes(snapshot_dir.join("payload.bin"), payload.bytes.to_vec())
-            .await?;
-        self.harness
-            .inner
-            .storage
-            .put_json(snapshot_dir.join("manifest.json"), &manifest)
-            .await?;
+        let storage = &self.harness.inner.storage;
+        tokio::try_join!(
+            storage.put_bytes(snapshot_dir.join("payload.bin"), payload.bytes.to_vec()),
+            storage.put_json(snapshot_dir.join("manifest.json"), &manifest),
+        )?;
 
         sandbox.latest_snapshot_id = Some(snapshot_id);
         self.harness
@@ -993,27 +988,19 @@ impl ConversationHandle for BasicConversationHandle {
         // Load the snapshot payload before acquiring the write lock — it can
         // be many MB and we don't want to block writers while we read.
         let snapshot_dir = self.snapshot_dir(&request.snapshot_id);
-        let manifest: StoredSnapshotManifest = self
-            .harness
-            .inner
-            .storage
-            .get_json(snapshot_dir.join("manifest.json"))
-            .await
-            .with_context(|| {
-                format!(
-                    "loading snapshot manifest for {} (have you taken a snapshot?)",
-                    request.snapshot_id
-                )
-            })?;
-        let payload_bytes = self
-            .harness
-            .inner
-            .storage
-            .get_bytes(snapshot_dir.join("payload.bin"))
-            .await
-            .with_context(|| {
-                format!("loading snapshot payload for {}", request.snapshot_id)
-            })?;
+        let storage = &self.harness.inner.storage;
+        let (manifest_result, payload_result) = tokio::join!(
+            storage.get_json::<StoredSnapshotManifest>(snapshot_dir.join("manifest.json")),
+            storage.get_bytes(snapshot_dir.join("payload.bin")),
+        );
+        let manifest = manifest_result.with_context(|| {
+            format!(
+                "loading snapshot manifest for {} (have you taken a snapshot?)",
+                request.snapshot_id
+            )
+        })?;
+        let payload_bytes = payload_result
+            .with_context(|| format!("loading snapshot payload for {}", request.snapshot_id))?;
         let payload = SnapshotPayload {
             kind: manifest.kind,
             bytes: Bytes::from(payload_bytes),
@@ -1887,25 +1874,6 @@ fn merge_secret_metadata(scopes: Vec<Vec<SecretMetadata>>) -> Vec<SecretMetadata
     let mut secrets = effective.into_values().collect::<Vec<_>>();
     secrets.sort_by_key(|metadata| metadata.id);
     secrets
-}
-
-fn event_type(data: &EventData) -> String {
-    match data {
-        EventData::ConversationForked { .. } => "conversation_forked".to_string(),
-        EventData::SessionStarted => "session_started".to_string(),
-        EventData::SessionEnded => "session_ended".to_string(),
-        EventData::TurnStarted => "turn_started".to_string(),
-        EventData::TurnEnded => "turn_ended".to_string(),
-        EventData::Messages { .. } => "messages".to_string(),
-        EventData::ToolRequested { .. } => "tool_requested".to_string(),
-        EventData::ToolResult { .. } => "tool_result".to_string(),
-        EventData::ArtifactWritten { .. } => "artifact_written".to_string(),
-        EventData::SandboxCreated { .. } => "sandbox_created".to_string(),
-        EventData::SandboxStarted { .. } => "sandbox_started".to_string(),
-        EventData::SandboxStopped { .. } => "sandbox_stopped".to_string(),
-        EventData::SandboxSnapshotted { .. } => "sandbox_snapshotted".to_string(),
-        EventData::Custom { event_type, .. } => event_type.clone(),
-    }
 }
 
 fn binding_type(binding: &Binding) -> BindingType {

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -6,7 +6,7 @@ use tokio::fs;
 
 use crate::{
     Artifact, ArtifactVersion, BasicExoHarness, BasicExoHarnessConfig, BeginTurnRequest, Binding,
-    CreateSandboxRequest, EventData, EventQuery, EventQueryDirection, ExoHarness,
+    CreateSandboxRequest, EventData, EventKind, EventQuery, EventQueryDirection, ExoHarness,
     ForkConversationRequest, NewAgentRequest, NewConversationRequest, PutSecretRequest,
     RunInSandboxRequest, SandboxBackendChoice, Secret, SecretBackendChoice, WriteArtifactRequest,
 };
@@ -165,7 +165,7 @@ async fn turn_events_continue_after_artifact_writes() {
             limit: None,
             session_id: None,
             turn_id: None,
-            types: Some(vec!["artifact_written".to_string()]),
+            types: Some(vec![EventKind::ARTIFACT_WRITTEN]),
         }))
         .await
         .expect("artifact event")

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -147,7 +147,7 @@ pub trait ManagedSandboxBackend: Send + Sync {
     ) -> Result<Arc<dyn ManagedSandboxHandle>>;
 }
 
-pub const DEFAULT_SANDBOX_IMAGE: &str = "docker.io/library/debian:bookworm";
+pub const DEFAULT_SANDBOX_IMAGE: &str = "docker.io/library/ubuntu:24.04";
 pub const SANDBOX_HOME_DIR: &str = "/home/exo";
 pub const SANDBOX_MAIN_MOUNT_DIR: &str = "/home/exo/workspace";
 

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -9,7 +9,8 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use anyhow::{Context, Result, anyhow, bail};
 use async_trait::async_trait;
 use futures::future::BoxFuture;
-use serde::Deserialize;
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
 use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 use tokio::time;
@@ -94,6 +95,27 @@ pub struct SandboxCommandOutput {
     pub cwd: String,
 }
 
+/// Opaque blob produced by `ManagedSandboxHandle::snapshot` and consumed by
+/// `ManagedSandboxBackend::acquire_from_snapshot`. The `kind` tag is the
+/// contract: a snapshot produced by one backend can only be restored by a
+/// backend that knows how to interpret that kind.
+#[derive(Debug, Clone)]
+pub struct SnapshotPayload {
+    pub kind: SnapshotKind,
+    pub bytes: Bytes,
+}
+
+/// Tag identifying the on-disk format of a snapshot payload. Backends both
+/// produce and consume a specific kind; the conversation layer just hands the
+/// bytes back to the same backend type that produced them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SnapshotKind {
+    /// `docker save` output: a tar of OCI image layers + manifest, loadable
+    /// with `docker load`.
+    DockerImageTar,
+}
+
 #[async_trait]
 pub trait ManagedSandboxHandle: Send + Sync {
     fn id(&self) -> &str;
@@ -103,11 +125,26 @@ pub trait ManagedSandboxHandle: Send + Sync {
     async fn start_process(&self, command: &SandboxCommand) -> Result<crate::SandboxProcessParts>;
 
     async fn stop(&self) -> Result<()>;
+
+    /// Capture the sandbox's current state as an opaque blob. Returns an
+    /// error if this backend doesn't (yet) support snapshotting.
+    async fn snapshot(&self) -> Result<SnapshotPayload>;
 }
 
 #[async_trait]
 pub trait ManagedSandboxBackend: Send + Sync {
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>>;
+
+    /// Acquire a sandbox initialised from a previously-captured snapshot.
+    /// The request is honoured for mounts, network, lifecycle, etc., but the
+    /// container's filesystem is sourced from the payload instead of
+    /// `request.spec.image`. Returns an error if this backend can't restore
+    /// the supplied `payload.kind`.
+    async fn acquire_from_snapshot(
+        &self,
+        request: SandboxRequest,
+        payload: SnapshotPayload,
+    ) -> Result<Arc<dyn ManagedSandboxHandle>>;
 }
 
 pub const DEFAULT_SANDBOX_IMAGE: &str = "docker.io/library/debian:bookworm";
@@ -384,6 +421,62 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
             warm_sandboxes: Arc::clone(&self.warm_sandboxes),
         }))
     }
+
+    async fn acquire_from_snapshot(
+        &self,
+        request: SandboxRequest,
+        payload: SnapshotPayload,
+    ) -> Result<Arc<dyn ManagedSandboxHandle>> {
+        if request.lifecycle.idle_ttl.is_none() {
+            bail!("restore-from-snapshot requires a warm sandbox lifecycle (idle_ttl must be set)");
+        }
+        match (self.cli, payload.kind) {
+            (ContainerCliFlavor::Docker, SnapshotKind::DockerImageTar) => {}
+            (ContainerCliFlavor::AppleContainer, _) => bail!(
+                "restore-from-snapshot is not yet implemented for the apple-container backend"
+            ),
+        }
+
+        let image_tag = docker_load_image(&self.container_bin, &payload.bytes).await?;
+
+        // Build a fresh request that points at the loaded image. Mounts,
+        // network policy, lifecycle, and key are all preserved from the
+        // original request so the restored sandbox is otherwise identical.
+        let mut request = self.prepare_request(request).await?;
+        request.spec.image = image_tag;
+
+        // Evict any pre-existing warm container for this key — we want a
+        // fresh container booted from the restored image, not a reuse of
+        // whatever was running before.
+        let replaced = {
+            let mut warm_sandboxes = self.warm_sandboxes.lock().await;
+            warm_sandboxes.remove(&request.key)
+        };
+        if let Some(entry) = replaced {
+            schedule_cleanup_named_container(self.container_bin.clone(), self.cli, entry.name);
+        }
+
+        let name = create_unique_warm_sandbox(&self.container_bin, &request).await?;
+        {
+            let mut warm_sandboxes = self.warm_sandboxes.lock().await;
+            warm_sandboxes.insert(
+                request.key.clone(),
+                WarmSandboxEntry {
+                    name: name.clone(),
+                    request: request.clone(),
+                    last_used_at: Instant::now(),
+                },
+            );
+        }
+
+        Ok(Arc::new(WarmSandboxHandle {
+            id: format!("warm:{}", request.key),
+            cli: self.cli,
+            container_bin: self.container_bin.clone(),
+            request,
+            warm_sandboxes: Arc::clone(&self.warm_sandboxes),
+        }))
+    }
 }
 
 struct OneShotSandboxHandle {
@@ -420,6 +513,12 @@ impl ManagedSandboxHandle for OneShotSandboxHandle {
 
     async fn stop(&self) -> Result<()> {
         Ok(())
+    }
+
+    async fn snapshot(&self) -> Result<SnapshotPayload> {
+        bail!(
+            "snapshot is not supported for one-shot sandboxes (set a positive idle_ttl to enable warm sandbox + snapshotting)"
+        )
     }
 }
 
@@ -475,6 +574,33 @@ impl ManagedSandboxHandle for WarmSandboxHandle {
             Ok(())
         }
     }
+
+    async fn snapshot(&self) -> Result<SnapshotPayload> {
+        match self.cli {
+            ContainerCliFlavor::Docker => {
+                let name = ensure_warm_sandbox_ready(
+                    &self.container_bin,
+                    self.cli,
+                    &self.request,
+                    &self.warm_sandboxes,
+                )
+                .await?;
+                touch_warm_sandbox(&self.warm_sandboxes, &self.request.key).await;
+                docker_snapshot_container(&self.container_bin, &name).await
+            }
+            // The Apple `container` CLI exposes `container image save` and a
+            // `container commit`-style flow on its roadmap but neither is in
+            // the released versions we target today. When it lands, the path
+            // will mirror docker_snapshot_container: produce a single tarball
+            // and tag it with a new SnapshotKind variant (e.g.
+            // AppleContainerImageTar). Until then, fail explicitly so callers
+            // know to choose Docker for snapshot-using flows.
+            ContainerCliFlavor::AppleContainer => bail!(
+                "snapshot is not yet implemented for the apple-container backend; \
+                 use --sandbox-backend docker for snapshot-using flows"
+            ),
+        }
+    }
 }
 
 #[derive(Debug, Default)]
@@ -493,6 +619,14 @@ impl ManagedSandboxBackend for LocalProcessSandboxBackend {
             id: format!("local:{}", request.key),
             request,
         }))
+    }
+
+    async fn acquire_from_snapshot(
+        &self,
+        _request: SandboxRequest,
+        _payload: SnapshotPayload,
+    ) -> Result<Arc<dyn ManagedSandboxHandle>> {
+        bail!("restore-from-snapshot is not supported by the local-process sandbox backend")
     }
 }
 
@@ -545,6 +679,15 @@ impl ManagedSandboxHandle for LocalProcessSandboxHandle {
 
     async fn stop(&self) -> Result<()> {
         Ok(())
+    }
+
+    async fn snapshot(&self) -> Result<SnapshotPayload> {
+        // The local-process backend runs commands directly on the host; there
+        // is no container filesystem to capture. A meaningful implementation
+        // would tar up the writable mounts, but the semantics differ enough
+        // from container snapshots (no isolated filesystem, no rollback of
+        // host-side state) that we don't pretend to support it.
+        bail!("snapshot is not supported by the local-process sandbox backend")
     }
 }
 
@@ -1175,4 +1318,134 @@ fn new_warm_container_name(key: &SandboxKey) -> String {
     let hash = hasher.finish();
     let generation = Uuid::new_v4().simple().to_string();
     format!("exo-{hash:016x}-{}", &generation[..8])
+}
+
+/// Capture a docker container's filesystem state as a SnapshotPayload.
+///
+/// Pipeline:
+///   docker commit -p <container>  exo-snap-<uuid>     // image from container fs
+///   docker save exo-snap-<uuid>                       // tarball on stdout
+///   docker image rm exo-snap-<uuid>                   // local image no longer needed
+///
+/// `commit -p` pauses the container during commit to ensure a consistent
+/// filesystem capture (no half-written files).
+async fn docker_snapshot_container(
+    container_bin: &Path,
+    container_name: &str,
+) -> Result<SnapshotPayload> {
+    let snap_tag = format!("exo-snap-{}", Uuid::new_v4().simple());
+
+    let commit_output = Command::new(container_bin)
+        .arg("commit")
+        .arg("-p")
+        .arg(container_name)
+        .arg(&snap_tag)
+        .output()
+        .await
+        .with_context(|| format!("running `docker commit` for {container_name}"))?;
+    if !commit_output.status.success() {
+        bail!(
+            "docker commit {container_name} {snap_tag} failed: {}",
+            render_command_error(&commit_output.stderr)
+        );
+    }
+
+    let save_output = Command::new(container_bin)
+        .arg("save")
+        .arg(&snap_tag)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .await
+        .with_context(|| format!("running `docker save {snap_tag}`"))?;
+    if !save_output.status.success() {
+        // Best-effort cleanup of the tag we just created.
+        let _ = Command::new(container_bin)
+            .arg("image")
+            .arg("rm")
+            .arg(&snap_tag)
+            .output()
+            .await;
+        bail!(
+            "docker save {snap_tag} failed: {}",
+            render_command_error(&save_output.stderr)
+        );
+    }
+    let bytes = Bytes::from(save_output.stdout);
+
+    // Remove the local image tag now that the bytes are captured — the
+    // canonical store of the snapshot is exoharness, not the docker daemon.
+    let rm_output = Command::new(container_bin)
+        .arg("image")
+        .arg("rm")
+        .arg(&snap_tag)
+        .output()
+        .await;
+    if let Ok(output) = &rm_output
+        && !output.status.success()
+    {
+        eprintln!(
+            "warning: failed to remove ephemeral snapshot image {snap_tag}: {}",
+            render_command_error(&output.stderr)
+        );
+    }
+
+    Ok(SnapshotPayload {
+        kind: SnapshotKind::DockerImageTar,
+        bytes,
+    })
+}
+
+/// Load a docker-save tarball back into the local docker daemon and return
+/// the image reference docker assigned to it. The reference is what
+/// subsequent `docker run` invocations use to start a container from this
+/// snapshot's state.
+async fn docker_load_image(container_bin: &Path, payload: &Bytes) -> Result<String> {
+    use tokio::io::AsyncWriteExt;
+
+    let mut child = Command::new(container_bin)
+        .arg("load")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("spawning `docker load`")?;
+    let mut stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow!("docker load: failed to acquire stdin"))?;
+    stdin
+        .write_all(payload)
+        .await
+        .context("writing snapshot bytes to `docker load` stdin")?;
+    stdin.shutdown().await.ok();
+    drop(stdin);
+
+    let output = child
+        .wait_with_output()
+        .await
+        .context("waiting on `docker load`")?;
+    if !output.status.success() {
+        bail!(
+            "docker load failed: {}",
+            render_command_error(&output.stderr)
+        );
+    }
+
+    // docker load prints lines like:
+    //   Loaded image: <ref>
+    //   Loaded image ID: sha256:<digest>
+    // Prefer the named-tag line; fall back to image-ID.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    for line in stdout.lines() {
+        if let Some(rest) = line.strip_prefix("Loaded image: ") {
+            return Ok(rest.trim().to_string());
+        }
+    }
+    for line in stdout.lines() {
+        if let Some(rest) = line.strip_prefix("Loaded image ID: ") {
+            return Ok(rest.trim().to_string());
+        }
+    }
+    bail!("docker load completed but no image reference found in output: {stdout}")
 }

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -8,8 +8,8 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result, anyhow, bail};
 use async_trait::async_trait;
-use futures::future::BoxFuture;
 use bytes::Bytes;
+use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
 use tokio::process::{Child, Command};
 use tokio::sync::Mutex;

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::ops::Bound;
 use std::pin::Pin;
@@ -147,7 +148,44 @@ pub struct EventQuery {
     pub limit: Option<u32>,
     pub session_id: Option<SessionId>,
     pub turn_id: Option<TurnId>,
-    pub types: Option<Vec<String>>,
+    pub types: Option<Vec<EventKind>>,
+}
+
+/// Tag identifying an `EventData` variant — used by `EventQuery::types` to
+/// filter events by kind without stringly comparing snake_case names. The
+/// constants below cover every built-in variant; `EventKind::custom(name)`
+/// is the escape hatch for `EventData::Custom { event_type, .. }`.
+///
+/// Wire format is the same single-string-per-kind shape the underlying
+/// `EventData` serde tag uses (`#[serde(transparent)]`), so changing
+/// `EventQuery::types` from `Vec<String>` to `Vec<EventKind>` is a
+/// source-level change only.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct EventKind(Cow<'static, str>);
+
+impl EventKind {
+    pub const CONVERSATION_FORKED: EventKind = EventKind(Cow::Borrowed("conversation_forked"));
+    pub const SESSION_STARTED: EventKind = EventKind(Cow::Borrowed("session_started"));
+    pub const SESSION_ENDED: EventKind = EventKind(Cow::Borrowed("session_ended"));
+    pub const TURN_STARTED: EventKind = EventKind(Cow::Borrowed("turn_started"));
+    pub const TURN_ENDED: EventKind = EventKind(Cow::Borrowed("turn_ended"));
+    pub const MESSAGES: EventKind = EventKind(Cow::Borrowed("messages"));
+    pub const TOOL_REQUESTED: EventKind = EventKind(Cow::Borrowed("tool_requested"));
+    pub const TOOL_RESULT: EventKind = EventKind(Cow::Borrowed("tool_result"));
+    pub const ARTIFACT_WRITTEN: EventKind = EventKind(Cow::Borrowed("artifact_written"));
+    pub const SANDBOX_CREATED: EventKind = EventKind(Cow::Borrowed("sandbox_created"));
+    pub const SANDBOX_STARTED: EventKind = EventKind(Cow::Borrowed("sandbox_started"));
+    pub const SANDBOX_STOPPED: EventKind = EventKind(Cow::Borrowed("sandbox_stopped"));
+    pub const SANDBOX_SNAPSHOTTED: EventKind = EventKind(Cow::Borrowed("sandbox_snapshotted"));
+
+    pub fn custom(name: impl Into<Cow<'static, str>>) -> Self {
+        Self(name.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -246,6 +284,29 @@ pub enum EventData {
         event_type: String,
         payload: Value,
     },
+}
+
+impl EventData {
+    /// Tag identifying this event's variant. Source of truth for the
+    /// `EventQuery::types` filter on `get_events`.
+    pub fn kind(&self) -> EventKind {
+        match self {
+            Self::ConversationForked { .. } => EventKind::CONVERSATION_FORKED,
+            Self::SessionStarted => EventKind::SESSION_STARTED,
+            Self::SessionEnded => EventKind::SESSION_ENDED,
+            Self::TurnStarted => EventKind::TURN_STARTED,
+            Self::TurnEnded => EventKind::TURN_ENDED,
+            Self::Messages { .. } => EventKind::MESSAGES,
+            Self::ToolRequested { .. } => EventKind::TOOL_REQUESTED,
+            Self::ToolResult { .. } => EventKind::TOOL_RESULT,
+            Self::ArtifactWritten { .. } => EventKind::ARTIFACT_WRITTEN,
+            Self::SandboxCreated { .. } => EventKind::SANDBOX_CREATED,
+            Self::SandboxStarted { .. } => EventKind::SANDBOX_STARTED,
+            Self::SandboxStopped { .. } => EventKind::SANDBOX_STOPPED,
+            Self::SandboxSnapshotted { .. } => EventKind::SANDBOX_SNAPSHOTTED,
+            Self::Custom { event_type, .. } => EventKind::custom(event_type.clone()),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/docs/sandbox-snapshots.md
+++ b/docs/sandbox-snapshots.md
@@ -1,0 +1,224 @@
+# Sandbox Snapshots
+
+Status: implemented for the Docker sandbox backend; stubs in place for the
+other backends.
+
+## Summary
+
+A snapshot captures the current filesystem state of a sandboxed container so
+that the sandbox can later be rewound to that state. Snapshots are taken,
+listed, and replayed within an `exo` conversation. They give the user — or in
+a later iteration, an executor policy — the ability to time-travel a
+sandbox's state without forking the conversation itself.
+
+The earlier model only recorded snapshot _metadata_ (a UUID written to the
+event log). This work adds the captured artifact, the persistence layer for
+it, and the restore path that actually consumes it.
+
+## What you get
+
+- `ConversationHandle::snapshot_sandbox(id)` actually captures the live
+  container's filesystem and persists it.
+- `ConversationHandle::start_sandbox(StartSandboxRequest { id, snapshot_id, .. })`
+  starts a fresh container whose filesystem is sourced from the snapshot,
+  preserving the original sandbox's mounts, network policy, and lifecycle.
+- A chat-REPL slash-command surface — `/snapshot`, `/snapshots`, `/rewind <id>`
+  — that drives the round-trip without leaving the conversation.
+
+## What this is not
+
+- **Not a process or memory checkpoint.** Only filesystem state is captured.
+  Running processes inside the container are not preserved; they are
+  re-launched fresh from the restored image.
+- **Not a conversation rewind.** The event log, message history, and prior
+  tool calls are untouched. Use `conversation fork` to rewind the
+  conversation itself.
+- **Not yet cross-process.** A snapshot can only be taken of a sandbox that
+  is live in the _current_ `exo` process (`running_sandboxes` is per-process).
+  See "Known limits" below.
+
+## Model
+
+Snapshots are an interaction between three layers:
+
+```
+ConversationHandle             ManagedSandboxHandle           ManagedSandboxBackend
+       │                              │                                │
+  snapshot_sandbox(id) ──► running_sandboxes.get(id).snapshot() ──┐    │
+       │                                                          │    │
+       ◄────────── SnapshotPayload { kind, bytes } ────────────────┘    │
+       │                                                                │
+  put_bytes / put_json                                                  │
+  (manifest.json + payload.bin)                                         │
+                                                                        │
+  start_sandbox(req) ─── load manifest + payload ──► acquire_from_snapshot(req, payload)
+```
+
+`ConversationHandle` orchestrates: it locates the live handle, asks for a
+payload, persists the bytes, updates sandbox metadata, and emits the
+`SandboxSnapshotted` event. `ManagedSandboxHandle::snapshot` and
+`ManagedSandboxBackend::acquire_from_snapshot` are the backend-specific
+methods that produce and consume the bytes.
+
+### SnapshotPayload and SnapshotKind
+
+```rust
+pub struct SnapshotPayload {
+    pub kind: SnapshotKind,
+    pub bytes: Bytes,
+}
+
+pub enum SnapshotKind {
+    DockerImageTar,
+    // future: AppleContainerImageTar, etc.
+}
+```
+
+`SnapshotPayload` is opaque to the harness. The `kind` tag is the contract
+between producer and consumer: a payload produced by one backend can only be
+restored by a backend that knows how to interpret that kind. The harness
+never inspects `bytes` — it just persists them and hands them back on
+restore.
+
+## Docker pipeline
+
+`ManagedSandboxHandle::snapshot` (Docker):
+
+1. `ensure_warm_sandbox_ready` — make sure the container exists and is the
+   one in the warm cache for this `SandboxKey`.
+2. `docker commit -p <container> exo-snap-<uuid>` — pause the container
+   during commit for a consistent filesystem capture, then create a new
+   image from its layers.
+3. `docker save exo-snap-<uuid>` — export the image as a tarball on stdout;
+   capture into `Bytes`.
+4. `docker image rm exo-snap-<uuid>` — drop the local image. The canonical
+   store of the snapshot lives in exoharness storage, not the docker daemon.
+
+`ManagedSandboxBackend::acquire_from_snapshot` (Docker):
+
+1. Validate that `payload.kind == DockerImageTar`.
+2. `docker load < payload.bytes` — load the image back into the local
+   daemon; parse stdout to find the assigned image reference (the line
+   `Loaded image: <ref>`).
+3. Build a fresh `SandboxRequest` with `spec.image` swapped for the loaded
+   reference. Mounts, network policy, default workdir, lifecycle, and
+   `SandboxKey` are preserved from the original request.
+4. Evict any pre-existing warm container for this key (we want a fresh
+   container booted from the restored image, not a reuse of whatever was
+   running before).
+5. `docker run --detach …` with the loaded image — exactly the same path as
+   a normal cold-start container, just with a different image.
+
+## On-disk layout
+
+Snapshots live under the conversation directory, alongside other
+conversation-scoped artifacts:
+
+```
+agents/<agent_id>/conversations/<conversation_id>/snapshots/<snapshot_id>/
+├── manifest.json   JSON sidecar (StoredSnapshotManifest)
+└── payload.bin     raw blob (docker save tarball for SnapshotKind::DockerImageTar)
+```
+
+The manifest schema:
+
+```json
+{
+  "snapshot_id": "019e5782-7c6b-72a2-b4fa-a81bf56eb37e",
+  "sandbox_id": "sandbox-019e5782-2a46-7970-a5bf-62900a2233e8",
+  "kind": "docker_image_tar",
+  "created_at": "2026-05-24T01:03:49.867230008Z",
+  "payload_size_bytes": 48498688
+}
+```
+
+This mirrors the existing artifact layout (sidecar `.json` + `.bin` blob in
+a per-id directory). A future migration to chunked or streamed storage
+would touch a small surface.
+
+The snapshot's existence is also recorded in the conversation event log as
+`SandboxSnapshotted { sandbox_id, snapshot_id }`, which is what
+`/snapshots` walks to list past snapshots.
+
+## CLI surface
+
+Inside the chat REPL (`exo chat repl <agent> <conv>`):
+
+```
+/snapshot           capture the conversation's currently-running sandbox;
+                    prints the new snapshot id
+/snapshots          list snapshots taken in this conversation
+/rewind <id>        stop the current sandbox, start a fresh one from the
+                    named snapshot
+/help               show command list
+```
+
+There is intentionally no top-level `exo conversation snapshot` subcommand
+today — see "Known limits" for the cross-invocation gap that makes such
+a subcommand useless until it's resolved.
+
+## Extending to another sandbox backend
+
+To add snapshot support for a new backend (say, Apple's `container` CLI
+when it grows a commit/save flow):
+
+1. Add a new variant to `SnapshotKind` — e.g. `AppleContainerImageTar`.
+   The tag is the contract; pick a name that names the on-disk format.
+2. Implement `ManagedSandboxHandle::snapshot` for that backend's handle
+   type, producing the appropriate `SnapshotPayload`. The Docker version in
+   `docker_snapshot_container` is the template — three CLI calls and a
+   `Bytes` capture.
+3. Implement `ManagedSandboxBackend::acquire_from_snapshot` to consume the
+   same `kind`, including the safety check that the payload's `kind`
+   matches what the backend understands. The Docker version is the
+   template here too — load the bytes, get the loaded image reference,
+   swap `request.spec.image`, evict + recreate the warm container.
+4. Backends that genuinely can't snapshot (the local-process backend
+   today, since there's no isolated filesystem) should return an explicit
+   error from both methods rather than silently degrading.
+
+No other layer changes. The conversation orchestration, on-disk layout,
+and CLI surface are all backend-agnostic.
+
+## Known limits
+
+### Cross-invocation container adoption
+
+Today each `exo` process maintains its own `running_sandboxes` map. A
+container created by one invocation is not adopted by a later one even
+though it is still alive on the docker daemon, so snapshots can only be
+taken of sandboxes acquired in the current process. That is why the
+snapshot/rewind UX lives in the chat REPL (one long-running process holds
+the container for the conversation's duration) rather than as standalone
+`exo` subcommands.
+
+The fix is well-scoped — on `acquire`, query
+`docker ps --filter label=exo.sandbox.key=<key> --filter status=running` and
+adopt the existing container if its `exo.sandbox.spec-hash` label matches
+the requested spec. Once that lands, `exo conversation snapshot` and
+`exo conversation rewind` become trivial CLI subcommands that just call the
+same `ConversationHandle` methods the REPL slash commands use.
+
+### Payload size
+
+`SnapshotPayload::bytes` is a single `Bytes` blob and the harness's
+`put_bytes` / `get_bytes` take/return `Vec<u8>`. For the typical
+debian-base + small workspace, that is a 30-70 MB blob held in memory
+during capture and restore — acceptable but not great. A streamed
+producer/consumer interface (`AsyncRead`/`AsyncWrite`) is a clean
+follow-up if larger images become routine.
+
+### Snapshot lifecycle
+
+There is no GC. Snapshots remain on disk until the conversation directory
+is deleted. A future addition could prune snapshots older than the most
+recent N, or evict by total size.
+
+### Restore semantics
+
+Restore is a fresh container booted from the restored image, not a
+checkpoint of running processes or in-memory state. Any long-running
+processes the agent had started inside the container are not preserved;
+they would need to be re-launched from the restored filesystem state.
+This is consistent with how a fresh container is brought up for any chat
+turn.

--- a/docs/sandbox-snapshots.md
+++ b/docs/sandbox-snapshots.md
@@ -157,6 +157,22 @@ There is intentionally no top-level `exo conversation snapshot` subcommand
 today — see "Known limits" for the cross-invocation gap that makes such
 a subcommand useless until it's resolved.
 
+## Executable demo
+
+[`crates/cli/tests/snapshot_round_trip.rs`](../crates/cli/tests/snapshot_round_trip.rs)
+is the canonical, runnable reference for using the snapshot APIs. It drives
+the harness library directly (no LLM, no binary spawn) and exercises the same
+lifecycle this doc describes. Run it manually with:
+
+```
+EXO_TEST_SANDBOX_BACKEND=docker cargo test --package exo \
+    --test snapshot_round_trip -- --ignored --nocapture
+```
+
+The CI integration workflow runs it on push to `main` against each Linux
+matrix cell that supports docker. The test self-skips on cells that don't
+(`local-process`) so they don't false-fail.
+
 ## Extending to another sandbox backend
 
 To add snapshot support for a new backend (say, Apple's `container` CLI


### PR DESCRIPTION
Fills in the snapshot/rewind plumbing that was previously metadata-only. **Captures and restores a sandboxed container's filesystem state.** A separate PR (#12) stacks on top of this one for an experimental CRIU full-state path — that one is intentionally a draft because it's blocked by upstream docker bugs.

## What this does

Inside a chat REPL (`exo chat repl <agent> <conv>`), three new slash commands:

| Command | What it does |
|---|---|
| `/snapshot` | Capture the sandbox's **filesystem state** as it is right now — every file created, modified, or deleted since the base image. Prints a snapshot UUID. On disk this is a `docker save` tarball under `conversations/<conv>/snapshots/<id>/payload.bin` plus a `manifest.json` sidecar. |
| `/snapshots` | List every snapshot taken in this conversation. |
| `/rewind <uuid>` | Stop the current container, bring up a fresh one whose filesystem matches the snapshot. Subsequent tool calls see the rolled-back state. |

## What this does NOT do — be clear about the limit

The snapshot is **filesystem only**. Specifically:

- ✅ **Files persisted to disk inside the container** are captured and restored — files you created, packages you installed, configs you wrote.
- ❌ **Running processes are not preserved.** If you `/snapshot` while `nohup sleep 9999 &` is running and then `/rewind`, the file `/proc/<pid>` is not coming back; the process is gone. The new container boots fresh.
- ❌ **In-memory state is gone.** An interactive REPL's variables, an open TCP connection, a buffered write that hadn't been flushed — none of these survive a rewind.
- ❌ **Conversation history is not rewound.** Your chat messages and event log stay where they were. Use `conversation fork` if you want to rewind the conversation itself; snapshots only operate on the sandbox filesystem underneath.

For agent workflows where "state worth preserving" = "files written to disk + tools/packages installed", filesystem snapshots cover the case. For pause-and-resume of long-running in-memory processes, you'd need full-state (CRIU), which is #12's beat and currently impractical to ship due to upstream docker bugs.

## Demo

gif:
<img width="800" height="515" alt="snapshot-rewind" src="https://github.com/user-attachments/assets/55223d38-aae8-42ce-9884-1106b04bcc55" />


```bash
# Bootstrap a state dir + agent + conversation, drop into the REPL.
# (--networking enabled because the demo needs the LLM to reach OpenAI)
STATE=/tmp/exo-snapshot-demo && rm -rf $STATE && mkdir -p $STATE && \
EXO="./target/debug/exo --root $STATE --secret-backend file --sandbox-backend docker --master-key-path $STATE/master.key" && \
$EXO secret set OPENAI_KEY --env OPENAI_API_KEY && \
$EXO model register gpt-4o-mini --secret OPENAI_KEY && \
$EXO agent create demo --model gpt-4o-mini --networking enabled && \
$EXO conversation create demo first --repl
```

Then inside `first>`:

```
create /tmp/demo.txt with the content "version 1" and cat it back
```
*Sandbox now has `/tmp/demo.txt` with "version 1".*

```
/snapshot
```
> `snapshot 019e5782-7c6b-72a2-b4fa-a81bf56eb37e`
>
> Behind the scenes: `docker commit -p` → `docker save` → tarball (~47MB for the ubuntu:24.04 base) → written to `conversations/<conv>/snapshots/<id>/payload.bin` + `manifest.json`. The local docker image is dropped (`docker image rm`) — exoharness storage is the canonical home.

```
overwrite /tmp/demo.txt with "version 2" and cat it back
```
*Sandbox file now reads "version 2".*

```
/snapshots
```
> ```
> SNAPSHOT                              SANDBOX
> 019e5782-7c6b-72a2-b4fa-a81bf56eb37e  sandbox-019e5782-2a46-7970-a5bf-62900a2233e8
> ```

```
/rewind 019e5782-7c6b-72a2-b4fa-a81bf56eb37e
```
> `rewound to snapshot 019e5782-7c6b-72a2-b4fa-a81bf56eb37e`
>
> Behind the scenes: `docker load < payload.bin` → fresh container booted from the restored image → swapped into the warm pool, keyed identically. Mounts / network policy / lifecycle preserved from the original sandbox request.

```
cat /tmp/demo.txt
```
> `version 1`   ← the rewind worked

You can take many snapshots in a conversation and rewind to any of them.

## Six commits

| # | Commit | What |
|---|---|---|
| 1 | `exoharness: sandbox snapshot/restore trait surface and Docker implementation` | Adds `SnapshotPayload { kind, bytes }` + `SnapshotKind::DockerImageTar`. Extends `ManagedSandboxHandle::snapshot()` and `ManagedSandboxBackend::acquire_from_snapshot(req, payload)`. Stubs with explicit "not supported" errors for OneShot / LocalProcess / AppleContainer with clear "where the real impl goes" comments. |
| 2 | `exoharness: persist sandbox snapshots and restore via start_sandbox` | Wires `snapshot_sandbox` to actually capture and persist. Wires `start_sandbox` to load the payload by manifest kind and call `acquire_from_snapshot`. |
| 3 | `cli: /snapshot, /snapshots, /rewind slash commands in chat repl` | The user-facing surface. Lives in the REPL because the sandbox handle is per-process; a top-level `exo conversation snapshot` subcommand needs cross-invocation container adoption (separate follow-up). |
| 4 | `docs: sandbox snapshot/rewind design` | `docs/sandbox-snapshots.md` covering data flow, on-disk layout, backend extension story, known limits. |
| 5 | `exoharness: default sandbox image to ubuntu:24.04` | debian:bookworm doesn't ship `procps`; even basic "list running processes" tool calls hit `command not found`. Ubuntu 24.04 has procps + coreutils in the base. |
| 6 | `ci: end-to-end snapshot + rewind round-trip test (docker, linux)` | New `crates/cli/tests/snapshot_round_trip.rs` that drives the harness library directly against real Docker. Mirrors the demo's lifecycle and asserts on two independent rewind signals (file content rolls back AND a post-snapshot file disappears). Wired into the integration matrix workflow. |

## On-disk shape

```
agents/<agent_id>/conversations/<conv_id>/snapshots/<snapshot_id>/
├── manifest.json   { snapshot_id, sandbox_id, kind, created_at, payload_size_bytes }
└── payload.bin     docker save tarball for SnapshotKind::DockerImageTar
```

The snapshot's existence is also recorded in the conversation event log as `SandboxSnapshotted { sandbox_id, snapshot_id }`, which is what `/snapshots` walks to render the listing.

## Adding more backends

Anyone adding snapshot support for a new sandbox backend follows this recipe:

1. Add a new `SnapshotKind` variant naming the on-disk format (e.g. `AppleContainerImageTar`).
2. Implement `ManagedSandboxHandle::snapshot` to produce that kind. The Docker version is the template — three CLI calls and a `Bytes` capture.
3. Implement `ManagedSandboxBackend::acquire_from_snapshot` to consume the same kind, with an explicit kind-mismatch error.
4. Backends that genuinely can't snapshot (local-process today) keep returning an explicit error.

No other layer changes. The conversation orchestration, on-disk layout, and CLI surface are all backend-agnostic.

## Test plan

- [x] `cargo test --workspace` (51 unit tests pass)
- [x] **End-to-end CI test added: `crates/cli/tests/snapshot_round_trip.rs`** — drives the harness library directly against real Docker on Linux, asserts the file content rolls back AND a post-snapshot file disappears after `/rewind`. Passes locally in ~1.8s; self-skips on non-docker matrix cells. Wired into the existing `integration.yml` workflow alongside the existing `integration_chat` test.
- [x] Manual REPL verification (the demo above): `/snapshot` → file content modified → `/rewind` → file content rolled back. Verified visually before the automated test was written.
- [x] On-disk layout (manifest.json + payload.bin) verified by the round-trip test using `read_dir()`.