### PR TITLE
Daytona remote-container sandbox backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,6 +1879,7 @@ dependencies = [
  "keyring-core",
  "lingua",
  "object_store",
+ "reqwest",
  "serde",
  "serde_json 1.0.149",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1851,6 +1851,7 @@ name = "exo"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bytes",
  "clap",
  "executor",
  "exoharness",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,6 +21,7 @@ tokio.workspace = true
 tokio-stream.workspace = true
 
 [dev-dependencies]
+bytes.workspace = true
 exoharness = { path = "../exoharness", features = ["basic-backend"] }
 futures.workspace = true
 tempfile = "3.23.0"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -22,11 +22,10 @@ use executor::{
     AgentHarnessKind, BasicExoHarness, BasicExoHarnessConfig, BasicHarness, Binding,
     BraintrustProject, BraintrustRuntimeConfig, BraintrustTracingConfig, ConversationModelConfig,
     CreateAgentRequest, CreateConversationRequest, DaytonaConfig, EventKind, EventQuery,
-    EventQueryDirection,
-    ExoHarness, FileSystemMount, FileSystemMountMode, ForkConversationRequest, Harness,
-    HarnessAgent, HarnessConversation, PutSecretRequest, RlmHarness, SANDBOX_MAIN_MOUNT_DIR,
-    SandboxBackendChoice, Secret, SecretBackendChoice, SendRequest, TypeScriptHarness,
-    TypeScriptHarnessConfig, Uuid7, load_agent_config,
+    EventQueryDirection, ExoHarness, FileSystemMount, FileSystemMountMode, ForkConversationRequest,
+    Harness, HarnessAgent, HarnessConversation, PutSecretRequest, RlmHarness,
+    SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, Secret, SecretBackendChoice, SendRequest,
+    TypeScriptHarness, TypeScriptHarnessConfig, Uuid7, load_agent_config,
 };
 use lingua::Message;
 use lingua::universal::{AssistantContent, AssistantContentPart, ToolContentPart, UserContent};

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -21,7 +21,8 @@ use clap::{Parser, Subcommand, ValueEnum};
 use executor::{
     AgentHarnessKind, BasicExoHarness, BasicExoHarnessConfig, BasicHarness, Binding,
     BraintrustProject, BraintrustRuntimeConfig, BraintrustTracingConfig, ConversationModelConfig,
-    CreateAgentRequest, CreateConversationRequest, EventKind, EventQuery, EventQueryDirection,
+    CreateAgentRequest, CreateConversationRequest, DaytonaConfig, EventKind, EventQuery,
+    EventQueryDirection,
     ExoHarness, FileSystemMount, FileSystemMountMode, ForkConversationRequest, Harness,
     HarnessAgent, HarnessConversation, PutSecretRequest, RlmHarness, SANDBOX_MAIN_MOUNT_DIR,
     SandboxBackendChoice, Secret, SecretBackendChoice, SendRequest, TypeScriptHarness,
@@ -180,6 +181,7 @@ enum SandboxBackendArg {
     Docker,
     #[value(name = "local-process")]
     LocalProcess,
+    Daytona,
 }
 
 fn build_exo_config(cli: &Cli) -> Result<BasicExoHarnessConfig> {
@@ -193,6 +195,7 @@ fn build_exo_config(cli: &Cli) -> Result<BasicExoHarnessConfig> {
         SandboxBackendArg::AppleContainer => SandboxBackendChoice::AppleContainer,
         SandboxBackendArg::Docker => SandboxBackendChoice::Docker,
         SandboxBackendArg::LocalProcess => SandboxBackendChoice::LocalProcess,
+        SandboxBackendArg::Daytona => SandboxBackendChoice::Daytona(DaytonaConfig::from_env()?),
     };
     Ok(BasicExoHarnessConfig {
         root: cli.root.join("exoharness"),

--- a/crates/cli/src/tui.rs
+++ b/crates/cli/src/tui.rs
@@ -660,28 +660,17 @@ fn print_help() {
 /// event, returning the sandbox id. Returns `None` if no sandbox has been
 /// created yet (e.g. nothing has been chatted with).
 async fn latest_sandbox_id(conversation: &dyn HarnessConversation) -> Result<Option<SandboxId>> {
-    let result = conversation
-        .exoharness_handle()
-        .get_events(Some(EventQuery {
-            cursor: None,
-            direction: Some(EventQueryDirection::Desc),
-            limit: Some(1),
-            session_id: None,
-            turn_id: None,
-            types: Some(vec![EventKind::SANDBOX_CREATED]),
-        }))
-        .await?;
-    let Some(event) = result.events.into_iter().next() else {
-        return Ok(None);
-    };
-    match event.data {
-        EventData::SandboxCreated { sandbox_id, .. } => Ok(Some(sandbox_id)),
-        other => anyhow::bail!(
-            "type-filtered query for {} returned unexpected variant {}",
-            EventKind::SANDBOX_CREATED.as_str(),
-            other.kind().as_str(),
-        ),
-    }
+    executor::first_matching_event(
+        conversation.exoharness_handle().as_ref(),
+        EventKind::SANDBOX_CREATED,
+        EventQueryDirection::Desc,
+        1,
+        |data| match data {
+            EventData::SandboxCreated { sandbox_id, .. } => Some(sandbox_id),
+            _ => None,
+        },
+    )
+    .await
 }
 
 /// All snapshots taken in the conversation, oldest-first. Each tuple is

--- a/crates/cli/tests/daytona_backend.rs
+++ b/crates/cli/tests/daytona_backend.rs
@@ -190,7 +190,10 @@ async fn try_resume_finds_running_sandbox_without_starting() {
         .try_resume(request)
         .await
         .expect("try_resume should not error");
-    assert!(handle.is_some(), "try_resume should find the running sandbox");
+    assert!(
+        handle.is_some(),
+        "try_resume should find the running sandbox"
+    );
 
     // Crucially: no POST /sandbox/sb-running/start should have happened.
     let requests = server.received_requests().await.unwrap_or_default();
@@ -282,10 +285,7 @@ async fn try_resume_filters_by_label_as_single_json_query_param() {
 
     let requests = server.received_requests().await.unwrap_or_default();
     let url = &requests[0].url;
-    let label_params: Vec<_> = url
-        .query_pairs()
-        .filter(|(k, _)| k == "labels")
-        .collect();
+    let label_params: Vec<_> = url.query_pairs().filter(|(k, _)| k == "labels").collect();
     assert_eq!(
         label_params.len(),
         1,
@@ -489,11 +489,7 @@ async fn acquire_from_snapshot_rejects_wrong_kind() {
     // No API call should have happened — we rejected the payload before
     // hitting the network.
     let requests = server.received_requests().await.unwrap_or_default();
-    assert_eq!(
-        requests.len(),
-        0,
-        "kind-mismatch must not reach the API"
-    );
+    assert_eq!(requests.len(), 0, "kind-mismatch must not reach the API");
 }
 
 // ─────────────────────── exec (toolbox URL) ───────────────────────

--- a/crates/cli/tests/daytona_backend.rs
+++ b/crates/cli/tests/daytona_backend.rs
@@ -1,0 +1,565 @@
+//! Wiremock-driven tests for the Daytona sandbox backend (PR #22).
+//!
+//! Daytona is a remote SaaS, so exercising the backend against the real
+//! service in CI would require credentials, network egress, real sandbox
+//! provisioning (which costs money and takes seconds per test), and
+//! cleanup that's brittle if a test panics partway through. Instead, each
+//! test stands up an in-process `wiremock` HTTP server that pretends to
+//! be Daytona's REST API, points a `DaytonaSandboxBackend` at it, and
+//! asserts on:
+//!
+//!   - which endpoints were hit (verifying URL routing — control plane
+//!     vs the separate toolbox host),
+//!   - what request bodies/query params were sent (verifying the
+//!     translation from `SandboxRequest` etc. into Daytona's wire
+//!     format), and
+//!   - how the backend interprets the canned responses (state machine
+//!     transitions, payload encoding).
+//!
+//! This catches code-defects in the backend without catching upstream
+//! Daytona drift. Drift detection is the job of the manual live test
+//! plan documented in the PR description.
+
+use std::collections::HashMap;
+
+use bytes::Bytes;
+use exoharness::{
+    DaytonaConfig, DaytonaSandboxBackend, ManagedSandboxBackend, SandboxKey,
+    SandboxLifecycleConfig, SandboxMount, SandboxMountAccess, SandboxNetworkPolicy, SandboxRequest,
+    SandboxSpec, SnapshotKind, SnapshotPayload,
+};
+use serde_json::{Value, json};
+use std::path::PathBuf;
+use std::time::Duration;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// ─────────────────────── Test fixtures / helpers ───────────────────────
+
+/// Standard sandbox request used across tests. Conversation-keyed so the
+/// label format matches what try_resume's filter expects to see.
+fn make_request(conversation_id: &str, sandbox_id: &str) -> SandboxRequest {
+    SandboxRequest {
+        key: SandboxKey::ConversationSandbox {
+            conversation_id: conversation_id.into(),
+            sandbox_id: sandbox_id.into(),
+        },
+        spec: SandboxSpec {
+            image: "docker.io/library/ubuntu:24.04".into(),
+            mounts: Vec::new(),
+            network: SandboxNetworkPolicy::Enabled,
+            default_workdir: "/".into(),
+        },
+        lifecycle: SandboxLifecycleConfig {
+            // idle_ttl required for try_resume to even attempt a lookup
+            // (try_resume short-circuits to None for non-warm sandboxes).
+            idle_ttl: Some(Duration::from_secs(300)),
+        },
+    }
+}
+
+/// Construct a backend pointed at a wiremock instance. Same wiremock host
+/// for both control-plane and toolbox URLs — Daytona's real deployment
+/// uses separate hosts, but tests differentiate by path prefix.
+fn backend_for_mock(server: &MockServer) -> DaytonaSandboxBackend {
+    DaytonaSandboxBackend::new(DaytonaConfig {
+        api_key: "test-api-key".into(),
+        api_url: server.uri(),
+        toolbox_url: server.uri(),
+        target: None,
+        organization_id: Some("test-org".into()),
+    })
+    .expect("DaytonaSandboxBackend::new")
+}
+
+fn sandbox_json(id: &str, state: &str) -> Value {
+    json!({
+        "id": id,
+        "state": state,
+        "createdAt": "2026-05-25T08:00:00Z"
+    })
+}
+
+fn list_response(items: Vec<Value>) -> Value {
+    json!({ "items": items })
+}
+
+// ─────────────────────── acquire ───────────────────────
+
+#[tokio::test]
+async fn acquire_posts_to_sandbox_endpoint_with_labels() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("POST"))
+        .and(path("/sandbox"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sandbox_json("sb-fresh", "started")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let request = make_request("conv-1", "sandbox-1");
+    let _handle = backend
+        .acquire(request)
+        .await
+        .expect("acquire should succeed against a 200-returning mock");
+
+    // Inspect what the backend actually sent on the wire.
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert_eq!(requests.len(), 1);
+    let body: Value = serde_json::from_slice(&requests[0].body).expect("body is JSON");
+
+    // Labels carry the SandboxKey + spec hash. We only assert the key is
+    // present (spec hash is computed internally); the absence of these
+    // labels would break try_resume across processes.
+    let labels = body
+        .get("labels")
+        .and_then(Value::as_object)
+        .expect("labels present");
+    assert!(
+        labels.contains_key("exo.sandbox.key"),
+        "labels should include exo.sandbox.key: {labels:?}"
+    );
+    assert!(
+        labels.contains_key("exo.sandbox.spec-hash"),
+        "labels should include exo.sandbox.spec-hash: {labels:?}"
+    );
+
+    // Daytona's `snapshot` field refers to a pre-registered named
+    // snapshot, not a docker image — `acquire` (fresh-create) should
+    // never set it, so the platform falls back to its default image.
+    assert!(
+        body.get("snapshot").is_none() || body["snapshot"].is_null(),
+        "fresh acquire must NOT set `snapshot`: {body:?}"
+    );
+}
+
+#[tokio::test]
+async fn acquire_rejects_host_mounts() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    let mut request = make_request("conv-2", "sandbox-2");
+    request.spec.mounts.push(SandboxMount {
+        host_path: PathBuf::from("/tmp/foo"),
+        guest_path: "/workspace".into(),
+        access: SandboxMountAccess::ReadWrite,
+        internal: false,
+    });
+
+    let error = match backend.acquire(request).await {
+        Ok(_) => panic!("acquire should reject requests with host mounts"),
+        Err(e) => e,
+    };
+    let msg = format!("{error:#}");
+    assert!(
+        msg.to_lowercase().contains("mount") || msg.to_lowercase().contains("daytona"),
+        "error should mention mounts and/or Daytona: {msg}"
+    );
+
+    // No HTTP call should have happened — request was rejected up front.
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert_eq!(
+        requests.len(),
+        0,
+        "mount-rejected request must not reach the API"
+    );
+}
+
+// ─────────────────────── try_resume ───────────────────────
+
+#[tokio::test]
+async fn try_resume_finds_running_sandbox_without_starting() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    // GET /sandbox returns one labelled match in `started` state — no
+    // /start call should follow.
+    Mock::given(method("GET"))
+        .and(path("/sandbox"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(list_response(vec![sandbox_json("sb-running", "started")])),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let request = make_request("conv-3", "sandbox-3");
+    let handle = backend
+        .try_resume(request)
+        .await
+        .expect("try_resume should not error");
+    assert!(handle.is_some(), "try_resume should find the running sandbox");
+
+    // Crucially: no POST /sandbox/sb-running/start should have happened.
+    let requests = server.received_requests().await.unwrap_or_default();
+    let start_calls = requests
+        .iter()
+        .filter(|r| r.url.path().contains("/start"))
+        .count();
+    assert_eq!(start_calls, 0, "must not start an already-running sandbox");
+}
+
+#[tokio::test]
+async fn try_resume_starts_stopped_sandbox() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("GET"))
+        .and(path("/sandbox"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(list_response(vec![sandbox_json("sb-stopped", "stopped")])),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/sandbox/sb-stopped/start"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let request = make_request("conv-4", "sandbox-4");
+    let handle = backend.try_resume(request).await.expect("try_resume ok");
+    assert!(handle.is_some(), "try_resume should produce a handle");
+
+    // Both endpoints should have fired.
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert!(
+        requests.iter().any(|r| r.url.path().ends_with("/sandbox")),
+        "list /sandbox must be called"
+    );
+    assert!(
+        requests
+            .iter()
+            .any(|r| r.url.path() == "/sandbox/sb-stopped/start"),
+        "start endpoint must be called for a stopped sandbox"
+    );
+}
+
+#[tokio::test]
+async fn try_resume_returns_none_when_no_match() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("GET"))
+        .and(path("/sandbox"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(list_response(Vec::new())))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let request = make_request("conv-5", "sandbox-5");
+    let handle = backend.try_resume(request).await.expect("try_resume ok");
+    assert!(
+        handle.is_none(),
+        "try_resume must return None when the label query is empty"
+    );
+}
+
+#[tokio::test]
+async fn try_resume_filters_by_label_as_single_json_query_param() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    // The matcher requires `labels` to be present as a single query
+    // param (not repeated). Wiremock's `query_param` matches the *first*
+    // value — if multiple were sent we'd want to fail; the absence-of-
+    // assertion is covered below by parsing the URL after the fact.
+    Mock::given(method("GET"))
+        .and(path("/sandbox"))
+        .and(query_param_present("labels"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(list_response(Vec::new())))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let request = make_request("conv-6", "sandbox-6");
+    backend.try_resume(request).await.unwrap();
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let url = &requests[0].url;
+    let label_params: Vec<_> = url
+        .query_pairs()
+        .filter(|(k, _)| k == "labels")
+        .collect();
+    assert_eq!(
+        label_params.len(),
+        1,
+        "labels must be one query param, not repeated: {url}"
+    );
+    // Confirm the value is JSON, not k=v-style.
+    let value = &label_params[0].1;
+    let parsed: Value =
+        serde_json::from_str(value).expect("labels query value must be JSON-encoded");
+    assert!(
+        parsed.get("exo.sandbox.key").is_some(),
+        "labels JSON should include exo.sandbox.key: {parsed:?}"
+    );
+}
+
+/// Helper: assert that a given query param key is present in the URL
+/// (without asserting on its value).
+fn query_param_present(name: &'static str) -> impl wiremock::Match {
+    struct Present(&'static str);
+    impl wiremock::Match for Present {
+        fn matches(&self, request: &wiremock::Request) -> bool {
+            request.url.query_pairs().any(|(k, _)| k == self.0)
+        }
+    }
+    Present(name)
+}
+
+// ─────────────────────── stop / Drop ───────────────────────
+
+#[tokio::test]
+async fn stop_calls_stop_endpoint_not_delete() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("POST"))
+        .and(path("/sandbox"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sandbox_json("sb-stop", "started")))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/sandbox/sb-stop/stop"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend
+        .acquire(make_request("conv-7", "sandbox-7"))
+        .await
+        .unwrap();
+    handle.stop().await.expect("stop should succeed");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    // No DELETE should have been issued — the resume contract requires
+    // stopped sandboxes to survive so the next process can resume them.
+    let deletes: Vec<_> = requests
+        .iter()
+        .filter(|r| r.method.to_string().to_uppercase() == "DELETE")
+        .collect();
+    assert!(
+        deletes.is_empty(),
+        "stop must not DELETE the sandbox: {deletes:?}"
+    );
+    assert!(
+        requests
+            .iter()
+            .any(|r| r.url.path() == "/sandbox/sb-stop/stop"),
+        "POST /sandbox/<id>/stop should have been called"
+    );
+}
+
+// ─────────────────────── snapshot ───────────────────────
+
+#[tokio::test]
+async fn snapshot_returns_daytona_snapshot_payload_with_manifest() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("POST"))
+        .and(path("/sandbox"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sandbox_json("sb-snap", "started")))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/sandbox/sb-snap/snapshot"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let request = make_request("conv-8", "sandbox-8");
+    let handle = backend.acquire(request).await.unwrap();
+    let payload = handle
+        .snapshot()
+        // Snapshot mode is filesystem-only on this backend; we go through
+        // SnapshotMode::Filesystem to hit the implemented path. The
+        // current trait shape on this PR doesn't take a mode arg yet —
+        // if the snapshot API signature ever grows it, this call site
+        // updates trivially.
+        .await
+        .expect("snapshot should succeed against the mock");
+
+    assert!(
+        matches!(payload.kind, SnapshotKind::DaytonaSnapshot),
+        "kind should be DaytonaSnapshot, got {:?}",
+        payload.kind
+    );
+
+    let manifest: Value =
+        serde_json::from_slice(&payload.bytes).expect("payload should be a JSON manifest");
+    assert!(
+        manifest
+            .get("snapshot_name")
+            .and_then(Value::as_str)
+            .is_some_and(|n| n.starts_with("exo-snap-")),
+        "manifest should carry a snapshot_name with the exo-snap- prefix: {manifest:?}"
+    );
+    assert!(
+        manifest.get("base_image").is_some(),
+        "manifest should carry the base_image: {manifest:?}"
+    );
+
+    // Verify request body sent the snapshot name to Daytona.
+    let requests = server.received_requests().await.unwrap_or_default();
+    let snap_call = requests
+        .iter()
+        .find(|r| r.url.path() == "/sandbox/sb-snap/snapshot")
+        .expect("snapshot endpoint should have been called");
+    let body: Value = serde_json::from_slice(&snap_call.body).unwrap();
+    let name = body
+        .get("name")
+        .and_then(Value::as_str)
+        .expect("snapshot request body must contain `name`");
+    assert!(name.starts_with("exo-snap-"));
+}
+
+#[tokio::test]
+async fn acquire_from_snapshot_passes_snapshot_name_in_create_body() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("POST"))
+        .and(path("/sandbox"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(sandbox_json("sb-restored", "started")),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Construct a DaytonaSnapshot payload by hand. The manifest schema is
+    // private to daytona.rs; we serialize the same shape directly.
+    let manifest = json!({
+        "snapshot_name": "exo-snap-canonical-fixture",
+        "base_image": "ubuntu:24.04",
+    });
+    let payload = SnapshotPayload {
+        kind: SnapshotKind::DaytonaSnapshot,
+        bytes: Bytes::from(serde_json::to_vec(&manifest).unwrap()),
+    };
+
+    let request = make_request("conv-9", "sandbox-9");
+    let _handle = backend
+        .acquire_from_snapshot(request, payload)
+        .await
+        .expect("acquire_from_snapshot should succeed against a 200 mock");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let create_call = requests
+        .iter()
+        .find(|r| r.url.path() == "/sandbox" && r.method.to_string().to_uppercase() == "POST")
+        .expect("POST /sandbox should have been called");
+    let body: Value = serde_json::from_slice(&create_call.body).unwrap();
+    assert_eq!(
+        body.get("snapshot").and_then(Value::as_str),
+        Some("exo-snap-canonical-fixture"),
+        "create-from-snapshot must pass the manifest's snapshot_name to Daytona: {body:?}"
+    );
+}
+
+#[tokio::test]
+async fn acquire_from_snapshot_rejects_wrong_kind() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    let payload = SnapshotPayload {
+        kind: SnapshotKind::DockerImageTar,
+        bytes: Bytes::from_static(b"\x00not-a-real-tar"),
+    };
+    let request = make_request("conv-10", "sandbox-10");
+    let error = match backend.acquire_from_snapshot(request, payload).await {
+        Ok(_) => panic!("Daytona backend must reject a DockerImageTar payload"),
+        Err(e) => e,
+    };
+    let msg = format!("{error:#}").to_lowercase();
+    assert!(
+        msg.contains("daytona") || msg.contains("docker") || msg.contains("kind"),
+        "error should explain the kind mismatch: {msg}"
+    );
+
+    // No API call should have happened — we rejected the payload before
+    // hitting the network.
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert_eq!(
+        requests.len(),
+        0,
+        "kind-mismatch must not reach the API"
+    );
+}
+
+// ─────────────────────── exec (toolbox URL) ───────────────────────
+
+#[tokio::test]
+async fn exec_uses_toolbox_url_not_api_url() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("POST"))
+        .and(path("/sandbox"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sandbox_json("sb-exec", "started")))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/toolbox/sb-exec/process/execute"))
+        .and(body_json_includes_command())
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "exitCode": 0,
+            "result": "hello from mock",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let request = make_request("conv-11", "sandbox-11");
+    let handle = backend.acquire(request).await.unwrap();
+    let output = handle
+        .exec(&exoharness::SandboxCommand {
+            argv: vec!["/bin/echo".into(), "hello".into()],
+            env: HashMap::new(),
+            display_argv: None,
+            cwd: None,
+            timeout: None,
+        })
+        .await
+        .expect("exec should succeed");
+
+    assert_eq!(output.exit_code, Some(0));
+    assert_eq!(output.stdout, "hello from mock");
+
+    // Most important assertion: the toolbox path was used. The same
+    // hostname is fine in test (one wiremock), but in production the
+    // toolbox lives on a different DNS name; routing in the code MUST
+    // call `toolbox_endpoint` here, not `api_endpoint`.
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert!(
+        requests
+            .iter()
+            .any(|r| r.url.path() == "/toolbox/sb-exec/process/execute"),
+        "exec must hit /toolbox/<id>/process/execute"
+    );
+}
+
+/// Match any POST body that has a `command` field — keeps the test from
+/// over-asserting on the precise shell-rendering, while still proving
+/// the body shape lines up with Daytona's expected schema.
+fn body_json_includes_command() -> impl wiremock::Match {
+    struct Has;
+    impl wiremock::Match for Has {
+        fn matches(&self, request: &wiremock::Request) -> bool {
+            serde_json::from_slice::<Value>(&request.body)
+                .ok()
+                .and_then(|v| v.get("command").and_then(Value::as_str).map(str::to_string))
+                .is_some()
+        }
+    }
+    Has
+}

--- a/crates/cli/tests/integration_chat.rs
+++ b/crates/cli/tests/integration_chat.rs
@@ -251,25 +251,179 @@ async fn conversation_send_round_trips_through_real_sandbox_and_mocked_openai() 
     );
 
     if backend == SandboxBackend::Docker {
-        let leftover_containers = Command::new("docker")
-            .args([
-                "ps",
-                "-aq",
-                "--filter",
-                "label=exo.sandbox.owner-pid",
-                "--filter",
-                "status=exited",
-            ])
-            .output()
-            .expect("docker ps");
-        let stdout = String::from_utf8_lossy(&leftover_containers.stdout);
-        let stale = stdout
-            .lines()
-            .filter(|l| !l.trim().is_empty())
-            .collect::<Vec<_>>();
-        assert!(
-            stale.is_empty(),
-            "expected zero leftover Exited exo containers after binary exit; found: {stale:?}"
+        // Drop stops (not rm's) the container so the next process can resume it.
+        let leftover = list_exo_containers_for_conversation(&conv_dir);
+        assert_eq!(
+            leftover.len(),
+            1,
+            "expected exactly one stopped exo container after binary exit (resume target); found: {leftover:?}"
         );
+
+        // Test cleanup: don't leak the resume target onto the docker host.
+        for id in &leftover {
+            let _ = Command::new("docker").args(["rm", "-f", id]).output();
+        }
+    }
+}
+
+/// Docker container IDs labelled for the conversation at `conv_dir`.
+fn list_exo_containers_for_conversation(conv_dir: &std::path::Path) -> Vec<String> {
+    let conv_id = conv_dir
+        .file_name()
+        .and_then(|s| s.to_str())
+        .expect("conv dir name");
+    let key_prefix = format!("conversation:{conv_id}:");
+    let output = Command::new("docker")
+        .args([
+            "ps",
+            "-a",
+            "--filter",
+            "label=exo.sandbox.key",
+            "--format",
+            "{{json .}}",
+        ])
+        .output()
+        .expect("docker ps");
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|line| !line.is_empty())
+        .filter_map(|line| {
+            let row: Value = serde_json::from_str(line).expect("docker ps row is json");
+            let id = row.get("ID")?.as_str()?.to_string();
+            let labels = row.get("Labels")?.as_str()?;
+            let key = labels
+                .split(',')
+                .filter_map(|kv| kv.split_once('='))
+                .find_map(|(k, v)| (k == "exo.sandbox.key").then_some(v))?;
+            key.starts_with(&key_prefix).then_some(id)
+        })
+        .collect()
+}
+
+/// Two separate `conversation send` invocations on the same conversation must
+/// hit the same docker container — the cross-process resume path.
+#[tokio::test]
+#[ignore = "spawns real exo binary + real sandbox + wiremock; run with cargo test -- --ignored"]
+async fn cross_process_send_resumes_the_same_sandbox_container() {
+    let backend = SandboxBackend::from_env();
+    // LocalProcess returns None from try_resume; AppleContainer isn't in CI.
+    if backend != SandboxBackend::Docker {
+        eprintln!("cross-process resume test only meaningful on docker; skipping");
+        return;
+    }
+    if !backend.runtime_available() {
+        eprintln!("docker not available on this runner; skipping");
+        return;
+    }
+
+    let root_dir = TempDir::new().expect("tempdir for --root");
+    let xdg_dir = TempDir::new().expect("tempdir for XDG_CONFIG_HOME");
+    let root = root_dir.path().to_string_lossy().into_owned();
+    let xdg = xdg_dir.path().to_string_lossy().into_owned();
+
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(canned_response_body()))
+        .mount(&mock_server)
+        .await;
+
+    run_exo(
+        &["secret", "set", "test-key", "--env", "OPENAI_API_KEY"],
+        &root,
+        &xdg,
+        backend,
+    );
+    run_exo(
+        &[
+            "model",
+            "register",
+            "gpt-test",
+            "--secret",
+            "test-key",
+            "--base-url",
+            &mock_server.uri(),
+        ],
+        &root,
+        &xdg,
+        backend,
+    );
+    run_exo(
+        &[
+            "agent",
+            "create",
+            "--slug",
+            "test-agent",
+            "--model",
+            "gpt-test",
+            "Integration Test Agent",
+        ],
+        &root,
+        &xdg,
+        backend,
+    );
+    run_exo(
+        &["conversation", "create", "test-agent", "first"],
+        &root,
+        &xdg,
+        backend,
+    );
+
+    // First send provisions the warm sandbox.
+    run_exo(
+        &[
+            "conversation",
+            "send",
+            "test-agent",
+            "first",
+            "first message",
+        ],
+        &root,
+        &xdg,
+        backend,
+    );
+
+    // Second send is a fresh exo process; should `try_resume` the same container.
+    run_exo(
+        &[
+            "conversation",
+            "send",
+            "test-agent",
+            "first",
+            "second message",
+        ],
+        &root,
+        &xdg,
+        backend,
+    );
+
+    let conv_dir = root_dir
+        .path()
+        .join("exoharness/agents")
+        .read_dir()
+        .expect("agents dir")
+        .next()
+        .expect("agent")
+        .unwrap()
+        .path()
+        .join("conversations")
+        .read_dir()
+        .expect("conversations dir")
+        .next()
+        .expect("conversation")
+        .unwrap()
+        .path();
+
+    let containers = list_exo_containers_for_conversation(&conv_dir);
+    assert_eq!(
+        containers.len(),
+        1,
+        "expected exactly one docker container after two cross-process sends \
+         (resume should reuse, not create new); found: {containers:?}"
+    );
+
+    // Cleanup.
+    for id in &containers {
+        let _ = Command::new("docker").args(["rm", "-f", id]).output();
     }
 }

--- a/crates/cli/tests/lifecycle_resume.rs
+++ b/crates/cli/tests/lifecycle_resume.rs
@@ -1,0 +1,437 @@
+//! End-to-end tests for the 3-tier resume fallback in `ensure_shell_sandbox`:
+//!
+//!   1. `try_resume` finds a labelled container → `docker start` + attach.
+//!      Same container, same `sandbox_id`.
+//!   2. Container is gone but a snapshot exists → `acquire_from_snapshot`.
+//!      New docker id, same `sandbox_id`, filesystem restored.
+//!   3. No container, no snapshot → `create_sandbox` fresh.
+//!      New docker id, new `sandbox_id`.
+//!
+//! Each test simulates two exo processes against the same `--root` and checks
+//! which tier fired. Docker only; LocalProcess has no cross-process identity.
+
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+
+use executor::{AgentConfig, AgentHarnessKind, BasicToolRuntime, ConversationConfig, ToolRuntime};
+use exoharness::{
+    AgentId, BasicExoHarness, BasicExoHarnessConfig, ConversationHandle, ConversationId, EventData,
+    EventKind, EventQuery, EventQueryDirection, ExoHarness, NewAgentRequest,
+    NewConversationRequest, RunInSandboxRequest, SandboxBackendChoice, SandboxId,
+    SandboxProcessParts, SecretBackendChoice,
+};
+use futures::io::AsyncReadExt;
+use tempfile::TempDir;
+
+const SANDBOX_IMAGE: &str = "docker.io/library/ubuntu:24.04";
+
+// Tier 1: harness #1 drops (Drop stops, doesn't rm) → harness #2 finds the
+// stopped container via labels and `docker start`s it. Same container, marker
+// survives.
+
+#[tokio::test]
+#[ignore = "spawns real docker container; run with `cargo test -- --ignored`"]
+async fn tier_1_stopped_container_is_resumed_same_id() {
+    if !preflight() {
+        return;
+    }
+    let root_dir = TempDir::new().expect("tempdir");
+
+    let (agent_id, conv_id, sandbox_id, container_id) = {
+        let harness = make_harness(root_dir.path()).await;
+        let (agent_id, conv_id) = make_agent_and_conv(&harness, "tier-1-agent").await;
+        let conv = open_conv(&harness, &agent_id, &conv_id).await;
+        prepare(conv.as_ref()).await;
+
+        let sandbox_id = latest_sandbox_id(conv.as_ref())
+            .await
+            .expect("ensure_shell_sandbox should have created a sandbox");
+        let containers = list_containers_for_sandbox(&conv_id, &sandbox_id);
+        assert_eq!(
+            containers.len(),
+            1,
+            "round 1 should have exactly one container, got: {containers:?}"
+        );
+        let container_id = containers.into_iter().next().unwrap();
+
+        let (rc, _, _) =
+            exec_shell(conv.as_ref(), &sandbox_id, "echo 'tier-1-marker' > /tmp/x").await;
+        assert_eq!(rc, 0, "writing marker should succeed");
+
+        drop(conv);
+        (agent_id, conv_id, sandbox_id, container_id)
+    };
+
+    // Drop stops, doesn't rm.
+    let state = docker_container_state(&container_id);
+    assert_eq!(
+        state, "exited",
+        "container should be stopped (not rm'd) after harness drop; state={state:?}"
+    );
+
+    {
+        let harness = make_harness(root_dir.path()).await;
+        let conv = open_conv(&harness, &agent_id, &conv_id).await;
+        prepare(conv.as_ref()).await;
+
+        let containers = list_containers_for_sandbox(&conv_id, &sandbox_id);
+        assert_eq!(
+            containers,
+            vec![container_id.clone()],
+            "round 2 should reuse the same container ID, not create a new one"
+        );
+
+        let (rc, stdout, _) = exec_shell(conv.as_ref(), &sandbox_id, "cat /tmp/x").await;
+        assert_eq!(rc, 0);
+        assert_eq!(stdout.trim(), "tier-1-marker");
+
+        let created = count_events_of_type(conv.as_ref(), "sandbox_created").await;
+        assert_eq!(created, 1, "tier 1 should not create a second sandbox");
+    }
+
+    rm_container(&container_id);
+}
+
+// Tier 2: harness #1 takes a snapshot, then container is rm'd. Harness #2
+// finds no container, falls through to `acquire_from_snapshot`. New docker
+// container, same `sandbox_id`, marker survives via the snapshot.
+
+#[tokio::test]
+#[ignore = "spawns real docker container; run with `cargo test -- --ignored`"]
+async fn tier_2_gone_container_with_snapshot_restores() {
+    if !preflight() {
+        return;
+    }
+    let root_dir = TempDir::new().expect("tempdir");
+
+    let (agent_id, conv_id, sandbox_id, container_id_round1) = {
+        let harness = make_harness(root_dir.path()).await;
+        let (agent_id, conv_id) = make_agent_and_conv(&harness, "tier-2-agent").await;
+        let conv = open_conv(&harness, &agent_id, &conv_id).await;
+        prepare(conv.as_ref()).await;
+
+        let sandbox_id = latest_sandbox_id(conv.as_ref()).await.unwrap();
+        let containers = list_containers_for_sandbox(&conv_id, &sandbox_id);
+        assert_eq!(containers.len(), 1);
+        let container_id = containers.into_iter().next().unwrap();
+
+        exec_shell(conv.as_ref(), &sandbox_id, "echo 'tier-2-marker' > /tmp/x").await;
+
+        conv.snapshot_sandbox(sandbox_id.clone())
+            .await
+            .expect("snapshot_sandbox should succeed while container is live");
+
+        drop(conv);
+        (agent_id, conv_id, sandbox_id, container_id)
+    };
+
+    rm_container(&container_id_round1);
+    assert!(
+        list_containers_for_sandbox(&conv_id, &sandbox_id).is_empty(),
+        "container should be gone after rm",
+    );
+
+    {
+        let harness = make_harness(root_dir.path()).await;
+        let conv = open_conv(&harness, &agent_id, &conv_id).await;
+        prepare(conv.as_ref()).await;
+
+        let containers = list_containers_for_sandbox(&conv_id, &sandbox_id);
+        assert_eq!(containers.len(), 1);
+        assert_ne!(
+            containers[0], container_id_round1,
+            "tier 2 should create a NEW container (restored from snapshot)"
+        );
+
+        let (rc, stdout, _) = exec_shell(conv.as_ref(), &sandbox_id, "cat /tmp/x").await;
+        assert_eq!(rc, 0);
+        assert_eq!(stdout.trim(), "tier-2-marker");
+
+        assert_eq!(
+            count_events_of_type(conv.as_ref(), "sandbox_created").await,
+            1,
+            "tier 2 must not create a new sandbox"
+        );
+        assert!(
+            count_events_of_type(conv.as_ref(), "sandbox_started").await >= 1,
+            "tier 2 should emit a SandboxStarted event when restoring"
+        );
+
+        let containers = list_containers_for_sandbox(&conv_id, &sandbox_id);
+        for c in containers {
+            rm_container(&c);
+        }
+    }
+}
+
+// Tier 3: container rm'd and no snapshot was ever taken. Harness #2 has
+// nothing to resume from, falls through to `create_sandbox`. New `sandbox_id`,
+// fresh container, no surviving state.
+
+#[tokio::test]
+#[ignore = "spawns real docker container; run with `cargo test -- --ignored`"]
+async fn tier_3_gone_container_without_snapshot_creates_fresh() {
+    if !preflight() {
+        return;
+    }
+    let root_dir = TempDir::new().expect("tempdir");
+
+    let (agent_id, conv_id, sandbox_id_round1, container_id_round1) = {
+        let harness = make_harness(root_dir.path()).await;
+        let (agent_id, conv_id) = make_agent_and_conv(&harness, "tier-3-agent").await;
+        let conv = open_conv(&harness, &agent_id, &conv_id).await;
+        prepare(conv.as_ref()).await;
+
+        let sandbox_id = latest_sandbox_id(conv.as_ref()).await.unwrap();
+        let containers = list_containers_for_sandbox(&conv_id, &sandbox_id);
+        assert_eq!(containers.len(), 1);
+        let container_id = containers.into_iter().next().unwrap();
+
+        exec_shell(conv.as_ref(), &sandbox_id, "echo 'tier-3-marker' > /tmp/x").await;
+
+        drop(conv);
+        (agent_id, conv_id, sandbox_id, container_id)
+    };
+
+    rm_container(&container_id_round1);
+
+    {
+        let harness = make_harness(root_dir.path()).await;
+        let conv = open_conv(&harness, &agent_id, &conv_id).await;
+        prepare(conv.as_ref()).await;
+
+        let sandbox_id_round2 = latest_sandbox_id(conv.as_ref()).await.unwrap();
+        assert_ne!(
+            sandbox_id_round2, sandbox_id_round1,
+            "tier 3 should create a new sandbox with a new id"
+        );
+
+        assert_eq!(
+            count_events_of_type(conv.as_ref(), "sandbox_created").await,
+            2,
+            "tier 3 should record a second SandboxCreated event"
+        );
+
+        let (rc, _, _) = exec_shell(conv.as_ref(), &sandbox_id_round2, "test -f /tmp/x").await;
+        assert_ne!(rc, 0, "marker should NOT exist in the fresh container");
+
+        let containers = list_containers_for_sandbox(&conv_id, &sandbox_id_round2);
+        for c in containers {
+            rm_container(&c);
+        }
+    }
+}
+
+// helpers
+
+fn preflight() -> bool {
+    let docker_ok = Command::new("docker")
+        .arg("info")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if !docker_ok {
+        eprintln!("docker not available, skipping lifecycle test");
+        return false;
+    }
+    let backend = std::env::var("EXO_TEST_SANDBOX_BACKEND").unwrap_or_else(|_| "docker".into());
+    if backend != "docker" {
+        eprintln!("lifecycle test is docker-only, skipping (EXO_TEST_SANDBOX_BACKEND={backend})");
+        return false;
+    }
+    true
+}
+
+async fn make_harness(root: &Path) -> BasicExoHarness {
+    BasicExoHarness::new(BasicExoHarnessConfig {
+        root: root.to_path_buf(),
+        secret_backend: SecretBackendChoice::Static([9u8; 32]),
+        sandbox_backend: SandboxBackendChoice::Docker,
+    })
+    .await
+    .expect("BasicExoHarness::new")
+}
+
+async fn make_agent_and_conv(
+    harness: &BasicExoHarness,
+    agent_slug: &str,
+) -> (AgentId, ConversationId) {
+    let agent = harness
+        .new_agent(NewAgentRequest {
+            slug: agent_slug.into(),
+            name: agent_slug.into(),
+        })
+        .await
+        .expect("new_agent");
+    let agent_id = agent.record().id;
+    let conv = agent
+        .new_conversation(NewConversationRequest {
+            slug: Some("conv".into()),
+            name: Some("conversation".into()),
+        })
+        .await
+        .expect("new_conversation");
+    let conv_id = conv.record().id;
+    (agent_id, conv_id)
+}
+
+async fn open_conv(
+    harness: &BasicExoHarness,
+    agent_id: &AgentId,
+    conv_id: &ConversationId,
+) -> Arc<dyn ConversationHandle> {
+    let agent = harness
+        .get_agent(agent_id)
+        .await
+        .expect("get_agent")
+        .expect("agent should exist on disk");
+    agent
+        .get_conversation(conv_id)
+        .await
+        .expect("get_conversation")
+        .expect("conversation should exist on disk")
+}
+
+fn test_agent_config() -> AgentConfig {
+    AgentConfig {
+        instructions: Vec::new(),
+        harness: AgentHarnessKind::Basic,
+        typescript: None,
+        enable_agent_tool_creation: false,
+        sandbox_image: Some(SANDBOX_IMAGE.into()),
+        enable_networking: false,
+        model: "lifecycle-test-model".into(),
+        max_output_tokens: None,
+        max_tool_round_trips: None,
+        braintrust: None,
+    }
+}
+
+fn test_conv_config() -> ConversationConfig {
+    ConversationConfig {
+        enable_networking: false,
+        // shell_program: Some(_) is the trigger for ensure_shell_sandbox.
+        shell_program: Some("bash".into()),
+        mounts: Vec::new(),
+    }
+}
+
+/// Fire `BasicToolRuntime::prepare_conversation`, which is the public-ish
+/// entry point that internally calls `ensure_shell_sandbox` — the
+/// function that runs the 3-tier lifecycle fallback we're testing.
+async fn prepare(conv: &dyn ConversationHandle) {
+    BasicToolRuntime
+        .prepare_conversation(conv, &test_agent_config(), &test_conv_config())
+        .await
+        .expect("prepare_conversation");
+}
+
+async fn exec_shell(
+    conv: &dyn ConversationHandle,
+    sandbox_id: &SandboxId,
+    cmd: &str,
+) -> (i32, String, String) {
+    let process = conv
+        .run_in_sandbox(RunInSandboxRequest {
+            id: sandbox_id.clone(),
+            command: vec!["/bin/bash".into(), "-c".into(), cmd.into()],
+            env: Default::default(),
+        })
+        .await
+        .unwrap_or_else(|error| panic!("run_in_sandbox({cmd:?}) failed: {error:#}"));
+    let mut parts: SandboxProcessParts = process.into_parts();
+    drop(parts.stdin);
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let (a, b, c) = tokio::join!(
+        parts.stdout.read_to_end(&mut stdout),
+        parts.stderr.read_to_end(&mut stderr),
+        parts.wait,
+    );
+    a.expect("read stdout");
+    b.expect("read stderr");
+    let exit_code = c.expect("wait");
+    (
+        exit_code,
+        String::from_utf8_lossy(&stdout).into_owned(),
+        String::from_utf8_lossy(&stderr).into_owned(),
+    )
+}
+
+async fn latest_sandbox_id(conv: &dyn ConversationHandle) -> Option<SandboxId> {
+    let result = conv
+        .get_events(Some(EventQuery {
+            cursor: None,
+            direction: Some(EventQueryDirection::Desc),
+            limit: Some(50),
+            session_id: None,
+            turn_id: None,
+            types: Some(vec![EventKind::SANDBOX_CREATED]),
+        }))
+        .await
+        .ok()?;
+    for event in result.events {
+        if let EventData::SandboxCreated { sandbox_id, .. } = event.data {
+            return Some(sandbox_id);
+        }
+    }
+    None
+}
+
+async fn count_events_of_type(conv: &dyn ConversationHandle, ty: &str) -> usize {
+    let mut cursor = None;
+    let mut count = 0;
+    loop {
+        let result = conv
+            .get_events(Some(EventQuery {
+                cursor,
+                direction: Some(EventQueryDirection::Asc),
+                limit: Some(100),
+                session_id: None,
+                turn_id: None,
+                types: Some(vec![EventKind::custom(ty.to_string())]),
+            }))
+            .await
+            .expect("get_events");
+        let events_empty = result.events.is_empty();
+        count += result.events.len();
+        if events_empty || result.cursor.is_none() {
+            break;
+        }
+        cursor = result.cursor;
+    }
+    count
+}
+
+fn list_containers_for_sandbox(conv_id: &ConversationId, sandbox_id: &SandboxId) -> Vec<String> {
+    let label = format!("exo.sandbox.key=conversation:{conv_id}:{sandbox_id}");
+    let output = Command::new("docker")
+        .args([
+            "ps",
+            "-a",
+            "--filter",
+            &format!("label={label}"),
+            "--format",
+            "{{.ID}}",
+        ])
+        .output()
+        .expect("docker ps");
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|s| !s.trim().is_empty())
+        .map(|s| s.trim().to_string())
+        .collect()
+}
+
+fn docker_container_state(id: &str) -> String {
+    let output = Command::new("docker")
+        .args(["inspect", "--format", "{{.State.Status}}", id])
+        .output()
+        .expect("docker inspect");
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn rm_container(id: &str) {
+    let _ = Command::new("docker").args(["rm", "-f", id]).output();
+}

--- a/crates/executor/src/harness_tool.rs
+++ b/crates/executor/src/harness_tool.rs
@@ -2,8 +2,8 @@ use crate::{AgentConfig, ConversationConfig, ToolRuntime};
 use async_trait::async_trait;
 use exoharness::{
     ConversationHandle, CreateSandboxRequest, DEFAULT_SANDBOX_IMAGE, EventData, EventKind,
-    EventQuery, EventQueryDirection, FileSystemMount, FileSystemMountMode, Result,
-    RunInSandboxRequest, ToolRequest, ToolResult,
+    EventQueryDirection, FileSystemMount, FileSystemMountMode, Result, RunInSandboxRequest,
+    SnapshotId, StartSandboxRequest, ToolRequest, ToolResult,
 };
 use futures::io::AsyncReadExt;
 use serde::{Deserialize, Serialize};
@@ -115,6 +115,14 @@ pub(crate) async fn ensure_shell_sandbox(
         .unwrap_or_else(|| DEFAULT_SANDBOX_IMAGE.to_string());
     let desired_enable_networking = agent_config.enable_networking || config.enable_networking;
 
+    // 3-tier fallback for an existing conversation sandbox:
+    //   Tier 1: resume the same container/sandbox by SandboxKey.
+    //           This is what `run_in_sandbox` -> backend.try_resume now does
+    //           internally when the in-memory handle is missing.
+    //   Tier 2: if Tier 1 failed (container is truly gone — TTL expired,
+    //           server-side auto-delete, manual cleanup), restore from the
+    //           latest snapshot recorded in the conversation log.
+    //   Tier 3: nothing to resume, create fresh.
     if let Some(sandbox) = latest_shell_sandbox(conversation).await? {
         let Some(program) = &config.shell_program else {
             return Ok(sandbox.id);
@@ -127,6 +135,8 @@ pub(crate) async fn ensure_shell_sandbox(
             && sandbox.idle_seconds == 300;
 
         if config_matches {
+            // Tier 1: try a no-op exec; the harness will resume from the
+            // backend on cache miss.
             let healthcheck = conversation
                 .run_in_sandbox(RunInSandboxRequest {
                     id: sandbox.id.clone(),
@@ -137,9 +147,26 @@ pub(crate) async fn ensure_shell_sandbox(
             if healthcheck.is_ok() {
                 return Ok(sandbox.id);
             }
+
+            // Tier 2: container is gone. If we ever took a snapshot of this
+            // sandbox in this conversation, restore from the latest one.
+            if let Some(snapshot_id) =
+                latest_snapshot_for_sandbox(conversation, &sandbox.id).await?
+                && conversation
+                    .start_sandbox(StartSandboxRequest {
+                        id: sandbox.id.clone(),
+                        snapshot_id,
+                        idle_seconds: Some(sandbox.idle_seconds),
+                    })
+                    .await
+                    .is_ok()
+            {
+                return Ok(sandbox.id);
+            }
         }
     }
 
+    // Tier 3: nothing reusable; create fresh.
     conversation
         .create_sandbox(CreateSandboxRequest {
             image: desired_image,
@@ -149,6 +176,26 @@ pub(crate) async fn ensure_shell_sandbox(
             idle_seconds: Some(300),
         })
         .await
+}
+
+async fn latest_snapshot_for_sandbox(
+    conversation: &dyn ConversationHandle,
+    sandbox_id: &str,
+) -> Result<Option<SnapshotId>> {
+    exoharness::first_matching_event(
+        conversation,
+        EventKind::SANDBOX_SNAPSHOTTED,
+        EventQueryDirection::Desc,
+        100,
+        |data| match data {
+            EventData::SandboxSnapshotted {
+                sandbox_id: sid,
+                snapshot_id,
+            } if sid == sandbox_id => Some(snapshot_id),
+            _ => None,
+        },
+    )
+    .await
 }
 
 fn normalize_mounts(mounts: &[FileSystemMount]) -> Vec<FileSystemMount> {
@@ -179,41 +226,29 @@ struct ShellSandboxInfo {
 async fn latest_shell_sandbox(
     conversation: &dyn ConversationHandle,
 ) -> Result<Option<ShellSandboxInfo>> {
-    let events = conversation
-        .get_events(Some(EventQuery {
-            cursor: None,
-            direction: Some(EventQueryDirection::Desc),
-            limit: Some(50),
-            session_id: None,
-            turn_id: None,
-            types: Some(vec![EventKind::SANDBOX_CREATED]),
-        }))
-        .await?
-        .events;
-
-    let Some(event) = events.into_iter().next() else {
-        return Ok(None);
-    };
-    match event.data {
-        EventData::SandboxCreated {
-            sandbox_id,
-            image,
-            default_workdir,
-            file_system_mounts,
-            enable_networking,
-            idle_seconds,
-        } => Ok(Some(ShellSandboxInfo {
-            id: sandbox_id,
-            image,
-            default_workdir,
-            file_system_mounts,
-            enable_networking,
-            idle_seconds,
-        })),
-        other => Err(anyhow::anyhow!(
-            "type-filtered query for {} returned unexpected variant {}",
-            EventKind::SANDBOX_CREATED.as_str(),
-            other.kind().as_str(),
-        )),
-    }
+    exoharness::first_matching_event(
+        conversation,
+        EventKind::SANDBOX_CREATED,
+        EventQueryDirection::Desc,
+        1,
+        |data| match data {
+            EventData::SandboxCreated {
+                sandbox_id,
+                image,
+                default_workdir,
+                file_system_mounts,
+                enable_networking,
+                idle_seconds,
+            } => Some(ShellSandboxInfo {
+                id: sandbox_id,
+                image,
+                default_workdir,
+                file_system_mounts,
+                enable_networking,
+                idle_seconds,
+            }),
+            _ => None,
+        },
+    )
+    .await
 }

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -32,8 +32,9 @@ pub use executor_types::{
 };
 pub use exoharness::{
     AgentHandle, BasicExoHarness, BasicExoHarnessConfig, Binding, BindingMetadata,
-    ConversationHandle, EventData, EventId, EventKind, EventQuery, EventQueryDirection, ExoHarness,
-    FileSystemMount, FileSystemMountMode, ForkConversationRequest, PutSecretRequest,
+    ConversationHandle, DaytonaConfig, EventData, EventId, EventKind, EventQuery,
+    EventQueryDirection, ExoHarness, FileSystemMount, FileSystemMountMode, ForkConversationRequest,
+    PutSecretRequest,
     SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, SandboxId, Secret, SecretBackendChoice,
     SecretMetadata, SessionId, SnapshotId, StartSandboxRequest, Uuid7, first_matching_event,
 };

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -34,9 +34,9 @@ pub use exoharness::{
     AgentHandle, BasicExoHarness, BasicExoHarnessConfig, Binding, BindingMetadata,
     ConversationHandle, DaytonaConfig, EventData, EventId, EventKind, EventQuery,
     EventQueryDirection, ExoHarness, FileSystemMount, FileSystemMountMode, ForkConversationRequest,
-    PutSecretRequest,
-    SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, SandboxId, Secret, SecretBackendChoice,
-    SecretMetadata, SessionId, SnapshotId, StartSandboxRequest, Uuid7, first_matching_event,
+    PutSecretRequest, SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, SandboxId, Secret,
+    SecretBackendChoice, SecretMetadata, SessionId, SnapshotId, StartSandboxRequest, Uuid7,
+    first_matching_event,
 };
 pub use harness_basic::BasicHarness;
 pub use harness_config::load_agent_config;

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -35,7 +35,7 @@ pub use exoharness::{
     ConversationHandle, EventData, EventId, EventKind, EventQuery, EventQueryDirection, ExoHarness,
     FileSystemMount, FileSystemMountMode, ForkConversationRequest, PutSecretRequest,
     SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, SandboxId, Secret, SecretBackendChoice,
-    SecretMetadata, SessionId, SnapshotId, StartSandboxRequest, Uuid7,
+    SecretMetadata, SessionId, SnapshotId, StartSandboxRequest, Uuid7, first_matching_event,
 };
 pub use harness_basic::BasicHarness;
 pub use harness_config::load_agent_config;

--- a/crates/exoharness/Cargo.toml
+++ b/crates/exoharness/Cargo.toml
@@ -12,6 +12,7 @@ basic-backend = [
   "dep:keyring",
   "dep:keyring-core",
   "dep:object_store",
+  "dep:reqwest",
   "dep:tokio",
   "dep:tokio-stream",
   "dep:tokio-util",
@@ -28,6 +29,7 @@ keyring = { version = "4.0.0-rc.3", optional = true }
 keyring-core = { version = "0.7.2", optional = true }
 lingua.workspace = true
 object_store = { workspace = true, optional = true }
+reqwest = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex as AsyncMutex, mpsc};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
+use crate::daytona::DaytonaSandboxBackend;
 use crate::sandbox::{
     CliContainerSandboxBackend, LocalProcessSandboxBackend, ManagedSandboxBackend,
     ManagedSandboxHandle, SANDBOX_MAIN_MOUNT_DIR, SandboxCommand, SandboxKey,
@@ -43,11 +44,12 @@ pub enum SecretBackendChoice {
     Static([u8; 32]),
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub enum SandboxBackendChoice {
     AppleContainer,
     Docker,
     LocalProcess,
+    Daytona(crate::DaytonaConfig),
 }
 
 // TODO: as more knobs land here, swap to a builder pattern.
@@ -82,7 +84,7 @@ impl BasicExoHarness {
         let storage = BasicObjectStore::local_filesystem(&root).await?;
         let secret_cipher =
             build_secret_cipher(secret_backend, root.to_string_lossy().to_string())?;
-        let sandbox_backend = build_sandbox_backend(sandbox_backend);
+        let sandbox_backend = build_sandbox_backend(sandbox_backend)?;
         Ok(Self {
             inner: Arc::new(BasicExoHarnessInner {
                 storage,
@@ -1977,12 +1979,14 @@ fn build_secret_cipher(
     Ok(SecretCipher::new(provider))
 }
 
-fn build_sandbox_backend(choice: SandboxBackendChoice) -> Arc<dyn ManagedSandboxBackend> {
-    match choice {
+fn build_sandbox_backend(choice: SandboxBackendChoice) -> Result<Arc<dyn ManagedSandboxBackend>> {
+    let backend: Arc<dyn ManagedSandboxBackend> = match choice {
         SandboxBackendChoice::AppleContainer => {
             Arc::new(CliContainerSandboxBackend::apple_container())
         }
         SandboxBackendChoice::Docker => Arc::new(CliContainerSandboxBackend::docker()),
         SandboxBackendChoice::LocalProcess => Arc::new(LocalProcessSandboxBackend::new()),
-    }
+        SandboxBackendChoice::Daytona(config) => Arc::new(DaytonaSandboxBackend::new(config)?),
+    };
+    Ok(backend)
 }

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -1122,15 +1122,43 @@ impl ConversationHandle for BasicConversationHandle {
         if request.command.is_empty() {
             bail!("sandbox command must not be empty");
         }
-        let sandbox_handle = self
-            .harness
-            .inner
-            .running_sandboxes
-            .lock()
-            .await
-            .get(&request.id)
-            .cloned()
-            .ok_or_else(|| anyhow!("sandbox is not active in this process: {}", request.id))?;
+        let sandbox_handle = {
+            let cached = self
+                .harness
+                .inner
+                .running_sandboxes
+                .lock()
+                .await
+                .get(&request.id)
+                .cloned();
+            match cached {
+                Some(handle) => handle,
+                None => {
+                    // The handle isn't in this process's in-memory pool. That's
+                    // expected on the first tool call after exo starts up: the
+                    // conversation remembered the sandbox_id from a prior
+                    // process, but we haven't bound a handle to it yet. Ask the
+                    // backend to resume by SandboxKey — that's the moment the
+                    // cross-process resume contract actually triggers.
+                    let req = sandbox_request(self.record.id, &request.id, &sandbox);
+                    let Some(handle) = self.harness.inner.sandbox_backend.try_resume(req).await?
+                    else {
+                        bail!(
+                            "sandbox {} no longer exists on the backend; \
+                             create a new one or restore from a snapshot",
+                            request.id
+                        );
+                    };
+                    self.harness
+                        .inner
+                        .running_sandboxes
+                        .lock()
+                        .await
+                        .insert(request.id.clone(), Arc::clone(&handle));
+                    handle
+                }
+            }
+        };
         let parts = sandbox_handle
             .start_process(&SandboxCommand {
                 argv: request.command.clone(),

--- a/crates/exoharness/src/daytona.rs
+++ b/crates/exoharness/src/daytona.rs
@@ -1,0 +1,610 @@
+//! Daytona remote-container sandbox backend.
+//!
+//! Speaks Daytona's REST API directly via `reqwest`. State persistence is
+//! handled by Daytona itself: `stop` preserves the sandbox filesystem and the
+//! next `acquire` finds the same sandbox by label and `start`s it. Explicit
+//! `/snapshot` and `/rewind` go through [`SnapshotKind::DaytonaSnapshot`]
+//! payloads whose bytes are a small JSON manifest pointing at a named snapshot
+//! in Daytona's registry.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow, bail};
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::future::BoxFuture;
+use futures::io::Cursor;
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::sandbox::{
+    DEFAULT_SANDBOX_IMAGE, ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand,
+    SandboxCommandOutput, SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotKind,
+    SnapshotPayload, WARM_SANDBOX_KEY_LABEL, WARM_SANDBOX_SPEC_HASH_LABEL, sandbox_spec_hash,
+};
+
+pub const DEFAULT_DAYTONA_API_URL: &str = "https://app.daytona.io/api";
+
+/// Per-sandbox operations (exec, fs) go through Daytona's toolbox proxy rather
+/// than the control-plane API. The two have different base hosts.
+pub const DEFAULT_DAYTONA_TOOLBOX_URL: &str = "https://proxy.app.daytona.io";
+
+#[derive(Debug, Clone)]
+pub struct DaytonaConfig {
+    pub api_key: String,
+    pub api_url: String,
+    pub toolbox_url: String,
+    /// Optional region target (`eu` / `us`). Passed through to Daytona on
+    /// sandbox creation when set.
+    pub target: Option<String>,
+    /// Organization ID to scope requests to. Sent as the
+    /// `X-Daytona-Organization-ID` header. API keys can belong to multiple
+    /// organizations; without this, Daytona may default to a "personal" org
+    /// that isn't the one with credit / the one the user expects.
+    pub organization_id: Option<String>,
+}
+
+impl DaytonaConfig {
+    pub fn from_env() -> Result<Self> {
+        let api_key = std::env::var("DAYTONA_API_KEY")
+            .map_err(|_| anyhow!("DAYTONA_API_KEY is not set; required for the Daytona sandbox backend"))?;
+        let api_url =
+            std::env::var("DAYTONA_API_URL").unwrap_or_else(|_| DEFAULT_DAYTONA_API_URL.to_string());
+        let toolbox_url = std::env::var("DAYTONA_TOOLBOX_URL")
+            .unwrap_or_else(|_| DEFAULT_DAYTONA_TOOLBOX_URL.to_string());
+        let target = std::env::var("DAYTONA_TARGET").ok();
+        let organization_id = std::env::var("DAYTONA_ORGANIZATION_ID").ok();
+        Ok(Self {
+            api_key,
+            api_url,
+            toolbox_url,
+            target,
+            organization_id,
+        })
+    }
+}
+
+/// JSON payload persisted alongside a `SnapshotKind::DaytonaSnapshot`. The
+/// canonical filesystem bytes live in Daytona — we only persist enough
+/// metadata to ask Daytona to create a sandbox from the same snapshot later.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DaytonaSnapshotManifest {
+    /// Name of the snapshot in Daytona's snapshot registry.
+    snapshot_name: String,
+    /// Image the snapshotted sandbox was originally created from. Used as a
+    /// fallback if the snapshot itself doesn't carry enough info to recreate.
+    base_image: String,
+}
+
+pub struct DaytonaSandboxBackend {
+    client: reqwest::Client,
+    api_url: String,
+    toolbox_url: String,
+    target: Option<String>,
+}
+
+impl DaytonaSandboxBackend {
+    pub fn new(config: DaytonaConfig) -> Result<Self> {
+        let mut headers = HeaderMap::new();
+        let mut auth = HeaderValue::from_str(&format!("Bearer {}", config.api_key))
+            .context("DAYTONA_API_KEY contains characters that aren't valid in an HTTP header")?;
+        auth.set_sensitive(true);
+        headers.insert(AUTHORIZATION, auth);
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        if let Some(org_id) = config.organization_id.as_deref() {
+            let value = HeaderValue::from_str(org_id).context(
+                "DAYTONA_ORGANIZATION_ID contains characters that aren't valid in an HTTP header",
+            )?;
+            headers.insert("X-Daytona-Organization-ID", value);
+        }
+        let client = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()
+            .context("building Daytona HTTP client")?;
+        Ok(Self {
+            client,
+            api_url: config.api_url.trim_end_matches('/').to_string(),
+            toolbox_url: config.toolbox_url.trim_end_matches('/').to_string(),
+            target: config.target,
+        })
+    }
+
+    fn api_endpoint(&self, path: &str) -> String {
+        format!("{}{}", self.api_url, path)
+    }
+
+    fn toolbox_endpoint(&self, path: &str) -> String {
+        format!("{}{}", self.toolbox_url, path)
+    }
+
+    async fn find_sandbox_by_labels(
+        &self,
+        key_label: &str,
+        spec_hash: &str,
+    ) -> Result<Option<DaytonaSandbox>> {
+        // Daytona expects `labels` as a single query parameter whose value is a
+        // JSON-encoded object. Both label keys go into the same object so a
+        // spec change yields a fresh sandbox (matching the CLI backend's
+        // "evict on spec change" semantics).
+        let labels_filter = serde_json::json!({
+            WARM_SANDBOX_KEY_LABEL: key_label,
+            WARM_SANDBOX_SPEC_HASH_LABEL: spec_hash,
+        });
+        let response = self
+            .client
+            .get(self.api_endpoint("/sandbox"))
+            .query(&[("labels", labels_filter.to_string())])
+            .send()
+            .await
+            .context("listing Daytona sandboxes")?
+            .error_for_status()
+            .context("Daytona list sandboxes returned an error status")?;
+        let list: DaytonaSandboxList = response
+            .json()
+            .await
+            .context("decoding Daytona sandbox list response")?;
+        let mut sandboxes = list.items;
+        // If Daytona returned more than one match (e.g. concurrent creates),
+        // keep the most recent and let the rest age out via auto-stop /
+        // auto-archive. The prototype doesn't try to GC duplicates.
+        sandboxes.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(sandboxes.into_iter().next())
+    }
+
+    async fn create_sandbox(
+        &self,
+        request: &SandboxRequest,
+        spec_hash: &str,
+        snapshot_name: Option<&str>,
+    ) -> Result<DaytonaSandbox> {
+        let mut labels = HashMap::new();
+        labels.insert(WARM_SANDBOX_KEY_LABEL.to_string(), request.key.to_string());
+        labels.insert(WARM_SANDBOX_SPEC_HASH_LABEL.to_string(), spec_hash.to_string());
+
+        let auto_stop_minutes = request
+            .lifecycle
+            .idle_ttl
+            .map(|ttl| idle_ttl_to_minutes(ttl))
+            // 0 disables auto-stop in Daytona; we don't want that — pick a
+            // conservative default that matches Daytona's own (15 min).
+            .unwrap_or(15);
+
+        // `snapshot` on Daytona refers to a named, pre-registered snapshot in
+        // the user's account — not an arbitrary docker image ref. For fresh
+        // creates we omit it so Daytona falls back to its default base image;
+        // only the snapshot-restore path passes a name through. Honouring
+        // `spec.image` against Daytona would require registering it as a
+        // Daytona snapshot first; that's a follow-up.
+        let body = DaytonaCreateRequest {
+            snapshot: snapshot_name.map(str::to_string),
+            target: self.target.clone(),
+            labels,
+            env: HashMap::new(),
+            auto_stop_interval: auto_stop_minutes,
+            // Daytona's default auto-archive is one week; leave it alone.
+            network_block_all: matches!(request.spec.network, SandboxNetworkPolicy::Disabled),
+        };
+
+        let response = self
+            .client
+            .post(self.api_endpoint("/sandbox"))
+            .json(&body)
+            .send()
+            .await
+            .context("creating Daytona sandbox")?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            bail!("Daytona create-sandbox failed ({status}): {text}");
+        }
+        let sandbox: DaytonaSandbox = response
+            .json()
+            .await
+            .context("decoding Daytona create-sandbox response")?;
+        Ok(sandbox)
+    }
+
+    async fn start_sandbox(&self, id: &str) -> Result<()> {
+        let response = self
+            .client
+            .post(self.api_endpoint(&format!("/sandbox/{id}/start")))
+            .send()
+            .await
+            .with_context(|| format!("starting Daytona sandbox {id}"))?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            bail!("Daytona start-sandbox failed ({status}): {text}");
+        }
+        Ok(())
+    }
+
+}
+
+#[async_trait]
+impl ManagedSandboxBackend for DaytonaSandboxBackend {
+    async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
+        reject_host_mounts(&request)?;
+        let spec_hash = sandbox_spec_hash(&request.spec);
+        // `acquire` is "create fresh." The harness calls `try_resume` first
+        // when it wants to reuse an existing sandbox; once we're in `acquire`
+        // the contract is to mint a new one. Daytona's label-based lookup of
+        // existing sandboxes lives in `try_resume`.
+        let sandbox = self.create_sandbox(&request, &spec_hash, None).await?;
+        Ok(Arc::new(DaytonaSandboxHandle {
+            id: format!("daytona:{}", request.key),
+            sandbox_id: sandbox.id,
+            request,
+            backend: self.handle_backend()?,
+        }))
+    }
+
+    async fn try_resume(
+        &self,
+        request: SandboxRequest,
+    ) -> Result<Option<Arc<dyn ManagedSandboxHandle>>> {
+        reject_host_mounts(&request)?;
+        let spec_hash = sandbox_spec_hash(&request.spec);
+        let key_label = request.key.to_string();
+
+        let Some(existing) = self.find_sandbox_by_labels(&key_label, &spec_hash).await? else {
+            return Ok(None);
+        };
+        // Daytona preserves filesystem state across stop/start, so a
+        // labelled sandbox we find here always carries the previous
+        // session's writes. Start it if the auto-stop timer has fired.
+        if !existing.is_running() {
+            self.start_sandbox(&existing.id).await?;
+        }
+        Ok(Some(Arc::new(DaytonaSandboxHandle {
+            id: format!("daytona:{}", request.key),
+            sandbox_id: existing.id,
+            request,
+            backend: self.handle_backend()?,
+        })))
+    }
+
+    async fn acquire_from_snapshot(
+        &self,
+        request: SandboxRequest,
+        payload: SnapshotPayload,
+    ) -> Result<Arc<dyn ManagedSandboxHandle>> {
+        reject_host_mounts(&request)?;
+        if !matches!(payload.kind, SnapshotKind::DaytonaSnapshot) {
+            bail!(
+                "Daytona sandbox backend can only restore from SnapshotKind::DaytonaSnapshot, \
+                 got {:?}",
+                payload.kind
+            );
+        }
+        let manifest: DaytonaSnapshotManifest = serde_json::from_slice(&payload.bytes)
+            .context("decoding DaytonaSnapshot manifest")?;
+        let spec_hash = sandbox_spec_hash(&request.spec);
+        let sandbox = self
+            .create_sandbox(&request, &spec_hash, Some(&manifest.snapshot_name))
+            .await?;
+        Ok(Arc::new(DaytonaSandboxHandle {
+            id: format!("daytona-restored:{}", request.key),
+            sandbox_id: sandbox.id,
+            request,
+            backend: self.handle_backend()?,
+        }))
+    }
+}
+
+impl DaytonaSandboxBackend {
+    /// Clone the backend's HTTP state into a value the handle can hold. We
+    /// can't hand out `Arc<Self>` from `&self` without making the backend's
+    /// internals `Arc`-shared at construction; instead the handle holds its
+    /// own clone of the (cheap) client + URL + target.
+    fn handle_backend(&self) -> Result<DaytonaBackendHandle> {
+        Ok(DaytonaBackendHandle {
+            client: self.client.clone(),
+            api_url: self.api_url.clone(),
+            toolbox_url: self.toolbox_url.clone(),
+            target: self.target.clone(),
+        })
+    }
+}
+
+#[derive(Clone)]
+struct DaytonaBackendHandle {
+    client: reqwest::Client,
+    api_url: String,
+    toolbox_url: String,
+    #[allow(dead_code)] // available for future per-handle operations that re-target.
+    target: Option<String>,
+}
+
+impl DaytonaBackendHandle {
+    fn api_endpoint(&self, path: &str) -> String {
+        format!("{}{}", self.api_url, path)
+    }
+
+    fn toolbox_endpoint(&self, path: &str) -> String {
+        format!("{}{}", self.toolbox_url, path)
+    }
+}
+
+struct DaytonaSandboxHandle {
+    id: String,
+    sandbox_id: String,
+    request: SandboxRequest,
+    backend: DaytonaBackendHandle,
+}
+
+#[async_trait]
+impl ManagedSandboxHandle for DaytonaSandboxHandle {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    async fn exec(&self, command: &SandboxCommand) -> Result<SandboxCommandOutput> {
+        // Delegate to a free function so the backend struct doesn't need to
+        // be re-borrowed; the handle owns everything it needs.
+        exec_in_sandbox(&self.backend, &self.sandbox_id, &self.request.spec, command).await
+    }
+
+    async fn start_process(&self, command: &SandboxCommand) -> Result<crate::SandboxProcessParts> {
+        // Daytona's exec endpoint is request/response, not streaming. Run the
+        // command synchronously, then hand the caller a SandboxProcessParts
+        // whose stdout/stderr/wait are already populated. stdin goes to a
+        // sink — Daytona's exec doesn't accept piped input on this endpoint.
+        let output = exec_in_sandbox(
+            &self.backend,
+            &self.sandbox_id,
+            &self.request.spec,
+            command,
+        )
+        .await?;
+        let exit_code = output.exit_code.unwrap_or(0);
+        let stdout = Cursor::new(output.stdout.into_bytes());
+        let stderr = Cursor::new(output.stderr.into_bytes());
+        let stdin = futures::io::sink();
+        let wait: BoxFuture<'static, crate::Result<i32>> =
+            Box::pin(async move { Ok(exit_code) });
+        Ok(crate::SandboxProcessParts {
+            stdout: Box::pin(stdout),
+            stderr: Box::pin(stderr),
+            stdin: Box::pin(stdin),
+            wait,
+        })
+    }
+
+    async fn stop(&self) -> Result<()> {
+        // Stop, do NOT delete. Daytona preserves filesystem state across stop;
+        // the next acquire() for the same SandboxKey will find this sandbox by
+        // label and start() it back up. Auto-archive / auto-delete on the
+        // Daytona side eventually GCs sandboxes nobody comes back for.
+        stop_via_backend(&self.backend, &self.sandbox_id).await
+    }
+
+    async fn snapshot(&self) -> Result<SnapshotPayload> {
+        save_as_snapshot_via_backend(
+            &self.backend,
+            &self.sandbox_id,
+            resolve_image(&self.request.spec),
+        )
+        .await
+    }
+}
+
+async fn exec_in_sandbox(
+    backend: &DaytonaBackendHandle,
+    id: &str,
+    spec: &SandboxSpec,
+    command: &SandboxCommand,
+) -> Result<SandboxCommandOutput> {
+    if command.argv.is_empty() {
+        bail!("sandbox command requires at least one argv entry");
+    }
+    let cwd = command
+        .cwd
+        .clone()
+        .unwrap_or_else(|| spec.default_workdir.clone());
+    let body = DaytonaExecRequest {
+        command: render_shell_command(&command.argv),
+        cwd: Some(cwd.clone()),
+        env: command.env.clone(),
+        timeout: command.timeout.map(|t| t.as_secs()),
+    };
+    let response = backend
+        .client
+        .post(backend.toolbox_endpoint(&format!("/toolbox/{id}/process/execute")))
+        .json(&body)
+        .send()
+        .await
+        .with_context(|| format!("exec in Daytona sandbox {id}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        let text = response.text().await.unwrap_or_default();
+        bail!("Daytona exec failed ({status}): {text}");
+    }
+    let response: DaytonaExecResponse = response
+        .json()
+        .await
+        .context("decoding Daytona exec response")?;
+    Ok(SandboxCommandOutput {
+        ok: response.exit_code == 0,
+        exit_code: Some(response.exit_code),
+        stdout: response.result.unwrap_or_default(),
+        stderr: String::new(),
+        command: command
+            .display_argv
+            .clone()
+            .unwrap_or_else(|| command.argv.clone()),
+        cwd,
+    })
+}
+
+async fn stop_via_backend(backend: &DaytonaBackendHandle, id: &str) -> Result<()> {
+    let response = backend
+        .client
+        .post(backend.api_endpoint(&format!("/sandbox/{id}/stop")))
+        .send()
+        .await
+        .with_context(|| format!("stopping Daytona sandbox {id}"))?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        bail!("Daytona stop-sandbox failed ({status}): {text}");
+    }
+    Ok(())
+}
+
+async fn save_as_snapshot_via_backend(
+    backend: &DaytonaBackendHandle,
+    id: &str,
+    base_image: String,
+) -> Result<SnapshotPayload> {
+    let snapshot_name = format!("exo-snap-{}", Uuid::new_v4().simple());
+    let body = DaytonaSnapshotRequest {
+        name: snapshot_name.clone(),
+    };
+    let response = backend
+        .client
+        .post(backend.api_endpoint(&format!("/sandbox/{id}/snapshot")))
+        .json(&body)
+        .send()
+        .await
+        .with_context(|| format!("snapshotting Daytona sandbox {id}"))?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        bail!("Daytona snapshot failed ({status}): {text}");
+    }
+    let manifest = DaytonaSnapshotManifest {
+        snapshot_name,
+        base_image,
+    };
+    let bytes = serde_json::to_vec(&manifest)
+        .context("serializing Daytona snapshot manifest")?;
+    Ok(SnapshotPayload {
+        kind: SnapshotKind::DaytonaSnapshot,
+        bytes: Bytes::from(bytes),
+    })
+}
+
+fn reject_host_mounts(request: &SandboxRequest) -> Result<()> {
+    if request.spec.mounts.is_empty() {
+        return Ok(());
+    }
+    bail!(
+        "Daytona sandbox backend does not support host bind-mounts; \
+         remove conversation mounts or switch to --sandbox-backend docker. \
+         A remote-workspace provisioner (git clone / Daytona Volume) is planned as a follow-up."
+    )
+}
+
+fn resolve_image(spec: &SandboxSpec) -> String {
+    if spec.image.trim().is_empty() {
+        DEFAULT_SANDBOX_IMAGE.to_string()
+    } else {
+        spec.image.clone()
+    }
+}
+
+fn idle_ttl_to_minutes(ttl: Duration) -> u32 {
+    // Daytona auto-stop is in minutes with 0 meaning "disabled". Round up
+    // so we never expire earlier than the caller asked for, and floor at 1
+    // so the smallest meaningful TTL still produces an active timer.
+    let secs = ttl.as_secs();
+    let minutes = secs.div_ceil(60);
+    minutes.clamp(1, u32::MAX as u64) as u32
+}
+
+fn render_shell_command(argv: &[String]) -> String {
+    // Daytona's execute endpoint takes a single command string interpreted by
+    // a shell. Quote each argv element so spaces / metacharacters survive.
+    argv.iter()
+        .map(|arg| shell_quote(arg))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn shell_quote(arg: &str) -> String {
+    if !arg.is_empty()
+        && arg
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | '/' | ':' | '=' | ','))
+    {
+        return arg.to_string();
+    }
+    let mut quoted = String::with_capacity(arg.len() + 2);
+    quoted.push('\'');
+    for c in arg.chars() {
+        if c == '\'' {
+            quoted.push_str("'\\''");
+        } else {
+            quoted.push(c);
+        }
+    }
+    quoted.push('\'');
+    quoted
+}
+
+#[derive(Debug, Serialize)]
+struct DaytonaCreateRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    snapshot: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target: Option<String>,
+    labels: HashMap<String, String>,
+    env: HashMap<String, String>,
+    #[serde(rename = "autoStopInterval")]
+    auto_stop_interval: u32,
+    #[serde(rename = "networkBlockAll")]
+    network_block_all: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct DaytonaExecRequest {
+    command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cwd: Option<String>,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    env: HashMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    timeout: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DaytonaExecResponse {
+    #[serde(rename = "exitCode", alias = "exit_code")]
+    exit_code: i32,
+    #[serde(default)]
+    result: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct DaytonaSnapshotRequest {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DaytonaSandboxList {
+    #[serde(default)]
+    items: Vec<DaytonaSandbox>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DaytonaSandbox {
+    id: String,
+    state: String,
+    #[serde(default, rename = "createdAt", alias = "created_at")]
+    created_at: Option<String>,
+}
+
+impl DaytonaSandbox {
+    fn is_running(&self) -> bool {
+        // Daytona's state strings vary by API version; treat anything that
+        // looks like an active state as running, and anything else as
+        // requiring a `start` call. The conservative call is "if I'm not sure
+        // it's running, ask Daytona to start it" — `start` is a no-op on an
+        // already-running sandbox.
+        matches!(self.state.as_str(), "started" | "running")
+    }
+}

--- a/crates/exoharness/src/daytona.rs
+++ b/crates/exoharness/src/daytona.rs
@@ -49,10 +49,11 @@ pub struct DaytonaConfig {
 
 impl DaytonaConfig {
     pub fn from_env() -> Result<Self> {
-        let api_key = std::env::var("DAYTONA_API_KEY")
-            .map_err(|_| anyhow!("DAYTONA_API_KEY is not set; required for the Daytona sandbox backend"))?;
-        let api_url =
-            std::env::var("DAYTONA_API_URL").unwrap_or_else(|_| DEFAULT_DAYTONA_API_URL.to_string());
+        let api_key = std::env::var("DAYTONA_API_KEY").map_err(|_| {
+            anyhow!("DAYTONA_API_KEY is not set; required for the Daytona sandbox backend")
+        })?;
+        let api_url = std::env::var("DAYTONA_API_URL")
+            .unwrap_or_else(|_| DEFAULT_DAYTONA_API_URL.to_string());
         let toolbox_url = std::env::var("DAYTONA_TOOLBOX_URL")
             .unwrap_or_else(|_| DEFAULT_DAYTONA_TOOLBOX_URL.to_string());
         let target = std::env::var("DAYTONA_TARGET").ok();
@@ -116,10 +117,6 @@ impl DaytonaSandboxBackend {
         format!("{}{}", self.api_url, path)
     }
 
-    fn toolbox_endpoint(&self, path: &str) -> String {
-        format!("{}{}", self.toolbox_url, path)
-    }
-
     async fn find_sandbox_by_labels(
         &self,
         key_label: &str,
@@ -162,12 +159,15 @@ impl DaytonaSandboxBackend {
     ) -> Result<DaytonaSandbox> {
         let mut labels = HashMap::new();
         labels.insert(WARM_SANDBOX_KEY_LABEL.to_string(), request.key.to_string());
-        labels.insert(WARM_SANDBOX_SPEC_HASH_LABEL.to_string(), spec_hash.to_string());
+        labels.insert(
+            WARM_SANDBOX_SPEC_HASH_LABEL.to_string(),
+            spec_hash.to_string(),
+        );
 
         let auto_stop_minutes = request
             .lifecycle
             .idle_ttl
-            .map(|ttl| idle_ttl_to_minutes(ttl))
+            .map(idle_ttl_to_minutes)
             // 0 disables auto-stop in Daytona; we don't want that — pick a
             // conservative default that matches Daytona's own (15 min).
             .unwrap_or(15);
@@ -221,7 +221,6 @@ impl DaytonaSandboxBackend {
         }
         Ok(())
     }
-
 }
 
 #[async_trait]
@@ -280,8 +279,8 @@ impl ManagedSandboxBackend for DaytonaSandboxBackend {
                 payload.kind
             );
         }
-        let manifest: DaytonaSnapshotManifest = serde_json::from_slice(&payload.bytes)
-            .context("decoding DaytonaSnapshot manifest")?;
+        let manifest: DaytonaSnapshotManifest =
+            serde_json::from_slice(&payload.bytes).context("decoding DaytonaSnapshot manifest")?;
         let spec_hash = sandbox_spec_hash(&request.spec);
         let sandbox = self
             .create_sandbox(&request, &spec_hash, Some(&manifest.snapshot_name))
@@ -353,19 +352,13 @@ impl ManagedSandboxHandle for DaytonaSandboxHandle {
         // command synchronously, then hand the caller a SandboxProcessParts
         // whose stdout/stderr/wait are already populated. stdin goes to a
         // sink — Daytona's exec doesn't accept piped input on this endpoint.
-        let output = exec_in_sandbox(
-            &self.backend,
-            &self.sandbox_id,
-            &self.request.spec,
-            command,
-        )
-        .await?;
+        let output =
+            exec_in_sandbox(&self.backend, &self.sandbox_id, &self.request.spec, command).await?;
         let exit_code = output.exit_code.unwrap_or(0);
         let stdout = Cursor::new(output.stdout.into_bytes());
         let stderr = Cursor::new(output.stderr.into_bytes());
         let stdin = futures::io::sink();
-        let wait: BoxFuture<'static, crate::Result<i32>> =
-            Box::pin(async move { Ok(exit_code) });
+        let wait: BoxFuture<'static, crate::Result<i32>> = Box::pin(async move { Ok(exit_code) });
         Ok(crate::SandboxProcessParts {
             stdout: Box::pin(stdout),
             stderr: Box::pin(stderr),
@@ -480,8 +473,7 @@ async fn save_as_snapshot_via_backend(
         snapshot_name,
         base_image,
     };
-    let bytes = serde_json::to_vec(&manifest)
-        .context("serializing Daytona snapshot manifest")?;
+    let bytes = serde_json::to_vec(&manifest).context("serializing Daytona snapshot manifest")?;
     Ok(SnapshotPayload {
         kind: SnapshotKind::DaytonaSnapshot,
         bytes: Bytes::from(bytes),
@@ -527,9 +519,9 @@ fn render_shell_command(argv: &[String]) -> String {
 
 fn shell_quote(arg: &str) -> String {
     if !arg.is_empty()
-        && arg
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | '/' | ':' | '=' | ','))
+        && arg.chars().all(|c| {
+            c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | '/' | ':' | '=' | ',')
+        })
     {
         return arg.to_string();
     }

--- a/crates/exoharness/src/lib.rs
+++ b/crates/exoharness/src/lib.rs
@@ -2,6 +2,8 @@
 mod basic;
 #[cfg(all(test, not(target_arch = "wasm32"), feature = "basic-backend"))]
 mod basic_tests;
+#[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
+mod daytona;
 mod error;
 pub mod protocol;
 #[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
@@ -17,6 +19,8 @@ mod uuid7;
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
 pub use basic::*;
+#[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
+pub use daytona::{DEFAULT_DAYTONA_API_URL, DaytonaConfig, DaytonaSandboxBackend};
 pub use error::*;
 #[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
 pub use sandbox::*;

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -133,7 +133,20 @@ pub trait ManagedSandboxHandle: Send + Sync {
 
 #[async_trait]
 pub trait ManagedSandboxBackend: Send + Sync {
+    /// Bring up a sandbox for `request.key`. Reuses an in-process warm
+    /// sandbox if one matches; otherwise creates fresh from
+    /// `request.spec.image`. Cross-process reuse goes through
+    /// [`Self::try_resume`].
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>>;
+
+    /// Reattach to a sandbox from a previous exo process (e.g. a stopped
+    /// docker container labelled with `exo.sandbox.key`). Starts it if
+    /// stopped. Returns `Ok(None)` if no match. Backends with no
+    /// cross-process identity (local-process) always return `Ok(None)`.
+    async fn try_resume(
+        &self,
+        request: SandboxRequest,
+    ) -> Result<Option<Arc<dyn ManagedSandboxHandle>>>;
 
     /// Acquire a sandbox initialised from a previously-captured snapshot.
     /// The request is honoured for mounts, network, lifecycle, etc., but the
@@ -351,6 +364,7 @@ impl CliContainerSandboxBackend {
 
 impl Drop for CliContainerSandboxBackend {
     fn drop(&mut self) {
+        // Stop, don't delete — let the next process `try_resume` by label.
         let Ok(mut warm_sandboxes) = self.warm_sandboxes.try_lock() else {
             return;
         };
@@ -359,7 +373,7 @@ impl Drop for CliContainerSandboxBackend {
             .map(|(_, entry)| entry.name)
             .collect::<Vec<_>>();
         for name in names {
-            cleanup_named_container_blocking(&self.container_bin, self.cli, &name);
+            stop_named_container_blocking(&self.container_bin, self.cli, &name);
         }
     }
 }
@@ -420,6 +434,77 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
             request,
             warm_sandboxes: Arc::clone(&self.warm_sandboxes),
         }))
+    }
+
+    async fn try_resume(
+        &self,
+        request: SandboxRequest,
+    ) -> Result<Option<Arc<dyn ManagedSandboxHandle>>> {
+        let request = self.prepare_request(request).await?;
+
+        // No warm pool, no cross-process identity.
+        let Some(idle_ttl) = request.lifecycle.idle_ttl else {
+            return Ok(None);
+        };
+
+        // In-process warm pool first.
+        {
+            let warm_sandboxes = self.warm_sandboxes.lock().await;
+            if let Some(entry) = warm_sandboxes.get(&request.key)
+                && entry.request.spec == request.spec
+            {
+                return Ok(Some(Arc::new(WarmSandboxHandle {
+                    id: format!("warm:{}", request.key),
+                    cli: self.cli,
+                    container_bin: self.container_bin.clone(),
+                    request,
+                    warm_sandboxes: Arc::clone(&self.warm_sandboxes),
+                })));
+            }
+        }
+
+        // Cross-process: look up by label; stale spec-hashes are reaped.
+        let spec_hash = sandbox_spec_hash(&request.spec);
+        let key_str = request.key.to_string();
+        let Some(existing) =
+            find_resumable_container(&self.container_bin, self.cli, &key_str, &spec_hash).await?
+        else {
+            return Ok(None);
+        };
+
+        // Drop containers idle past the TTL.
+        if !existing.is_running
+            && let Some(finished_at) = existing.finished_at
+            && let Ok(idle_for) = SystemTime::now().duration_since(finished_at)
+            && idle_for > idle_ttl
+        {
+            cleanup_named_container(&self.container_bin, self.cli, &existing.name).await?;
+            return Ok(None);
+        }
+
+        if !existing.is_running {
+            start_named_container(&self.container_bin, self.cli, &existing.name).await?;
+        }
+
+        {
+            let mut warm_sandboxes = self.warm_sandboxes.lock().await;
+            warm_sandboxes.insert(
+                request.key.clone(),
+                WarmSandboxEntry {
+                    name: existing.name.clone(),
+                    request: request.clone(),
+                    last_used_at: Instant::now(),
+                },
+            );
+        }
+
+        Ok(Some(Arc::new(WarmSandboxHandle {
+            id: format!("warm:{}", request.key),
+            cli: self.cli,
+            container_bin: self.container_bin.clone(),
+            request,
+            warm_sandboxes: Arc::clone(&self.warm_sandboxes),
+        })))
     }
 
     async fn acquire_from_snapshot(
@@ -619,6 +704,14 @@ impl ManagedSandboxBackend for LocalProcessSandboxBackend {
             id: format!("local:{}", request.key),
             request,
         }))
+    }
+
+    async fn try_resume(
+        &self,
+        _request: SandboxRequest,
+    ) -> Result<Option<Arc<dyn ManagedSandboxHandle>>> {
+        // Local-process "sandboxes" don't outlive the exo invocation.
+        Ok(None)
     }
 
     async fn acquire_from_snapshot(
@@ -1222,16 +1315,12 @@ fn owner_pid_is_alive(pid: &str) -> bool {
         .is_ok_and(|status| status.success())
 }
 
-fn cleanup_named_container_blocking(container_bin: &Path, cli: ContainerCliFlavor, name: &str) {
-    match cli {
-        ContainerCliFlavor::AppleContainer => {
-            run_container_admin_command_blocking(container_bin, ["stop", name]);
-            run_container_admin_command_blocking(container_bin, ["delete", name]);
-        }
-        ContainerCliFlavor::Docker => {
-            run_container_admin_command_blocking(container_bin, ["rm", "-f", name]);
-        }
-    }
+/// Stop without deleting, so the next process can `try_resume` by label.
+/// For destructive cleanup use `cleanup_named_container`.
+fn stop_named_container_blocking(container_bin: &Path, cli: ContainerCliFlavor, name: &str) {
+    let _ = cli; // both flavors accept `stop <name>`
+    // `-t 0` = SIGKILL immediately on Docker (no 10s SIGTERM grace).
+    run_container_admin_command_blocking(container_bin, ["stop", "-t", "0", name]);
 }
 
 fn schedule_cleanup_named_container(container_bin: PathBuf, cli: ContainerCliFlavor, name: String) {
@@ -1291,6 +1380,241 @@ fn run_container_admin_command_blocking<const N: usize>(container_bin: &Path, ar
 fn is_missing_container_error(stderr: &str) -> bool {
     let lower = stderr.to_ascii_lowercase();
     lower.contains("not found") || lower.contains("no such")
+}
+
+#[derive(Debug)]
+struct ResumableContainerInfo {
+    name: String,
+    is_running: bool,
+    /// `None` for running containers or backends without a `FinishedAt`.
+    finished_at: Option<SystemTime>,
+}
+
+/// Look up any container labelled with this `SandboxKey`. Stale spec-hash
+/// containers are reaped on the way out.
+async fn find_resumable_container(
+    container_bin: &Path,
+    cli: ContainerCliFlavor,
+    key: &str,
+    spec_hash: &str,
+) -> Result<Option<ResumableContainerInfo>> {
+    match cli {
+        ContainerCliFlavor::Docker => find_docker_resumable(container_bin, key, spec_hash).await,
+        ContainerCliFlavor::AppleContainer => {
+            find_apple_resumable(container_bin, key, spec_hash).await
+        }
+    }
+}
+
+/// One row of `docker ps --format '{{json .}}'`.
+#[derive(Debug, Deserialize)]
+struct DockerPsItem {
+    #[serde(rename = "Names")]
+    names: String,
+    /// `"k1=v1,k2=v2"`; parse with [`parse_docker_labels`].
+    #[serde(rename = "Labels")]
+    labels: String,
+    #[serde(rename = "State")]
+    state: String,
+    #[serde(rename = "CreatedAt")]
+    created_at: String,
+}
+
+fn parse_docker_labels(raw: &str) -> HashMap<&str, &str> {
+    raw.split(',').filter_map(|kv| kv.split_once('=')).collect()
+}
+
+async fn find_docker_resumable(
+    container_bin: &Path,
+    key: &str,
+    spec_hash: &str,
+) -> Result<Option<ResumableContainerInfo>> {
+    // `docker ps -a --filter label=...` already does an exact-match on
+    // the key label server-side. We still pull every candidate so we can
+    // pick the most recent if there are duplicates (concurrent races)
+    // and reap any whose spec hash has drifted.
+    let key_filter = format!("label={WARM_SANDBOX_KEY_LABEL}={key}");
+    let mut command = Command::new(container_bin);
+    command
+        .arg("ps")
+        .arg("-a")
+        .arg("--filter")
+        .arg(&key_filter)
+        .arg("--format")
+        .arg("{{json .}}")
+        .kill_on_drop(true);
+    let output = match time::timeout(WARM_SANDBOX_CLEANUP_TIMEOUT, command.output()).await {
+        Ok(out) => out?,
+        Err(_) => {
+            return Err(anyhow!(
+                "docker ps timed out while listing resumable containers"
+            ));
+        }
+    };
+    if !output.status.success() {
+        return Err(anyhow!(
+            "docker ps failed while listing resumable containers: {}",
+            render_command_error(&output.stderr)
+        ));
+    }
+
+    let stdout = std::str::from_utf8(&output.stdout).context("docker ps output is not utf-8")?;
+    let mut matches: Vec<(String, String, String)> = Vec::new();
+    let mut stale_names: Vec<String> = Vec::new();
+    for line in stdout.lines() {
+        if line.is_empty() {
+            continue;
+        }
+        let item: DockerPsItem = serde_json::from_str(line)
+            .with_context(|| format!("decoding docker ps json line: {line}"))?;
+        let hash = parse_docker_labels(&item.labels)
+            .get(WARM_SANDBOX_SPEC_HASH_LABEL)
+            .copied()
+            .unwrap_or("");
+        if hash == spec_hash {
+            matches.push((item.names, item.state, item.created_at));
+        } else {
+            stale_names.push(item.names);
+        }
+    }
+    for name in stale_names {
+        if let Err(err) =
+            cleanup_named_container(container_bin, ContainerCliFlavor::Docker, &name).await
+        {
+            eprintln!("failed to reap container {name} with stale spec hash: {err}");
+        }
+    }
+    // Prefer the most-recent entry (Docker's CreatedAt sorts
+    // lexicographically as ISO-8601-ish text).
+    matches.sort_by(|a, b| b.2.cmp(&a.2));
+    let Some((name, state, _created)) = matches.into_iter().next() else {
+        return Ok(None);
+    };
+    let is_running = state.eq_ignore_ascii_case("running");
+    let finished_at = if !is_running {
+        docker_container_finished_at(container_bin, &name).await?
+    } else {
+        None
+    };
+    Ok(Some(ResumableContainerInfo {
+        name,
+        is_running,
+        finished_at,
+    }))
+}
+
+async fn docker_container_finished_at(
+    container_bin: &Path,
+    name: &str,
+) -> Result<Option<SystemTime>> {
+    let mut command = Command::new(container_bin);
+    command
+        .arg("inspect")
+        .arg("--format")
+        .arg("{{.State.FinishedAt}}")
+        .arg(name)
+        .kill_on_drop(true);
+    let output = match time::timeout(WARM_SANDBOX_CLEANUP_TIMEOUT, command.output()).await {
+        Ok(out) => out?,
+        Err(_) => return Ok(None),
+    };
+    if !output.status.success() {
+        // Container disappeared between list and inspect — treat as
+        // unknown, the caller will create fresh.
+        return Ok(None);
+    }
+    let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    // "0001-01-01T00:00:00Z" is Docker's "never finished" sentinel.
+    if s.is_empty() || s.starts_with("0001-01-01") {
+        return Ok(None);
+    }
+    Ok(parse_rfc3339_to_system_time(&s))
+}
+
+fn parse_rfc3339_to_system_time(s: &str) -> Option<SystemTime> {
+    let dt = chrono::DateTime::parse_from_rfc3339(s).ok()?;
+    let nanos = dt.timestamp_nanos_opt()?;
+    if nanos < 0 {
+        return None;
+    }
+    Some(SystemTime::UNIX_EPOCH + Duration::from_nanos(nanos as u64))
+}
+
+async fn find_apple_resumable(
+    container_bin: &Path,
+    key: &str,
+    spec_hash: &str,
+) -> Result<Option<ResumableContainerInfo>> {
+    // Apple's `container` CLI doesn't expose a label filter; we list
+    // everything and match in-process.
+    let output = run_container_admin_command(
+        container_bin,
+        WARM_SANDBOX_CLEANUP_TIMEOUT,
+        ["list", "--format", "json"],
+    )
+    .await?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "container list failed: {}",
+            render_command_error(&output.stderr)
+        ));
+    }
+    let containers: Vec<ContainerListItem> = serde_json::from_slice(&output.stdout)?;
+    let mut chosen: Option<ResumableContainerInfo> = None;
+    let mut stale_names: Vec<String> = Vec::new();
+    for c in containers {
+        let labels = &c.configuration.labels;
+        let Some(matched_key) = labels.get(WARM_SANDBOX_KEY_LABEL) else {
+            continue;
+        };
+        if matched_key != key {
+            continue;
+        }
+        let hash_matches = labels
+            .get(WARM_SANDBOX_SPEC_HASH_LABEL)
+            .map(|s| s == spec_hash)
+            .unwrap_or(false);
+        if !hash_matches {
+            stale_names.push(c.configuration.id);
+            continue;
+        }
+        // We don't have a portable finished-at signal from the apple
+        // CLI's list output; trust the status field for run-state and
+        // leave finished_at as None (the TTL guard simply skips its
+        // staleness check when finished_at is unknown).
+        let is_running = c.status.as_deref() == Some("running");
+        chosen = Some(ResumableContainerInfo {
+            name: c.configuration.id,
+            is_running,
+            finished_at: None,
+        });
+    }
+    for name in stale_names {
+        if let Err(err) =
+            cleanup_named_container(container_bin, ContainerCliFlavor::AppleContainer, &name).await
+        {
+            eprintln!("failed to reap apple-container {name} with stale spec hash: {err}");
+        }
+    }
+    Ok(chosen)
+}
+
+async fn start_named_container(
+    container_bin: &Path,
+    cli: ContainerCliFlavor,
+    name: &str,
+) -> Result<()> {
+    let _ = cli; // both flavors take `start <name>`
+    let output =
+        run_container_admin_command(container_bin, WARM_SANDBOX_CLEANUP_TIMEOUT, ["start", name])
+            .await?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "failed to start container {name}: {}",
+            render_command_error(&output.stderr)
+        ));
+    }
+    Ok(())
 }
 
 fn is_already_exists_error(message: &str) -> bool {
@@ -1448,4 +1772,18 @@ async fn docker_load_image(container_bin: &Path, payload: &Bytes) -> Result<Stri
         }
     }
     bail!("docker load completed but no image reference found in output: {stdout}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_docker_labels_handles_empty_and_multi() {
+        assert!(!parse_docker_labels("").contains_key("anything"));
+        let labels =
+            parse_docker_labels("exo.sandbox.key=conversation:c1:s1,exo.sandbox.spec-hash=abc123");
+        assert_eq!(labels.get("exo.sandbox.key"), Some(&"conversation:c1:s1"));
+        assert_eq!(labels.get("exo.sandbox.spec-hash"), Some(&"abc123"));
+    }
 }

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -114,6 +114,12 @@ pub enum SnapshotKind {
     /// `docker save` output: a tar of OCI image layers + manifest, loadable
     /// with `docker load`.
     DockerImageTar,
+    /// Reference to a named snapshot held inside Daytona's own snapshot
+    /// registry. The payload bytes are a small JSON manifest pointing at
+    /// the Daytona snapshot name; the actual filesystem state stays on
+    /// Daytona. Bytes-by-reference, not bytes-by-value — restoring is a
+    /// `POST /sandbox { snapshot: <name> }` call, not a tarball load.
+    DaytonaSnapshot,
 }
 
 #[async_trait]
@@ -188,8 +194,8 @@ const WARM_SANDBOX_KEEPALIVE_ARGV: &[&str] = &["sleep", "infinity"];
 const WARM_SANDBOX_HEALTHCHECK_TIMEOUT: Duration = Duration::from_secs(3);
 const WARM_SANDBOX_CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
 const ORPHANED_WARM_SANDBOX_MIN_AGE: Duration = Duration::from_secs(60 * 60);
-const WARM_SANDBOX_KEY_LABEL: &str = "exo.sandbox.key";
-const WARM_SANDBOX_SPEC_HASH_LABEL: &str = "exo.sandbox.spec-hash";
+pub(crate) const WARM_SANDBOX_KEY_LABEL: &str = "exo.sandbox.key";
+pub(crate) const WARM_SANDBOX_SPEC_HASH_LABEL: &str = "exo.sandbox.spec-hash";
 const WARM_SANDBOX_OWNER_PID_LABEL: &str = "exo.sandbox.owner-pid";
 const APPLE_ABSOLUTE_TIME_UNIX_OFFSET_SECONDS: f64 = 978_307_200.0;
 
@@ -517,6 +523,10 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
         }
         match (self.cli, payload.kind) {
             (ContainerCliFlavor::Docker, SnapshotKind::DockerImageTar) => {}
+            (_, SnapshotKind::DaytonaSnapshot) => bail!(
+                "DaytonaSnapshot payloads can only be restored by the Daytona sandbox backend; \
+                 switch to --sandbox-backend daytona to rewind this snapshot"
+            ),
             (ContainerCliFlavor::AppleContainer, _) => bail!(
                 "restore-from-snapshot is not yet implemented for the apple-container backend"
             ),
@@ -1622,7 +1632,7 @@ fn is_already_exists_error(message: &str) -> bool {
     lower.contains("already exists")
 }
 
-fn sandbox_spec_hash(spec: &SandboxSpec) -> String {
+pub(crate) fn sandbox_spec_hash(spec: &SandboxSpec) -> String {
     let mut hasher = DefaultHasher::new();
     spec.hash(&mut hasher);
     format!("{:016x}", hasher.finish())

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -151,6 +151,32 @@ pub struct EventQuery {
     pub types: Option<Vec<EventKind>>,
 }
 
+/// Return the first event of `kind` (in `direction` order) for which
+/// `extract` yields `Some`. `limit` caps the scan; set it generously
+/// when `extract` may filter most candidates out.
+pub async fn first_matching_event<T>(
+    conversation: &dyn ConversationHandle,
+    kind: EventKind,
+    direction: EventQueryDirection,
+    limit: u32,
+    mut extract: impl FnMut(EventData) -> Option<T>,
+) -> Result<Option<T>> {
+    let result = conversation
+        .get_events(Some(EventQuery {
+            cursor: None,
+            direction: Some(direction),
+            limit: Some(limit),
+            session_id: None,
+            turn_id: None,
+            types: Some(vec![kind]),
+        }))
+        .await?;
+    Ok(result
+        .events
+        .into_iter()
+        .find_map(|event| extract(event.data)))
+}
+
 /// Tag identifying an `EventData` variant — used by `EventQuery::types` to
 /// filter events by kind without stringly comparing snake_case names. The
 /// constants below cover every built-in variant; `EventKind::custom(name)`


### PR DESCRIPTION
A new sandbox backend that runs containers on [Daytona](https://daytona.io/) instead of locally. Selected via `--sandbox-backend daytona` (env: `EXO_SANDBOX_BACKEND=daytona`). All the harness machinery — tool dispatch, snapshot/rewind, the cross-process resume contract from #21 — works against it transparently.

```bash
export DAYTONA_API_KEY=...
export DAYTONA_ORGANIZATION_ID=...
exo --sandbox-backend daytona chat repl my-agent my-convo
```

## Inheriting the resume contract

The lifecycle work in #21 was designed so Daytona slots in cleanly:

- `ManagedSandboxBackend::acquire` → `POST /api/sandbox` (create fresh).
- `ManagedSandboxBackend::try_resume` → label-based lookup against Daytona's control plane, `POST /api/sandbox/{id}/start` if stopped. Daytona's server-side `stop` preserves filesystem state, so resume comes essentially free.
- `ManagedSandboxHandle::stop` → `POST /api/sandbox/{id}/stop` (not delete).
- `ManagedSandboxHandle::snapshot` → `POST /api/sandbox/{id}/snapshot`. Returns a `SnapshotKind::DaytonaSnapshot` payload whose bytes are a small JSON manifest pointing at the named Daytona snapshot (**bytes-by-reference**, in contrast to Docker's `DockerImageTar` bytes-by-value). No multi-MB tarball ever crosses the wire.

End-to-end verified live: two `chat send` invocations against the same conversation, in separate exo processes, write a marker file in send 1, read it back in send 2 — same Daytona sandbox UUID, file persists.

## Snapshot status: code is in, endpoint is not

Discovered while live-testing: the snapshot path is **upstream-unavailable** at the moment, not a code defect.

The code follows Daytona's published OpenAPI spec exactly:
- `POST /api/sandbox/{sandboxIdOrName}/snapshot`, body `{"name": "..."}` — matches `CreateSandboxSnapshot` in their `api-json`.
- The flag is consistent with the SDK naming: TypeScript SDK calls it `_experimental_createSnapshot` (note the leading underscore).

But the endpoint returns `404 Cannot POST` on `app.daytona.io`. Cross-checked three ways, all hit the same wall:
1. Raw curl with the spec-matching body shape → 404.
2. exo `/snapshot` slash command → same 404 surfaced through to the user.
3. **Daytona's official Python SDK** calling `sandbox._experimental_create_snapshot(...)` → `DaytonaNotFoundError: Failed to create snapshot: Cannot POST /api/sandbox/<id>/snapshot`.

So the operation is documented + present in SDKs but not actually deployed on the public API host yet. When Daytona enables it our code will Just Work without modification.

Related harness gap noticed while testing: `ConversationHandle::snapshot_sandbox` requires the sandbox to be in this process's `running_sandboxes` HashMap, so calling `/snapshot` cold (before any tool call has bound a handle in-process) errors with `sandbox is not running`. The fix is the same `try_resume`-on-miss pattern PR #21 added to `run_in_sandbox`; extending it to `snapshot_sandbox` is a small follow-up orthogonal to this PR.

## What changed

| File | Change |
|---|---|
| `crates/exoharness/src/daytona.rs` (new, ~600 LOC) | REST client + `DaytonaSandboxBackend` + `DaytonaConfig`. Implements `acquire`, `try_resume`, `acquire_from_snapshot`. Synchronous-exec bridge for `start_process`. |
| `crates/exoharness/src/sandbox.rs` | New `SnapshotKind::DaytonaSnapshot` variant + a `(_, DaytonaSnapshot)` arm in the CLI backend's `acquire_from_snapshot` so the wrong-backend case errors clearly. Constants & spec-hash helper exposed `pub(crate)`. |
| `crates/exoharness/src/basic.rs` | `SandboxBackendChoice::Daytona(DaytonaConfig)` variant + `build_sandbox_backend` returns `Result`. |
| `crates/exoharness/src/lib.rs`, `crates/executor/src/lib.rs` | Module registration + re-exports. |
| `crates/cli/src/main.rs` | `--sandbox-backend daytona` + `DaytonaConfig::from_env()` at CLI parse time. |

## Daytona-specific knobs

The REST API has a few non-obvious shapes; documented inline. Highlights surfaced during live debugging:

- `labels` is one JSON-encoded query param, not multiple repeated `?labels=k=v` params.
- List response is `{items, nextCursor}`, not a bare array.
- `env` on create is an object, not an array of `{name, value}`.
- `snapshot` on create refers to a **pre-registered** snapshot name in the user's Daytona dashboard, not an arbitrary docker image ref. We omit it on fresh creates.
- Per-sandbox operations (exec, fs) live on a **different host** — `proxy.app.daytona.io/toolbox/<id>/...` — than the control plane (`app.daytona.io/api`). Both configurable via `DAYTONA_API_URL` / `DAYTONA_TOOLBOX_URL`.
- API keys belong to one organization. Required: `X-Daytona-Organization-ID` header (set via `DAYTONA_ORGANIZATION_ID` env var).

## Out of scope (deliberate)

- **Mounts.** Daytona has no host filesystem to bind-mount. Mounts in `SandboxSpec` are rejected with a clear error. The longer-term answer is a workspace provisioner abstraction at the conversation level — separate effort.
- **Streaming `start_process`.** Daytona's exec endpoint is request/response, not streaming. We buffer stdout/stderr into in-memory `Cursor`s.
- **Cross-backend snapshot interchange.** A `DaytonaSnapshot` payload can't be restored under Docker and vice versa — `kind`-mismatch errors clearly.

## Stack

```
main
  └── #20  sandbox-snapshots-filesystem    Docker snapshot + rewind
        └── #21  cross-process-resume      try_resume contract + 3-tier fallback
              └── #22  this PR             Daytona backend (slots into the contract)
```

## Test plan

- [x] `cargo build --workspace` clean.
- [x] `cargo test --workspace` — 51 unit tests pass; existing integration tests still pass.
- [x] Live end-to-end against real Daytona: `chat send` creates a real sandbox, executes via the toolbox proxy, returns output.
- [x] **Cross-process resume verified live**: two `chat send` invocations in fresh exo processes hit the same Daytona sandbox UUID; marker file written in send 1 is readable in send 2.
- [x] Cleanup via `DELETE /api/sandbox/{id}?force=true` works; no orphaned sandboxes after testing.
- [x] `/snapshot` reaches Daytona and returns a clear error (endpoint not currently deployed upstream — see "Snapshot status" above). Restore path is unreachable until snapshot is available upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
