### PR TITLE
cli: /usage (alias /cost) REPL command

### DIFF
--- a/crates/cli/src/tui.rs
+++ b/crates/cli/src/tui.rs
@@ -364,6 +364,24 @@ impl ChatRepl {
         Ok(())
     }
 
+    async fn print_usage(&self) -> Result<()> {
+        let result = self
+            .conversation
+            .exoharness_handle()
+            .get_events(Some(EventQuery {
+                cursor: None,
+                direction: Some(EventQueryDirection::Asc),
+                limit: None,
+                session_id: None,
+                turn_id: None,
+                types: Some(vec!["messages".to_string()]),
+            }))
+            .await?;
+        let summary = summarize_usage(result.events.iter().map(|event| &event.data));
+        print!("{}", render_usage(&summary));
+        Ok(())
+    }
+
     async fn run(&mut self) -> Result<()> {
         loop {
             let prompt = format!("{}> ", self.conversation.record().slug);
@@ -378,6 +396,10 @@ impl ChatRepl {
                     }
                     if trimmed == "/history" {
                         self.print_transcript().await?;
+                        continue;
+                    }
+                    if trimmed == "/usage" || trimmed == "/cost" {
+                        self.print_usage().await?;
                         continue;
                     }
 
@@ -493,6 +515,115 @@ fn print_ttft(ttft: Duration) {
     }
 }
 
+/// Running totals over the `UsageRecord`s attached to a conversation's
+/// model responses. `priced_calls` tracks how many of `calls` carried a
+/// `cost_usd` — so a partial total (some models missing from the price
+/// table) can be reported honestly rather than silently undercounting.
+#[derive(Debug, Default, PartialEq)]
+struct UsageSummary {
+    calls: u64,
+    priced_calls: u64,
+    prompt_tokens: i64,
+    completion_tokens: i64,
+    cached_tokens: i64,
+    cache_creation_tokens: i64,
+    reasoning_tokens: i64,
+    cost_usd: f64,
+    duration_ms: u64,
+}
+
+fn summarize_usage<'a>(events: impl IntoIterator<Item = &'a EventData>) -> UsageSummary {
+    let mut summary = UsageSummary::default();
+    for data in events {
+        let EventData::Messages {
+            usage: Some(usage), ..
+        } = data
+        else {
+            continue;
+        };
+        summary.calls += 1;
+        summary.prompt_tokens += usage.prompt_tokens.unwrap_or(0);
+        summary.completion_tokens += usage.completion_tokens.unwrap_or(0);
+        summary.cached_tokens += usage.prompt_cached_tokens.unwrap_or(0);
+        summary.cache_creation_tokens += usage.prompt_cache_creation_tokens.unwrap_or(0);
+        summary.reasoning_tokens += usage.completion_reasoning_tokens.unwrap_or(0);
+        summary.duration_ms += usage.duration_ms.unwrap_or(0);
+        if let Some(cost) = usage.cost_usd {
+            summary.cost_usd += cost;
+            summary.priced_calls += 1;
+        }
+    }
+    summary
+}
+
+fn render_usage(summary: &UsageSummary) -> String {
+    if summary.calls == 0 {
+        return "No model usage recorded for this conversation yet.\n".to_string();
+    }
+
+    let mut input = format!("{} tokens", with_commas(summary.prompt_tokens));
+    let mut input_extras = Vec::new();
+    if summary.cached_tokens > 0 {
+        input_extras.push(format!("{} cached", with_commas(summary.cached_tokens)));
+    }
+    if summary.cache_creation_tokens > 0 {
+        input_extras.push(format!(
+            "{} cache-write",
+            with_commas(summary.cache_creation_tokens)
+        ));
+    }
+    if !input_extras.is_empty() {
+        input.push_str(&format!(" ({})", input_extras.join(", ")));
+    }
+
+    let mut output = format!("{} tokens", with_commas(summary.completion_tokens));
+    if summary.reasoning_tokens > 0 {
+        output.push_str(&format!(
+            " ({} reasoning)",
+            with_commas(summary.reasoning_tokens)
+        ));
+    }
+
+    let mut lines = vec![
+        "usage (this conversation):".to_string(),
+        format!("  model calls : {}", summary.calls),
+        format!("  input       : {input}"),
+        format!("  output      : {output}"),
+        format!("  cost        : ${:.4}", summary.cost_usd),
+        format!(
+            "  model time  : {:.1}s",
+            summary.duration_ms as f64 / 1000.0
+        ),
+    ];
+    if summary.priced_calls < summary.calls {
+        let unpriced = summary.calls - summary.priced_calls;
+        lines.push(format!(
+            "  note        : {unpriced} of {} call(s) had no price in the table; cost is a partial total",
+            summary.calls
+        ));
+    }
+    lines.push(String::new());
+    lines.join("\n")
+}
+
+/// Format an integer with thousands separators, e.g. `14500` -> `14,500`.
+fn with_commas(value: i64) -> String {
+    let negative = value < 0;
+    let digits = value.unsigned_abs().to_string();
+    let mut grouped = String::new();
+    for (index, ch) in digits.chars().enumerate() {
+        if index > 0 && (digits.len() - index).is_multiple_of(3) {
+            grouped.push(',');
+        }
+        grouped.push(ch);
+    }
+    if negative {
+        format!("-{grouped}")
+    } else {
+        grouped
+    }
+}
+
 fn render_tool_call(tool_name: &str, arguments: &Map<String, Value>) -> String {
     let mut lines = vec![format!("tool call {tool_name}")];
     append_object_fields(&mut lines, arguments, "  ");
@@ -561,9 +692,97 @@ fn render_user_content_for_history(content: &UserContent) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{render_tool_call, render_tool_result, render_user_content_for_history};
+    use super::{
+        render_tool_call, render_tool_result, render_usage, render_user_content_for_history,
+        summarize_usage, with_commas,
+    };
+    use executor::{EventData, UsageRecord};
     use lingua::universal::UserContent;
     use serde_json::{Map, Value};
+
+    fn usage_event(
+        prompt: Option<i64>,
+        completion: Option<i64>,
+        cached: Option<i64>,
+        cost_usd: Option<f64>,
+        duration_ms: Option<u64>,
+    ) -> EventData {
+        EventData::Messages {
+            messages: vec![],
+            response_id: None,
+            usage: Some(Box::new(UsageRecord {
+                model: "claude-sonnet-4-6".to_string(),
+                prompt_tokens: prompt,
+                completion_tokens: completion,
+                prompt_cached_tokens: cached,
+                cost_usd,
+                duration_ms,
+                ..Default::default()
+            })),
+        }
+    }
+
+    #[test]
+    fn summarize_usage_aggregates_priced_calls_and_skips_usageless_events() {
+        let events = [
+            // A user-input Messages event carries no usage and must be ignored.
+            EventData::Messages {
+                messages: vec![],
+                response_id: None,
+                usage: None,
+            },
+            usage_event(Some(1_000), Some(500), Some(200), Some(0.0105), Some(1_200)),
+            usage_event(Some(800), Some(300), None, Some(0.0039), Some(800)),
+        ];
+
+        let summary = summarize_usage(events.iter());
+
+        assert_eq!(summary.calls, 2);
+        assert_eq!(summary.priced_calls, 2);
+        assert_eq!(summary.prompt_tokens, 1_800);
+        assert_eq!(summary.completion_tokens, 800);
+        assert_eq!(summary.cached_tokens, 200);
+        assert_eq!(summary.duration_ms, 2_000);
+        assert!((summary.cost_usd - 0.0144).abs() < 1e-9);
+    }
+
+    #[test]
+    fn summarize_usage_counts_unpriced_calls_separately() {
+        let events = [
+            usage_event(Some(1_000), Some(500), None, Some(0.01), Some(1_000)),
+            // An unknown model leaves cost_usd None: counted as a call, not a priced one.
+            usage_event(Some(500), Some(200), None, None, Some(500)),
+        ];
+
+        let summary = summarize_usage(events.iter());
+
+        assert_eq!(summary.calls, 2);
+        assert_eq!(summary.priced_calls, 1);
+        assert!((summary.cost_usd - 0.01).abs() < 1e-9);
+
+        let rendered = render_usage(&summary);
+        assert!(
+            rendered.contains("1 of 2 call(s) had no price"),
+            "expected partial-total note, got:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn render_usage_reports_empty_conversation() {
+        let summary = summarize_usage(std::iter::empty());
+        assert_eq!(summary.calls, 0);
+        assert!(render_usage(&summary).contains("No model usage recorded"));
+    }
+
+    #[test]
+    fn with_commas_groups_thousands() {
+        assert_eq!(with_commas(0), "0");
+        assert_eq!(with_commas(999), "999");
+        assert_eq!(with_commas(1_000), "1,000");
+        assert_eq!(with_commas(14_500), "14,500");
+        assert_eq!(with_commas(1_234_567), "1,234,567");
+        assert_eq!(with_commas(-2_500), "-2,500");
+    }
 
     #[test]
     fn renders_multiline_tool_call_arguments_as_indented_block() {

--- a/crates/cli/src/tui.rs
+++ b/crates/cli/src/tui.rs
@@ -10,7 +10,7 @@ use executor::{
     HarnessConversation, SendRequest, SessionId,
 };
 use lingua::universal::{UserContent, UserContentPart};
-use lingua::{Message, UniversalStreamChunk};
+use lingua::{Message, UniversalStreamChunk, UniversalUsage};
 use rustyline::error::ReadlineError;
 use rustyline::history::{History, MemHistory, SearchDirection, SearchResult};
 use rustyline::{Cmd, Config, Editor, KeyCode, KeyEvent, Modifiers};
@@ -516,20 +516,26 @@ fn print_ttft(ttft: Duration) {
 }
 
 /// Running totals over the `UsageRecord`s attached to a conversation's
-/// model responses. `priced_calls` tracks how many of `calls` carried a
-/// `cost_usd` — so a partial total (some models missing from the price
-/// table) can be reported honestly rather than silently undercounting.
-#[derive(Debug, Default, PartialEq)]
+/// model responses. Token counts accumulate into lingua's `UniversalUsage`
+/// so the field list stays sourced from one place as usage definitions
+/// evolve. `priced_calls` tracks how many of `calls` carried a `cost_usd`,
+/// so a partial total (some models missing from the price table) can be
+/// reported honestly rather than silently undercounting.
+#[derive(Debug, Default)]
 struct UsageSummary {
+    usage: UniversalUsage,
     calls: u64,
     priced_calls: u64,
-    prompt_tokens: i64,
-    completion_tokens: i64,
-    cached_tokens: i64,
-    cache_creation_tokens: i64,
-    reasoning_tokens: i64,
     cost_usd: f64,
     duration_ms: u64,
+}
+
+/// Add two optional token counts, keeping `None` only when both are absent.
+fn add_tokens(acc: Option<i64>, next: Option<i64>) -> Option<i64> {
+    match (acc, next) {
+        (None, None) => None,
+        _ => Some(acc.unwrap_or(0) + next.unwrap_or(0)),
+    }
 }
 
 fn summarize_usage<'a>(events: impl IntoIterator<Item = &'a EventData>) -> UsageSummary {
@@ -542,11 +548,18 @@ fn summarize_usage<'a>(events: impl IntoIterator<Item = &'a EventData>) -> Usage
             continue;
         };
         summary.calls += 1;
-        summary.prompt_tokens += usage.prompt_tokens.unwrap_or(0);
-        summary.completion_tokens += usage.completion_tokens.unwrap_or(0);
-        summary.cached_tokens += usage.prompt_cached_tokens.unwrap_or(0);
-        summary.cache_creation_tokens += usage.prompt_cache_creation_tokens.unwrap_or(0);
-        summary.reasoning_tokens += usage.completion_reasoning_tokens.unwrap_or(0);
+        let acc = &mut summary.usage;
+        acc.prompt_tokens = add_tokens(acc.prompt_tokens, usage.prompt_tokens);
+        acc.completion_tokens = add_tokens(acc.completion_tokens, usage.completion_tokens);
+        acc.prompt_cached_tokens = add_tokens(acc.prompt_cached_tokens, usage.prompt_cached_tokens);
+        acc.prompt_cache_creation_tokens = add_tokens(
+            acc.prompt_cache_creation_tokens,
+            usage.prompt_cache_creation_tokens,
+        );
+        acc.completion_reasoning_tokens = add_tokens(
+            acc.completion_reasoning_tokens,
+            usage.completion_reasoning_tokens,
+        );
         summary.duration_ms += usage.duration_ms.unwrap_or(0);
         if let Some(cost) = usage.cost_usd {
             summary.cost_usd += cost;
@@ -561,27 +574,28 @@ fn render_usage(summary: &UsageSummary) -> String {
         return "No model usage recorded for this conversation yet.\n".to_string();
     }
 
-    let mut input = format!("{} tokens", with_commas(summary.prompt_tokens));
+    let usage = &summary.usage;
+    let mut input = format!("{} tokens", with_commas(usage.prompt_tokens.unwrap_or(0)));
     let mut input_extras = Vec::new();
-    if summary.cached_tokens > 0 {
-        input_extras.push(format!("{} cached", with_commas(summary.cached_tokens)));
+    let cached = usage.prompt_cached_tokens.unwrap_or(0);
+    if cached > 0 {
+        input_extras.push(format!("{} cached", with_commas(cached)));
     }
-    if summary.cache_creation_tokens > 0 {
-        input_extras.push(format!(
-            "{} cache-write",
-            with_commas(summary.cache_creation_tokens)
-        ));
+    let cache_creation = usage.prompt_cache_creation_tokens.unwrap_or(0);
+    if cache_creation > 0 {
+        input_extras.push(format!("{} cache-write", with_commas(cache_creation)));
     }
     if !input_extras.is_empty() {
         input.push_str(&format!(" ({})", input_extras.join(", ")));
     }
 
-    let mut output = format!("{} tokens", with_commas(summary.completion_tokens));
-    if summary.reasoning_tokens > 0 {
-        output.push_str(&format!(
-            " ({} reasoning)",
-            with_commas(summary.reasoning_tokens)
-        ));
+    let mut output = format!(
+        "{} tokens",
+        with_commas(usage.completion_tokens.unwrap_or(0))
+    );
+    let reasoning = usage.completion_reasoning_tokens.unwrap_or(0);
+    if reasoning > 0 {
+        output.push_str(&format!(" ({} reasoning)", with_commas(reasoning)));
     }
 
     let mut lines = vec![
@@ -589,7 +603,7 @@ fn render_usage(summary: &UsageSummary) -> String {
         format!("  model calls : {}", summary.calls),
         format!("  input       : {input}"),
         format!("  output      : {output}"),
-        format!("  cost        : ${:.4}", summary.cost_usd),
+        format!("  cost        : {}", format_cost(summary.cost_usd)),
         format!(
             "  model time  : {:.1}s",
             summary.duration_ms as f64 / 1000.0
@@ -604,6 +618,21 @@ fn render_usage(summary: &UsageSummary) -> String {
     }
     lines.push(String::new());
     lines.join("\n")
+}
+
+/// Format a USD cost. Four decimals at or above $0.0001; below that, extend
+/// precision just far enough to show the first significant digit, so a tiny
+/// cached-call total like $0.00000724 renders as `$0.000007` rather than
+/// rounding to a misleading `$0.0000`.
+fn format_cost(cost: f64) -> String {
+    if cost <= 0.0 {
+        return "$0.0000".to_string();
+    }
+    if cost >= 0.0001 {
+        return format!("${cost:.4}");
+    }
+    let decimals = ((-cost.log10()).floor() as usize + 1).min(12);
+    format!("${:.*}", decimals, cost)
 }
 
 /// Format an integer with thousands separators, e.g. `14500` -> `14,500`.
@@ -693,8 +722,8 @@ fn render_user_content_for_history(content: &UserContent) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        render_tool_call, render_tool_result, render_usage, render_user_content_for_history,
-        summarize_usage, with_commas,
+        format_cost, render_tool_call, render_tool_result, render_usage,
+        render_user_content_for_history, summarize_usage, with_commas,
     };
     use executor::{EventData, UsageRecord};
     use lingua::universal::UserContent;
@@ -739,9 +768,9 @@ mod tests {
 
         assert_eq!(summary.calls, 2);
         assert_eq!(summary.priced_calls, 2);
-        assert_eq!(summary.prompt_tokens, 1_800);
-        assert_eq!(summary.completion_tokens, 800);
-        assert_eq!(summary.cached_tokens, 200);
+        assert_eq!(summary.usage.prompt_tokens, Some(1_800));
+        assert_eq!(summary.usage.completion_tokens, Some(800));
+        assert_eq!(summary.usage.prompt_cached_tokens, Some(200));
         assert_eq!(summary.duration_ms, 2_000);
         assert!((summary.cost_usd - 0.0144).abs() < 1e-9);
     }
@@ -772,6 +801,23 @@ mod tests {
         let summary = summarize_usage(std::iter::empty());
         assert_eq!(summary.calls, 0);
         assert!(render_usage(&summary).contains("No model usage recorded"));
+    }
+
+    #[test]
+    fn format_cost_uses_four_decimals_at_or_above_a_tenth_milli_dollar() {
+        assert_eq!(format_cost(0.0), "$0.0000");
+        assert_eq!(format_cost(0.0105), "$0.0105");
+        assert_eq!(format_cost(0.012521), "$0.0125");
+        assert_eq!(format_cost(0.0002001), "$0.0002");
+        assert_eq!(format_cost(0.0001), "$0.0001");
+    }
+
+    #[test]
+    fn format_cost_extends_precision_for_tiny_totals() {
+        // below $0.0001, show just enough decimals to reveal the first digit
+        assert_eq!(format_cost(0.00000724), "$0.000007");
+        assert_eq!(format_cost(0.00005), "$0.00005");
+        assert_eq!(format_cost(0.0000004), "$0.0000004");
     }
 
     #[test]

--- a/crates/executor/src/basic.rs
+++ b/crates/executor/src/basic.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use exoharness::{
     AgentHandle, ConversationHandle, ConversationId, EventData, EventId, EventQuery,
     EventQueryDirection, Result, ToolCallId, ToolRequest, TurnHandle, UsageRecord,
-    pricing::{TokenCounts, compute_cost_usd},
+    pricing::{PricingTable, TokenCounts},
 };
 use lingua::Message;
 use lingua::universal::{ToolContentPart, ToolResultContentPart};
@@ -25,6 +25,10 @@ pub struct BasicExecutor<M, T> {
     model: Arc<M>,
     tools: Arc<T>,
     history_cache: Arc<RwLock<HashMap<ConversationId, HistoryCacheEntry>>>,
+    /// If `Some`, this table is used for cost computation in place of the
+    /// global LiteLLM loader. Lets tests inject a deterministic price set
+    /// and lets embedders supply their own.
+    pricing_override: Option<Arc<PricingTable>>,
 }
 
 impl<M, T> BasicExecutor<M, T> {
@@ -33,6 +37,26 @@ impl<M, T> BasicExecutor<M, T> {
             model,
             tools,
             history_cache: Arc::new(RwLock::new(HashMap::new())),
+            pricing_override: None,
+        }
+    }
+
+    /// Construct with an explicit pricing table. Bypasses the global
+    /// LiteLLM loader — useful for tests, embedders that vendor their
+    /// own price data, or air-gapped deployments.
+    pub fn with_pricing(model: Arc<M>, tools: Arc<T>, pricing: Arc<PricingTable>) -> Self {
+        Self {
+            model,
+            tools,
+            history_cache: Arc::new(RwLock::new(HashMap::new())),
+            pricing_override: Some(pricing),
+        }
+    }
+
+    async fn pricing_table(&self) -> Arc<PricingTable> {
+        match &self.pricing_override {
+            Some(p) => Arc::clone(p),
+            None => crate::pricing_loader::get_pricing_table().await,
         }
     }
 }
@@ -43,6 +67,7 @@ impl<M, T> Clone for BasicExecutor<M, T> {
             model: Arc::clone(&self.model),
             tools: Arc::clone(&self.tools),
             history_cache: Arc::clone(&self.history_cache),
+            pricing_override: self.pricing_override.clone(),
         }
     }
 }
@@ -133,7 +158,8 @@ where
                 .complete_model_round(request, round as usize, stream_mode, turn_trace)
                 .await?;
 
-            let events = interpret_model_response(response);
+            let pricing = self.pricing_table().await;
+            let events = interpret_model_response(response, &pricing);
             turn.add_events(events.clone()).await?;
 
             let tool_requests = collect_tool_requests(&events);
@@ -411,11 +437,14 @@ fn extend_message_history(
     }
 }
 
-fn interpret_model_response(response: ModelResponse) -> Vec<EventData> {
+fn interpret_model_response(
+    response: ModelResponse,
+    pricing: &PricingTable,
+) -> Vec<EventData> {
     let mut events = Vec::new();
 
     if !response.messages.is_empty() {
-        let usage = build_usage_record(&response);
+        let usage = build_usage_record(&response, pricing);
         events.push(EventData::Messages {
             messages: response.messages,
             response_id: response.response_id,
@@ -434,7 +463,7 @@ fn interpret_model_response(response: ModelResponse) -> Vec<EventData> {
     events
 }
 
-fn build_usage_record(response: &ModelResponse) -> Option<UsageRecord> {
+fn build_usage_record(response: &ModelResponse, pricing: &PricingTable) -> Option<UsageRecord> {
     // Only emit a record when we have *something* worth recording — token usage
     // or timing. Skipping when both are absent keeps event JSON clean for
     // tests/fakes that don't populate metadata.
@@ -463,7 +492,7 @@ fn build_usage_record(response: &ModelResponse) -> Option<UsageRecord> {
     };
 
     let cost_usd = if has_usage && !model.is_empty() {
-        compute_cost_usd(
+        pricing.compute_cost_usd(
             &model,
             TokenCounts {
                 prompt: prompt_tokens,

--- a/crates/executor/src/basic.rs
+++ b/crates/executor/src/basic.rs
@@ -5,7 +5,8 @@ use std::time::Instant;
 use async_trait::async_trait;
 use exoharness::{
     AgentHandle, ConversationHandle, ConversationId, EventData, EventId, EventQuery,
-    EventQueryDirection, Result, ToolCallId, ToolRequest, TurnHandle,
+    EventQueryDirection, Result, ToolCallId, ToolRequest, TurnHandle, UsageRecord,
+    pricing::{TokenCounts, compute_cost_usd},
 };
 use lingua::Message;
 use lingua::universal::{ToolContentPart, ToolResultContentPart};
@@ -167,9 +168,11 @@ where
             Some(turn_trace) => turn_trace.start_llm_round(&request, round).await,
             None => None,
         };
+        let requested_model = request.model.clone();
 
         match stream_mode {
             ExecutorStreamMode::Disabled => {
+                let started_at = Instant::now();
                 let response = match self.model.complete(request).await {
                     Ok(response) => response,
                     Err(error) => {
@@ -179,6 +182,14 @@ where
                         return Err(error);
                     }
                 };
+                let duration = started_at.elapsed();
+                let mut response = response;
+                if response.model.is_none() {
+                    response.model = Some(requested_model);
+                }
+                if response.duration.is_none() {
+                    response.duration = Some(duration);
+                }
                 if let Some(llm_trace) = llm_trace {
                     llm_trace.finish_success(&response, None).await;
                 }
@@ -233,6 +244,17 @@ where
                         return Err(error);
                     }
                 };
+                let duration = started_at.elapsed();
+                let mut response = response;
+                if response.model.is_none() {
+                    response.model = Some(requested_model);
+                }
+                if response.ttft.is_none() {
+                    response.ttft = ttft;
+                }
+                if response.duration.is_none() {
+                    response.duration = Some(duration);
+                }
                 if let Some(llm_trace) = llm_trace {
                     llm_trace.finish_success(&response, ttft).await;
                 }
@@ -393,9 +415,11 @@ fn interpret_model_response(response: ModelResponse) -> Vec<EventData> {
     let mut events = Vec::new();
 
     if !response.messages.is_empty() {
+        let usage = build_usage_record(&response);
         events.push(EventData::Messages {
             messages: response.messages,
             response_id: response.response_id,
+            usage,
         });
     }
 
@@ -408,6 +432,62 @@ fn interpret_model_response(response: ModelResponse) -> Vec<EventData> {
     }
 
     events
+}
+
+fn build_usage_record(response: &ModelResponse) -> Option<UsageRecord> {
+    // Only emit a record when we have *something* worth recording — token usage
+    // or timing. Skipping when both are absent keeps event JSON clean for
+    // tests/fakes that don't populate metadata.
+    let has_usage = response.usage.is_some();
+    let has_timing = response.ttft.is_some() || response.duration.is_some();
+    if !has_usage && !has_timing {
+        return None;
+    }
+
+    let model = response.model.clone().unwrap_or_default();
+    let (
+        prompt_tokens,
+        completion_tokens,
+        prompt_cached_tokens,
+        prompt_cache_creation_tokens,
+        completion_reasoning_tokens,
+    ) = match &response.usage {
+        Some(u) => (
+            u.prompt_tokens,
+            u.completion_tokens,
+            u.prompt_cached_tokens,
+            u.prompt_cache_creation_tokens,
+            u.completion_reasoning_tokens,
+        ),
+        None => (None, None, None, None, None),
+    };
+
+    let cost_usd = if has_usage && !model.is_empty() {
+        compute_cost_usd(
+            &model,
+            TokenCounts {
+                prompt: prompt_tokens,
+                completion: completion_tokens,
+                prompt_cached: prompt_cached_tokens,
+                prompt_cache_creation: prompt_cache_creation_tokens,
+            },
+        )
+    } else {
+        None
+    };
+
+    Some(UsageRecord {
+        model,
+        prompt_tokens,
+        completion_tokens,
+        prompt_cached_tokens,
+        prompt_cache_creation_tokens,
+        completion_reasoning_tokens,
+        cost_usd,
+        ttft_ms: response.ttft.map(|d| d.as_millis() as u64),
+        duration_ms: response.duration.map(|d| d.as_millis() as u64),
+        server_duration_ms: None,
+    })
 }
 
 #[derive(Debug, Clone)]

--- a/crates/executor/src/basic.rs
+++ b/crates/executor/src/basic.rs
@@ -437,10 +437,7 @@ fn extend_message_history(
     }
 }
 
-fn interpret_model_response(
-    response: ModelResponse,
-    pricing: &PricingTable,
-) -> Vec<EventData> {
+fn interpret_model_response(response: ModelResponse, pricing: &PricingTable) -> Vec<EventData> {
     let mut events = Vec::new();
 
     if !response.messages.is_empty() {
@@ -463,7 +460,10 @@ fn interpret_model_response(
     events
 }
 
-fn build_usage_record(response: &ModelResponse, pricing: &PricingTable) -> Option<UsageRecord> {
+fn build_usage_record(
+    response: &ModelResponse,
+    pricing: &PricingTable,
+) -> Option<Box<UsageRecord>> {
     // Only emit a record when we have *something* worth recording — token usage
     // or timing. Skipping when both are absent keeps event JSON clean for
     // tests/fakes that don't populate metadata.
@@ -505,7 +505,7 @@ fn build_usage_record(response: &ModelResponse, pricing: &PricingTable) -> Optio
         None
     };
 
-    Some(UsageRecord {
+    Some(Box::new(UsageRecord {
         model,
         prompt_tokens,
         completion_tokens,
@@ -516,7 +516,7 @@ fn build_usage_record(response: &ModelResponse, pricing: &PricingTable) -> Optio
         ttft_ms: response.ttft.map(|d| d.as_millis() as u64),
         duration_ms: response.duration.map(|d| d.as_millis() as u64),
         server_duration_ms: None,
-    })
+    }))
 }
 
 #[derive(Debug, Clone)]

--- a/crates/executor/src/basic_tests.rs
+++ b/crates/executor/src/basic_tests.rs
@@ -47,6 +47,9 @@ async fn send_appends_user_and_assistant_messages() {
             messages: vec![assistant_message("pong")],
             tool_calls: vec![],
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         }])),
         Arc::new(FakeToolRuntime::default()),
     );
@@ -134,12 +137,18 @@ async fn send_executes_tool_round_trip() {
                 },
             }],
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("done")],
             tool_calls: vec![],
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
     ]));
     let executor = BasicExecutor::new(
@@ -246,6 +255,9 @@ async fn send_stream_emits_chunks_and_persists_final_response() {
                 messages: vec![assistant_message("hello")],
                 tool_calls: vec![],
                 usage: None,
+                model: None,
+                ttft: None,
+                duration: None,
             },
         }])),
         Arc::new(FakeToolRuntime::default()),
@@ -668,6 +680,7 @@ impl ConversationHandle for FakeConversationHandle {
                 EventData::Messages {
                     messages: request.input,
                     response_id: None,
+                    usage: None,
                 },
             ));
         }

--- a/crates/executor/src/executor_types.rs
+++ b/crates/executor/src/executor_types.rs
@@ -133,12 +133,21 @@ pub struct ModelRequest {
     pub max_output_tokens: Option<i64>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ModelResponse {
     pub response_id: Option<ResponseId>,
     pub messages: Vec<Message>,
     pub tool_calls: Vec<PendingToolCall>,
     pub usage: Option<UniversalUsage>,
+    /// Model identifier echoed back by the provider, if available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Time to first token (streaming path only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ttft: Option<Duration>,
+    /// Wall-clock duration from request start to end of response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration: Option<Duration>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/executor/src/executor_types.rs
+++ b/crates/executor/src/executor_types.rs
@@ -133,7 +133,7 @@ pub struct ModelRequest {
     pub max_output_tokens: Option<i64>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelResponse {
     pub response_id: Option<ResponseId>,
     pub messages: Vec<Message>,

--- a/crates/executor/src/harness_basic.rs
+++ b/crates/executor/src/harness_basic.rs
@@ -40,10 +40,8 @@ impl<M, T> BasicHarness<M, T> {
         M: ModelClient + 'static,
         T: ToolRuntime + 'static,
     {
-        let runtime = ExecutorHarnessRuntime::new(
-            BasicExecutor::with_pricing(model, tools, pricing),
-            None,
-        );
+        let runtime =
+            ExecutorHarnessRuntime::new(BasicExecutor::with_pricing(model, tools, pricing), None);
         Self {
             inner: SharedHarness::new(exoharness, runtime),
         }

--- a/crates/executor/src/harness_basic.rs
+++ b/crates/executor/src/harness_basic.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::{BasicExecutor, BraintrustRuntimeConfig, ModelClient, ToolRuntime};
+use exoharness::pricing::PricingTable;
 use exoharness::{BasicExoHarness, BasicExoHarnessConfig, ExoHarness, Result};
 
 use crate::harness_executor::ExecutorHarnessRuntime;
@@ -20,6 +21,29 @@ impl<M, T> BasicHarness<M, T> {
         T: ToolRuntime + 'static,
     {
         let runtime = ExecutorHarnessRuntime::new(BasicExecutor::new(model, tools), None);
+        Self {
+            inner: SharedHarness::new(exoharness, runtime),
+        }
+    }
+
+    /// Construct a harness whose executor uses an explicit pricing table
+    /// instead of the global LiteLLM loader. Use this when you want
+    /// deterministic, hermetic cost computation (tests) or you're
+    /// running offline.
+    pub fn with_pricing_table(
+        exoharness: Arc<dyn ExoHarness>,
+        model: Arc<M>,
+        tools: Arc<T>,
+        pricing: Arc<PricingTable>,
+    ) -> Self
+    where
+        M: ModelClient + 'static,
+        T: ToolRuntime + 'static,
+    {
+        let runtime = ExecutorHarnessRuntime::new(
+            BasicExecutor::with_pricing(model, tools, pricing),
+            None,
+        );
         Self {
             inner: SharedHarness::new(exoharness, runtime),
         }

--- a/crates/executor/src/harness_basic_tests.rs
+++ b/crates/executor/src/harness_basic_tests.rs
@@ -196,7 +196,7 @@ async fn usage_record_is_persisted_with_computed_cost() {
             ttft: None,
             duration: None,
         }])),
-        Arc::new(BasicToolRuntime::default()),
+        Arc::new(BasicToolRuntime),
         pricing,
     );
 
@@ -225,6 +225,7 @@ async fn usage_record_is_persisted_with_computed_cost() {
             name: None,
             harness: crate::AgentHarnessKind::Basic,
             typescript: None,
+            enable_agent_tool_creation: true,
             sandbox_image: None,
             enable_networking: false,
             model: "claude-sonnet-4-6".to_string(),
@@ -340,7 +341,7 @@ async fn usage_record_with_anthropic_cache_hits() {
             ttft: None,
             duration: None,
         }])),
-        Arc::new(BasicToolRuntime::default()),
+        Arc::new(BasicToolRuntime),
         pricing,
     );
 
@@ -369,6 +370,7 @@ async fn usage_record_with_anthropic_cache_hits() {
             name: None,
             harness: crate::AgentHarnessKind::Basic,
             typescript: None,
+            enable_agent_tool_creation: true,
             sandbox_image: None,
             enable_networking: false,
             model: "claude-sonnet-4-6".to_string(),
@@ -459,7 +461,7 @@ async fn usage_record_with_openai_inclusive_accounting() {
             ttft: None,
             duration: None,
         }])),
-        Arc::new(BasicToolRuntime::default()),
+        Arc::new(BasicToolRuntime),
         pricing,
     );
 
@@ -488,6 +490,7 @@ async fn usage_record_with_openai_inclusive_accounting() {
             name: None,
             harness: crate::AgentHarnessKind::Basic,
             typescript: None,
+            enable_agent_tool_creation: true,
             sandbox_image: None,
             enable_networking: false,
             model: "gpt-4o-mini".to_string(),
@@ -1222,7 +1225,7 @@ async fn assistant_usage_record(
                 .iter()
                 .any(|m| matches!(m, Message::Assistant { .. })) =>
             {
-                Some(usage)
+                Some(*usage)
             }
             _ => None,
         })

--- a/crates/executor/src/harness_basic_tests.rs
+++ b/crates/executor/src/harness_basic_tests.rs
@@ -155,13 +155,31 @@ async fn send_persists_messages_through_harness() {
 
 #[tokio::test(flavor = "current_thread")]
 async fn usage_record_is_persisted_with_computed_cost() {
+    // Use an inline LiteLLM-schema fixture so the assertion is hermetic
+    // and doesn't depend on whatever rates the upstream JSON happens to
+    // ship today.
+    const PRICING_FIXTURE: &str = r#"{
+        "claude-sonnet-4-6": {
+            "litellm_provider": "anthropic",
+            "mode": "chat",
+            "input_cost_per_token": 3e-06,
+            "output_cost_per_token": 1.5e-05,
+            "cache_read_input_token_cost": 3e-07,
+            "cache_creation_input_token_cost": 3.75e-06
+        }
+    }"#;
+    let pricing = Arc::new(
+        exoharness::pricing::PricingTable::from_json_str(PRICING_FIXTURE)
+            .expect("fixture should parse"),
+    );
+
     let tempdir = TempDir::new().expect("tempdir should exist");
     let exoharness = Arc::new(
         BasicExoHarness::new(local_test_config(tempdir.path().join("exoharness")))
             .await
             .expect("basic exoharness should initialize"),
     ) as Arc<dyn ExoHarness>;
-    let harness = BasicHarness::new(
+    let harness = BasicHarness::with_pricing_table(
         Arc::clone(&exoharness),
         Arc::new(FakeModelClient::new(vec![ModelResponse {
             response_id: Some(Uuid7::now()),
@@ -179,6 +197,7 @@ async fn usage_record_is_persisted_with_computed_cost() {
             duration: None,
         }])),
         Arc::new(BasicToolRuntime::default()),
+        pricing,
     );
 
     let secret_id = exoharness

--- a/crates/executor/src/harness_basic_tests.rs
+++ b/crates/executor/src/harness_basic_tests.rs
@@ -20,7 +20,7 @@ fn local_test_config(root: impl Into<std::path::PathBuf>) -> BasicExoHarnessConf
     }
 }
 use lingua::universal::{AssistantContent, UserContent};
-use lingua::{Message, UniversalStreamChunk};
+use lingua::{Message, UniversalStreamChunk, UniversalUsage};
 use serde_json::{Map, Value};
 use tempfile::TempDir;
 
@@ -110,6 +110,9 @@ async fn send_persists_messages_through_harness() {
             messages: vec![assistant_message("pong")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         }])),
         Arc::new(BasicToolRuntime),
     );
@@ -151,6 +154,128 @@ async fn send_persists_messages_through_harness() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn usage_record_is_persisted_with_computed_cost() {
+    let tempdir = TempDir::new().expect("tempdir should exist");
+    let exoharness = Arc::new(
+        BasicExoHarness::new(local_test_config(tempdir.path().join("exoharness")))
+            .await
+            .expect("basic exoharness should initialize"),
+    ) as Arc<dyn ExoHarness>;
+    let harness = BasicHarness::new(
+        Arc::clone(&exoharness),
+        Arc::new(FakeModelClient::new(vec![ModelResponse {
+            response_id: Some(Uuid7::now()),
+            messages: vec![assistant_message("pong")],
+            tool_calls: Vec::new(),
+            usage: Some(UniversalUsage {
+                prompt_tokens: Some(1_000),
+                completion_tokens: Some(500),
+                prompt_cached_tokens: None,
+                prompt_cache_creation_tokens: None,
+                completion_reasoning_tokens: None,
+            }),
+            model: Some("claude-sonnet-4-6".to_string()),
+            ttft: None,
+            duration: None,
+        }])),
+        Arc::new(BasicToolRuntime::default()),
+    );
+
+    let secret_id = exoharness
+        .put_secret(PutSecretRequest {
+            name: "cost-test-key".to_string(),
+            secret: Secret::Key {
+                value: "test-key".to_string(),
+            },
+        })
+        .await
+        .expect("test secret should register");
+    exoharness
+        .put_binding(Binding::Llm {
+            name: "claude-sonnet-4-6".to_string(),
+            model: "claude-sonnet-4-6".to_string(),
+            base_url: None,
+            secret_id: Some(secret_id),
+        })
+        .await
+        .expect("binding should register");
+
+    let agent = harness
+        .create_agent(CreateAgentRequest {
+            slug: "cost-demo".to_string(),
+            name: None,
+            harness: crate::AgentHarnessKind::Basic,
+            typescript: None,
+            sandbox_image: None,
+            enable_networking: false,
+            model: "claude-sonnet-4-6".to_string(),
+            max_output_tokens: None,
+            max_tool_round_trips: Some(2),
+            braintrust: None,
+        })
+        .await
+        .expect("agent should be created");
+    let conversation = agent
+        .create_conversation(CreateConversationRequest::default())
+        .await
+        .expect("conversation should be created");
+
+    conversation
+        .send(SendRequest {
+            input: vec![user_message("ping")],
+            session_id: None,
+        })
+        .await
+        .expect("send should succeed");
+
+    let events = conversation
+        .exoharness_handle()
+        .get_events(Some(EventQuery {
+            cursor: None,
+            direction: Some(EventQueryDirection::Asc),
+            limit: None,
+            session_id: None,
+            turn_id: None,
+            types: None,
+        }))
+        .await
+        .expect("get events should succeed")
+        .events;
+
+    let assistant_usage = events
+        .iter()
+        .find_map(|event| match &event.data {
+            EventData::Messages {
+                messages,
+                usage: Some(usage),
+                ..
+            } if messages
+                .iter()
+                .any(|m| matches!(m, Message::Assistant { .. })) =>
+            {
+                Some(usage)
+            }
+            _ => None,
+        })
+        .expect("assistant message event should carry a UsageRecord");
+
+    assert_eq!(assistant_usage.model, "claude-sonnet-4-6");
+    assert_eq!(assistant_usage.prompt_tokens, Some(1_000));
+    assert_eq!(assistant_usage.completion_tokens, Some(500));
+    // 1000 prompt @ $3/M + 500 completion @ $15/M = $0.003 + $0.0075 = $0.0105
+    let cost = assistant_usage.cost_usd.expect("cost should be computed");
+    assert!(
+        (cost - 0.0105).abs() < 1e-9,
+        "expected cost ~0.0105, got {cost}"
+    );
+    // Non-streaming path measures total duration.
+    assert!(
+        assistant_usage.duration_ms.is_some(),
+        "duration should be recorded"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn close_session_appends_session_ended_event() {
     let tempdir = TempDir::new().expect("tempdir should exist");
     let exoharness: Arc<dyn ExoHarness> = Arc::new(
@@ -165,6 +290,9 @@ async fn close_session_appends_session_ended_event() {
             messages: vec![assistant_message("pong")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         }])),
         Arc::new(BasicToolRuntime),
     );
@@ -239,12 +367,18 @@ async fn updating_agent_config_refreshes_executor_cache() {
             messages: vec![assistant_message("pong-1")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("pong-2")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
     ]));
     let harness = BasicHarness::new(exoharness, Arc::clone(&model), Arc::new(BasicToolRuntime));
@@ -320,12 +454,18 @@ async fn send_executes_shell_tool_when_enabled() {
                 },
             }],
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("done")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
     ]));
     let harness = BasicHarness::new(exoharness, Arc::clone(&model), Arc::new(BasicToolRuntime));
@@ -489,12 +629,18 @@ async fn updating_mounts_recreates_shell_sandbox() {
             messages: vec![assistant_message("done-1")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("done-2")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
     ]));
     let harness = BasicHarness::new(exoharness, model, Arc::new(BasicToolRuntime));
@@ -611,18 +757,27 @@ async fn conversation_model_override_changes_effective_model() {
             messages: vec![assistant_message("first")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("second")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("third")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
     ]));
     let harness = BasicHarness::new(exoharness, Arc::clone(&model), Arc::new(BasicToolRuntime));

--- a/crates/executor/src/harness_basic_tests.rs
+++ b/crates/executor/src/harness_basic_tests.rs
@@ -295,6 +295,249 @@ async fn usage_record_is_persisted_with_computed_cost() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn usage_record_with_anthropic_cache_hits() {
+    // Anthropic accounting is additive: prompt_tokens is the fresh slice,
+    // and cache_read / cache_creation are billed separately on top. The
+    // pricing math is unit-tested in exoharness::pricing; this test is the
+    // end-to-end proof that cached counts (a) reach the persisted
+    // UsageRecord and (b) hit the discounted cache-read rate when
+    // compute_cost_usd is invoked through the executor.
+    const PRICING_FIXTURE: &str = r#"{
+        "claude-sonnet-4-6": {
+            "litellm_provider": "anthropic",
+            "mode": "chat",
+            "input_cost_per_token": 3e-06,
+            "output_cost_per_token": 1.5e-05,
+            "cache_read_input_token_cost": 3e-07,
+            "cache_creation_input_token_cost": 3.75e-06
+        }
+    }"#;
+    let pricing = Arc::new(
+        exoharness::pricing::PricingTable::from_json_str(PRICING_FIXTURE)
+            .expect("fixture should parse"),
+    );
+
+    let tempdir = TempDir::new().expect("tempdir should exist");
+    let exoharness = Arc::new(
+        BasicExoHarness::new(local_test_config(tempdir.path().join("exoharness")))
+            .await
+            .expect("basic exoharness should initialize"),
+    ) as Arc<dyn ExoHarness>;
+    let harness = BasicHarness::with_pricing_table(
+        Arc::clone(&exoharness),
+        Arc::new(FakeModelClient::new(vec![ModelResponse {
+            response_id: Some(Uuid7::now()),
+            messages: vec![assistant_message("pong")],
+            tool_calls: Vec::new(),
+            usage: Some(UniversalUsage {
+                prompt_tokens: Some(500),
+                completion_tokens: Some(200),
+                prompt_cached_tokens: Some(10_000),
+                prompt_cache_creation_tokens: Some(2_000),
+                completion_reasoning_tokens: None,
+            }),
+            model: Some("claude-sonnet-4-6".to_string()),
+            ttft: None,
+            duration: None,
+        }])),
+        Arc::new(BasicToolRuntime::default()),
+        pricing,
+    );
+
+    let secret_id = exoharness
+        .put_secret(PutSecretRequest {
+            name: "anthropic-cache-key".to_string(),
+            secret: Secret::Key {
+                value: "test-key".to_string(),
+            },
+        })
+        .await
+        .expect("test secret should register");
+    exoharness
+        .put_binding(Binding::Llm {
+            name: "claude-sonnet-4-6".to_string(),
+            model: "claude-sonnet-4-6".to_string(),
+            base_url: None,
+            secret_id: Some(secret_id),
+        })
+        .await
+        .expect("binding should register");
+
+    let agent = harness
+        .create_agent(CreateAgentRequest {
+            slug: "anthropic-cache".to_string(),
+            name: None,
+            harness: crate::AgentHarnessKind::Basic,
+            typescript: None,
+            sandbox_image: None,
+            enable_networking: false,
+            model: "claude-sonnet-4-6".to_string(),
+            max_output_tokens: None,
+            max_tool_round_trips: Some(2),
+            braintrust: None,
+        })
+        .await
+        .expect("agent should be created");
+    let conversation = agent
+        .create_conversation(CreateConversationRequest::default())
+        .await
+        .expect("conversation should be created");
+
+    conversation
+        .send(SendRequest {
+            input: vec![user_message("ping")],
+            session_id: None,
+        })
+        .await
+        .expect("send should succeed");
+
+    let usage = assistant_usage_record(&conversation).await;
+
+    assert_eq!(usage.model, "claude-sonnet-4-6");
+    assert_eq!(usage.prompt_tokens, Some(500));
+    assert_eq!(usage.completion_tokens, Some(200));
+    assert_eq!(usage.prompt_cached_tokens, Some(10_000));
+    assert_eq!(usage.prompt_cache_creation_tokens, Some(2_000));
+    // Anthropic-style additive:
+    //   500    fresh prompt    @ $3/M     = 0.0015
+    //   10000  cache read      @ $0.30/M  = 0.003
+    //   2000   cache creation  @ $3.75/M  = 0.0075
+    //   200    completion      @ $15/M    = 0.003
+    // total = 0.015
+    let cost = usage.cost_usd.expect("cost should be computed");
+    assert!(
+        (cost - 0.015).abs() < 1e-9,
+        "expected cost ~0.015, got {cost}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn usage_record_with_openai_inclusive_accounting() {
+    // OpenAI accounting is inclusive: prompt_tokens is the *total* input
+    // including any cache hits, so the executor must subtract
+    // prompt_cached_tokens before billing the fresh-input rate. Getting
+    // this wrong silently double-bills cached tokens. This test pins the
+    // behavior at the conversation-log level — the same accounting that
+    // pricing.rs exercises in isolation now also has to survive the round
+    // trip through ModelResponse → UsageRecord → persisted event.
+    const PRICING_FIXTURE: &str = r#"{
+        "gpt-4o-mini": {
+            "litellm_provider": "openai",
+            "mode": "chat",
+            "input_cost_per_token": 1.5e-07,
+            "output_cost_per_token": 6e-07,
+            "cache_read_input_token_cost": 7.5e-08
+        }
+    }"#;
+    let pricing = Arc::new(
+        exoharness::pricing::PricingTable::from_json_str(PRICING_FIXTURE)
+            .expect("fixture should parse"),
+    );
+
+    let tempdir = TempDir::new().expect("tempdir should exist");
+    let exoharness = Arc::new(
+        BasicExoHarness::new(local_test_config(tempdir.path().join("exoharness")))
+            .await
+            .expect("basic exoharness should initialize"),
+    ) as Arc<dyn ExoHarness>;
+    let harness = BasicHarness::with_pricing_table(
+        Arc::clone(&exoharness),
+        Arc::new(FakeModelClient::new(vec![ModelResponse {
+            response_id: Some(Uuid7::now()),
+            messages: vec![assistant_message("pong")],
+            tool_calls: Vec::new(),
+            usage: Some(UniversalUsage {
+                // prompt_tokens here *includes* the 500 cached — OpenAI
+                // convention.
+                prompt_tokens: Some(2_000),
+                completion_tokens: Some(1_000),
+                prompt_cached_tokens: Some(500),
+                prompt_cache_creation_tokens: None,
+                completion_reasoning_tokens: None,
+            }),
+            model: Some("gpt-4o-mini".to_string()),
+            ttft: None,
+            duration: None,
+        }])),
+        Arc::new(BasicToolRuntime::default()),
+        pricing,
+    );
+
+    let secret_id = exoharness
+        .put_secret(PutSecretRequest {
+            name: "openai-cache-key".to_string(),
+            secret: Secret::Key {
+                value: "test-key".to_string(),
+            },
+        })
+        .await
+        .expect("test secret should register");
+    exoharness
+        .put_binding(Binding::Llm {
+            name: "gpt-4o-mini".to_string(),
+            model: "gpt-4o-mini".to_string(),
+            base_url: None,
+            secret_id: Some(secret_id),
+        })
+        .await
+        .expect("binding should register");
+
+    let agent = harness
+        .create_agent(CreateAgentRequest {
+            slug: "openai-cache".to_string(),
+            name: None,
+            harness: crate::AgentHarnessKind::Basic,
+            typescript: None,
+            sandbox_image: None,
+            enable_networking: false,
+            model: "gpt-4o-mini".to_string(),
+            max_output_tokens: None,
+            max_tool_round_trips: Some(2),
+            braintrust: None,
+        })
+        .await
+        .expect("agent should be created");
+    let conversation = agent
+        .create_conversation(CreateConversationRequest::default())
+        .await
+        .expect("conversation should be created");
+
+    conversation
+        .send(SendRequest {
+            input: vec![user_message("ping")],
+            session_id: None,
+        })
+        .await
+        .expect("send should succeed");
+
+    let usage = assistant_usage_record(&conversation).await;
+
+    assert_eq!(usage.model, "gpt-4o-mini");
+    // Raw counts are preserved as the provider reported them — the
+    // inclusive convention only matters for the cost computation, not for
+    // the stored tokens.
+    assert_eq!(usage.prompt_tokens, Some(2_000));
+    assert_eq!(usage.completion_tokens, Some(1_000));
+    assert_eq!(usage.prompt_cached_tokens, Some(500));
+    // OpenAI-style inclusive:
+    //   non_cached = 2000 - 500       = 1500
+    //   1500   fresh prompt @ $0.15/M = 0.000225
+    //   500    cache read   @ $0.075/M = 0.0000375
+    //   1000   completion   @ $0.60/M = 0.0006
+    // total = 0.0008625
+    // If the executor mistakenly used the Anthropic-style additive
+    // formula here, it would bill all 2000 prompt tokens at the fresh
+    // rate and the total would be 0.0009375 — ~9% high — so this
+    // assertion catches the provider-classification bug the PR
+    // description calls out.
+    let cost = usage.cost_usd.expect("cost should be computed");
+    assert!(
+        (cost - 0.0008625).abs() < 1e-9,
+        "expected cost ~0.0008625, got {cost}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn close_session_appends_session_ended_event() {
     let tempdir = TempDir::new().expect("tempdir should exist");
     let exoharness: Arc<dyn ExoHarness> = Arc::new(
@@ -945,6 +1188,45 @@ fn assistant_message(text: &str) -> Message {
         content: AssistantContent::String(text.to_string()),
         id: None,
     }
+}
+
+/// Fetch the UsageRecord attached to the first Messages event that
+/// contains an assistant message. Mirrors the pattern in
+/// `usage_record_is_persisted_with_computed_cost` so the new tests stay
+/// readable.
+async fn assistant_usage_record(
+    conversation: &Arc<dyn crate::HarnessConversation>,
+) -> exoharness::UsageRecord {
+    let events = conversation
+        .exoharness_handle()
+        .get_events(Some(EventQuery {
+            cursor: None,
+            direction: Some(EventQueryDirection::Asc),
+            limit: None,
+            session_id: None,
+            turn_id: None,
+            types: None,
+        }))
+        .await
+        .expect("get events should succeed")
+        .events;
+
+    events
+        .into_iter()
+        .find_map(|event| match event.data {
+            EventData::Messages {
+                messages,
+                usage: Some(usage),
+                ..
+            } if messages
+                .iter()
+                .any(|m| matches!(m, Message::Assistant { .. })) =>
+            {
+                Some(usage)
+            }
+            _ => None,
+        })
+        .expect("assistant message event should carry a UsageRecord")
 }
 
 fn shell_command_arguments(command: &str) -> Map<String, Value> {

--- a/crates/executor/src/harness_runtime.rs
+++ b/crates/executor/src/harness_runtime.rs
@@ -400,6 +400,9 @@ fn normalize_model_response(response: UniversalResponse) -> Result<ModelResponse
         messages: response.messages,
         tool_calls,
         usage: response.usage,
+        model: response.model,
+        ttft: None,
+        duration: None,
     })
 }
 

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -36,7 +36,7 @@ pub use exoharness::{
     ConversationHandle, EventData, EventId, EventQuery, EventQueryDirection, ExoHarness,
     FileSystemMount, FileSystemMountMode, ForkConversationRequest, PutSecretRequest,
     SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, Secret, SecretBackendChoice, SecretMetadata,
-    SessionId, Uuid7,
+    SessionId, UsageRecord, Uuid7,
 };
 pub use harness_basic::BasicHarness;
 pub use harness_config::load_agent_config;

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -17,6 +17,7 @@ mod harness_js_repl;
 mod harness_runtime;
 mod harness_tool;
 mod harness_types;
+mod pricing_loader;
 mod rlm;
 #[cfg(test)]
 mod rlm_tests;

--- a/crates/executor/src/pricing_loader.rs
+++ b/crates/executor/src/pricing_loader.rs
@@ -69,32 +69,64 @@ async fn try_load() -> anyhow::Result<PricingTable> {
         None => (None, false),
     };
 
-    // 2. Fresh cache → use as-is.
+    // 2. Fresh cache → use as-is. A corrupt cache is treated as "no
+    //    pricing data" (empty table), never a hard error: a truncated or
+    //    garbage cache file must not poison the process, and we'd rather
+    //    leave cost unset than fill in wrong numbers.
     if let (true, Some(content)) = (cache_is_fresh, &cached_content) {
-        return PricingTable::from_json_str(content);
+        return Ok(parse_cache_or_empty(content));
     }
 
     // 3. Try a network fetch.
     let url = std::env::var("EXO_LITELLM_PRICES_URL")
         .unwrap_or_else(|_| LITELLM_PRICES_URL.to_string());
     match fetch(&url).await {
-        Ok(body) => {
-            if let Some(cache) = &cache {
-                write_cache(cache, &body).await;
+        Ok(body) => match PricingTable::from_json_str(&body) {
+            Ok(table) => {
+                // Only cache a body we could actually parse — never persist
+                // garbage (e.g. an HTML error page returned with 200).
+                if let Some(cache) = &cache {
+                    write_cache(cache, &body).await;
+                }
+                Ok(table)
             }
-            PricingTable::from_json_str(&body)
-        }
+            Err(err) => {
+                eprintln!(
+                    "[exo] fetched LiteLLM pricing is unparseable ({err}); \
+                     per-message cost will be unavailable"
+                );
+                Ok(PricingTable::empty())
+            }
+        },
         Err(fetch_err) => {
-            // 4. Stale cache is better than no cache.
+            // 4. Stale cache is better than no cache — same corrupt-safe
+            //    handling as the fresh path.
             if let Some(content) = cached_content {
                 eprintln!(
                     "[exo] LiteLLM pricing fetch failed ({fetch_err}); \
                      using stale cache"
                 );
-                return PricingTable::from_json_str(&content);
+                return Ok(parse_cache_or_empty(&content));
             }
             // 5. Nothing usable.
             Err(fetch_err)
+        }
+    }
+}
+
+/// Parse a cached pricing document, degrading a corrupt/unparseable cache
+/// to an empty table (every cost computation returns `None`) rather than
+/// surfacing an error. Cost data is best-effort; a bad cache should never
+/// take down a turn.
+fn parse_cache_or_empty(content: &str) -> PricingTable {
+    match PricingTable::from_json_str(content) {
+        Ok(table) => table,
+        Err(err) => {
+            eprintln!(
+                "[exo] cached LiteLLM pricing is unparseable ({err}); \
+                 per-message cost will be unavailable until the cache refreshes"
+            );
+            PricingTable::empty()
         }
     }
 }
@@ -180,5 +212,20 @@ mod tests {
         assert!(!table.is_empty());
         let entry = table.lookup("claude-sonnet-4-6").expect("entry");
         assert_eq!(entry.litellm_provider.as_deref(), Some("anthropic"));
+    }
+
+    #[test]
+    fn corrupt_cache_degrades_to_empty_table() {
+        // A truncated/garbage cache must not error or fill in wrong numbers —
+        // it degrades to an empty table so cost_usd ends up None.
+        let table = parse_cache_or_empty("{ this is not valid json ");
+        assert!(table.is_empty());
+    }
+
+    #[test]
+    fn valid_cache_parses_to_populated_table() {
+        let table = parse_cache_or_empty(FIXTURE_JSON);
+        assert!(!table.is_empty());
+        assert!(table.lookup("claude-sonnet-4-6").is_some());
     }
 }

--- a/crates/executor/src/pricing_loader.rs
+++ b/crates/executor/src/pricing_loader.rs
@@ -78,8 +78,8 @@ async fn try_load() -> anyhow::Result<PricingTable> {
     }
 
     // 3. Try a network fetch.
-    let url = std::env::var("EXO_LITELLM_PRICES_URL")
-        .unwrap_or_else(|_| LITELLM_PRICES_URL.to_string());
+    let url =
+        std::env::var("EXO_LITELLM_PRICES_URL").unwrap_or_else(|_| LITELLM_PRICES_URL.to_string());
     match fetch(&url).await {
         Ok(body) => match PricingTable::from_json_str(&body) {
             Ok(table) => {

--- a/crates/executor/src/pricing_loader.rs
+++ b/crates/executor/src/pricing_loader.rs
@@ -1,0 +1,184 @@
+//! Loader for the LiteLLM pricing database.
+//!
+//! Resolves a [`PricingTable`] from (in order):
+//! 1. `EXO_LITELLM_PRICES_PATH` — local file override, used by tests and
+//!    air-gapped deployments.
+//! 2. On-disk cache at `$XDG_CACHE_HOME/exo/litellm_prices.json` (or
+//!    `$HOME/.cache/exo/...`). Used directly if younger than
+//!    [`CACHE_TTL`].
+//! 3. HTTP fetch from
+//!    [`EXO_LITELLM_PRICES_URL`] (defaulting to the LiteLLM main branch).
+//!    The result is written back to the cache.
+//! 4. If the fetch fails but a *stale* cache file exists, that stale
+//!    cache is used rather than producing an empty table.
+//! 5. Otherwise, the table is empty (every cost computation returns
+//!    `None`; tokens are still persisted).
+//!
+//! The load runs at most once per process (gated by an
+//! [`OnceCell`]); subsequent calls are zero-cost clones of an `Arc`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use exoharness::pricing::PricingTable;
+use tokio::sync::OnceCell;
+
+const LITELLM_PRICES_URL: &str =
+    "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
+const CACHE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+const FETCH_TIMEOUT: Duration = Duration::from_secs(5);
+const CACHE_FILENAME: &str = "litellm_prices.json";
+
+static PRICING_TABLE: OnceCell<Arc<PricingTable>> = OnceCell::const_new();
+
+/// Resolve the global pricing table, loading it on the first call.
+///
+/// Never panics; on any load failure returns an empty table (cost
+/// computation will yield `None`, tokens are still persisted).
+pub async fn get_pricing_table() -> Arc<PricingTable> {
+    PRICING_TABLE
+        .get_or_init(|| async {
+            match try_load().await {
+                Ok(table) => Arc::new(table),
+                Err(err) => {
+                    eprintln!(
+                        "[exo] failed to load LiteLLM pricing table: {err}; \
+                         per-message cost will be unavailable"
+                    );
+                    Arc::new(PricingTable::empty())
+                }
+            }
+        })
+        .await
+        .clone()
+}
+
+async fn try_load() -> anyhow::Result<PricingTable> {
+    // 1. Local path override — used by tests and air-gapped setups.
+    if let Ok(path) = std::env::var("EXO_LITELLM_PRICES_PATH") {
+        let content = tokio::fs::read_to_string(&path)
+            .await
+            .map_err(|err| anyhow::anyhow!("reading EXO_LITELLM_PRICES_PATH={path}: {err}"))?;
+        return PricingTable::from_json_str(&content);
+    }
+
+    let cache = cache_path();
+    let (cached_content, cache_is_fresh) = match &cache {
+        Some(path) => read_cache(path).await,
+        None => (None, false),
+    };
+
+    // 2. Fresh cache → use as-is.
+    if let (true, Some(content)) = (cache_is_fresh, &cached_content) {
+        return PricingTable::from_json_str(content);
+    }
+
+    // 3. Try a network fetch.
+    let url = std::env::var("EXO_LITELLM_PRICES_URL")
+        .unwrap_or_else(|_| LITELLM_PRICES_URL.to_string());
+    match fetch(&url).await {
+        Ok(body) => {
+            if let Some(cache) = &cache {
+                write_cache(cache, &body).await;
+            }
+            PricingTable::from_json_str(&body)
+        }
+        Err(fetch_err) => {
+            // 4. Stale cache is better than no cache.
+            if let Some(content) = cached_content {
+                eprintln!(
+                    "[exo] LiteLLM pricing fetch failed ({fetch_err}); \
+                     using stale cache"
+                );
+                return PricingTable::from_json_str(&content);
+            }
+            // 5. Nothing usable.
+            Err(fetch_err)
+        }
+    }
+}
+
+async fn fetch(url: &str) -> anyhow::Result<String> {
+    let client = reqwest::Client::builder().timeout(FETCH_TIMEOUT).build()?;
+    let body = client
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?;
+    Ok(body)
+}
+
+/// Returns `(content, is_fresh)`. `is_fresh` is true only when the file
+/// exists, is readable, and its mtime is younger than [`CACHE_TTL`].
+async fn read_cache(path: &PathBuf) -> (Option<String>, bool) {
+    let metadata = match tokio::fs::metadata(path).await {
+        Ok(meta) => meta,
+        Err(_) => return (None, false),
+    };
+    let is_fresh = metadata
+        .modified()
+        .ok()
+        .and_then(|t| t.elapsed().ok())
+        .is_some_and(|age| age < CACHE_TTL);
+    let content = tokio::fs::read_to_string(path).await.ok();
+    (content, is_fresh)
+}
+
+async fn write_cache(path: &PathBuf, content: &str) {
+    if let Some(parent) = path.parent() {
+        let _ = tokio::fs::create_dir_all(parent).await;
+    }
+    let _ = tokio::fs::write(path, content).await;
+}
+
+fn cache_path() -> Option<PathBuf> {
+    let base = std::env::var_os("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".cache")))?;
+    Some(base.join("exo").join(CACHE_FILENAME))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    const FIXTURE_JSON: &str = r#"{
+        "claude-sonnet-4-6": {
+            "litellm_provider": "anthropic",
+            "mode": "chat",
+            "input_cost_per_token": 3e-06,
+            "output_cost_per_token": 1.5e-05,
+            "cache_read_input_token_cost": 3e-07,
+            "cache_creation_input_token_cost": 3.75e-06
+        }
+    }"#;
+
+    /// We can't reuse the global OnceCell across test invocations, so
+    /// the loader's public surface is tested only indirectly here via
+    /// `try_load`. Exercises the EXO_LITELLM_PRICES_PATH branch.
+    #[tokio::test(flavor = "current_thread")]
+    async fn local_path_override_is_honored() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("fixture.json");
+        tokio::fs::write(&path, FIXTURE_JSON).await.unwrap();
+
+        // Set in a scope so we can also test the absence path if needed.
+        // SAFETY: tests run in a single tokio current_thread runtime here;
+        // env mutation is not racing with other tasks.
+        unsafe {
+            std::env::set_var("EXO_LITELLM_PRICES_PATH", &path);
+        }
+        let table = try_load().await.expect("override load");
+        unsafe {
+            std::env::remove_var("EXO_LITELLM_PRICES_PATH");
+        }
+
+        assert!(!table.is_empty());
+        let entry = table.lookup("claude-sonnet-4-6").expect("entry");
+        assert_eq!(entry.litellm_provider.as_deref(), Some("anthropic"));
+    }
+}

--- a/crates/executor/src/pricing_loader.rs
+++ b/crates/executor/src/pricing_loader.rs
@@ -36,6 +36,12 @@ static PRICING_TABLE: OnceCell<Arc<PricingTable>> = OnceCell::const_new();
 ///
 /// Never panics; on any load failure returns an empty table (cost
 /// computation will yield `None`, tokens are still persisted).
+///
+/// Note: the table is loaded once per process and held for its lifetime.
+/// The 24h cache TTL is only re-evaluated at that first load, so a
+/// short-lived CLI run picks up fresh-ish pricing each invocation. For a
+/// long-running process this snapshot can go stale — if exo ever runs as a
+/// long-lived service, this should refresh the pricing every 24 hours.
 pub async fn get_pricing_table() -> Arc<PricingTable> {
     PRICING_TABLE
         .get_or_init(|| async {

--- a/crates/executor/src/rlm.rs
+++ b/crates/executor/src/rlm.rs
@@ -536,6 +536,7 @@ async fn append_final_answer(
     turn.add_events(vec![EventData::Messages {
         messages: vec![assistant_message(final_answer)],
         response_id,
+        usage: None,
     }])
     .await?;
     append_custom_event(

--- a/crates/executor/src/rlm_tests.rs
+++ b/crates/executor/src/rlm_tests.rs
@@ -54,12 +54,18 @@ async fn rlm_send_executes_repl_steps_and_persists_final_answer() {
                 },
             }],
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("FINAL(done)")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
     ]));
     let harness = RlmHarness::new(exoharness, model);
@@ -150,6 +156,9 @@ async fn rlm_subquery_variable_can_store_final_answer() {
                 },
             }],
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
@@ -175,18 +184,27 @@ async fn rlm_subquery_variable_can_store_final_answer() {
                 },
             }],
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("4")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("FINAL_VAR(final_answer)")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
     ]));
     let harness = RlmHarness::new(exoharness, Arc::clone(&model));
@@ -252,6 +270,9 @@ async fn rlm_send_stream_suppresses_internal_control_text() {
             messages: vec![assistant_message("FINAL(2)")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
     }]));
     let harness = RlmHarness::new(exoharness, model);
@@ -320,6 +341,9 @@ async fn rlm_exposes_history_via_get_messages() {
             messages: vec![assistant_message("FINAL(recorded)")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
@@ -348,12 +372,18 @@ globalThis.answer = String(\n\
                 },
             }],
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("FINAL_VAR(answer)")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
     ]));
     let harness = RlmHarness::new(exoharness, model);
@@ -425,6 +455,9 @@ async fn rlm_can_finish_by_setting_final_in_repl() {
             },
         }],
         usage: None,
+        model: None,
+        ttft: None,
+        duration: None,
     }]));
     let harness = RlmHarness::new(exoharness, Arc::clone(&model));
     register_test_model(harness.exoharness_handle().as_ref()).await;

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -585,6 +585,7 @@ impl ConversationHandle for BasicConversationHandle {
             events_to_append.push(EventData::Messages {
                 messages: request.input,
                 response_id: None,
+                usage: None,
             });
         }
 

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -93,6 +93,7 @@ async fn begin_turn_tracks_events_through_finish() {
     turn.add_events(vec![EventData::Messages {
         messages: vec![assistant_message("pong")],
         response_id: None,
+        usage: None,
     }])
     .await
     .expect("append assistant message");

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -154,6 +154,7 @@ async fn turn_events_continue_after_artifact_writes() {
     turn.add_events(vec![EventData::Messages {
         messages: vec![assistant_message("pong")],
         response_id: None,
+        usage: None,
     }])
     .await
     .expect("append after artifact write");

--- a/crates/exoharness/src/lib.rs
+++ b/crates/exoharness/src/lib.rs
@@ -3,6 +3,7 @@ mod basic;
 #[cfg(all(test, not(target_arch = "wasm32"), feature = "basic-backend"))]
 mod basic_tests;
 mod error;
+pub mod pricing;
 pub mod protocol;
 #[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
 mod sandbox;

--- a/crates/exoharness/src/pricing.rs
+++ b/crates/exoharness/src/pricing.rs
@@ -1,107 +1,163 @@
-//! Per-model price table and cost computation.
+//! Pure data + computation for per-message LLM cost.
 //!
-//! Rates are stored as USD per 1M tokens and the cost is computed at the
-//! moment the API call completes, so the recorded value reflects the price
-//! that applied then — not whatever the rate happens to be when the event
-//! log is later read.
+//! This module deserializes the
+//! [LiteLLM pricing database](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json)
+//! (used here as the canonical, frequently-updated source of model rates
+//! across providers) and computes per-call cost given a model name and
+//! token counts.
 //!
-//! Upstream provider APIs (Anthropic, OpenAI, Google, Bedrock) return token
-//! counts in their `usage` block but not dollar amounts; cost is always a
-//! local computation. The table here is intentionally small and easy to
-//! grow; unknown models simply produce `None` for cost (tokens are still
-//! recorded).
+//! It is intentionally network-free; loading the JSON (from cache, env
+//! override, or HTTP fetch) is the responsibility of the consuming crate.
+//!
+//! ## Why per-provider math is necessary
+//!
+//! Providers disagree on what `prompt_tokens` *includes*:
+//!
+//! - **Anthropic-family** (`anthropic`, `bedrock_converse`, `vertex_ai-*`,
+//!   `azure_ai` for Claude models): `prompt_tokens` is the *fresh*
+//!   (non-cached) input only. `prompt_cached_tokens` and
+//!   `prompt_cache_creation_tokens` are reported separately. Cost is
+//!   additive across the three.
+//!
+//! - **OpenAI-family** (`openai`, `mistral`, et al.): `prompt_tokens` is
+//!   the *total* input including any cache hits. `prompt_cached_tokens`
+//!   is a subset that must be subtracted to avoid double-billing.
+//!
+//! Mixing these conventions silently over- or under-counts cost by a
+//! large factor on cached responses (cache hits are typically 10× cheaper
+//! than fresh input).
 
-#[derive(Debug, Clone, Copy)]
-pub struct ModelPricing {
-    pub input_per_million: f64,
-    pub output_per_million: f64,
-    pub cached_input_per_million: Option<f64>,
-    pub cache_creation_per_million: Option<f64>,
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct ModelEntry {
+    /// Provider classification used to pick the cost formula. Examples:
+    /// `"anthropic"`, `"openai"`, `"bedrock_converse"`,
+    /// `"vertex_ai-anthropic_models"`, `"azure_ai"`, `"mistral"`.
+    #[serde(default)]
+    pub litellm_provider: Option<String>,
+    /// `chat`, `embedding`, `image_generation`, etc. We only price `chat`
+    /// entries here; others are loaded but lookups for non-chat usage
+    /// return `None`.
+    #[serde(default)]
+    pub mode: Option<String>,
+
+    #[serde(default)]
+    pub input_cost_per_token: Option<f64>,
+    #[serde(default)]
+    pub output_cost_per_token: Option<f64>,
+    /// Per-token rate for cache *reads* (Anthropic discounted tier;
+    /// OpenAI cached input).
+    #[serde(default)]
+    pub cache_read_input_token_cost: Option<f64>,
+    /// Per-token rate for cache *writes* — the surcharge for the request
+    /// that populates a cache entry. Anthropic-specific; absent on OpenAI.
+    #[serde(default)]
+    pub cache_creation_input_token_cost: Option<f64>,
+    /// Anthropic 1-hour cache tier (more expensive than the default 5-min
+    /// write rate). Currently unused — we default to the 5-minute rate
+    /// because lingua does not surface which tier was hit.
+    #[serde(default)]
+    pub cache_creation_input_token_cost_above_1hr: Option<f64>,
 }
 
-/// Pricing entries keyed by canonical model id. Lookups also accept any
-/// model name that starts with one of these keys (the longest matching
-/// prefix wins), which covers dated revisions like
-/// `claude-sonnet-4-6-20251022`.
-const PRICING_TABLE: &[(&str, ModelPricing)] = &[
-    // Anthropic Claude 4.x
-    (
-        "claude-opus-4-7",
-        ModelPricing {
-            input_per_million: 15.0,
-            output_per_million: 75.0,
-            cached_input_per_million: Some(1.50),
-            cache_creation_per_million: Some(18.75),
-        },
-    ),
-    (
-        "claude-sonnet-4-6",
-        ModelPricing {
-            input_per_million: 3.0,
-            output_per_million: 15.0,
-            cached_input_per_million: Some(0.30),
-            cache_creation_per_million: Some(3.75),
-        },
-    ),
-    (
-        "claude-haiku-4-5",
-        ModelPricing {
-            input_per_million: 1.0,
-            output_per_million: 5.0,
-            cached_input_per_million: Some(0.10),
-            cache_creation_per_million: Some(1.25),
-        },
-    ),
-    // OpenAI
-    (
-        "gpt-4o-mini",
-        ModelPricing {
-            input_per_million: 0.15,
-            output_per_million: 0.60,
-            cached_input_per_million: Some(0.075),
-            cache_creation_per_million: None,
-        },
-    ),
-    (
-        "gpt-4o",
-        ModelPricing {
-            input_per_million: 2.50,
-            output_per_million: 10.0,
-            cached_input_per_million: Some(1.25),
-            cache_creation_per_million: None,
-        },
-    ),
-    (
-        "o3-mini",
-        ModelPricing {
-            input_per_million: 1.10,
-            output_per_million: 4.40,
-            cached_input_per_million: Some(0.55),
-            cache_creation_per_million: None,
-        },
-    ),
-    (
-        "o1",
-        ModelPricing {
-            input_per_million: 15.0,
-            output_per_million: 60.0,
-            cached_input_per_million: Some(7.50),
-            cache_creation_per_million: None,
-        },
-    ),
-];
+#[derive(Debug, Clone, Default)]
+pub struct PricingTable {
+    entries: HashMap<String, ModelEntry>,
+}
 
-pub fn lookup(model: &str) -> Option<&'static ModelPricing> {
-    if let Some((_, pricing)) = PRICING_TABLE.iter().find(|(name, _)| *name == model) {
-        return Some(pricing);
+impl PricingTable {
+    pub fn empty() -> Self {
+        Self::default()
     }
-    PRICING_TABLE
-        .iter()
-        .filter(|(name, _)| model.starts_with(name))
-        .max_by_key(|(name, _)| name.len())
-        .map(|(_, pricing)| pricing)
+
+    /// Parse a LiteLLM `model_prices_and_context_window.json` document.
+    ///
+    /// Unknown fields and the `sample_spec` doc entry are silently
+    /// ignored; entries that don't deserialize into [`ModelEntry`]
+    /// (e.g., embedding-only entries with no per-token rates) are
+    /// included but will simply produce `None` from [`Self::compute_cost_usd`].
+    pub fn from_json_str(s: &str) -> anyhow::Result<Self> {
+        let raw: HashMap<String, serde_json::Value> = serde_json::from_str(s)?;
+        let mut entries = HashMap::with_capacity(raw.len());
+        for (key, value) in raw {
+            if key == "sample_spec" {
+                continue;
+            }
+            if let Ok(entry) = serde_json::from_value::<ModelEntry>(value) {
+                entries.insert(key, entry);
+            }
+        }
+        Ok(Self { entries })
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Resolve a model name to an entry. Matches exact key first; falls
+    /// back to the longest entry-key that is a prefix of `model`, so
+    /// dated revisions like `claude-sonnet-4-6-20251022` resolve to
+    /// `claude-sonnet-4-6`.
+    pub fn lookup(&self, model: &str) -> Option<&ModelEntry> {
+        if let Some(entry) = self.entries.get(model) {
+            return Some(entry);
+        }
+        self.entries
+            .iter()
+            .filter(|(key, _)| model.starts_with(key.as_str()))
+            .max_by_key(|(key, _)| key.len())
+            .map(|(_, entry)| entry)
+    }
+
+    /// Compute USD cost for a single call. Returns `None` when the model
+    /// is unknown or the entry has no `input_cost_per_token` (e.g., a
+    /// non-chat entry).
+    pub fn compute_cost_usd(&self, model: &str, tokens: TokenCounts) -> Option<f64> {
+        let entry = self.lookup(model)?;
+        let input_rate = entry.input_cost_per_token?;
+        let output_rate = entry.output_cost_per_token.unwrap_or(0.0);
+        // For cache rates, fall back to the input rate if the provider
+        // doesn't publish a separate cached tier.
+        let cache_read_rate = entry.cache_read_input_token_cost.unwrap_or(input_rate);
+        let cache_creation_rate = entry
+            .cache_creation_input_token_cost
+            .unwrap_or(input_rate);
+
+        let prompt = tokens.prompt.unwrap_or(0).max(0) as f64;
+        let completion = tokens.completion.unwrap_or(0).max(0) as f64;
+        let cached = tokens.prompt_cached.unwrap_or(0).max(0) as f64;
+        let cache_creation = tokens.prompt_cache_creation.unwrap_or(0).max(0) as f64;
+
+        let style = ProviderStyle::for_litellm_provider(entry.litellm_provider.as_deref());
+
+        let cost = match style {
+            ProviderStyle::Additive => {
+                prompt * input_rate
+                    + cached * cache_read_rate
+                    + cache_creation * cache_creation_rate
+                    + completion * output_rate
+            }
+            ProviderStyle::Inclusive => {
+                let non_cached = (prompt - cached).max(0.0);
+                non_cached * input_rate
+                    + cached * cache_read_rate
+                    + cache_creation * cache_creation_rate
+                    + completion * output_rate
+            }
+        };
+        Some(cost)
+    }
 }
 
+/// Token counts from a single API response, in lingua's
+/// provider-agnostic shape.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct TokenCounts {
     pub prompt: Option<i64>,
@@ -110,136 +166,263 @@ pub struct TokenCounts {
     pub prompt_cache_creation: Option<i64>,
 }
 
-/// Compute the dollar cost of a single API call from its token counts.
-///
-/// Returns `None` if the model is not in the pricing table.
-///
-/// Accounting assumption: `prompt`, `prompt_cached`, and
-/// `prompt_cache_creation` are treated as additive line items, each billed
-/// at its own rate. This matches Anthropic's published billing model
-/// (where `prompt_tokens` reports only fresh, non-cached input). Providers
-/// that instead report cached tokens as a subset of `prompt_tokens` (some
-/// OpenAI accountings) will slightly over-count by `cached × input_rate`;
-/// this is acceptable for now and can be refined per-provider later.
-pub fn compute_cost_usd(model: &str, tokens: TokenCounts) -> Option<f64> {
-    let pricing = lookup(model)?;
-    let prompt = tokens.prompt.unwrap_or(0).max(0) as f64;
-    let completion = tokens.completion.unwrap_or(0).max(0) as f64;
-    let cached = tokens.prompt_cached.unwrap_or(0).max(0) as f64;
-    let cache_creation = tokens.prompt_cache_creation.unwrap_or(0).max(0) as f64;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProviderStyle {
+    /// Anthropic-family: `prompt_tokens` excludes cached. Bill all three
+    /// buckets separately.
+    Additive,
+    /// OpenAI-family: `prompt_tokens` includes cached. Subtract cached
+    /// from prompt before billing fresh-input rate.
+    Inclusive,
+}
 
-    let mut cost = prompt / 1_000_000.0 * pricing.input_per_million
-        + completion / 1_000_000.0 * pricing.output_per_million;
-
-    let cached_rate = pricing
-        .cached_input_per_million
-        .unwrap_or(pricing.input_per_million);
-    cost += cached / 1_000_000.0 * cached_rate;
-
-    let creation_rate = pricing
-        .cache_creation_per_million
-        .unwrap_or(pricing.input_per_million);
-    cost += cache_creation / 1_000_000.0 * creation_rate;
-
-    Some(cost)
+impl ProviderStyle {
+    fn for_litellm_provider(provider: Option<&str>) -> Self {
+        // LiteLLM uses these strings (see model_prices_and_context_window.json
+        // values for litellm_provider). Anything not classified here defaults
+        // to Inclusive — same convention as OpenAI, which is the safer of the
+        // two when cached==0 (the typical case).
+        match provider {
+            Some(p) if p.starts_with("anthropic") => Self::Additive,
+            Some(p) if p.starts_with("bedrock") => Self::Additive,
+            Some(p) if p.starts_with("vertex_ai-anthropic") => Self::Additive,
+            Some("azure_ai") => Self::Additive, // azure_ai is used for Claude on Azure
+            _ => Self::Inclusive,
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    fn approx(a: f64, b: f64) -> bool {
-        (a - b).abs() < 1e-9
+    // A tiny vendored slice of LiteLLM's JSON, just enough to exercise the
+    // accounting formulas. Rates are taken from real entries so the
+    // assertions correspond to numbers you can verify on each provider's
+    // pricing page.
+    const FIXTURE: &str = r#"{
+        "sample_spec": {
+            "comment": "doc entry, must be ignored"
+        },
+        "claude-sonnet-4-6": {
+            "litellm_provider": "anthropic",
+            "mode": "chat",
+            "input_cost_per_token": 3e-06,
+            "output_cost_per_token": 1.5e-05,
+            "cache_read_input_token_cost": 3e-07,
+            "cache_creation_input_token_cost": 3.75e-06
+        },
+        "gpt-4o-mini": {
+            "litellm_provider": "openai",
+            "mode": "chat",
+            "input_cost_per_token": 1.5e-07,
+            "output_cost_per_token": 6e-07,
+            "cache_read_input_token_cost": 7.5e-08
+        },
+        "us.anthropic.claude-sonnet-4-6": {
+            "litellm_provider": "bedrock_converse",
+            "mode": "chat",
+            "input_cost_per_token": 3.3e-06,
+            "output_cost_per_token": 1.65e-05,
+            "cache_read_input_token_cost": 3.3e-07,
+            "cache_creation_input_token_cost": 4.125e-06
+        }
+    }"#;
+
+    fn approx(a: f64, b: f64) {
+        let rel = (a - b).abs() / b.abs().max(1e-12);
+        assert!(rel < 1e-9, "expected {b}, got {a} (rel diff {rel})");
+    }
+
+    fn table() -> PricingTable {
+        PricingTable::from_json_str(FIXTURE).expect("fixture parses")
     }
 
     #[test]
-    fn lookup_finds_exact_match() {
-        let pricing = lookup("claude-sonnet-4-6").expect("known model");
-        assert!(approx(pricing.input_per_million, 3.0));
-        assert!(approx(pricing.output_per_million, 15.0));
-    }
-
-    #[test]
-    fn lookup_finds_longest_prefix() {
-        // dated revision should match the un-dated entry
-        let pricing = lookup("claude-sonnet-4-6-20251022").expect("dated revision");
-        assert!(approx(pricing.input_per_million, 3.0));
-    }
-
-    #[test]
-    fn lookup_prefers_longer_prefix() {
-        // gpt-4o-mini should not match the bare gpt-4o entry
-        let pricing = lookup("gpt-4o-mini-2024-07-18").expect("mini revision");
-        assert!(approx(pricing.input_per_million, 0.15));
-    }
-
-    #[test]
-    fn lookup_returns_none_for_unknown_model() {
-        assert!(lookup("acme-llm-7000").is_none());
-    }
-
-    #[test]
-    fn compute_cost_basic() {
-        let cost = compute_cost_usd(
+    fn empty_table_returns_none() {
+        let cost = PricingTable::empty().compute_cost_usd(
             "claude-sonnet-4-6",
             TokenCounts {
-                prompt: Some(1_000_000),
-                completion: Some(1_000_000),
-                prompt_cached: None,
-                prompt_cache_creation: None,
+                prompt: Some(100),
+                completion: Some(50),
+                ..Default::default()
             },
-        )
-        .expect("known model");
-        // 1M prompt @ $3 + 1M completion @ $15 = $18
-        assert!(approx(cost, 18.0));
+        );
+        assert!(cost.is_none());
     }
 
     #[test]
-    fn compute_cost_includes_cached_at_discounted_rate() {
-        let cost = compute_cost_usd(
-            "claude-sonnet-4-6",
-            TokenCounts {
-                prompt: Some(0),
-                completion: Some(0),
-                prompt_cached: Some(1_000_000),
-                prompt_cache_creation: Some(1_000_000),
-            },
-        )
-        .expect("known model");
-        // 1M cached @ $0.30 + 1M cache_creation @ $3.75 = $4.05
-        assert!(approx(cost, 4.05));
+    fn skips_sample_spec_doc_entry() {
+        let t = table();
+        assert!(t.lookup("sample_spec").is_none());
+        assert_eq!(t.len(), 3);
     }
 
     #[test]
-    fn compute_cost_handles_missing_cached_rate() {
-        // gpt-4o has no cache_creation_per_million; should fall back to input rate.
-        let cost = compute_cost_usd(
-            "gpt-4o",
-            TokenCounts {
-                prompt: Some(0),
-                completion: Some(0),
-                prompt_cached: Some(0),
-                prompt_cache_creation: Some(1_000_000),
-            },
-        )
-        .expect("known model");
-        // 1M cache_creation @ input rate $2.50 = $2.50
-        assert!(approx(cost, 2.50));
+    fn longest_prefix_match() {
+        let t = table();
+        let entry = t.lookup("claude-sonnet-4-6-20251022").expect("prefix");
+        // Should match the direct anthropic entry, not the bedrock one
+        // (because "claude-sonnet-4-6" is a prefix of the input but
+        // "us.anthropic.claude-sonnet-4-6" is not).
+        assert_eq!(entry.litellm_provider.as_deref(), Some("anthropic"));
     }
 
     #[test]
-    fn compute_cost_returns_none_for_unknown_model() {
-        assert!(
-            compute_cost_usd(
-                "acme-llm-7000",
+    fn anthropic_additive_no_cache() {
+        // 1000 prompt @ $3/M + 500 completion @ $15/M = $0.003 + $0.0075 = $0.0105
+        let cost = table()
+            .compute_cost_usd(
+                "claude-sonnet-4-6",
                 TokenCounts {
-                    prompt: Some(100),
-                    completion: Some(50),
-                    prompt_cached: None,
-                    prompt_cache_creation: None,
-                }
+                    prompt: Some(1_000),
+                    completion: Some(500),
+                    ..Default::default()
+                },
             )
-            .is_none()
+            .expect("cost");
+        approx(cost, 0.0105);
+    }
+
+    #[test]
+    fn anthropic_additive_with_cache_hits() {
+        // For Anthropic, prompt_tokens excludes cached. So 500 fresh + 10k
+        // cached read + 0 cache_creation + 200 completion:
+        //   500   * 3e-06  = 0.0015
+        //   10000 * 3e-07  = 0.003
+        //   200   * 1.5e-05 = 0.003
+        // total = 0.0075
+        let cost = table()
+            .compute_cost_usd(
+                "claude-sonnet-4-6",
+                TokenCounts {
+                    prompt: Some(500),
+                    completion: Some(200),
+                    prompt_cached: Some(10_000),
+                    prompt_cache_creation: None,
+                },
+            )
+            .expect("cost");
+        approx(cost, 0.0075);
+    }
+
+    #[test]
+    fn anthropic_additive_with_cache_creation() {
+        // 0 fresh + 0 cached + 5000 cache_creation + 100 completion:
+        //   5000 * 3.75e-06 = 0.01875
+        //   100  * 1.5e-05  = 0.0015
+        // total = 0.02025
+        let cost = table()
+            .compute_cost_usd(
+                "claude-sonnet-4-6",
+                TokenCounts {
+                    prompt: Some(0),
+                    completion: Some(100),
+                    prompt_cached: None,
+                    prompt_cache_creation: Some(5_000),
+                },
+            )
+            .expect("cost");
+        approx(cost, 0.02025);
+    }
+
+    #[test]
+    fn openai_inclusive_subtracts_cached_from_prompt() {
+        // For OpenAI, prompt_tokens=2000 includes the 500 cached. So:
+        //   non_cached = 2000 - 500 = 1500
+        //   1500 * 1.5e-07 = 0.000225
+        //   500  * 7.5e-08 = 0.0000375
+        //   1000 * 6e-07   = 0.0006
+        // total = 0.0008625
+        let cost = table()
+            .compute_cost_usd(
+                "gpt-4o-mini",
+                TokenCounts {
+                    prompt: Some(2_000),
+                    completion: Some(1_000),
+                    prompt_cached: Some(500),
+                    prompt_cache_creation: None,
+                },
+            )
+            .expect("cost");
+        approx(cost, 0.0008625);
+    }
+
+    #[test]
+    fn openai_inclusive_collapses_to_naive_when_no_cache() {
+        // 1000 prompt @ $0.15/M + 500 completion @ $0.60/M
+        //   = 1.5e-4 + 3e-4 = 4.5e-4
+        let cost = table()
+            .compute_cost_usd(
+                "gpt-4o-mini",
+                TokenCounts {
+                    prompt: Some(1_000),
+                    completion: Some(500),
+                    ..Default::default()
+                },
+            )
+            .expect("cost");
+        approx(cost, 0.00045);
+    }
+
+    #[test]
+    fn bedrock_uses_additive_with_regional_surcharge() {
+        // us.anthropic.claude-sonnet-4-6 has 10% higher rates than the direct
+        // Anthropic entry: 1000 prompt @ $3.30/M + 500 completion @ $16.50/M.
+        let cost = table()
+            .compute_cost_usd(
+                "us.anthropic.claude-sonnet-4-6",
+                TokenCounts {
+                    prompt: Some(1_000),
+                    completion: Some(500),
+                    ..Default::default()
+                },
+            )
+            .expect("cost");
+        approx(cost, 0.01155);
+    }
+
+    #[test]
+    fn unknown_model_returns_none() {
+        assert!(
+            table()
+                .compute_cost_usd(
+                    "acme-llm-9000",
+                    TokenCounts {
+                        prompt: Some(100),
+                        completion: Some(50),
+                        ..Default::default()
+                    },
+                )
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn provider_style_classification() {
+        assert_eq!(
+            ProviderStyle::for_litellm_provider(Some("anthropic")),
+            ProviderStyle::Additive
+        );
+        assert_eq!(
+            ProviderStyle::for_litellm_provider(Some("bedrock_converse")),
+            ProviderStyle::Additive
+        );
+        assert_eq!(
+            ProviderStyle::for_litellm_provider(Some("vertex_ai-anthropic_models")),
+            ProviderStyle::Additive
+        );
+        assert_eq!(
+            ProviderStyle::for_litellm_provider(Some("openai")),
+            ProviderStyle::Inclusive
+        );
+        assert_eq!(
+            ProviderStyle::for_litellm_provider(Some("mistral")),
+            ProviderStyle::Inclusive
+        );
+        assert_eq!(
+            ProviderStyle::for_litellm_provider(None),
+            ProviderStyle::Inclusive
         );
     }
 }

--- a/crates/exoharness/src/pricing.rs
+++ b/crates/exoharness/src/pricing.rs
@@ -126,9 +126,7 @@ impl PricingTable {
         // For cache rates, fall back to the input rate if the provider
         // doesn't publish a separate cached tier.
         let cache_read_rate = entry.cache_read_input_token_cost.unwrap_or(input_rate);
-        let cache_creation_rate = entry
-            .cache_creation_input_token_cost
-            .unwrap_or(input_rate);
+        let cache_creation_rate = entry.cache_creation_input_token_cost.unwrap_or(input_rate);
 
         let prompt = tokens.prompt.unwrap_or(0).max(0) as f64;
         let completion = tokens.completion.unwrap_or(0).max(0) as f64;

--- a/crates/exoharness/src/pricing.rs
+++ b/crates/exoharness/src/pricing.rs
@@ -1,0 +1,245 @@
+//! Per-model price table and cost computation.
+//!
+//! Rates are stored as USD per 1M tokens and the cost is computed at the
+//! moment the API call completes, so the recorded value reflects the price
+//! that applied then — not whatever the rate happens to be when the event
+//! log is later read.
+//!
+//! Upstream provider APIs (Anthropic, OpenAI, Google, Bedrock) return token
+//! counts in their `usage` block but not dollar amounts; cost is always a
+//! local computation. The table here is intentionally small and easy to
+//! grow; unknown models simply produce `None` for cost (tokens are still
+//! recorded).
+
+#[derive(Debug, Clone, Copy)]
+pub struct ModelPricing {
+    pub input_per_million: f64,
+    pub output_per_million: f64,
+    pub cached_input_per_million: Option<f64>,
+    pub cache_creation_per_million: Option<f64>,
+}
+
+/// Pricing entries keyed by canonical model id. Lookups also accept any
+/// model name that starts with one of these keys (the longest matching
+/// prefix wins), which covers dated revisions like
+/// `claude-sonnet-4-6-20251022`.
+const PRICING_TABLE: &[(&str, ModelPricing)] = &[
+    // Anthropic Claude 4.x
+    (
+        "claude-opus-4-7",
+        ModelPricing {
+            input_per_million: 15.0,
+            output_per_million: 75.0,
+            cached_input_per_million: Some(1.50),
+            cache_creation_per_million: Some(18.75),
+        },
+    ),
+    (
+        "claude-sonnet-4-6",
+        ModelPricing {
+            input_per_million: 3.0,
+            output_per_million: 15.0,
+            cached_input_per_million: Some(0.30),
+            cache_creation_per_million: Some(3.75),
+        },
+    ),
+    (
+        "claude-haiku-4-5",
+        ModelPricing {
+            input_per_million: 1.0,
+            output_per_million: 5.0,
+            cached_input_per_million: Some(0.10),
+            cache_creation_per_million: Some(1.25),
+        },
+    ),
+    // OpenAI
+    (
+        "gpt-4o-mini",
+        ModelPricing {
+            input_per_million: 0.15,
+            output_per_million: 0.60,
+            cached_input_per_million: Some(0.075),
+            cache_creation_per_million: None,
+        },
+    ),
+    (
+        "gpt-4o",
+        ModelPricing {
+            input_per_million: 2.50,
+            output_per_million: 10.0,
+            cached_input_per_million: Some(1.25),
+            cache_creation_per_million: None,
+        },
+    ),
+    (
+        "o3-mini",
+        ModelPricing {
+            input_per_million: 1.10,
+            output_per_million: 4.40,
+            cached_input_per_million: Some(0.55),
+            cache_creation_per_million: None,
+        },
+    ),
+    (
+        "o1",
+        ModelPricing {
+            input_per_million: 15.0,
+            output_per_million: 60.0,
+            cached_input_per_million: Some(7.50),
+            cache_creation_per_million: None,
+        },
+    ),
+];
+
+pub fn lookup(model: &str) -> Option<&'static ModelPricing> {
+    if let Some((_, pricing)) = PRICING_TABLE.iter().find(|(name, _)| *name == model) {
+        return Some(pricing);
+    }
+    PRICING_TABLE
+        .iter()
+        .filter(|(name, _)| model.starts_with(name))
+        .max_by_key(|(name, _)| name.len())
+        .map(|(_, pricing)| pricing)
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TokenCounts {
+    pub prompt: Option<i64>,
+    pub completion: Option<i64>,
+    pub prompt_cached: Option<i64>,
+    pub prompt_cache_creation: Option<i64>,
+}
+
+/// Compute the dollar cost of a single API call from its token counts.
+///
+/// Returns `None` if the model is not in the pricing table.
+///
+/// Accounting assumption: `prompt`, `prompt_cached`, and
+/// `prompt_cache_creation` are treated as additive line items, each billed
+/// at its own rate. This matches Anthropic's published billing model
+/// (where `prompt_tokens` reports only fresh, non-cached input). Providers
+/// that instead report cached tokens as a subset of `prompt_tokens` (some
+/// OpenAI accountings) will slightly over-count by `cached × input_rate`;
+/// this is acceptable for now and can be refined per-provider later.
+pub fn compute_cost_usd(model: &str, tokens: TokenCounts) -> Option<f64> {
+    let pricing = lookup(model)?;
+    let prompt = tokens.prompt.unwrap_or(0).max(0) as f64;
+    let completion = tokens.completion.unwrap_or(0).max(0) as f64;
+    let cached = tokens.prompt_cached.unwrap_or(0).max(0) as f64;
+    let cache_creation = tokens.prompt_cache_creation.unwrap_or(0).max(0) as f64;
+
+    let mut cost = prompt / 1_000_000.0 * pricing.input_per_million
+        + completion / 1_000_000.0 * pricing.output_per_million;
+
+    let cached_rate = pricing
+        .cached_input_per_million
+        .unwrap_or(pricing.input_per_million);
+    cost += cached / 1_000_000.0 * cached_rate;
+
+    let creation_rate = pricing
+        .cache_creation_per_million
+        .unwrap_or(pricing.input_per_million);
+    cost += cache_creation / 1_000_000.0 * creation_rate;
+
+    Some(cost)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn approx(a: f64, b: f64) -> bool {
+        (a - b).abs() < 1e-9
+    }
+
+    #[test]
+    fn lookup_finds_exact_match() {
+        let pricing = lookup("claude-sonnet-4-6").expect("known model");
+        assert!(approx(pricing.input_per_million, 3.0));
+        assert!(approx(pricing.output_per_million, 15.0));
+    }
+
+    #[test]
+    fn lookup_finds_longest_prefix() {
+        // dated revision should match the un-dated entry
+        let pricing = lookup("claude-sonnet-4-6-20251022").expect("dated revision");
+        assert!(approx(pricing.input_per_million, 3.0));
+    }
+
+    #[test]
+    fn lookup_prefers_longer_prefix() {
+        // gpt-4o-mini should not match the bare gpt-4o entry
+        let pricing = lookup("gpt-4o-mini-2024-07-18").expect("mini revision");
+        assert!(approx(pricing.input_per_million, 0.15));
+    }
+
+    #[test]
+    fn lookup_returns_none_for_unknown_model() {
+        assert!(lookup("acme-llm-7000").is_none());
+    }
+
+    #[test]
+    fn compute_cost_basic() {
+        let cost = compute_cost_usd(
+            "claude-sonnet-4-6",
+            TokenCounts {
+                prompt: Some(1_000_000),
+                completion: Some(1_000_000),
+                prompt_cached: None,
+                prompt_cache_creation: None,
+            },
+        )
+        .expect("known model");
+        // 1M prompt @ $3 + 1M completion @ $15 = $18
+        assert!(approx(cost, 18.0));
+    }
+
+    #[test]
+    fn compute_cost_includes_cached_at_discounted_rate() {
+        let cost = compute_cost_usd(
+            "claude-sonnet-4-6",
+            TokenCounts {
+                prompt: Some(0),
+                completion: Some(0),
+                prompt_cached: Some(1_000_000),
+                prompt_cache_creation: Some(1_000_000),
+            },
+        )
+        .expect("known model");
+        // 1M cached @ $0.30 + 1M cache_creation @ $3.75 = $4.05
+        assert!(approx(cost, 4.05));
+    }
+
+    #[test]
+    fn compute_cost_handles_missing_cached_rate() {
+        // gpt-4o has no cache_creation_per_million; should fall back to input rate.
+        let cost = compute_cost_usd(
+            "gpt-4o",
+            TokenCounts {
+                prompt: Some(0),
+                completion: Some(0),
+                prompt_cached: Some(0),
+                prompt_cache_creation: Some(1_000_000),
+            },
+        )
+        .expect("known model");
+        // 1M cache_creation @ input rate $2.50 = $2.50
+        assert!(approx(cost, 2.50));
+    }
+
+    #[test]
+    fn compute_cost_returns_none_for_unknown_model() {
+        assert!(
+            compute_cost_usd(
+                "acme-llm-7000",
+                TokenCounts {
+                    prompt: Some(100),
+                    completion: Some(50),
+                    prompt_cached: None,
+                    prompt_cache_creation: None,
+                }
+            )
+            .is_none()
+        );
+    }
+}

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -184,6 +184,36 @@ pub struct ForkConversationRequest {
     pub name: Option<String>,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct UsageRecord {
+    pub model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_tokens: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completion_tokens: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_cached_tokens: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_creation_tokens: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completion_reasoning_tokens: Option<i64>,
+    /// Cost in USD, computed at call time from the price table baked into
+    /// this binary. `None` if the model is not in the table.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost_usd: Option<f64>,
+    /// Time to first token (streaming only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ttft_ms: Option<u64>,
+    /// Wall-clock duration from request start to end of response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    /// Server-reported processing time, if the provider surfaces one. Not
+    /// currently populated — lingua does not yet expose this field — but
+    /// reserved so the event format is stable when it does.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub server_duration_ms: Option<u64>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Event {
     pub id: EventId,
@@ -208,6 +238,8 @@ pub enum EventData {
     Messages {
         messages: Vec<Message>,
         response_id: Option<ResponseId>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        usage: Option<UsageRecord>,
     },
     ToolRequested {
         tool_call_id: ToolCallId,
@@ -442,6 +474,47 @@ mod tests {
             value.get("type").and_then(Value::as_str),
             Some("session_started")
         );
+    }
+
+    #[test]
+    fn messages_event_deserializes_without_usage_field() {
+        // Older logs predate per-message cost tracking and have no `usage`
+        // field on Messages events; serde(default) must keep them readable.
+        let json = serde_json::json!({
+            "type": "messages",
+            "messages": [],
+            "response_id": null,
+        });
+        let event: EventData = serde_json::from_value(json).expect("legacy event should parse");
+        match event {
+            EventData::Messages { usage, .. } => assert!(usage.is_none()),
+            _ => panic!("expected Messages variant"),
+        }
+    }
+
+    #[test]
+    fn messages_event_serializes_usage_when_present() {
+        let event = EventData::Messages {
+            messages: vec![],
+            response_id: None,
+            usage: Some(UsageRecord {
+                model: "claude-sonnet-4-6".to_string(),
+                prompt_tokens: Some(100),
+                completion_tokens: Some(50),
+                cost_usd: Some(0.001),
+                ..Default::default()
+            }),
+        };
+        let value = serde_json::to_value(&event).expect("event should serialize");
+        let usage = value.get("usage").expect("usage field present");
+        assert_eq!(usage.get("model").and_then(Value::as_str), Some("claude-sonnet-4-6"));
+        assert_eq!(usage.get("prompt_tokens").and_then(Value::as_i64), Some(100));
+        assert!(
+            (usage.get("cost_usd").and_then(Value::as_f64).unwrap() - 0.001).abs() < 1e-9
+        );
+        // Round-trip back through the legacy-event parser
+        let parsed: EventData = serde_json::from_value(value).expect("round-trip parse");
+        assert!(matches!(parsed, EventData::Messages { usage: Some(_), .. }));
     }
 
     #[test]

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -238,8 +238,11 @@ pub enum EventData {
     Messages {
         messages: Vec<Message>,
         response_id: Option<ResponseId>,
+        // Boxed to keep `EventData` small: `UsageRecord` is ~170 bytes and
+        // most events don't carry it, so inlining it would bloat every
+        // variant (and every enum that embeds `EventData`).
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        usage: Option<UsageRecord>,
+        usage: Option<Box<UsageRecord>>,
     },
     ToolRequested {
         tool_call_id: ToolCallId,
@@ -497,21 +500,25 @@ mod tests {
         let event = EventData::Messages {
             messages: vec![],
             response_id: None,
-            usage: Some(UsageRecord {
+            usage: Some(Box::new(UsageRecord {
                 model: "claude-sonnet-4-6".to_string(),
                 prompt_tokens: Some(100),
                 completion_tokens: Some(50),
                 cost_usd: Some(0.001),
                 ..Default::default()
-            }),
+            })),
         };
         let value = serde_json::to_value(&event).expect("event should serialize");
         let usage = value.get("usage").expect("usage field present");
-        assert_eq!(usage.get("model").and_then(Value::as_str), Some("claude-sonnet-4-6"));
-        assert_eq!(usage.get("prompt_tokens").and_then(Value::as_i64), Some(100));
-        assert!(
-            (usage.get("cost_usd").and_then(Value::as_f64).unwrap() - 0.001).abs() < 1e-9
+        assert_eq!(
+            usage.get("model").and_then(Value::as_str),
+            Some("claude-sonnet-4-6")
         );
+        assert_eq!(
+            usage.get("prompt_tokens").and_then(Value::as_i64),
+            Some(100)
+        );
+        assert!((usage.get("cost_usd").and_then(Value::as_f64).unwrap() - 0.001).abs() < 1e-9);
         // Round-trip back through the legacy-event parser
         let parsed: EventData = serde_json::from_value(value).expect("round-trip parse");
         assert!(matches!(parsed, EventData::Messages { usage: Some(_), .. }));


### PR DESCRIPTION
## Summary

Adds a `/usage` command (alias `/cost`) to the chat REPL so you can see, at any point in a conversation, what it has cost so far. This is the demo surface for the per-message cost tracking in #16.

Example output:

```
usage (this conversation):
  model calls : 3
  input       : 14,500 tokens (1,200 cached, 800 cache-write)
  output      : 2,100 tokens (450 reasoning)
  cost        : $0.0182
  model time  : 8.3s
```

If some calls used a model not in the LiteLLM price table, their tokens still count but they're excluded from the dollar total, with an honest note:

```
  note        : 1 of 3 call(s) had no price in the table; cost is a partial total
```

## How it works

- New `/usage` / `/cost` branch in the REPL input loop (`tui.rs`), alongside the existing `/history`, `/quit`, `/exit`.
- `print_usage` reads the conversation's `messages` events via `get_events` and folds the `UsageRecord` on each — no new persistence, it's pure read-side.
- Aggregation/formatting split into pure functions (`summarize_usage`, `render_usage`, `with_commas`) so they're unit-testable without a live model.
- `priced_calls` is tracked separately from `calls` so the partial-total case is reported rather than silently undercounted.

## Stacking

**Stacked on #16** (`feature/message-cost-tracking`) — this reads the `UsageRecord` that #16 introduces, so its base is that branch, not `main`. Will retarget to `main` once #16 merges. Also adds a one-line re-export of `UsageRecord` from `executor` for the CLI.

## Test plan

- [x] `cargo test --workspace` — +4 unit tests in `tui::tests`:
  - `summarize_usage_aggregates_priced_calls_and_skips_usageless_events` (user-input events without usage are ignored; totals sum correctly)
  - `summarize_usage_counts_unpriced_calls_separately` (None cost → counted but not priced; partial-total note rendered)
  - `render_usage_reports_empty_conversation`
  - `with_commas_groups_thousands`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`

## Not in scope

- Per-turn breakdown / live inline display after each turn (this is a cumulative on-demand summary).
- A REPL command help banner (none exists today; `/usage` follows the same undocumented-but-discoverable convention as `/history`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)