### PR TITLE
Generate exoharness secret key and nonce from a CSPRNG

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2170,6 +2170,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
+ "getrandom 0.3.4",
  "keyring",
  "keyring-core",
  "lingua",

--- a/crates/exoharness/Cargo.toml
+++ b/crates/exoharness/Cargo.toml
@@ -10,6 +10,7 @@ default = []
 basic-backend = [
   "dep:aes-gcm",
   "dep:actix-web",
+  "dep:getrandom",
   "dep:object_store",
   "dep:reqwest",
   "dep:tokio",
@@ -29,6 +30,7 @@ async-trait.workspace = true
 bytes.workspace = true
 chrono.workspace = true
 futures.workspace = true
+getrandom = { version = "0.3", optional = true }
 keyring = { version = "4.0.0-rc.3", optional = true }
 keyring-core = { version = "0.7.2", optional = true }
 lingua.workspace = true

--- a/crates/exoharness/src/secrets.rs
+++ b/crates/exoharness/src/secrets.rs
@@ -5,7 +5,6 @@ use aes_gcm::aead::{Aead, KeyInit};
 use aes_gcm::{Aes256Gcm, Nonce};
 use anyhow::{Context, anyhow, bail};
 use serde::{Deserialize, Serialize};
-use uuid::Uuid;
 
 use crate::{Result, Secret};
 
@@ -31,7 +30,7 @@ impl SecretCipher {
         let payload = serde_json::to_vec(secret)?;
         let cipher = Aes256Gcm::new_from_slice(&key)
             .map_err(|_| anyhow!("invalid secret encryption key length"))?;
-        let nonce = random_nonce();
+        let nonce = random_nonce()?;
         let nonce = Nonce::from(nonce);
         let ciphertext = cipher
             .encrypt(&nonce, payload.as_slice())
@@ -114,7 +113,7 @@ impl SecretKeyProvider for AppleKeychainSecretKeyProvider {
         let key = match entry.get_password() {
             Ok(serialized) => deserialize_key(&serialized)?,
             Err(KeyringError::NoEntry) => {
-                let key = random_master_key();
+                let key = random_master_key()?;
                 entry
                     .set_password(&serde_json::to_string(&key.to_vec())?)
                     .context("failed to persist exoharness master key in keychain")?;
@@ -152,7 +151,7 @@ impl SecretKeyProvider for FileBackedSecretKeyProvider {
             Ok(bytes) => parse_master_key_bytes(&bytes)
                 .with_context(|| format!("reading master key at {}", self.path.display()))?,
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                let key = random_master_key();
+                let key = random_master_key()?;
                 write_master_key_file(&self.path, &key)?;
                 key
             }
@@ -190,17 +189,17 @@ fn deserialize_key(serialized: &str) -> Result<[u8; MASTER_KEY_LEN]> {
     Ok(key)
 }
 
-fn random_master_key() -> [u8; MASTER_KEY_LEN] {
+// Key and nonce material must be uniformly random; fill directly from the OS CSPRNG.
+fn random_master_key() -> Result<[u8; MASTER_KEY_LEN]> {
     let mut key = [0u8; MASTER_KEY_LEN];
-    key[..16].copy_from_slice(Uuid::new_v4().as_bytes());
-    key[16..].copy_from_slice(Uuid::new_v4().as_bytes());
-    key
+    getrandom::fill(&mut key).context("failed to generate secret master key")?;
+    Ok(key)
 }
 
-fn random_nonce() -> [u8; NONCE_LEN] {
+fn random_nonce() -> Result<[u8; NONCE_LEN]> {
     let mut nonce = [0u8; NONCE_LEN];
-    nonce.copy_from_slice(&Uuid::new_v4().as_bytes()[..NONCE_LEN]);
-    nonce
+    getrandom::fill(&mut nonce).context("failed to generate secret nonce")?;
+    Ok(nonce)
 }
 
 #[cfg(feature = "apple-keychain")]
@@ -276,4 +275,51 @@ pub(crate) fn default_master_key_path() -> Result<PathBuf> {
         }
     }
     bail!("could not determine config directory: set XDG_CONFIG_HOME or HOME")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn master_keys_are_random_and_distinct() {
+        let a = random_master_key().expect("master key");
+        let b = random_master_key().expect("master key");
+        assert_ne!(a, b, "two generated master keys must differ");
+    }
+
+    #[test]
+    fn nonce_is_full_entropy_not_uuid_derived() {
+        // The old UUIDv4 nonce pinned byte 6 into the version range (0x40..=0x4f)
+        // on every draw (256/256). Under a CSPRNG that range has p=1/16, so over
+        // 256 draws the mean is 16 and the threshold of 64 is ~12 std devs out.
+        let mut pinned = 0;
+        for _ in 0..256 {
+            if (random_nonce().expect("nonce")[6] & 0xf0) == 0x40 {
+                pinned += 1;
+            }
+        }
+        assert!(
+            pinned < 64,
+            "nonce byte 6 looks version-biased: {pinned}/256"
+        );
+    }
+
+    #[test]
+    fn encrypt_decrypt_round_trips_with_distinct_nonces() {
+        let cipher = SecretCipher::new(Arc::new(StaticSecretKeyProvider::new(
+            [7u8; MASTER_KEY_LEN],
+        )));
+        let secret = Secret::Key {
+            value: "s3cr3t".to_string(),
+        };
+        let first = cipher.encrypt_secret(&secret).expect("encrypt");
+        let second = cipher.encrypt_secret(&secret).expect("encrypt");
+        assert_eq!(first.nonce.len(), NONCE_LEN);
+        assert_ne!(
+            first.nonce, second.nonce,
+            "each encryption must use a fresh nonce"
+        );
+        assert_eq!(cipher.decrypt_secret(&first).expect("decrypt"), secret);
+    }
 }


### PR DESCRIPTION
## What changed

`random_master_key` and `random_nonce` in `crates/exoharness/src/secrets.rs`
built the AES-256-GCM key and nonce from `Uuid::new_v4()` bytes. A v4 UUID has
fixed bits (the version nibble at byte 6 and the variant bits at byte 8), so the
32-byte key was not uniformly random (~244 bits, with fixed bits at known
offsets) and the 12-byte GCM nonce was effectively 90 bits, not 96.

Both now fill the buffer directly from the OS CSPRNG with `getrandom::fill`.

This is a hygiene fix, not an exploit. The UUID bytes were already CSPRNG-backed
on these targets so nothing was crackable. The reason to change it: key material
should not carry fixed structural bits, and it should not rely on uuid's v4 RNG
being a CSPRNG, which uuid does not promise as an API guarantee.

## Notes

- No format change, no migration. `EncryptedSecret` serialization and the
  nonce-length check are untouched, the nonce is still stored per ciphertext, and
  the master key is still read back as-is from the keychain or key file. Existing
  secrets still decrypt.
- `getrandom` is added as an optional dep under `basic-backend`. 0.3.4 was already
  in the lockfile (via keyring/turso/uuid), so the lock gains one edge and no new
  crate compiles.
- I used `getrandom` directly instead of aes-gcm's `generate_key` / `Generate`
  helpers. Those bottom out in the same getrandom crate, and calling it directly
  keeps the `[u8; 32]` the on-disk format already uses, without coupling the key
  provider to the AEAD type.

## Out of scope

- The file-backed master key is still 0600 plaintext on disk (no OS keyring on
  Linux). Not changed here.
- Nonce uniqueness still relies on random 96-bit nonces under a long-lived key.
  Fine at this scale, but a separate topic if write volume grows.

## Testing

`cargo build`, `cargo clippy -p exoharness --features basic-backend --all-targets
-- -D warnings`, `cargo fmt --check`, and `cargo test -p exoharness --features
basic-backend` all pass (15 tests, including the existing
`secrets_are_encrypted_at_rest`). Added three tests in `secrets.rs`: key
distinctness, a nonce check that would catch the old UUID derivation, and an
encrypt/decrypt round trip with distinct nonces.
