### PR TITLE
fix: honor repl --model (#30) + send prompt_cache_key on Responses API (#24)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -511,6 +511,20 @@ async fn main() -> Result<()> {
                     if let Some(selection) = harness_selection.as_ref() {
                         ensure_agent_matches_harness_selection(agent.as_ref(), selection).await?;
                     }
+                    // Honor an explicit --model on an already-existing agent
+                    // instead of silently ignoring it (#30). Update the stored
+                    // model and tell the user; a no-op when it already matches.
+                    if let Some(requested) = model {
+                        let resolved = ensure_repl_model(harness.as_ref(), Some(requested)).await?;
+                        let mut config = agent.config().await?;
+                        if config.model != resolved {
+                            let previous = std::mem::replace(&mut config.model, resolved.clone());
+                            agent.put_config(config).await?;
+                            println!(
+                                "updated agent '{agent_slug}' model: {previous} -> {resolved}"
+                            );
+                        }
+                    }
                     agent
                 }
                 None => {

--- a/crates/executor/src/basic.rs
+++ b/crates/executor/src/basic.rs
@@ -556,6 +556,9 @@ async fn build_model_request(
         messages,
         tools: build_tool_definitions(conversation_config),
         max_output_tokens: agent_config.max_output_tokens,
+        // Per-conversation cache key so each turn's request reuses the
+        // growing shared prefix (system prompt + tools + prior history).
+        prompt_cache_key: Some(conversation.record().id.to_string()),
     })
 }
 

--- a/crates/executor/src/executor_types.rs
+++ b/crates/executor/src/executor_types.rs
@@ -131,6 +131,11 @@ pub struct ModelRequest {
     pub messages: Vec<Message>,
     pub tools: Vec<ToolDefinition>,
     pub max_output_tokens: Option<i64>,
+    /// Stable label used to route prompt-cache hits (OpenAI Responses API
+    /// `prompt_cache_key`). Per-conversation, so each turn reuses the
+    /// growing shared prefix. `None` leaves caching to provider defaults.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_key: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/executor/src/harness_runtime.rs
+++ b/crates/executor/src/harness_runtime.rs
@@ -198,7 +198,7 @@ fn build_router(
 fn build_universal_request(request: &ModelRequest, stream: bool) -> Result<UniversalRequest> {
     let tools = build_universal_tools(&request.tools)?;
     let has_tools = !tools.is_empty();
-    let params = UniversalParams {
+    let mut params = UniversalParams {
         token_budget: request.max_output_tokens.map(TokenBudget::OutputTokens),
         tools: if tools.is_empty() { None } else { Some(tools) },
         tool_choice: has_tools.then_some(ToolChoiceConfig {
@@ -209,6 +209,21 @@ fn build_universal_request(request: &ModelRequest, stream: bool) -> Result<Unive
         stream: Some(stream),
         ..Default::default()
     };
+
+    // Route prompt-cache hits via a stable `prompt_cache_key` on the OpenAI
+    // Responses API (#24). Without it, the Responses endpoint sees ~0% cache
+    // hit rate at low request volume. Carried through lingua's per-format
+    // extras passthrough.
+    if let Some(cache_key) = &request.prompt_cache_key {
+        let mut responses_extras = lingua_json::Map::new();
+        responses_extras.insert(
+            "prompt_cache_key".to_string(),
+            lingua_json::Value::String(cache_key.clone()),
+        );
+        params
+            .extras
+            .insert(ProviderFormat::Responses, responses_extras);
+    }
 
     Ok(UniversalRequest {
         model: Some(request.model.clone()),
@@ -263,6 +278,7 @@ mod tests {
             messages: Vec::new(),
             tools: Vec::new(),
             max_output_tokens: None,
+            prompt_cache_key: None,
         }
     }
 
@@ -275,6 +291,29 @@ mod tests {
 
         assert_eq!(payload.stream, Some(true));
         assert!(payload.stream_options.is_none());
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct SerializedResponsesCacheKey {
+        prompt_cache_key: Option<String>,
+    }
+
+    #[test]
+    fn responses_request_includes_prompt_cache_key_when_set() {
+        let mut request = model_request();
+        request.prompt_cache_key = Some("conv-abc123".to_string());
+        let universal = build_universal_request(&request, true).unwrap();
+        let serialized = serialize_request(ProviderFormat::Responses, &universal).unwrap();
+        let payload: SerializedResponsesCacheKey = lingua_json::from_slice(&serialized).unwrap();
+        assert_eq!(payload.prompt_cache_key.as_deref(), Some("conv-abc123"));
+    }
+
+    #[test]
+    fn responses_request_omits_prompt_cache_key_when_unset() {
+        let universal = build_universal_request(&model_request(), true).unwrap();
+        let serialized = serialize_request(ProviderFormat::Responses, &universal).unwrap();
+        let payload: SerializedResponsesCacheKey = lingua_json::from_slice(&serialized).unwrap();
+        assert!(payload.prompt_cache_key.is_none());
     }
 
     #[test]

--- a/crates/executor/src/rlm.rs
+++ b/crates/executor/src/rlm.rs
@@ -111,6 +111,9 @@ where
                 messages: history.clone(),
                 tools: build_rlm_tool_definitions(),
                 max_output_tokens: agent_config.max_output_tokens,
+                // RLM's prompt-cache strategy is out of scope here (#24 targets
+                // the basic chat path); leave it to provider defaults.
+                prompt_cache_key: None,
             };
             let llm_trace = match turn_trace {
                 Some(turn_trace) => turn_trace.start_llm_round(&request, round as usize).await,
@@ -390,6 +393,7 @@ where
                 messages,
                 tools: Vec::new(),
                 max_output_tokens: agent_config.max_output_tokens,
+                prompt_cache_key: None,
             })
             .await?;
 


### PR DESCRIPTION
Fixes two bugs found while building the cost-tracking stack. **Stacked on #29** (`usage-command`), since the before/after is demonstrated via that PR's `/usage` command. Two independent commits.

## #30 — `exo repl --model X` silently ignored on an existing agent

`exo repl` reused an existing agent and dropped `--model` with no feedback, so you'd think you'd switched models but hadn't. Now an explicit `--model` that differs from the agent's stored model **updates it and prints a notice**:

```
updated agent 'demo' model: gpt-4o-mini -> gpt-5.5
```

No-op when it already matches. (`crates/cli/src/main.rs`, the `Repl` arm.)

## #24 — no `prompt_cache_key` on the OpenAI Responses API → ~0% cache hits

The Responses endpoint needs a stable `prompt_cache_key` to reliably route prompt-cache hits at low request volume; exo never sent one, so cached input was billed at full rate and `UsageRecord.prompt_cached_tokens` was always 0.

Fix: a **per-conversation** cache key.
- `ModelRequest` gains a `prompt_cache_key` field.
- `build_model_request` sets it to the conversation id.
- `build_universal_request` injects it into lingua's per-format extras (`prompt_cache_key`) for the Responses API.

Per-conversation so each turn reuses the growing shared prefix (system prompt + tools + prior history), and each conversation gets its own key — staying well under OpenAI's ~15 req/min-per-key guidance. RLM paths pass `None` (different caching dynamics, out of scope). No lingua fork needed — the passthrough already exists.

### Verified live (gpt-4o-mini, ~2.5k-token shared prefix, two turns in one conversation)

| call | prompt | cached |
|---|---:|---:|
| 1 | 2513 | 0 |
| 2 | 2541 | **2304** |

`/usage` after: `input : 5,054 tokens (2,304 cached)` — the savings PR16's cost tracking was built to surface.

## Test plan

- [x] `cargo test --workspace` (84 tests) — adds `responses_request_includes_prompt_cache_key_when_set` / `..._omits_..._when_unset`, which assert the key lands in (and stays out of) the **serialized** Responses body.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] Manual: #30 model-switch notice + persisted model change; #24 cache-hit jump shown above.

## Stacking note

Base is `usage-command` (#29), which is itself on `feature/message-cost-tracking` (#16). Merge order: #16 → #29 → this. Bases auto-retarget as each lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)