### PR TITLE
Sprites backend - 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1873,6 +1873,7 @@ dependencies = [
  "aes-gcm 0.11.0-rc.3",
  "anyhow",
  "async-trait",
+ "base64",
  "bytes",
  "chrono",
  "futures",
@@ -1888,6 +1889,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "url",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1879,6 +1879,7 @@ dependencies = [
  "keyring-core",
  "lingua",
  "object_store",
+ "reqwest",
  "serde",
  "serde_json 1.0.149",
  "tempfile",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1851,6 +1851,7 @@ name = "exo"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bytes",
  "clap",
  "executor",
  "exoharness",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ rust-version = "1.95"
 
 [workspace.dependencies]
 anyhow = "1.0.100"
+base64 = "0.22.1"
 async-trait = "0.1.89"
 braintrust-sdk-rust = { git = "https://github.com/braintrustdata/braintrust-sdk-rust", rev = "55dcefd989b6038edb5ef8dfc438384340d5f4ae" }
 bytes = "1.10.1"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -21,6 +21,7 @@ tokio.workspace = true
 tokio-stream.workspace = true
 
 [dev-dependencies]
+bytes.workspace = true
 exoharness = { path = "../exoharness", features = ["basic-backend"] }
 futures.workspace = true
 tempfile = "3.23.0"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -22,11 +22,10 @@ use executor::{
     AgentHarnessKind, BasicExoHarness, BasicExoHarnessConfig, BasicHarness, Binding,
     BraintrustProject, BraintrustRuntimeConfig, BraintrustTracingConfig, ConversationModelConfig,
     CreateAgentRequest, CreateConversationRequest, DaytonaConfig, EventKind, EventQuery,
-    EventQueryDirection,
-    ExoHarness, FileSystemMount, FileSystemMountMode, ForkConversationRequest, Harness,
-    HarnessAgent, HarnessConversation, PutSecretRequest, RlmHarness, SANDBOX_MAIN_MOUNT_DIR,
-    SandboxBackendChoice, Secret, SecretBackendChoice, SendRequest, TypeScriptHarness,
-    TypeScriptHarnessConfig, Uuid7, load_agent_config,
+    EventQueryDirection, ExoHarness, FileSystemMount, FileSystemMountMode, ForkConversationRequest,
+    Harness, HarnessAgent, HarnessConversation, PutSecretRequest, RlmHarness,
+    SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, Secret, SecretBackendChoice, SendRequest,
+    TypeScriptHarness, TypeScriptHarnessConfig, Uuid7, load_agent_config,
 };
 use lingua::Message;
 use lingua::universal::{AssistantContent, AssistantContentPart, ToolContentPart, UserContent};

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -21,7 +21,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 use executor::{
     AgentHarnessKind, BasicExoHarness, BasicExoHarnessConfig, BasicHarness, Binding,
     BraintrustProject, BraintrustRuntimeConfig, BraintrustTracingConfig, ConversationModelConfig,
-    CreateAgentRequest, CreateConversationRequest, DaytonaConfig, EventKind, EventQuery,
+    CreateAgentRequest, CreateConversationRequest, DaytonaConfig, E2bConfig, EventKind, EventQuery,
     EventQueryDirection, ExoHarness, FileSystemMount, FileSystemMountMode, ForkConversationRequest,
     Harness, HarnessAgent, HarnessConversation, PutSecretRequest, RlmHarness,
     SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, Secret, SecretBackendChoice, SendRequest,
@@ -181,6 +181,7 @@ enum SandboxBackendArg {
     #[value(name = "local-process")]
     LocalProcess,
     Daytona,
+    E2b,
 }
 
 fn build_exo_config(cli: &Cli) -> Result<BasicExoHarnessConfig> {
@@ -195,6 +196,7 @@ fn build_exo_config(cli: &Cli) -> Result<BasicExoHarnessConfig> {
         SandboxBackendArg::Docker => SandboxBackendChoice::Docker,
         SandboxBackendArg::LocalProcess => SandboxBackendChoice::LocalProcess,
         SandboxBackendArg::Daytona => SandboxBackendChoice::Daytona(DaytonaConfig::from_env()?),
+        SandboxBackendArg::E2b => SandboxBackendChoice::E2b(E2bConfig::from_env()?),
     };
     Ok(BasicExoHarnessConfig {
         root: cli.root.join("exoharness"),

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -22,6 +22,7 @@ use executor::{
     AgentHarnessKind, BasicExoHarness, BasicExoHarnessConfig, BasicHarness, Binding,
     BraintrustProject, BraintrustRuntimeConfig, BraintrustTracingConfig, ConversationModelConfig,
     CreateAgentRequest, CreateConversationRequest, DaytonaConfig, E2bConfig, EventKind, EventQuery,
+    SpritesConfig,
     EventQueryDirection, ExoHarness, FileSystemMount, FileSystemMountMode, ForkConversationRequest,
     Harness, HarnessAgent, HarnessConversation, PutSecretRequest, RlmHarness,
     SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, Secret, SecretBackendChoice, SendRequest,
@@ -182,6 +183,7 @@ enum SandboxBackendArg {
     LocalProcess,
     Daytona,
     E2b,
+    Sprites,
 }
 
 fn build_exo_config(cli: &Cli) -> Result<BasicExoHarnessConfig> {
@@ -197,6 +199,9 @@ fn build_exo_config(cli: &Cli) -> Result<BasicExoHarnessConfig> {
         SandboxBackendArg::LocalProcess => SandboxBackendChoice::LocalProcess,
         SandboxBackendArg::Daytona => SandboxBackendChoice::Daytona(DaytonaConfig::from_env()?),
         SandboxBackendArg::E2b => SandboxBackendChoice::E2b(E2bConfig::from_env()?),
+        SandboxBackendArg::Sprites => {
+            SandboxBackendChoice::Sprites(SpritesConfig::from_env()?)
+        }
     };
     Ok(BasicExoHarnessConfig {
         root: cli.root.join("exoharness"),

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -21,7 +21,8 @@ use clap::{Parser, Subcommand, ValueEnum};
 use executor::{
     AgentHarnessKind, BasicExoHarness, BasicExoHarnessConfig, BasicHarness, Binding,
     BraintrustProject, BraintrustRuntimeConfig, BraintrustTracingConfig, ConversationModelConfig,
-    CreateAgentRequest, CreateConversationRequest, EventKind, EventQuery, EventQueryDirection,
+    CreateAgentRequest, CreateConversationRequest, DaytonaConfig, EventKind, EventQuery,
+    EventQueryDirection,
     ExoHarness, FileSystemMount, FileSystemMountMode, ForkConversationRequest, Harness,
     HarnessAgent, HarnessConversation, PutSecretRequest, RlmHarness, SANDBOX_MAIN_MOUNT_DIR,
     SandboxBackendChoice, Secret, SecretBackendChoice, SendRequest, TypeScriptHarness,
@@ -180,6 +181,7 @@ enum SandboxBackendArg {
     Docker,
     #[value(name = "local-process")]
     LocalProcess,
+    Daytona,
 }
 
 fn build_exo_config(cli: &Cli) -> Result<BasicExoHarnessConfig> {
@@ -193,6 +195,7 @@ fn build_exo_config(cli: &Cli) -> Result<BasicExoHarnessConfig> {
         SandboxBackendArg::AppleContainer => SandboxBackendChoice::AppleContainer,
         SandboxBackendArg::Docker => SandboxBackendChoice::Docker,
         SandboxBackendArg::LocalProcess => SandboxBackendChoice::LocalProcess,
+        SandboxBackendArg::Daytona => SandboxBackendChoice::Daytona(DaytonaConfig::from_env()?),
     };
     Ok(BasicExoHarnessConfig {
         root: cli.root.join("exoharness"),

--- a/crates/cli/src/tui.rs
+++ b/crates/cli/src/tui.rs
@@ -660,28 +660,17 @@ fn print_help() {
 /// event, returning the sandbox id. Returns `None` if no sandbox has been
 /// created yet (e.g. nothing has been chatted with).
 async fn latest_sandbox_id(conversation: &dyn HarnessConversation) -> Result<Option<SandboxId>> {
-    let result = conversation
-        .exoharness_handle()
-        .get_events(Some(EventQuery {
-            cursor: None,
-            direction: Some(EventQueryDirection::Desc),
-            limit: Some(1),
-            session_id: None,
-            turn_id: None,
-            types: Some(vec![EventKind::SANDBOX_CREATED]),
-        }))
-        .await?;
-    let Some(event) = result.events.into_iter().next() else {
-        return Ok(None);
-    };
-    match event.data {
-        EventData::SandboxCreated { sandbox_id, .. } => Ok(Some(sandbox_id)),
-        other => anyhow::bail!(
-            "type-filtered query for {} returned unexpected variant {}",
-            EventKind::SANDBOX_CREATED.as_str(),
-            other.kind().as_str(),
-        ),
-    }
+    executor::first_matching_event(
+        conversation.exoharness_handle().as_ref(),
+        EventKind::SANDBOX_CREATED,
+        EventQueryDirection::Desc,
+        1,
+        |data| match data {
+            EventData::SandboxCreated { sandbox_id, .. } => Some(sandbox_id),
+            _ => None,
+        },
+    )
+    .await
 }
 
 /// All snapshots taken in the conversation, oldest-first. Each tuple is

--- a/crates/cli/tests/daytona_backend.rs
+++ b/crates/cli/tests/daytona_backend.rs
@@ -190,7 +190,10 @@ async fn try_resume_finds_running_sandbox_without_starting() {
         .try_resume(request)
         .await
         .expect("try_resume should not error");
-    assert!(handle.is_some(), "try_resume should find the running sandbox");
+    assert!(
+        handle.is_some(),
+        "try_resume should find the running sandbox"
+    );
 
     // Crucially: no POST /sandbox/sb-running/start should have happened.
     let requests = server.received_requests().await.unwrap_or_default();
@@ -282,10 +285,7 @@ async fn try_resume_filters_by_label_as_single_json_query_param() {
 
     let requests = server.received_requests().await.unwrap_or_default();
     let url = &requests[0].url;
-    let label_params: Vec<_> = url
-        .query_pairs()
-        .filter(|(k, _)| k == "labels")
-        .collect();
+    let label_params: Vec<_> = url.query_pairs().filter(|(k, _)| k == "labels").collect();
     assert_eq!(
         label_params.len(),
         1,
@@ -489,11 +489,7 @@ async fn acquire_from_snapshot_rejects_wrong_kind() {
     // No API call should have happened — we rejected the payload before
     // hitting the network.
     let requests = server.received_requests().await.unwrap_or_default();
-    assert_eq!(
-        requests.len(),
-        0,
-        "kind-mismatch must not reach the API"
-    );
+    assert_eq!(requests.len(), 0, "kind-mismatch must not reach the API");
 }
 
 // ─────────────────────── exec (toolbox URL) ───────────────────────

--- a/crates/cli/tests/daytona_backend.rs
+++ b/crates/cli/tests/daytona_backend.rs
@@ -1,0 +1,565 @@
+//! Wiremock-driven tests for the Daytona sandbox backend (PR #22).
+//!
+//! Daytona is a remote SaaS, so exercising the backend against the real
+//! service in CI would require credentials, network egress, real sandbox
+//! provisioning (which costs money and takes seconds per test), and
+//! cleanup that's brittle if a test panics partway through. Instead, each
+//! test stands up an in-process `wiremock` HTTP server that pretends to
+//! be Daytona's REST API, points a `DaytonaSandboxBackend` at it, and
+//! asserts on:
+//!
+//!   - which endpoints were hit (verifying URL routing — control plane
+//!     vs the separate toolbox host),
+//!   - what request bodies/query params were sent (verifying the
+//!     translation from `SandboxRequest` etc. into Daytona's wire
+//!     format), and
+//!   - how the backend interprets the canned responses (state machine
+//!     transitions, payload encoding).
+//!
+//! This catches code-defects in the backend without catching upstream
+//! Daytona drift. Drift detection is the job of the manual live test
+//! plan documented in the PR description.
+
+use std::collections::HashMap;
+
+use bytes::Bytes;
+use exoharness::{
+    DaytonaConfig, DaytonaSandboxBackend, ManagedSandboxBackend, SandboxKey,
+    SandboxLifecycleConfig, SandboxMount, SandboxMountAccess, SandboxNetworkPolicy, SandboxRequest,
+    SandboxSpec, SnapshotKind, SnapshotPayload,
+};
+use serde_json::{Value, json};
+use std::path::PathBuf;
+use std::time::Duration;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// ─────────────────────── Test fixtures / helpers ───────────────────────
+
+/// Standard sandbox request used across tests. Conversation-keyed so the
+/// label format matches what try_resume's filter expects to see.
+fn make_request(conversation_id: &str, sandbox_id: &str) -> SandboxRequest {
+    SandboxRequest {
+        key: SandboxKey::ConversationSandbox {
+            conversation_id: conversation_id.into(),
+            sandbox_id: sandbox_id.into(),
+        },
+        spec: SandboxSpec {
+            image: "docker.io/library/ubuntu:24.04".into(),
+            mounts: Vec::new(),
+            network: SandboxNetworkPolicy::Enabled,
+            default_workdir: "/".into(),
+        },
+        lifecycle: SandboxLifecycleConfig {
+            // idle_ttl required for try_resume to even attempt a lookup
+            // (try_resume short-circuits to None for non-warm sandboxes).
+            idle_ttl: Some(Duration::from_secs(300)),
+        },
+    }
+}
+
+/// Construct a backend pointed at a wiremock instance. Same wiremock host
+/// for both control-plane and toolbox URLs — Daytona's real deployment
+/// uses separate hosts, but tests differentiate by path prefix.
+fn backend_for_mock(server: &MockServer) -> DaytonaSandboxBackend {
+    DaytonaSandboxBackend::new(DaytonaConfig {
+        api_key: "test-api-key".into(),
+        api_url: server.uri(),
+        toolbox_url: server.uri(),
+        target: None,
+        organization_id: Some("test-org".into()),
+    })
+    .expect("DaytonaSandboxBackend::new")
+}
+
+fn sandbox_json(id: &str, state: &str) -> Value {
+    json!({
+        "id": id,
+        "state": state,
+        "createdAt": "2026-05-25T08:00:00Z"
+    })
+}
+
+fn list_response(items: Vec<Value>) -> Value {
+    json!({ "items": items })
+}
+
+// ─────────────────────── acquire ───────────────────────
+
+#[tokio::test]
+async fn acquire_posts_to_sandbox_endpoint_with_labels() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("POST"))
+        .and(path("/sandbox"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sandbox_json("sb-fresh", "started")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let request = make_request("conv-1", "sandbox-1");
+    let _handle = backend
+        .acquire(request)
+        .await
+        .expect("acquire should succeed against a 200-returning mock");
+
+    // Inspect what the backend actually sent on the wire.
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert_eq!(requests.len(), 1);
+    let body: Value = serde_json::from_slice(&requests[0].body).expect("body is JSON");
+
+    // Labels carry the SandboxKey + spec hash. We only assert the key is
+    // present (spec hash is computed internally); the absence of these
+    // labels would break try_resume across processes.
+    let labels = body
+        .get("labels")
+        .and_then(Value::as_object)
+        .expect("labels present");
+    assert!(
+        labels.contains_key("exo.sandbox.key"),
+        "labels should include exo.sandbox.key: {labels:?}"
+    );
+    assert!(
+        labels.contains_key("exo.sandbox.spec-hash"),
+        "labels should include exo.sandbox.spec-hash: {labels:?}"
+    );
+
+    // Daytona's `snapshot` field refers to a pre-registered named
+    // snapshot, not a docker image — `acquire` (fresh-create) should
+    // never set it, so the platform falls back to its default image.
+    assert!(
+        body.get("snapshot").is_none() || body["snapshot"].is_null(),
+        "fresh acquire must NOT set `snapshot`: {body:?}"
+    );
+}
+
+#[tokio::test]
+async fn acquire_rejects_host_mounts() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    let mut request = make_request("conv-2", "sandbox-2");
+    request.spec.mounts.push(SandboxMount {
+        host_path: PathBuf::from("/tmp/foo"),
+        guest_path: "/workspace".into(),
+        access: SandboxMountAccess::ReadWrite,
+        internal: false,
+    });
+
+    let error = match backend.acquire(request).await {
+        Ok(_) => panic!("acquire should reject requests with host mounts"),
+        Err(e) => e,
+    };
+    let msg = format!("{error:#}");
+    assert!(
+        msg.to_lowercase().contains("mount") || msg.to_lowercase().contains("daytona"),
+        "error should mention mounts and/or Daytona: {msg}"
+    );
+
+    // No HTTP call should have happened — request was rejected up front.
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert_eq!(
+        requests.len(),
+        0,
+        "mount-rejected request must not reach the API"
+    );
+}
+
+// ─────────────────────── try_resume ───────────────────────
+
+#[tokio::test]
+async fn try_resume_finds_running_sandbox_without_starting() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    // GET /sandbox returns one labelled match in `started` state — no
+    // /start call should follow.
+    Mock::given(method("GET"))
+        .and(path("/sandbox"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(list_response(vec![sandbox_json("sb-running", "started")])),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let request = make_request("conv-3", "sandbox-3");
+    let handle = backend
+        .try_resume(request)
+        .await
+        .expect("try_resume should not error");
+    assert!(handle.is_some(), "try_resume should find the running sandbox");
+
+    // Crucially: no POST /sandbox/sb-running/start should have happened.
+    let requests = server.received_requests().await.unwrap_or_default();
+    let start_calls = requests
+        .iter()
+        .filter(|r| r.url.path().contains("/start"))
+        .count();
+    assert_eq!(start_calls, 0, "must not start an already-running sandbox");
+}
+
+#[tokio::test]
+async fn try_resume_starts_stopped_sandbox() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("GET"))
+        .and(path("/sandbox"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(list_response(vec![sandbox_json("sb-stopped", "stopped")])),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/sandbox/sb-stopped/start"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let request = make_request("conv-4", "sandbox-4");
+    let handle = backend.try_resume(request).await.expect("try_resume ok");
+    assert!(handle.is_some(), "try_resume should produce a handle");
+
+    // Both endpoints should have fired.
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert!(
+        requests.iter().any(|r| r.url.path().ends_with("/sandbox")),
+        "list /sandbox must be called"
+    );
+    assert!(
+        requests
+            .iter()
+            .any(|r| r.url.path() == "/sandbox/sb-stopped/start"),
+        "start endpoint must be called for a stopped sandbox"
+    );
+}
+
+#[tokio::test]
+async fn try_resume_returns_none_when_no_match() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("GET"))
+        .and(path("/sandbox"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(list_response(Vec::new())))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let request = make_request("conv-5", "sandbox-5");
+    let handle = backend.try_resume(request).await.expect("try_resume ok");
+    assert!(
+        handle.is_none(),
+        "try_resume must return None when the label query is empty"
+    );
+}
+
+#[tokio::test]
+async fn try_resume_filters_by_label_as_single_json_query_param() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    // The matcher requires `labels` to be present as a single query
+    // param (not repeated). Wiremock's `query_param` matches the *first*
+    // value — if multiple were sent we'd want to fail; the absence-of-
+    // assertion is covered below by parsing the URL after the fact.
+    Mock::given(method("GET"))
+        .and(path("/sandbox"))
+        .and(query_param_present("labels"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(list_response(Vec::new())))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let request = make_request("conv-6", "sandbox-6");
+    backend.try_resume(request).await.unwrap();
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let url = &requests[0].url;
+    let label_params: Vec<_> = url
+        .query_pairs()
+        .filter(|(k, _)| k == "labels")
+        .collect();
+    assert_eq!(
+        label_params.len(),
+        1,
+        "labels must be one query param, not repeated: {url}"
+    );
+    // Confirm the value is JSON, not k=v-style.
+    let value = &label_params[0].1;
+    let parsed: Value =
+        serde_json::from_str(value).expect("labels query value must be JSON-encoded");
+    assert!(
+        parsed.get("exo.sandbox.key").is_some(),
+        "labels JSON should include exo.sandbox.key: {parsed:?}"
+    );
+}
+
+/// Helper: assert that a given query param key is present in the URL
+/// (without asserting on its value).
+fn query_param_present(name: &'static str) -> impl wiremock::Match {
+    struct Present(&'static str);
+    impl wiremock::Match for Present {
+        fn matches(&self, request: &wiremock::Request) -> bool {
+            request.url.query_pairs().any(|(k, _)| k == self.0)
+        }
+    }
+    Present(name)
+}
+
+// ─────────────────────── stop / Drop ───────────────────────
+
+#[tokio::test]
+async fn stop_calls_stop_endpoint_not_delete() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("POST"))
+        .and(path("/sandbox"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sandbox_json("sb-stop", "started")))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/sandbox/sb-stop/stop"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend
+        .acquire(make_request("conv-7", "sandbox-7"))
+        .await
+        .unwrap();
+    handle.stop().await.expect("stop should succeed");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    // No DELETE should have been issued — the resume contract requires
+    // stopped sandboxes to survive so the next process can resume them.
+    let deletes: Vec<_> = requests
+        .iter()
+        .filter(|r| r.method.to_string().to_uppercase() == "DELETE")
+        .collect();
+    assert!(
+        deletes.is_empty(),
+        "stop must not DELETE the sandbox: {deletes:?}"
+    );
+    assert!(
+        requests
+            .iter()
+            .any(|r| r.url.path() == "/sandbox/sb-stop/stop"),
+        "POST /sandbox/<id>/stop should have been called"
+    );
+}
+
+// ─────────────────────── snapshot ───────────────────────
+
+#[tokio::test]
+async fn snapshot_returns_daytona_snapshot_payload_with_manifest() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("POST"))
+        .and(path("/sandbox"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sandbox_json("sb-snap", "started")))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/sandbox/sb-snap/snapshot"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let request = make_request("conv-8", "sandbox-8");
+    let handle = backend.acquire(request).await.unwrap();
+    let payload = handle
+        .snapshot()
+        // Snapshot mode is filesystem-only on this backend; we go through
+        // SnapshotMode::Filesystem to hit the implemented path. The
+        // current trait shape on this PR doesn't take a mode arg yet —
+        // if the snapshot API signature ever grows it, this call site
+        // updates trivially.
+        .await
+        .expect("snapshot should succeed against the mock");
+
+    assert!(
+        matches!(payload.kind, SnapshotKind::DaytonaSnapshot),
+        "kind should be DaytonaSnapshot, got {:?}",
+        payload.kind
+    );
+
+    let manifest: Value =
+        serde_json::from_slice(&payload.bytes).expect("payload should be a JSON manifest");
+    assert!(
+        manifest
+            .get("snapshot_name")
+            .and_then(Value::as_str)
+            .is_some_and(|n| n.starts_with("exo-snap-")),
+        "manifest should carry a snapshot_name with the exo-snap- prefix: {manifest:?}"
+    );
+    assert!(
+        manifest.get("base_image").is_some(),
+        "manifest should carry the base_image: {manifest:?}"
+    );
+
+    // Verify request body sent the snapshot name to Daytona.
+    let requests = server.received_requests().await.unwrap_or_default();
+    let snap_call = requests
+        .iter()
+        .find(|r| r.url.path() == "/sandbox/sb-snap/snapshot")
+        .expect("snapshot endpoint should have been called");
+    let body: Value = serde_json::from_slice(&snap_call.body).unwrap();
+    let name = body
+        .get("name")
+        .and_then(Value::as_str)
+        .expect("snapshot request body must contain `name`");
+    assert!(name.starts_with("exo-snap-"));
+}
+
+#[tokio::test]
+async fn acquire_from_snapshot_passes_snapshot_name_in_create_body() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("POST"))
+        .and(path("/sandbox"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(sandbox_json("sb-restored", "started")),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Construct a DaytonaSnapshot payload by hand. The manifest schema is
+    // private to daytona.rs; we serialize the same shape directly.
+    let manifest = json!({
+        "snapshot_name": "exo-snap-canonical-fixture",
+        "base_image": "ubuntu:24.04",
+    });
+    let payload = SnapshotPayload {
+        kind: SnapshotKind::DaytonaSnapshot,
+        bytes: Bytes::from(serde_json::to_vec(&manifest).unwrap()),
+    };
+
+    let request = make_request("conv-9", "sandbox-9");
+    let _handle = backend
+        .acquire_from_snapshot(request, payload)
+        .await
+        .expect("acquire_from_snapshot should succeed against a 200 mock");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let create_call = requests
+        .iter()
+        .find(|r| r.url.path() == "/sandbox" && r.method.to_string().to_uppercase() == "POST")
+        .expect("POST /sandbox should have been called");
+    let body: Value = serde_json::from_slice(&create_call.body).unwrap();
+    assert_eq!(
+        body.get("snapshot").and_then(Value::as_str),
+        Some("exo-snap-canonical-fixture"),
+        "create-from-snapshot must pass the manifest's snapshot_name to Daytona: {body:?}"
+    );
+}
+
+#[tokio::test]
+async fn acquire_from_snapshot_rejects_wrong_kind() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    let payload = SnapshotPayload {
+        kind: SnapshotKind::DockerImageTar,
+        bytes: Bytes::from_static(b"\x00not-a-real-tar"),
+    };
+    let request = make_request("conv-10", "sandbox-10");
+    let error = match backend.acquire_from_snapshot(request, payload).await {
+        Ok(_) => panic!("Daytona backend must reject a DockerImageTar payload"),
+        Err(e) => e,
+    };
+    let msg = format!("{error:#}").to_lowercase();
+    assert!(
+        msg.contains("daytona") || msg.contains("docker") || msg.contains("kind"),
+        "error should explain the kind mismatch: {msg}"
+    );
+
+    // No API call should have happened — we rejected the payload before
+    // hitting the network.
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert_eq!(
+        requests.len(),
+        0,
+        "kind-mismatch must not reach the API"
+    );
+}
+
+// ─────────────────────── exec (toolbox URL) ───────────────────────
+
+#[tokio::test]
+async fn exec_uses_toolbox_url_not_api_url() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("POST"))
+        .and(path("/sandbox"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sandbox_json("sb-exec", "started")))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/toolbox/sb-exec/process/execute"))
+        .and(body_json_includes_command())
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "exitCode": 0,
+            "result": "hello from mock",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let request = make_request("conv-11", "sandbox-11");
+    let handle = backend.acquire(request).await.unwrap();
+    let output = handle
+        .exec(&exoharness::SandboxCommand {
+            argv: vec!["/bin/echo".into(), "hello".into()],
+            env: HashMap::new(),
+            display_argv: None,
+            cwd: None,
+            timeout: None,
+        })
+        .await
+        .expect("exec should succeed");
+
+    assert_eq!(output.exit_code, Some(0));
+    assert_eq!(output.stdout, "hello from mock");
+
+    // Most important assertion: the toolbox path was used. The same
+    // hostname is fine in test (one wiremock), but in production the
+    // toolbox lives on a different DNS name; routing in the code MUST
+    // call `toolbox_endpoint` here, not `api_endpoint`.
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert!(
+        requests
+            .iter()
+            .any(|r| r.url.path() == "/toolbox/sb-exec/process/execute"),
+        "exec must hit /toolbox/<id>/process/execute"
+    );
+}
+
+/// Match any POST body that has a `command` field — keeps the test from
+/// over-asserting on the precise shell-rendering, while still proving
+/// the body shape lines up with Daytona's expected schema.
+fn body_json_includes_command() -> impl wiremock::Match {
+    struct Has;
+    impl wiremock::Match for Has {
+        fn matches(&self, request: &wiremock::Request) -> bool {
+            serde_json::from_slice::<Value>(&request.body)
+                .ok()
+                .and_then(|v| v.get("command").and_then(Value::as_str).map(str::to_string))
+                .is_some()
+        }
+    }
+    Has
+}

--- a/crates/cli/tests/e2b_backend.rs
+++ b/crates/cli/tests/e2b_backend.rs
@@ -1,0 +1,427 @@
+//! Wiremock-driven tests for the E2B sandbox backend.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use bytes::Bytes;
+use exoharness::{
+    E2bConfig, E2bSandboxBackend, ManagedSandboxBackend, SandboxKey, SandboxLifecycleConfig,
+    SandboxMount, SandboxMountAccess, SandboxNetworkPolicy, SandboxRequest, SandboxSpec,
+    SnapshotKind, SnapshotPayload,
+};
+use serde_json::{Value, json};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn make_request(conversation_id: &str, sandbox_id: &str) -> SandboxRequest {
+    SandboxRequest {
+        key: SandboxKey::ConversationSandbox {
+            conversation_id: conversation_id.into(),
+            sandbox_id: sandbox_id.into(),
+        },
+        spec: SandboxSpec {
+            image: "base".into(),
+            mounts: Vec::new(),
+            network: SandboxNetworkPolicy::Enabled,
+            default_workdir: "/home/user".into(),
+        },
+        lifecycle: SandboxLifecycleConfig {
+            idle_ttl: Some(Duration::from_secs(300)),
+        },
+    }
+}
+
+fn backend_for_mock(server: &MockServer) -> E2bSandboxBackend {
+    E2bSandboxBackend::new(E2bConfig {
+        api_key: "test-api-key".into(),
+        api_url: server.uri(),
+        template_id: "base".into(),
+        envd_port: 49_983,
+        envd_base_url: Some(server.uri()),
+        secure: false,
+    })
+    .expect("E2bSandboxBackend::new")
+}
+
+fn sandbox_created_json(id: &str) -> Value {
+    json!({
+        "sandboxID": id,
+        "templateID": "base",
+        "envdVersion": "0.1.0",
+    })
+}
+
+fn listed_sandbox_json(id: &str, state: &str) -> Value {
+    json!({
+        "sandboxID": id,
+        "templateID": "base",
+        "state": state,
+        "startedAt": "2026-06-01T12:00:00Z",
+        "clientID": "client",
+        "cpuCount": 2,
+        "memoryMB": 512,
+        "diskSizeMB": 1024,
+        "endAt": "2026-06-01T13:00:00Z",
+        "envdVersion": "0.1.0",
+    })
+}
+
+#[tokio::test]
+async fn acquire_posts_to_sandboxes_with_metadata() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("POST"))
+        .and(path("/sandboxes"))
+        .respond_with(
+            ResponseTemplate::new(201).set_body_json(sandbox_created_json("sb-fresh")),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    backend
+        .acquire(make_request("conv-1", "sandbox-1"))
+        .await
+        .expect("acquire should succeed");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert_eq!(requests.len(), 1);
+    let body: Value = serde_json::from_slice(&requests[0].body).unwrap();
+    assert_eq!(body.get("templateID").and_then(Value::as_str), Some("base"));
+    let metadata = body
+        .get("metadata")
+        .and_then(Value::as_object)
+        .expect("metadata present");
+    assert!(metadata.contains_key("exo.sandbox.key"));
+    assert!(metadata.contains_key("exo.sandbox.spec-hash"));
+}
+
+#[tokio::test]
+async fn acquire_rejects_host_mounts() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    let mut request = make_request("conv-2", "sandbox-2");
+    request.spec.mounts.push(SandboxMount {
+        host_path: PathBuf::from("/tmp/foo"),
+        guest_path: "/workspace".into(),
+        access: SandboxMountAccess::ReadWrite,
+        internal: false,
+    });
+
+    let error = match backend.acquire(request).await {
+        Ok(_) => panic!("acquire should reject host mounts"),
+        Err(error) => error,
+    };
+    let msg = format!("{error:#}").to_lowercase();
+    assert!(msg.contains("mount") || msg.contains("e2b"), "unexpected: {msg}");
+    assert_eq!(
+        server.received_requests().await.unwrap_or_default().len(),
+        0
+    );
+}
+
+#[tokio::test]
+async fn try_resume_finds_running_sandbox_without_connect() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("GET"))
+        .and(path("/v2/sandboxes"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            listed_sandbox_json("sb-running", "running"),
+        ])))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend
+        .try_resume(make_request("conv-3", "sandbox-3"))
+        .await
+        .expect("try_resume ok")
+        .expect("should find sandbox");
+
+    assert_eq!(handle.id(), "e2b:conversation:conv-3:sandbox-3");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert!(
+        !requests.iter().any(|r| r.url.path().contains("/connect")),
+        "running sandbox must not call connect"
+    );
+}
+
+#[tokio::test]
+async fn try_resume_connects_paused_sandbox() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("GET"))
+        .and(path("/v2/sandboxes"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            listed_sandbox_json("sb-paused", "paused"),
+        ])))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/sandboxes/sb-paused/connect"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(sandbox_created_json("sb-paused")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    backend
+        .try_resume(make_request("conv-4", "sandbox-4"))
+        .await
+        .expect("try_resume ok")
+        .expect("should find paused sandbox");
+}
+
+#[tokio::test]
+async fn try_resume_list_metadata_query_is_not_double_url_encoded() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("GET"))
+        .and(path("/v2/sandboxes"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([
+            listed_sandbox_json("sb-keyed", "running"),
+        ])))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    backend
+        .try_resume(make_request("conv-colons", "sandbox-colons"))
+        .await
+        .expect("try_resume ok")
+        .expect("should find sandbox");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let query = requests[0].url.query().expect("list request has query string");
+    assert!(
+        !query.contains("%253A"),
+        "metadata filter must not double-encode ':' in sandbox keys; got {query}"
+    );
+    assert!(
+        query.contains("conversation%3Aconv-colons%3Asandbox-colons")
+            || query.contains("conversation:conv-colons:sandbox-colons"),
+        "expected sandbox key in metadata query; got {query}"
+    );
+    assert!(
+        query.contains("state=running%2Cpaused") || query.contains("state=running,paused"),
+        "expected comma-separated state filter; got {query}"
+    );
+}
+
+#[tokio::test]
+async fn try_resume_returns_none_when_no_match() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("GET"))
+        .and(path("/v2/sandboxes"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let handle = backend
+        .try_resume(make_request("conv-5", "sandbox-5"))
+        .await
+        .expect("try_resume ok");
+    assert!(handle.is_none());
+}
+
+#[tokio::test]
+async fn stop_calls_pause_not_delete() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("POST"))
+        .and(path("/sandboxes"))
+        .respond_with(
+            ResponseTemplate::new(201).set_body_json(sandbox_created_json("sb-stop")),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/sandboxes/sb-stop/pause"))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend
+        .acquire(make_request("conv-6", "sandbox-6"))
+        .await
+        .unwrap();
+    handle.stop().await.expect("stop should pause");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert!(
+        !requests
+            .iter()
+            .any(|r| r.method.to_string().to_uppercase() == "DELETE")
+    );
+}
+
+#[tokio::test]
+async fn snapshot_returns_e2b_snapshot_payload() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("POST"))
+        .and(path("/sandboxes"))
+        .respond_with(
+            ResponseTemplate::new(201).set_body_json(sandbox_created_json("sb-snap")),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/sandboxes/sb-snap/snapshots"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "snapshotID": "team/exo-snap-test:default",
+            "names": ["team/exo-snap-test:default"],
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend.acquire(make_request("conv-7", "sandbox-7")).await.unwrap();
+    let payload = handle.snapshot().await.expect("snapshot ok");
+
+    assert!(matches!(payload.kind, SnapshotKind::E2bSnapshot));
+    let manifest: Value = serde_json::from_slice(&payload.bytes).unwrap();
+    assert_eq!(
+        manifest.get("snapshot_id").and_then(Value::as_str),
+        Some("team/exo-snap-test:default")
+    );
+}
+
+#[tokio::test]
+async fn acquire_from_snapshot_uses_snapshot_template_id() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("POST"))
+        .and(path("/sandboxes"))
+        .respond_with(
+            ResponseTemplate::new(201).set_body_json(sandbox_created_json("sb-restored")),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let manifest = json!({
+        "snapshot_id": "team/exo-snap-canonical:default",
+        "base_template": "base",
+    });
+    let payload = SnapshotPayload {
+        kind: SnapshotKind::E2bSnapshot,
+        bytes: Bytes::from(serde_json::to_vec(&manifest).unwrap()),
+    };
+
+    backend
+        .acquire_from_snapshot(make_request("conv-8", "sandbox-8"), payload)
+        .await
+        .expect("restore ok");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let create = requests
+        .iter()
+        .find(|r| r.url.path() == "/sandboxes" && r.method.as_str() == "POST")
+        .expect("create called");
+    let body: Value = serde_json::from_slice(&create.body).unwrap();
+    assert_eq!(
+        body.get("templateID").and_then(Value::as_str),
+        Some("team/exo-snap-canonical:default")
+    );
+}
+
+#[tokio::test]
+async fn acquire_from_snapshot_rejects_wrong_kind() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    let payload = SnapshotPayload {
+        kind: SnapshotKind::DockerImageTar,
+        bytes: Bytes::from_static(b"\x00"),
+    };
+    let error = match backend
+        .acquire_from_snapshot(make_request("conv-9", "sandbox-9"), payload)
+        .await
+    {
+        Ok(_) => panic!("expected kind mismatch error"),
+        Err(error) => error,
+    };
+    let msg = format!("{error:#}").to_lowercase();
+    assert!(msg.contains("e2b") || msg.contains("kind"));
+}
+
+#[tokio::test]
+async fn exec_uses_envd_process_start() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("POST"))
+        .and(path("/sandboxes"))
+        .respond_with(
+            ResponseTemplate::new(201).set_body_json(sandbox_created_json("sb-exec")),
+        )
+        .mount(&server)
+        .await;
+
+    let connect_stream = connect_enveloped_stream(&[
+        (
+            0,
+            json!({"event": {"data": {"stdout": "hello from mock"}}}),
+        ),
+        (
+            2,
+            json!({"event": {"end": {"status": "exit status 0"}}}),
+        ),
+    ]);
+
+    Mock::given(method("POST"))
+        .and(path("/process.Process/Start"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(connect_stream, "application/connect+json"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend.acquire(make_request("conv-10", "sandbox-10")).await.unwrap();
+    let output = handle
+        .exec(&exoharness::SandboxCommand {
+            argv: vec!["/bin/echo".into(), "hello".into()],
+            env: HashMap::new(),
+            display_argv: None,
+            cwd: None,
+            timeout: None,
+        })
+        .await
+        .expect("exec ok");
+
+    assert_eq!(output.exit_code, Some(0));
+    assert_eq!(output.stdout, "hello from mock");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert!(
+        requests.iter().any(|r| r.url.path() == "/process.Process/Start"),
+        "exec must hit envd process start"
+    );
+}
+
+/// Build a Connect server-stream body (5-byte framed JSON messages).
+fn connect_enveloped_stream(messages: &[(u8, Value)]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for (flags, value) in messages {
+        let payload = serde_json::to_vec(value).expect("json");
+        let len = payload.len() as u32;
+        out.push(*flags);
+        out.extend_from_slice(&len.to_be_bytes());
+        out.extend_from_slice(&payload);
+    }
+    out
+}

--- a/crates/cli/tests/e2b_live.rs
+++ b/crates/cli/tests/e2b_live.rs
@@ -1,0 +1,122 @@
+//! Live E2B smoke tests (require `E2B_API_KEY`). Run with:
+//!
+//! ```bash
+//! export E2B_API_KEY=...
+//! export E2B_TEMPLATE_ID=base   # optional, defaults to "base"
+//! cargo test --package exo --test e2b_live -- --ignored --nocapture
+//! ```
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use exoharness::{
+    E2bConfig, E2bSandboxBackend, ManagedSandboxBackend, SandboxKey, SandboxLifecycleConfig,
+    SandboxNetworkPolicy, SandboxRequest, SandboxSpec,
+};
+
+fn live_config() -> Option<E2bConfig> {
+    if std::env::var("E2B_API_KEY").is_err() {
+        eprintln!("skipping E2B live test: E2B_API_KEY not set");
+        return None;
+    }
+    E2bConfig::from_env().ok()
+}
+
+fn live_request(label: &str) -> SandboxRequest {
+    SandboxRequest {
+        key: SandboxKey::ConversationSandbox {
+            conversation_id: "live-conv".into(),
+            sandbox_id: label.into(),
+        },
+        spec: SandboxSpec {
+            image: String::new(),
+            mounts: Vec::new(),
+            network: SandboxNetworkPolicy::Enabled,
+            default_workdir: "/home/user".into(),
+        },
+        lifecycle: SandboxLifecycleConfig {
+            idle_ttl: Some(Duration::from_secs(300)),
+        },
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires E2B_API_KEY and bills E2B; run with cargo test --test e2b_live -- --ignored"]
+async fn live_acquire_exec_and_pause() {
+    let Some(config) = live_config() else {
+        return;
+    };
+    let backend = E2bSandboxBackend::new(config).expect("backend");
+    let handle = backend
+        .acquire(live_request("live-sandbox-1"))
+        .await
+        .expect("acquire");
+    let output = handle
+        .exec(&exoharness::SandboxCommand {
+            argv: vec!["/bin/sh".into(), "-lc".into(), "echo exo-e2b-live".into()],
+            env: HashMap::new(),
+            display_argv: None,
+            cwd: None,
+            timeout: None,
+        })
+        .await
+        .expect("exec");
+    assert!(
+        output.stdout.trim().contains("exo-e2b-live"),
+        "stdout: {:?}",
+        output.stdout
+    );
+    handle.stop().await.expect("pause");
+}
+
+#[tokio::test]
+#[ignore = "requires E2B_API_KEY and bills E2B; run with cargo test --test e2b_live -- --ignored"]
+async fn live_try_resume_finds_sandbox_after_process_boundary() {
+    let Some(config) = live_config() else {
+        return;
+    };
+    let backend = E2bSandboxBackend::new(config).expect("backend");
+    let request = live_request("live-resume-boundary");
+    let handle = backend.acquire(request.clone()).await.expect("acquire");
+    handle
+        .exec(&exoharness::SandboxCommand {
+            argv: vec![
+                "/bin/sh".into(),
+                "-lc".into(),
+                "echo resume-marker > /tmp/exo-e2b-resume".into(),
+            ],
+            env: HashMap::new(),
+            display_argv: None,
+            cwd: None,
+            timeout: None,
+        })
+        .await
+        .expect("write marker");
+    drop(handle);
+
+    let resumed = backend
+        .try_resume(request)
+        .await
+        .expect("try_resume")
+        .expect("E2B sandbox should be listed by metadata after acquire");
+    let output = resumed
+        .exec(&exoharness::SandboxCommand {
+            argv: vec![
+                "/bin/sh".into(),
+                "-lc".into(),
+                "cat /tmp/exo-e2b-resume".into(),
+            ],
+            env: HashMap::new(),
+            display_argv: None,
+            cwd: None,
+            timeout: None,
+        })
+        .await
+        .expect("read marker");
+    assert!(
+        output.stdout.trim().contains("resume-marker"),
+        "stdout: {:?}",
+        output.stdout
+    );
+    resumed.stop().await.expect("pause");
+}

--- a/crates/cli/tests/e2b_resume_harness.rs
+++ b/crates/cli/tests/e2b_resume_harness.rs
@@ -1,0 +1,319 @@
+//! Cross-process E2B resume through `ensure_shell_sandbox` / `run_in_sandbox`.
+//!
+//! Regression coverage for:
+//! - metadata list filter encoding (`try_resume` finds the VM)
+//! - `state=running,paused` list query
+//! - no second `sandbox_created` when the E2B VM is still reachable
+
+use std::path::Path;
+use std::sync::Arc;
+
+use executor::{AgentConfig, AgentHarnessKind, BasicToolRuntime, ConversationConfig, ToolRuntime};
+use exoharness::{
+    AgentHandle, AgentId, BasicExoHarness, BasicExoHarnessConfig, ConversationHandle,
+    ConversationId, E2bConfig, EventData, EventKind, EventQuery, EventQueryDirection, ExoHarness,
+    NewAgentRequest, NewConversationRequest, RunInSandboxRequest, SandboxBackendChoice,
+    SandboxId, SandboxProcessParts, SecretBackendChoice,
+};
+use futures::io::AsyncReadExt;
+use serde_json::{Value, json};
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const E2B_SANDBOX_ID: &str = "sb-resume-test";
+
+fn e2b_harness_config(root: &Path, server: &MockServer) -> BasicExoHarnessConfig {
+    BasicExoHarnessConfig {
+        root: root.to_path_buf(),
+        secret_backend: SecretBackendChoice::Static([8u8; 32]),
+        sandbox_backend: SandboxBackendChoice::E2b(E2bConfig {
+            api_key: "test-api-key".into(),
+            api_url: server.uri(),
+            template_id: "base".into(),
+            envd_port: 49_983,
+            envd_base_url: Some(server.uri()),
+            secure: false,
+        }),
+    }
+}
+
+fn sandbox_created_json() -> Value {
+    json!({
+        "sandboxID": E2B_SANDBOX_ID,
+        "templateID": "base",
+        "envdVersion": "0.1.0",
+    })
+}
+
+fn listed_running_sandbox_json() -> Value {
+    json!([{
+        "sandboxID": E2B_SANDBOX_ID,
+        "templateID": "base",
+        "state": "running",
+        "startedAt": "2026-06-01T12:00:00Z",
+    }])
+}
+
+fn connect_enveloped_stream(messages: &[(u8, Value)]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for (flags, value) in messages {
+        let payload = serde_json::to_vec(value).expect("json");
+        out.push(*flags);
+        out.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+        out.extend_from_slice(&payload);
+    }
+    out
+}
+
+fn connect_exit_ok() -> Vec<u8> {
+    connect_enveloped_stream(&[(
+        2,
+        json!({"event": {"end": {"status": "exit status 0"}}}),
+    )])
+}
+
+fn connect_stdout_and_exit(stdout: &str) -> Vec<u8> {
+    connect_enveloped_stream(&[
+        (
+            0,
+            json!({"event": {"data": {"stdout": stdout}}}),
+        ),
+        (
+            2,
+            json!({"event": {"end": {"status": "exit status 0"}}}),
+        ),
+    ])
+}
+
+async fn mount_e2b_mocks(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path("/sandboxes"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(sandbox_created_json()))
+        .expect(1)
+        .mount(server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/v2/sandboxes"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(listed_running_sandbox_json()))
+        .mount(server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/process.Process/Start"))
+        .respond_with(|req: &wiremock::Request| {
+            let body = String::from_utf8_lossy(&req.body);
+            let template = if body.contains("cat /tmp/x") {
+                ResponseTemplate::new(200).set_body_raw(
+                    connect_stdout_and_exit("tier-1-marker\n"),
+                    "application/connect+json",
+                )
+            } else {
+                ResponseTemplate::new(200).set_body_raw(connect_exit_ok(), "application/connect+json")
+            };
+            template
+        })
+        .mount(server)
+        .await;
+}
+
+fn test_agent_config() -> AgentConfig {
+    AgentConfig {
+        instructions: Vec::new(),
+        harness: AgentHarnessKind::Basic,
+        typescript: None,
+        enable_agent_tool_creation: false,
+        sandbox_image: Some("base".into()),
+        enable_networking: false,
+        model: "e2b-resume-test".into(),
+        max_output_tokens: None,
+        max_tool_round_trips: None,
+        braintrust: None,
+    }
+}
+
+fn test_conv_config() -> ConversationConfig {
+    ConversationConfig {
+        enable_networking: false,
+        shell_program: Some("bash".into()),
+        mounts: Vec::new(),
+    }
+}
+
+async fn prepare(conv: &dyn ConversationHandle) {
+    BasicToolRuntime
+        .prepare_conversation(conv, &test_agent_config(), &test_conv_config())
+        .await
+        .expect("prepare_conversation");
+}
+
+async fn exec_shell(conv: &dyn ConversationHandle, sandbox_id: &SandboxId, cmd: &str) -> (i32, String) {
+    let process = conv
+        .run_in_sandbox(RunInSandboxRequest {
+            id: sandbox_id.clone(),
+            command: vec!["bash".into(), "-lc".into(), cmd.into()],
+            env: Default::default(),
+        })
+        .await
+        .unwrap_or_else(|error| panic!("run_in_sandbox({cmd:?}) failed: {error:#}"));
+    let mut parts: SandboxProcessParts = process.into_parts();
+    drop(parts.stdin);
+    let mut stdout = Vec::new();
+    let (read_stdout, wait) = tokio::join!(parts.stdout.read_to_end(&mut stdout), parts.wait);
+    read_stdout.expect("read stdout");
+    let exit_code = wait.expect("wait");
+    (
+        exit_code,
+        String::from_utf8_lossy(&stdout).into_owned(),
+    )
+}
+
+async fn latest_sandbox_id(conv: &dyn ConversationHandle) -> SandboxId {
+    let result = conv
+        .get_events(Some(EventQuery {
+            cursor: None,
+            direction: Some(EventQueryDirection::Desc),
+            limit: Some(1),
+            session_id: None,
+            turn_id: None,
+            types: Some(vec![EventKind::SANDBOX_CREATED]),
+        }))
+        .await
+        .expect("get_events");
+    let event = result.events.first().expect("sandbox_created present");
+    match &event.data {
+        EventData::SandboxCreated { sandbox_id, .. } => sandbox_id.clone(),
+        other => panic!("unexpected event: {other:?}"),
+    }
+}
+
+async fn count_sandbox_created(conv: &dyn ConversationHandle) -> usize {
+    let mut cursor = None;
+    let mut count = 0usize;
+    loop {
+        let result = conv
+            .get_events(Some(EventQuery {
+                cursor,
+                direction: Some(EventQueryDirection::Asc),
+                limit: Some(100),
+                session_id: None,
+                turn_id: None,
+                types: Some(vec![EventKind::SANDBOX_CREATED]),
+            }))
+            .await
+            .expect("get_events");
+        let done = result.events.is_empty();
+        count += result.events.len();
+        if done || result.cursor.is_none() {
+            break;
+        }
+        cursor = result.cursor;
+    }
+    count
+}
+
+async fn setup_agent_and_conversation(
+    harness: &BasicExoHarness,
+) -> (AgentId, ConversationId, Arc<dyn ConversationHandle>) {
+    let agent: Arc<dyn AgentHandle> = harness
+        .new_agent(NewAgentRequest {
+            slug: "e2b-resume-agent".into(),
+            name: "e2b-resume-agent".into(),
+        })
+        .await
+        .expect("new_agent");
+    let agent_id = agent.record().id;
+    let conv: Arc<dyn ConversationHandle> = agent
+        .new_conversation(NewConversationRequest {
+            slug: Some("e2b-resume-conv".into()),
+            name: Some("e2b-resume-conv".into()),
+        })
+        .await
+        .expect("new_conversation");
+    let conv_id = conv.record().id;
+    (agent_id, conv_id, conv)
+}
+
+async fn open_conversation(
+    harness: &BasicExoHarness,
+    agent_id: &AgentId,
+    conv_id: &ConversationId,
+) -> Arc<dyn ConversationHandle> {
+    let agent: Arc<dyn AgentHandle> = harness
+        .get_agent(agent_id)
+        .await
+        .expect("get_agent")
+        .expect("agent");
+    agent
+        .get_conversation(conv_id)
+        .await
+        .expect("get_conversation")
+        .expect("conversation")
+}
+
+#[tokio::test]
+async fn e2b_cross_process_resume_keeps_single_sandbox_created_event() {
+    let server = MockServer::start().await;
+    mount_e2b_mocks(&server).await;
+    let root = TempDir::new().expect("tempdir");
+
+    let (agent_id, conv_id, sandbox_id) = {
+        let harness = BasicExoHarness::new(e2b_harness_config(root.path(), &server))
+            .await
+            .expect("harness");
+        let (agent_id, conv_id, conv) = setup_agent_and_conversation(&harness).await;
+        prepare(conv.as_ref()).await;
+        let sandbox_id: String = latest_sandbox_id(conv.as_ref()).await;
+        let (rc, stdout) = exec_shell(
+            conv.as_ref(),
+            &sandbox_id,
+            "echo exo-marker > /tmp/x",
+        )
+        .await;
+        assert_eq!(rc, 0, "write marker failed: stdout={stdout:?}");
+        (agent_id, conv_id, sandbox_id)
+    };
+
+    {
+        let harness = BasicExoHarness::new(e2b_harness_config(root.path(), &server))
+            .await
+            .expect("harness");
+        let conv = open_conversation(&harness, &agent_id, &conv_id).await;
+        prepare(conv.as_ref()).await;
+
+        let containers_created = count_sandbox_created(conv.as_ref()).await;
+        assert_eq!(
+            containers_created, 1,
+            "resume must not call create_sandbox again"
+        );
+
+        let (rc, stdout) = exec_shell(conv.as_ref(), &sandbox_id, "cat /tmp/x").await;
+        assert_eq!(rc, 0);
+        assert_eq!(stdout.trim(), "tier-1-marker");
+
+        let list_requests: Vec<_> = server
+            .received_requests()
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|r| r.method == "GET" && r.url.path() == "/v2/sandboxes")
+            .collect();
+        assert!(
+            !list_requests.is_empty(),
+            "second process should list sandboxes via try_resume"
+        );
+        let query = list_requests[0]
+            .url
+            .query()
+            .expect("list sandboxes query");
+        assert!(
+            !query.contains("%253A"),
+            "metadata must not be double-encoded: {query}"
+        );
+        assert!(
+            query.contains("state=running%2Cpaused") || query.contains("state=running,paused"),
+            "expected state filter: {query}"
+        );
+    }
+}

--- a/crates/cli/tests/integration_chat.rs
+++ b/crates/cli/tests/integration_chat.rs
@@ -251,25 +251,174 @@ async fn conversation_send_round_trips_through_real_sandbox_and_mocked_openai() 
     );
 
     if backend == SandboxBackend::Docker {
-        let leftover_containers = Command::new("docker")
-            .args([
-                "ps",
-                "-aq",
-                "--filter",
-                "label=exo.sandbox.owner-pid",
-                "--filter",
-                "status=exited",
-            ])
-            .output()
-            .expect("docker ps");
-        let stdout = String::from_utf8_lossy(&leftover_containers.stdout);
-        let stale = stdout
-            .lines()
-            .filter(|l| !l.trim().is_empty())
-            .collect::<Vec<_>>();
-        assert!(
-            stale.is_empty(),
-            "expected zero leftover Exited exo containers after binary exit; found: {stale:?}"
+        // After process exit, the warm container is stopped (not deleted)
+        // so the next exo invocation can `try_resume` it. The cross-process
+        // idle-TTL reaper will collect it later. So we expect *exactly one*
+        // Exited container labelled with this conversation's SandboxKey,
+        // not zero.
+        let leftover = list_exo_containers_for_conversation(&conv_dir);
+        assert_eq!(
+            leftover.len(),
+            1,
+            "expected exactly one stopped exo container after binary exit (resume target); found: {leftover:?}"
         );
+
+        // Cleanup: tear down the resume target so this test doesn't leak
+        // state into later runs / other tests.
+        for id in &leftover {
+            let _ = Command::new("docker").args(["rm", "-f", id]).output();
+        }
+    }
+}
+
+/// Returns the IDs of every docker container labelled for the conversation
+/// whose state dir is at `conv_dir`. Walks the conversation's persisted
+/// sandbox records to derive the SandboxKey, then filters docker ps.
+fn list_exo_containers_for_conversation(conv_dir: &std::path::Path) -> Vec<String> {
+    let conv_id = conv_dir
+        .file_name()
+        .and_then(|s| s.to_str())
+        .expect("conv dir name");
+    let key_prefix = format!("conversation:{conv_id}:");
+    let output = Command::new("docker")
+        .args([
+            "ps",
+            "-a",
+            "--filter",
+            "label=exo.sandbox.key",
+            "--format",
+            "{{.ID}}\t{{.Label \"exo.sandbox.key\"}}",
+        ])
+        .output()
+        .expect("docker ps");
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| {
+            let mut parts = line.splitn(2, '\t');
+            let id = parts.next()?.trim().to_string();
+            let key = parts.next()?.trim();
+            (key.starts_with(&key_prefix)).then_some(id)
+        })
+        .collect()
+}
+
+/// Resume scenario: two separate `chat send` invocations against the same
+/// conversation must hit the *same* underlying docker container. Validates
+/// that PR-#21's Tier 1 (try_resume) wires through end-to-end on Docker.
+#[tokio::test]
+#[ignore = "spawns real exo binary + real sandbox + wiremock; run with cargo test -- --ignored"]
+async fn cross_process_send_resumes_the_same_sandbox_container() {
+    let backend = SandboxBackend::from_env();
+    // Only Docker has a meaningful resume path; AppleContainer is similar
+    // but we don't exercise it in CI, and LocalProcess returns None from
+    // try_resume by design.
+    if backend != SandboxBackend::Docker {
+        eprintln!("cross-process resume test only meaningful on docker; skipping");
+        return;
+    }
+    if !backend.runtime_available() {
+        eprintln!("docker not available on this runner; skipping");
+        return;
+    }
+
+    let root_dir = TempDir::new().expect("tempdir for --root");
+    let xdg_dir = TempDir::new().expect("tempdir for XDG_CONFIG_HOME");
+    let root = root_dir.path().to_string_lossy().into_owned();
+    let xdg = xdg_dir.path().to_string_lossy().into_owned();
+
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(canned_response_body()))
+        .mount(&mock_server)
+        .await;
+
+    run_exo(
+        &["secret", "set", "test-key", "--env", "OPENAI_API_KEY"],
+        &root,
+        &xdg,
+        backend,
+    );
+    run_exo(
+        &[
+            "model",
+            "register",
+            "gpt-test",
+            "--secret",
+            "test-key",
+            "--base-url",
+            &mock_server.uri(),
+        ],
+        &root,
+        &xdg,
+        backend,
+    );
+    run_exo(
+        &[
+            "agent",
+            "create",
+            "--slug",
+            "test-agent",
+            "--model",
+            "gpt-test",
+            "Integration Test Agent",
+        ],
+        &root,
+        &xdg,
+        backend,
+    );
+    run_exo(
+        &["conversation", "create", "test-agent", "first"],
+        &root,
+        &xdg,
+        backend,
+    );
+
+    // First send: provisions the warm sandbox.
+    run_exo(
+        &["chat", "send", "test-agent", "first", "first message"],
+        &root,
+        &xdg,
+        backend,
+    );
+
+    // Second send: in a fresh exo process. ensure_shell_sandbox should hit
+    // Tier 1 — try_resume against the labelled container — instead of
+    // creating a new one.
+    run_exo(
+        &["chat", "send", "test-agent", "first", "second message"],
+        &root,
+        &xdg,
+        backend,
+    );
+
+    let conv_dir = root_dir
+        .path()
+        .join("exoharness/agents")
+        .read_dir()
+        .expect("agents dir")
+        .next()
+        .expect("agent")
+        .unwrap()
+        .path()
+        .join("conversations")
+        .read_dir()
+        .expect("conversations dir")
+        .next()
+        .expect("conversation")
+        .unwrap()
+        .path();
+
+    let containers = list_exo_containers_for_conversation(&conv_dir);
+    assert_eq!(
+        containers.len(),
+        1,
+        "expected exactly one docker container after two cross-process sends \
+         (resume should reuse, not create new); found: {containers:?}"
+    );
+
+    // Cleanup.
+    for id in &containers {
+        let _ = Command::new("docker").args(["rm", "-f", id]).output();
     }
 }

--- a/crates/cli/tests/integration_chat.rs
+++ b/crates/cli/tests/integration_chat.rs
@@ -287,22 +287,27 @@ fn list_exo_containers_for_conversation(conv_dir: &std::path::Path) -> Vec<Strin
             "--filter",
             "label=exo.sandbox.key",
             "--format",
-            "{{.ID}}\t{{.Label \"exo.sandbox.key\"}}",
+            "{{json .}}",
         ])
         .output()
         .expect("docker ps");
     String::from_utf8_lossy(&output.stdout)
         .lines()
+        .filter(|line| !line.is_empty())
         .filter_map(|line| {
-            let mut parts = line.splitn(2, '\t');
-            let id = parts.next()?.trim().to_string();
-            let key = parts.next()?.trim();
-            (key.starts_with(&key_prefix)).then_some(id)
+            let row: Value = serde_json::from_str(line).expect("docker ps row is json");
+            let id = row.get("ID")?.as_str()?.to_string();
+            let labels = row.get("Labels")?.as_str()?;
+            let key = labels
+                .split(',')
+                .filter_map(|kv| kv.split_once('='))
+                .find_map(|(k, v)| (k == "exo.sandbox.key").then_some(v))?;
+            key.starts_with(&key_prefix).then_some(id)
         })
         .collect()
 }
 
-/// Resume scenario: two separate `chat send` invocations against the same
+/// Resume scenario: two separate `conversation send` invocations against the same
 /// conversation must hit the *same* underlying docker container. Validates
 /// that PR-#21's Tier 1 (try_resume) wires through end-to-end on Docker.
 #[tokio::test]
@@ -376,7 +381,13 @@ async fn cross_process_send_resumes_the_same_sandbox_container() {
 
     // First send: provisions the warm sandbox.
     run_exo(
-        &["chat", "send", "test-agent", "first", "first message"],
+        &[
+            "conversation",
+            "send",
+            "test-agent",
+            "first",
+            "first message",
+        ],
         &root,
         &xdg,
         backend,
@@ -386,7 +397,13 @@ async fn cross_process_send_resumes_the_same_sandbox_container() {
     // Tier 1 — try_resume against the labelled container — instead of
     // creating a new one.
     run_exo(
-        &["chat", "send", "test-agent", "first", "second message"],
+        &[
+            "conversation",
+            "send",
+            "test-agent",
+            "first",
+            "second message",
+        ],
         &root,
         &xdg,
         backend,

--- a/crates/cli/tests/lifecycle_resume.rs
+++ b/crates/cli/tests/lifecycle_resume.rs
@@ -1,0 +1,507 @@
+//! Lifecycle tests for cross-process sandbox resume (PR #21).
+//!
+//! PR #21's `ensure_shell_sandbox` has a 3-tier fallback chain for
+//! recovering a previous conversation's sandbox:
+//!
+//!   Tier 1: container exists (running or stopped) under the recorded
+//!           `SandboxKey`. `try_resume` finds it via docker labels, starts
+//!           it if needed, attaches. Same container, same `sandbox_id`.
+//!   Tier 2: container is gone (idle-TTL expiry, manual rm, server-side
+//!           reclaim) but a snapshot was taken for this sandbox. The
+//!           harness restores the snapshot into a fresh container. New
+//!           container id, same `sandbox_id`.
+//!   Tier 3: container is gone and no snapshot was ever taken. Harness
+//!           creates a fresh sandbox. New container id, NEW `sandbox_id`.
+//!
+//! Each test below targets one tier by simulating two `exo` processes:
+//! drop the BasicExoHarness (Drop now stops containers instead of rm'ing
+//! them, so they survive the "process boundary"), then construct a new
+//! harness against the same `--root` directory. Whatever survives or
+//! doesn't survive between the two harnesses tells us which tier fired.
+//!
+//! Docker only; the LocalProcess backend returns `None` from `try_resume`
+//! by design so there's no lifecycle to exercise there.
+
+use std::path::Path;
+use std::process::Command;
+use std::sync::Arc;
+
+use executor::{AgentConfig, AgentHarnessKind, BasicToolRuntime, ConversationConfig, ToolRuntime};
+use exoharness::{
+    AgentId, BasicExoHarness, BasicExoHarnessConfig, ConversationHandle, ConversationId, EventData,
+    EventKind, EventQuery, EventQueryDirection, ExoHarness, NewAgentRequest,
+    NewConversationRequest, RunInSandboxRequest, SandboxBackendChoice, SandboxId,
+    SandboxProcessParts, SecretBackendChoice,
+};
+use futures::io::AsyncReadExt;
+use tempfile::TempDir;
+
+const SANDBOX_IMAGE: &str = "docker.io/library/ubuntu:24.04";
+
+// ───────────────────── Tier 1 ─────────────────────
+//
+// First harness creates a container and writes a marker file. Drop the
+// harness — Drop sends `docker stop`, leaving the container on disk in
+// `Exited` state. Second harness opens the same conversation; its
+// `try_resume` finds the stopped container via the `exo.sandbox.key`
+// label, `docker start`s it, and attaches. The container's filesystem
+// (and therefore the marker) is preserved by the stop+start cycle.
+
+#[tokio::test]
+#[ignore = "spawns real docker container; run with `cargo test -- --ignored`"]
+async fn tier_1_stopped_container_is_resumed_same_id() {
+    if !preflight() {
+        return;
+    }
+    let root_dir = TempDir::new().expect("tempdir");
+
+    // ── Harness #1: create sandbox + write marker ──
+    let (agent_id, conv_id, sandbox_id, container_id) = {
+        let harness = make_harness(root_dir.path()).await;
+        let (agent_id, conv_id) = make_agent_and_conv(&harness, "tier-1-agent").await;
+        let conv = open_conv(&harness, &agent_id, &conv_id).await;
+        prepare(conv.as_ref()).await;
+
+        let sandbox_id = latest_sandbox_id(conv.as_ref())
+            .await
+            .expect("ensure_shell_sandbox should have created a sandbox");
+        let containers = list_containers_for_sandbox(&conv_id, &sandbox_id);
+        assert_eq!(
+            containers.len(),
+            1,
+            "round 1 should have exactly one container, got: {containers:?}"
+        );
+        let container_id = containers.into_iter().next().unwrap();
+
+        let (rc, _, _) =
+            exec_shell(conv.as_ref(), &sandbox_id, "echo 'tier-1-marker' > /tmp/x").await;
+        assert_eq!(rc, 0, "writing marker should succeed");
+
+        drop(conv);
+        // harness drops at end of block; Drop stops the container.
+        (agent_id, conv_id, sandbox_id, container_id)
+    };
+
+    // Container should be stopped (not removed) — PR #21's Drop behaviour.
+    let state = docker_container_state(&container_id);
+    assert_eq!(
+        state, "exited",
+        "container should be stopped (not rm'd) after harness drop; state={state:?}"
+    );
+
+    // ── Harness #2: resume ──
+    {
+        let harness = make_harness(root_dir.path()).await;
+        let conv = open_conv(&harness, &agent_id, &conv_id).await;
+        prepare(conv.as_ref()).await;
+
+        // Same container, no new one.
+        let containers = list_containers_for_sandbox(&conv_id, &sandbox_id);
+        assert_eq!(
+            containers,
+            vec![container_id.clone()],
+            "round 2 should reuse the same container ID, not create a new one"
+        );
+
+        // Marker persists across the stop/start cycle.
+        let (rc, stdout, _) = exec_shell(conv.as_ref(), &sandbox_id, "cat /tmp/x").await;
+        assert_eq!(rc, 0);
+        assert_eq!(
+            stdout.trim(),
+            "tier-1-marker",
+            "marker should persist across resume"
+        );
+
+        // The conversation log should still report exactly one
+        // SandboxCreated event — Tier 1 never invokes create_sandbox.
+        let created = count_events_of_type(conv.as_ref(), "sandbox_created").await;
+        assert_eq!(created, 1, "tier 1 should not create a second sandbox");
+    }
+
+    rm_container(&container_id);
+}
+
+// ───────────────────── Tier 2 ─────────────────────
+//
+// First harness creates the container, writes a marker, takes a snapshot.
+// Drop the harness. Then `docker rm -f` the container to simulate the
+// idle-TTL or manual-cleanup case. Second harness's `try_resume` finds
+// nothing (label query empty); `ensure_shell_sandbox` falls through to
+// Tier 2, walks `SandboxSnapshotted` events for the recorded sandbox,
+// finds the snapshot, and calls `start_sandbox` which calls
+// `acquire_from_snapshot` (PR #20 path) to bring up a fresh container.
+// The new container is a brand-new docker id, but the `sandbox_id` (the
+// exoharness logical identifier) is reused, and the marker comes back
+// because the snapshot included it.
+
+#[tokio::test]
+#[ignore = "spawns real docker container; run with `cargo test -- --ignored`"]
+async fn tier_2_gone_container_with_snapshot_restores() {
+    if !preflight() {
+        return;
+    }
+    let root_dir = TempDir::new().expect("tempdir");
+
+    // ── Harness #1: provision + snapshot + drop ──
+    let (agent_id, conv_id, sandbox_id, container_id_round1) = {
+        let harness = make_harness(root_dir.path()).await;
+        let (agent_id, conv_id) = make_agent_and_conv(&harness, "tier-2-agent").await;
+        let conv = open_conv(&harness, &agent_id, &conv_id).await;
+        prepare(conv.as_ref()).await;
+
+        let sandbox_id = latest_sandbox_id(conv.as_ref()).await.unwrap();
+        let containers = list_containers_for_sandbox(&conv_id, &sandbox_id);
+        assert_eq!(containers.len(), 1);
+        let container_id = containers.into_iter().next().unwrap();
+
+        exec_shell(conv.as_ref(), &sandbox_id, "echo 'tier-2-marker' > /tmp/x").await;
+
+        // Snapshot the sandbox while the container is still live. PR #20's
+        // snapshot_sandbox needs the handle in the harness's
+        // running_sandboxes map, which prepare_conversation populated above.
+        conv.snapshot_sandbox(sandbox_id.clone())
+            .await
+            .expect("snapshot_sandbox should succeed while container is live");
+
+        drop(conv);
+        (agent_id, conv_id, sandbox_id, container_id)
+    };
+
+    // Simulate the container being reaped (idle-TTL expired, manual rm,
+    // host pruning, whatever). Tier 1 should miss in round 2.
+    rm_container(&container_id_round1);
+    assert!(
+        list_containers_for_sandbox(&conv_id, &sandbox_id).is_empty(),
+        "container should be gone after rm",
+    );
+
+    // ── Harness #2: restore-from-snapshot ──
+    {
+        let harness = make_harness(root_dir.path()).await;
+        let conv = open_conv(&harness, &agent_id, &conv_id).await;
+        prepare(conv.as_ref()).await;
+
+        // A new container exists, but it's a DIFFERENT docker id from the
+        // one we removed — the harness booted a new container from the
+        // snapshotted image, it didn't somehow resurrect the original.
+        let containers = list_containers_for_sandbox(&conv_id, &sandbox_id);
+        assert_eq!(
+            containers.len(),
+            1,
+            "tier 2 should leave exactly one container"
+        );
+        assert_ne!(
+            containers[0], container_id_round1,
+            "tier 2 should create a NEW container (restored from snapshot)"
+        );
+
+        // The marker from before the snapshot is back, proving the
+        // snapshot's filesystem layer was actually applied.
+        let (rc, stdout, _) = exec_shell(conv.as_ref(), &sandbox_id, "cat /tmp/x").await;
+        assert_eq!(rc, 0);
+        assert_eq!(
+            stdout.trim(),
+            "tier-2-marker",
+            "snapshot's filesystem state should be present after tier-2 restore"
+        );
+
+        // Still exactly one logical sandbox: tier 2 reuses the existing
+        // `sandbox_id`, it doesn't create a new one.
+        assert_eq!(
+            count_events_of_type(conv.as_ref(), "sandbox_created").await,
+            1,
+            "tier 2 must not create a new sandbox"
+        );
+        assert!(
+            count_events_of_type(conv.as_ref(), "sandbox_started").await >= 1,
+            "tier 2 should emit a SandboxStarted event when restoring"
+        );
+
+        let containers = list_containers_for_sandbox(&conv_id, &sandbox_id);
+        for c in containers {
+            rm_container(&c);
+        }
+    }
+}
+
+// ───────────────────── Tier 3 ─────────────────────
+//
+// First harness creates the container, writes a marker, **does not**
+// take a snapshot. Drop the harness, `docker rm -f` the container.
+// Second harness's `try_resume` misses (Tier 1), the snapshot lookup
+// returns nothing (Tier 2), so `ensure_shell_sandbox` falls through to
+// `create_sandbox` (Tier 3). Result: a brand-new sandbox with a new
+// logical `sandbox_id`, fresh container, and no trace of the previous
+// state.
+
+#[tokio::test]
+#[ignore = "spawns real docker container; run with `cargo test -- --ignored`"]
+async fn tier_3_gone_container_without_snapshot_creates_fresh() {
+    if !preflight() {
+        return;
+    }
+    let root_dir = TempDir::new().expect("tempdir");
+
+    // ── Harness #1: create, write marker, drop. NO snapshot. ──
+    let (agent_id, conv_id, sandbox_id_round1, container_id_round1) = {
+        let harness = make_harness(root_dir.path()).await;
+        let (agent_id, conv_id) = make_agent_and_conv(&harness, "tier-3-agent").await;
+        let conv = open_conv(&harness, &agent_id, &conv_id).await;
+        prepare(conv.as_ref()).await;
+
+        let sandbox_id = latest_sandbox_id(conv.as_ref()).await.unwrap();
+        let containers = list_containers_for_sandbox(&conv_id, &sandbox_id);
+        assert_eq!(containers.len(), 1);
+        let container_id = containers.into_iter().next().unwrap();
+
+        exec_shell(conv.as_ref(), &sandbox_id, "echo 'tier-3-marker' > /tmp/x").await;
+
+        drop(conv);
+        (agent_id, conv_id, sandbox_id, container_id)
+    };
+
+    rm_container(&container_id_round1);
+
+    // ── Harness #2: should create a fresh sandbox ──
+    {
+        let harness = make_harness(root_dir.path()).await;
+        let conv = open_conv(&harness, &agent_id, &conv_id).await;
+        prepare(conv.as_ref()).await;
+
+        let sandbox_id_round2 = latest_sandbox_id(conv.as_ref()).await.unwrap();
+        assert_ne!(
+            sandbox_id_round2, sandbox_id_round1,
+            "tier 3 should create a new sandbox with a new id"
+        );
+
+        // Event log should now show two `sandbox_created`s.
+        assert_eq!(
+            count_events_of_type(conv.as_ref(), "sandbox_created").await,
+            2,
+            "tier 3 should record a second SandboxCreated event"
+        );
+
+        // The marker from round 1 is gone — the new container is fresh.
+        let (rc, _, _) = exec_shell(conv.as_ref(), &sandbox_id_round2, "test -f /tmp/x").await;
+        assert_ne!(rc, 0, "marker should NOT exist in the fresh container");
+
+        // Cleanup the new container.
+        let containers = list_containers_for_sandbox(&conv_id, &sandbox_id_round2);
+        for c in containers {
+            rm_container(&c);
+        }
+    }
+}
+
+// ───────────────────── helpers ─────────────────────
+
+fn preflight() -> bool {
+    let docker_ok = Command::new("docker")
+        .arg("info")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if !docker_ok {
+        eprintln!("docker not available, skipping lifecycle test");
+        return false;
+    }
+    let backend = std::env::var("EXO_TEST_SANDBOX_BACKEND").unwrap_or_else(|_| "docker".into());
+    if backend != "docker" {
+        eprintln!("lifecycle test is docker-only, skipping (EXO_TEST_SANDBOX_BACKEND={backend})");
+        return false;
+    }
+    true
+}
+
+async fn make_harness(root: &Path) -> BasicExoHarness {
+    BasicExoHarness::new(BasicExoHarnessConfig {
+        root: root.to_path_buf(),
+        secret_backend: SecretBackendChoice::Static([9u8; 32]),
+        sandbox_backend: SandboxBackendChoice::Docker,
+    })
+    .await
+    .expect("BasicExoHarness::new")
+}
+
+async fn make_agent_and_conv(
+    harness: &BasicExoHarness,
+    agent_slug: &str,
+) -> (AgentId, ConversationId) {
+    let agent = harness
+        .new_agent(NewAgentRequest {
+            slug: agent_slug.into(),
+            name: agent_slug.into(),
+        })
+        .await
+        .expect("new_agent");
+    let agent_id = agent.record().id;
+    let conv = agent
+        .new_conversation(NewConversationRequest {
+            slug: Some("conv".into()),
+            name: Some("conversation".into()),
+        })
+        .await
+        .expect("new_conversation");
+    let conv_id = conv.record().id;
+    (agent_id, conv_id)
+}
+
+async fn open_conv(
+    harness: &BasicExoHarness,
+    agent_id: &AgentId,
+    conv_id: &ConversationId,
+) -> Arc<dyn ConversationHandle> {
+    let agent = harness
+        .get_agent(agent_id)
+        .await
+        .expect("get_agent")
+        .expect("agent should exist on disk");
+    agent
+        .get_conversation(conv_id)
+        .await
+        .expect("get_conversation")
+        .expect("conversation should exist on disk")
+}
+
+fn test_agent_config() -> AgentConfig {
+    AgentConfig {
+        instructions: Vec::new(),
+        harness: AgentHarnessKind::Basic,
+        typescript: None,
+        enable_agent_tool_creation: false,
+        sandbox_image: Some(SANDBOX_IMAGE.into()),
+        enable_networking: false,
+        model: "lifecycle-test-model".into(),
+        max_output_tokens: None,
+        max_tool_round_trips: None,
+        braintrust: None,
+    }
+}
+
+fn test_conv_config() -> ConversationConfig {
+    ConversationConfig {
+        enable_networking: false,
+        // shell_program: Some(_) is the trigger for ensure_shell_sandbox.
+        shell_program: Some("bash".into()),
+        mounts: Vec::new(),
+    }
+}
+
+/// Fire `BasicToolRuntime::prepare_conversation`, which is the public-ish
+/// entry point that internally calls `ensure_shell_sandbox` — the
+/// function that runs the 3-tier lifecycle fallback we're testing.
+async fn prepare(conv: &dyn ConversationHandle) {
+    BasicToolRuntime
+        .prepare_conversation(conv, &test_agent_config(), &test_conv_config())
+        .await
+        .expect("prepare_conversation");
+}
+
+async fn exec_shell(
+    conv: &dyn ConversationHandle,
+    sandbox_id: &SandboxId,
+    cmd: &str,
+) -> (i32, String, String) {
+    let process = conv
+        .run_in_sandbox(RunInSandboxRequest {
+            id: sandbox_id.clone(),
+            command: vec!["/bin/bash".into(), "-c".into(), cmd.into()],
+            env: Default::default(),
+        })
+        .await
+        .unwrap_or_else(|error| panic!("run_in_sandbox({cmd:?}) failed: {error:#}"));
+    let mut parts: SandboxProcessParts = process.into_parts();
+    drop(parts.stdin);
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let (a, b, c) = tokio::join!(
+        parts.stdout.read_to_end(&mut stdout),
+        parts.stderr.read_to_end(&mut stderr),
+        parts.wait,
+    );
+    a.expect("read stdout");
+    b.expect("read stderr");
+    let exit_code = c.expect("wait");
+    (
+        exit_code,
+        String::from_utf8_lossy(&stdout).into_owned(),
+        String::from_utf8_lossy(&stderr).into_owned(),
+    )
+}
+
+async fn latest_sandbox_id(conv: &dyn ConversationHandle) -> Option<SandboxId> {
+    let result = conv
+        .get_events(Some(EventQuery {
+            cursor: None,
+            direction: Some(EventQueryDirection::Desc),
+            limit: Some(50),
+            session_id: None,
+            turn_id: None,
+            types: Some(vec![EventKind::SANDBOX_CREATED]),
+        }))
+        .await
+        .ok()?;
+    for event in result.events {
+        if let EventData::SandboxCreated { sandbox_id, .. } = event.data {
+            return Some(sandbox_id);
+        }
+    }
+    None
+}
+
+async fn count_events_of_type(conv: &dyn ConversationHandle, ty: &str) -> usize {
+    let mut cursor = None;
+    let mut count = 0;
+    loop {
+        let result = conv
+            .get_events(Some(EventQuery {
+                cursor,
+                direction: Some(EventQueryDirection::Asc),
+                limit: Some(100),
+                session_id: None,
+                turn_id: None,
+                types: Some(vec![EventKind::custom(ty.to_string())]),
+            }))
+            .await
+            .expect("get_events");
+        let events_empty = result.events.is_empty();
+        count += result.events.len();
+        if events_empty || result.cursor.is_none() {
+            break;
+        }
+        cursor = result.cursor;
+    }
+    count
+}
+
+fn list_containers_for_sandbox(conv_id: &ConversationId, sandbox_id: &SandboxId) -> Vec<String> {
+    let label = format!("exo.sandbox.key=conversation:{conv_id}:{sandbox_id}");
+    let output = Command::new("docker")
+        .args([
+            "ps",
+            "-a",
+            "--filter",
+            &format!("label={label}"),
+            "--format",
+            "{{.ID}}",
+        ])
+        .output()
+        .expect("docker ps");
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter(|s| !s.trim().is_empty())
+        .map(|s| s.trim().to_string())
+        .collect()
+}
+
+fn docker_container_state(id: &str) -> String {
+    let output = Command::new("docker")
+        .args(["inspect", "--format", "{{.State.Status}}", id])
+        .output()
+        .expect("docker inspect");
+    String::from_utf8_lossy(&output.stdout).trim().to_string()
+}
+
+fn rm_container(id: &str) {
+    let _ = Command::new("docker").args(["rm", "-f", id]).output();
+}

--- a/crates/cli/tests/sprites_backend.rs
+++ b/crates/cli/tests/sprites_backend.rs
@@ -1,0 +1,375 @@
+//! Wiremock-driven tests for the Sprites sandbox backend.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use bytes::Bytes;
+use exoharness::{
+    ManagedSandboxBackend, SandboxKey, SandboxLifecycleConfig, SandboxMount, SandboxMountAccess,
+    SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotKind, SnapshotPayload,
+    SpritesConfig, SpritesSandboxBackend,
+};
+use serde_json::{Value, json};
+use wiremock::matchers::{method, path, path_regex};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn make_request(conversation_id: &str, sandbox_id: &str) -> SandboxRequest {
+    SandboxRequest {
+        key: SandboxKey::ConversationSandbox {
+            conversation_id: conversation_id.into(),
+            sandbox_id: sandbox_id.into(),
+        },
+        spec: SandboxSpec {
+            image: "default".into(),
+            mounts: Vec::new(),
+            network: SandboxNetworkPolicy::Enabled,
+            default_workdir: "/home/sprite".into(),
+        },
+        lifecycle: SandboxLifecycleConfig {
+            idle_ttl: Some(Duration::from_secs(300)),
+        },
+    }
+}
+
+fn sandbox_spec_hash(spec: &SandboxSpec) -> String {
+    let mut hasher = DefaultHasher::new();
+    spec.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+fn expected_sprite_name(request: &SandboxRequest) -> String {
+    let mut hasher = DefaultHasher::new();
+    request.key.hash(&mut hasher);
+    sandbox_spec_hash(&request.spec).hash(&mut hasher);
+    format!("exo-{:016x}", hasher.finish())
+}
+
+fn backend_for_mock(server: &MockServer) -> SpritesSandboxBackend {
+    SpritesSandboxBackend::new(SpritesConfig {
+        token: "test-token".into(),
+        api_url: server.uri(),
+    })
+    .expect("SpritesSandboxBackend::new")
+}
+
+fn sprite_info_json(name: &str) -> Value {
+    json!({
+        "id": "sprite-test-id",
+        "name": name,
+        "status": "cold",
+        "url": "https://example.sprites.app",
+        "organization": "test-org",
+        "created_at": "2026-06-01T12:00:00Z",
+        "updated_at": "2026-06-01T12:00:00Z",
+    })
+}
+
+#[tokio::test]
+async fn acquire_creates_sprite_when_missing() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-1", "sandbox-1");
+    let name = expected_sprite_name(&request);
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/sprites/{name}")))
+        .respond_with(ResponseTemplate::new(404))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/sprites"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(sprite_info_json(&name)))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend.acquire(request).await.expect("acquire");
+    assert_eq!(handle.id(), "sprites:conversation:conv-1:sandbox-1");
+}
+
+#[tokio::test]
+async fn acquire_rejects_host_mounts() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    let mut request = make_request("conv-2", "sandbox-2");
+    request.spec.mounts.push(SandboxMount {
+        host_path: PathBuf::from("/tmp/foo"),
+        guest_path: "/workspace".into(),
+        access: SandboxMountAccess::ReadWrite,
+        internal: false,
+    });
+
+    let error = match backend.acquire(request).await {
+        Ok(_) => panic!("acquire should reject host mounts"),
+        Err(error) => error,
+    };
+    let msg = format!("{error:#}").to_lowercase();
+    assert!(
+        msg.contains("mount") || msg.contains("sprites"),
+        "unexpected: {msg}"
+    );
+    assert_eq!(
+        server.received_requests().await.unwrap_or_default().len(),
+        0
+    );
+}
+
+#[tokio::test]
+async fn try_resume_returns_handle_when_sprite_exists() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-3", "sandbox-3");
+    let name = expected_sprite_name(&request);
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/sprites/{name}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sprite_info_json(&name)))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend
+        .try_resume(request)
+        .await
+        .expect("try_resume ok")
+        .expect("sprite should exist");
+    assert_eq!(handle.id(), "sprites:conversation:conv-3:sandbox-3");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert!(
+        !requests.iter().any(|r| r.method.as_str() == "POST"),
+        "try_resume must not create sprites"
+    );
+}
+
+#[tokio::test]
+async fn try_resume_returns_none_when_sprite_missing() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-4", "sandbox-4");
+    let name = expected_sprite_name(&request);
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/sprites/{name}")))
+        .respond_with(ResponseTemplate::new(404))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend.try_resume(request).await.expect("try_resume ok");
+    assert!(handle.is_none());
+}
+
+#[tokio::test]
+async fn stop_does_not_delete_sprite() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-5", "sandbox-5");
+    let name = expected_sprite_name(&request);
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/sprites/{name}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sprite_info_json(&name)))
+        .mount(&server)
+        .await;
+
+    let handle = backend.try_resume(request).await.unwrap().unwrap();
+    handle.stop().await.expect("stop is a no-op");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert!(
+        !requests
+            .iter()
+            .any(|r| r.method.as_str() == "DELETE"),
+        "stop must not delete the sprite"
+    );
+}
+
+#[tokio::test]
+async fn exec_accepts_plain_text_http_response() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-plain", "sandbox-plain");
+    let name = expected_sprite_name(&request);
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/sprites/{name}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sprite_info_json(&name)))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path_regex(r"/v1/sprites/.+/exec$"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("4\n"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend.try_resume(request).await.unwrap().unwrap();
+    let output = handle
+        .exec(&exoharness::SandboxCommand {
+            argv: vec!["python3".into(), "-c".into(), "print(2+2)".into()],
+            env: Default::default(),
+            display_argv: None,
+            cwd: None,
+            timeout: None,
+        })
+        .await
+        .expect("plain text exec body should parse");
+
+    assert_eq!(output.stdout, "4\n");
+    assert!(output.ok);
+}
+
+#[tokio::test]
+async fn exec_uses_http_post_with_cmd_query_params() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-6", "sandbox-6");
+    let name = expected_sprite_name(&request);
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/sprites/{name}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sprite_info_json(&name)))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path_regex(r"/v1/sprites/.+/exec$"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "exitCode": 0,
+            "stdout": "hello\n",
+            "stderr": "",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend.try_resume(request).await.unwrap().unwrap();
+    let output = handle
+        .exec(&exoharness::SandboxCommand {
+            argv: vec!["echo".into(), "hello".into()],
+            env: Default::default(),
+            display_argv: None,
+            cwd: None,
+            timeout: None,
+        })
+        .await
+        .expect("exec");
+
+    assert!(output.ok);
+    assert_eq!(output.stdout, "hello\n");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let exec_req = requests
+        .iter()
+        .find(|r| r.url.path().ends_with("/exec"))
+        .expect("exec request");
+    let query = exec_req.url.query().expect("query string");
+    assert!(query.contains("cmd=echo"));
+    assert!(query.contains("cmd=hello"));
+    assert!(query.contains("stdin=false"));
+}
+
+#[tokio::test]
+async fn snapshot_returns_sprites_snapshot_payload() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-7", "sandbox-7");
+    let name = expected_sprite_name(&request);
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/sprites/{name}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sprite_info_json(&name)))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(format!("/v1/sprites/{name}/checkpoint")))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            concat!(
+                r#"{"type":"info","data":"  ID: v3","time":"2026-06-01T12:00:00Z"}"#,
+                "\n",
+                r#"{"type":"complete","data":"Checkpoint v3 created","time":"2026-06-01T12:00:01Z"}"#,
+                "\n",
+            ),
+            "application/x-ndjson",
+        ))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend.try_resume(request).await.unwrap().unwrap();
+    let payload = handle.snapshot().await.expect("snapshot");
+
+    assert!(matches!(payload.kind, SnapshotKind::SpritesSnapshot));
+    let manifest: Value = serde_json::from_slice(&payload.bytes).unwrap();
+    assert_eq!(manifest.get("checkpoint_id").and_then(Value::as_str), Some("v3"));
+    assert_eq!(
+        manifest.get("sprite_name").and_then(Value::as_str),
+        Some(name.as_str())
+    );
+}
+
+#[tokio::test]
+async fn acquire_from_snapshot_restores_checkpoint() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-8", "sandbox-8");
+    let name = expected_sprite_name(&request);
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/sprites/{name}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sprite_info_json(&name)))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(format!("/v1/sprites/{name}/checkpoints/v2/restore")))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            r#"{"type":"complete","data":"Restore complete","time":"2026-06-01T12:00:00Z"}"#,
+            "application/x-ndjson",
+        ))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let manifest = json!({
+        "checkpoint_id": "v2",
+        "sprite_name": name,
+    });
+    let payload = SnapshotPayload {
+        kind: SnapshotKind::SpritesSnapshot,
+        bytes: Bytes::from(serde_json::to_vec(&manifest).unwrap()),
+    };
+
+    backend
+        .acquire_from_snapshot(request, payload)
+        .await
+        .expect("restore");
+}
+
+#[tokio::test]
+async fn acquire_from_snapshot_rejects_wrong_kind() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    let payload = SnapshotPayload {
+        kind: SnapshotKind::DockerImageTar,
+        bytes: Bytes::from_static(b"not-a-tar"),
+    };
+
+    let error = match backend
+        .acquire_from_snapshot(make_request("conv-9", "sandbox-9"), payload)
+        .await
+    {
+        Ok(_) => panic!("wrong snapshot kind should fail"),
+        Err(error) => error,
+    };
+    let msg = format!("{error:#}").to_lowercase();
+    assert!(
+        msg.contains("sprites") || msg.contains("kind"),
+        "unexpected: {msg}"
+    );
+}

--- a/crates/executor/src/harness_tool.rs
+++ b/crates/executor/src/harness_tool.rs
@@ -2,8 +2,8 @@ use crate::{AgentConfig, ConversationConfig, ToolRuntime};
 use async_trait::async_trait;
 use exoharness::{
     ConversationHandle, CreateSandboxRequest, DEFAULT_SANDBOX_IMAGE, EventData, EventKind,
-    EventQuery, EventQueryDirection, FileSystemMount, FileSystemMountMode, Result,
-    RunInSandboxRequest, SnapshotId, StartSandboxRequest, ToolRequest, ToolResult,
+    EventQueryDirection, FileSystemMount, FileSystemMountMode, Result, RunInSandboxRequest,
+    SnapshotId, StartSandboxRequest, ToolRequest, ToolResult,
 };
 use futures::io::AsyncReadExt;
 use serde::{Deserialize, Serialize};
@@ -182,28 +182,20 @@ async fn latest_snapshot_for_sandbox(
     conversation: &dyn ConversationHandle,
     sandbox_id: &str,
 ) -> Result<Option<SnapshotId>> {
-    let events = conversation
-        .get_events(Some(EventQuery {
-            cursor: None,
-            direction: Some(EventQueryDirection::Desc),
-            limit: Some(100),
-            session_id: None,
-            turn_id: None,
-            types: Some(vec![EventKind::SANDBOX_SNAPSHOTTED]),
-        }))
-        .await?
-        .events;
-    for event in events {
-        if let EventData::SandboxSnapshotted {
-            sandbox_id: sid,
-            snapshot_id,
-        } = event.data
-            && sid == sandbox_id
-        {
-            return Ok(Some(snapshot_id));
-        }
-    }
-    Ok(None)
+    exoharness::first_matching_event(
+        conversation,
+        EventKind::SANDBOX_SNAPSHOTTED,
+        EventQueryDirection::Desc,
+        100,
+        |data| match data {
+            EventData::SandboxSnapshotted {
+                sandbox_id: sid,
+                snapshot_id,
+            } if sid == sandbox_id => Some(snapshot_id),
+            _ => None,
+        },
+    )
+    .await
 }
 
 fn normalize_mounts(mounts: &[FileSystemMount]) -> Vec<FileSystemMount> {
@@ -234,41 +226,29 @@ struct ShellSandboxInfo {
 async fn latest_shell_sandbox(
     conversation: &dyn ConversationHandle,
 ) -> Result<Option<ShellSandboxInfo>> {
-    let events = conversation
-        .get_events(Some(EventQuery {
-            cursor: None,
-            direction: Some(EventQueryDirection::Desc),
-            limit: Some(50),
-            session_id: None,
-            turn_id: None,
-            types: Some(vec![EventKind::SANDBOX_CREATED]),
-        }))
-        .await?
-        .events;
-
-    let Some(event) = events.into_iter().next() else {
-        return Ok(None);
-    };
-    match event.data {
-        EventData::SandboxCreated {
-            sandbox_id,
-            image,
-            default_workdir,
-            file_system_mounts,
-            enable_networking,
-            idle_seconds,
-        } => Ok(Some(ShellSandboxInfo {
-            id: sandbox_id,
-            image,
-            default_workdir,
-            file_system_mounts,
-            enable_networking,
-            idle_seconds,
-        })),
-        other => Err(anyhow::anyhow!(
-            "type-filtered query for {} returned unexpected variant {}",
-            EventKind::SANDBOX_CREATED.as_str(),
-            other.kind().as_str(),
-        )),
-    }
+    exoharness::first_matching_event(
+        conversation,
+        EventKind::SANDBOX_CREATED,
+        EventQueryDirection::Desc,
+        1,
+        |data| match data {
+            EventData::SandboxCreated {
+                sandbox_id,
+                image,
+                default_workdir,
+                file_system_mounts,
+                enable_networking,
+                idle_seconds,
+            } => Some(ShellSandboxInfo {
+                id: sandbox_id,
+                image,
+                default_workdir,
+                file_system_mounts,
+                enable_networking,
+                idle_seconds,
+            }),
+            _ => None,
+        },
+    )
+    .await
 }

--- a/crates/executor/src/harness_tool.rs
+++ b/crates/executor/src/harness_tool.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use exoharness::{
     ConversationHandle, CreateSandboxRequest, DEFAULT_SANDBOX_IMAGE, EventData, EventKind,
     EventQuery, EventQueryDirection, FileSystemMount, FileSystemMountMode, Result,
-    RunInSandboxRequest, ToolRequest, ToolResult,
+    RunInSandboxRequest, SnapshotId, StartSandboxRequest, ToolRequest, ToolResult,
 };
 use futures::io::AsyncReadExt;
 use serde::{Deserialize, Serialize};
@@ -115,6 +115,14 @@ pub(crate) async fn ensure_shell_sandbox(
         .unwrap_or_else(|| DEFAULT_SANDBOX_IMAGE.to_string());
     let desired_enable_networking = agent_config.enable_networking || config.enable_networking;
 
+    // 3-tier fallback for an existing conversation sandbox:
+    //   Tier 1: resume the same container/sandbox by SandboxKey.
+    //           This is what `run_in_sandbox` -> backend.try_resume now does
+    //           internally when the in-memory handle is missing.
+    //   Tier 2: if Tier 1 failed (container is truly gone — TTL expired,
+    //           server-side auto-delete, manual cleanup), restore from the
+    //           latest snapshot recorded in the conversation log.
+    //   Tier 3: nothing to resume, create fresh.
     if let Some(sandbox) = latest_shell_sandbox(conversation).await? {
         let Some(program) = &config.shell_program else {
             return Ok(sandbox.id);
@@ -127,6 +135,8 @@ pub(crate) async fn ensure_shell_sandbox(
             && sandbox.idle_seconds == 300;
 
         if config_matches {
+            // Tier 1: try a no-op exec; the harness will resume from the
+            // backend on cache miss.
             let healthcheck = conversation
                 .run_in_sandbox(RunInSandboxRequest {
                     id: sandbox.id.clone(),
@@ -137,9 +147,26 @@ pub(crate) async fn ensure_shell_sandbox(
             if healthcheck.is_ok() {
                 return Ok(sandbox.id);
             }
+
+            // Tier 2: container is gone. If we ever took a snapshot of this
+            // sandbox in this conversation, restore from the latest one.
+            if let Some(snapshot_id) =
+                latest_snapshot_for_sandbox(conversation, &sandbox.id).await?
+                && conversation
+                    .start_sandbox(StartSandboxRequest {
+                        id: sandbox.id.clone(),
+                        snapshot_id,
+                        idle_seconds: Some(sandbox.idle_seconds),
+                    })
+                    .await
+                    .is_ok()
+            {
+                return Ok(sandbox.id);
+            }
         }
     }
 
+    // Tier 3: nothing reusable; create fresh.
     conversation
         .create_sandbox(CreateSandboxRequest {
             image: desired_image,
@@ -149,6 +176,34 @@ pub(crate) async fn ensure_shell_sandbox(
             idle_seconds: Some(300),
         })
         .await
+}
+
+async fn latest_snapshot_for_sandbox(
+    conversation: &dyn ConversationHandle,
+    sandbox_id: &str,
+) -> Result<Option<SnapshotId>> {
+    let events = conversation
+        .get_events(Some(EventQuery {
+            cursor: None,
+            direction: Some(EventQueryDirection::Desc),
+            limit: Some(100),
+            session_id: None,
+            turn_id: None,
+            types: Some(vec![EventKind::SANDBOX_SNAPSHOTTED]),
+        }))
+        .await?
+        .events;
+    for event in events {
+        if let EventData::SandboxSnapshotted {
+            sandbox_id: sid,
+            snapshot_id,
+        } = event.data
+            && sid == sandbox_id
+        {
+            return Ok(Some(snapshot_id));
+        }
+    }
+    Ok(None)
 }
 
 fn normalize_mounts(mounts: &[FileSystemMount]) -> Vec<FileSystemMount> {

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -32,8 +32,9 @@ pub use executor_types::{
 };
 pub use exoharness::{
     AgentHandle, BasicExoHarness, BasicExoHarnessConfig, Binding, BindingMetadata,
-    ConversationHandle, EventData, EventId, EventKind, EventQuery, EventQueryDirection, ExoHarness,
-    FileSystemMount, FileSystemMountMode, ForkConversationRequest, PutSecretRequest,
+    ConversationHandle, DaytonaConfig, EventData, EventId, EventKind, EventQuery,
+    EventQueryDirection, ExoHarness, FileSystemMount, FileSystemMountMode, ForkConversationRequest,
+    PutSecretRequest,
     SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, SandboxId, Secret, SecretBackendChoice,
     SecretMetadata, SessionId, SnapshotId, StartSandboxRequest, Uuid7, first_matching_event,
 };

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -32,7 +32,7 @@ pub use executor_types::{
 };
 pub use exoharness::{
     AgentHandle, BasicExoHarness, BasicExoHarnessConfig, Binding, BindingMetadata,
-    ConversationHandle, DaytonaConfig, EventData, EventId, EventKind, EventQuery,
+    ConversationHandle, DaytonaConfig, E2bConfig, EventData, EventId, EventKind, EventQuery,
     EventQueryDirection, ExoHarness, FileSystemMount, FileSystemMountMode, ForkConversationRequest,
     PutSecretRequest, SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, SandboxId, Secret,
     SecretBackendChoice, SecretMetadata, SessionId, SnapshotId, StartSandboxRequest, Uuid7,

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -33,6 +33,7 @@ pub use executor_types::{
 pub use exoharness::{
     AgentHandle, BasicExoHarness, BasicExoHarnessConfig, Binding, BindingMetadata,
     ConversationHandle, DaytonaConfig, E2bConfig, EventData, EventId, EventKind, EventQuery,
+    SpritesConfig,
     EventQueryDirection, ExoHarness, FileSystemMount, FileSystemMountMode, ForkConversationRequest,
     PutSecretRequest, SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, SandboxId, Secret,
     SecretBackendChoice, SecretMetadata, SessionId, SnapshotId, StartSandboxRequest, Uuid7,

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -34,9 +34,9 @@ pub use exoharness::{
     AgentHandle, BasicExoHarness, BasicExoHarnessConfig, Binding, BindingMetadata,
     ConversationHandle, DaytonaConfig, EventData, EventId, EventKind, EventQuery,
     EventQueryDirection, ExoHarness, FileSystemMount, FileSystemMountMode, ForkConversationRequest,
-    PutSecretRequest,
-    SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, SandboxId, Secret, SecretBackendChoice,
-    SecretMetadata, SessionId, SnapshotId, StartSandboxRequest, Uuid7, first_matching_event,
+    PutSecretRequest, SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, SandboxId, Secret,
+    SecretBackendChoice, SecretMetadata, SessionId, SnapshotId, StartSandboxRequest, Uuid7,
+    first_matching_event,
 };
 pub use harness_basic::BasicHarness;
 pub use harness_config::load_agent_config;

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -35,7 +35,7 @@ pub use exoharness::{
     ConversationHandle, EventData, EventId, EventKind, EventQuery, EventQueryDirection, ExoHarness,
     FileSystemMount, FileSystemMountMode, ForkConversationRequest, PutSecretRequest,
     SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, SandboxId, Secret, SecretBackendChoice,
-    SecretMetadata, SessionId, SnapshotId, StartSandboxRequest, Uuid7,
+    SecretMetadata, SessionId, SnapshotId, StartSandboxRequest, Uuid7, first_matching_event,
 };
 pub use harness_basic::BasicHarness;
 pub use harness_config::load_agent_config;

--- a/crates/exoharness/Cargo.toml
+++ b/crates/exoharness/Cargo.toml
@@ -12,6 +12,7 @@ basic-backend = [
   "dep:keyring",
   "dep:keyring-core",
   "dep:object_store",
+  "dep:reqwest",
   "dep:tokio",
   "dep:tokio-stream",
   "dep:tokio-util",
@@ -28,6 +29,7 @@ keyring = { version = "4.0.0-rc.3", optional = true }
 keyring-core = { version = "0.7.2", optional = true }
 lingua.workspace = true
 object_store = { workspace = true, optional = true }
+reqwest = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/exoharness/Cargo.toml
+++ b/crates/exoharness/Cargo.toml
@@ -12,7 +12,9 @@ basic-backend = [
   "dep:keyring",
   "dep:keyring-core",
   "dep:object_store",
+  "dep:base64",
   "dep:reqwest",
+  "dep:url",
   "dep:tokio",
   "dep:tokio-stream",
   "dep:tokio-util",
@@ -21,6 +23,7 @@ basic-backend = [
 [dependencies]
 aes-gcm = { version = "0.11.0-rc.3", optional = true }
 anyhow.workspace = true
+base64 = { workspace = true, optional = true }
 async-trait.workspace = true
 bytes.workspace = true
 chrono.workspace = true
@@ -30,6 +33,7 @@ keyring-core = { version = "0.7.2", optional = true }
 lingua.workspace = true
 object_store = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
+url = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex as AsyncMutex, mpsc};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
+use crate::daytona::DaytonaSandboxBackend;
 use crate::sandbox::{
     CliContainerSandboxBackend, LocalProcessSandboxBackend, ManagedSandboxBackend,
     ManagedSandboxHandle, SANDBOX_MAIN_MOUNT_DIR, SandboxCommand, SandboxKey,
@@ -43,11 +44,12 @@ pub enum SecretBackendChoice {
     Static([u8; 32]),
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub enum SandboxBackendChoice {
     AppleContainer,
     Docker,
     LocalProcess,
+    Daytona(crate::DaytonaConfig),
 }
 
 // TODO: as more knobs land here, swap to a builder pattern.
@@ -82,7 +84,7 @@ impl BasicExoHarness {
         let storage = BasicObjectStore::local_filesystem(&root).await?;
         let secret_cipher =
             build_secret_cipher(secret_backend, root.to_string_lossy().to_string())?;
-        let sandbox_backend = build_sandbox_backend(sandbox_backend);
+        let sandbox_backend = build_sandbox_backend(sandbox_backend)?;
         Ok(Self {
             inner: Arc::new(BasicExoHarnessInner {
                 storage,
@@ -1977,12 +1979,14 @@ fn build_secret_cipher(
     Ok(SecretCipher::new(provider))
 }
 
-fn build_sandbox_backend(choice: SandboxBackendChoice) -> Arc<dyn ManagedSandboxBackend> {
-    match choice {
+fn build_sandbox_backend(choice: SandboxBackendChoice) -> Result<Arc<dyn ManagedSandboxBackend>> {
+    let backend: Arc<dyn ManagedSandboxBackend> = match choice {
         SandboxBackendChoice::AppleContainer => {
             Arc::new(CliContainerSandboxBackend::apple_container())
         }
         SandboxBackendChoice::Docker => Arc::new(CliContainerSandboxBackend::docker()),
         SandboxBackendChoice::LocalProcess => Arc::new(LocalProcessSandboxBackend::new()),
-    }
+        SandboxBackendChoice::Daytona(config) => Arc::new(DaytonaSandboxBackend::new(config)?),
+    };
+    Ok(backend)
 }

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -1122,15 +1122,49 @@ impl ConversationHandle for BasicConversationHandle {
         if request.command.is_empty() {
             bail!("sandbox command must not be empty");
         }
-        let sandbox_handle = self
-            .harness
-            .inner
-            .running_sandboxes
-            .lock()
-            .await
-            .get(&request.id)
-            .cloned()
-            .ok_or_else(|| anyhow!("sandbox is not active in this process: {}", request.id))?;
+        let sandbox_handle = {
+            let cached = self
+                .harness
+                .inner
+                .running_sandboxes
+                .lock()
+                .await
+                .get(&request.id)
+                .cloned();
+            match cached {
+                Some(handle) => handle,
+                None => {
+                    // The handle isn't in this process's in-memory pool. That's
+                    // expected on the first tool call after exo starts up: the
+                    // conversation remembered the sandbox_id from a prior
+                    // process, but we haven't bound a handle to it yet. Ask the
+                    // backend to resume by SandboxKey — that's the moment the
+                    // cross-process resume contract actually triggers.
+                    let req =
+                        sandbox_request(self.record.id, &request.id, &sandbox);
+                    let Some(handle) = self
+                        .harness
+                        .inner
+                        .sandbox_backend
+                        .try_resume(req)
+                        .await?
+                    else {
+                        bail!(
+                            "sandbox {} no longer exists on the backend; \
+                             create a new one or restore from a snapshot",
+                            request.id
+                        );
+                    };
+                    self.harness
+                        .inner
+                        .running_sandboxes
+                        .lock()
+                        .await
+                        .insert(request.id.clone(), Arc::clone(&handle));
+                    handle
+                }
+            }
+        };
         let parts = sandbox_handle
             .start_process(&SandboxCommand {
                 argv: request.command.clone(),

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -15,6 +15,7 @@ use tokio::sync::{Mutex as AsyncMutex, mpsc};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use crate::daytona::DaytonaSandboxBackend;
+use crate::e2b::E2bSandboxBackend;
 use crate::sandbox::{
     CliContainerSandboxBackend, LocalProcessSandboxBackend, ManagedSandboxBackend,
     ManagedSandboxHandle, SANDBOX_MAIN_MOUNT_DIR, SandboxCommand, SandboxKey,
@@ -50,6 +51,7 @@ pub enum SandboxBackendChoice {
     Docker,
     LocalProcess,
     Daytona(crate::DaytonaConfig),
+    E2b(crate::E2bConfig),
 }
 
 // TODO: as more knobs land here, swap to a builder pattern.
@@ -1987,6 +1989,7 @@ fn build_sandbox_backend(choice: SandboxBackendChoice) -> Result<Arc<dyn Managed
         SandboxBackendChoice::Docker => Arc::new(CliContainerSandboxBackend::docker()),
         SandboxBackendChoice::LocalProcess => Arc::new(LocalProcessSandboxBackend::new()),
         SandboxBackendChoice::Daytona(config) => Arc::new(DaytonaSandboxBackend::new(config)?),
+        SandboxBackendChoice::E2b(config) => Arc::new(E2bSandboxBackend::new(config)?),
     };
     Ok(backend)
 }

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -16,6 +16,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use crate::daytona::DaytonaSandboxBackend;
 use crate::e2b::E2bSandboxBackend;
+use crate::sprites::SpritesSandboxBackend;
 use crate::sandbox::{
     CliContainerSandboxBackend, LocalProcessSandboxBackend, ManagedSandboxBackend,
     ManagedSandboxHandle, SANDBOX_MAIN_MOUNT_DIR, SandboxCommand, SandboxKey,
@@ -52,6 +53,7 @@ pub enum SandboxBackendChoice {
     LocalProcess,
     Daytona(crate::DaytonaConfig),
     E2b(crate::E2bConfig),
+    Sprites(crate::SpritesConfig),
 }
 
 // TODO: as more knobs land here, swap to a builder pattern.
@@ -1990,6 +1992,7 @@ fn build_sandbox_backend(choice: SandboxBackendChoice) -> Result<Arc<dyn Managed
         SandboxBackendChoice::LocalProcess => Arc::new(LocalProcessSandboxBackend::new()),
         SandboxBackendChoice::Daytona(config) => Arc::new(DaytonaSandboxBackend::new(config)?),
         SandboxBackendChoice::E2b(config) => Arc::new(E2bSandboxBackend::new(config)?),
+        SandboxBackendChoice::Sprites(config) => Arc::new(SpritesSandboxBackend::new(config)?),
     };
     Ok(backend)
 }

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -1140,14 +1140,8 @@ impl ConversationHandle for BasicConversationHandle {
                     // process, but we haven't bound a handle to it yet. Ask the
                     // backend to resume by SandboxKey — that's the moment the
                     // cross-process resume contract actually triggers.
-                    let req =
-                        sandbox_request(self.record.id, &request.id, &sandbox);
-                    let Some(handle) = self
-                        .harness
-                        .inner
-                        .sandbox_backend
-                        .try_resume(req)
-                        .await?
+                    let req = sandbox_request(self.record.id, &request.id, &sandbox);
+                    let Some(handle) = self.harness.inner.sandbox_backend.try_resume(req).await?
                     else {
                         bail!(
                             "sandbox {} no longer exists on the backend; \

--- a/crates/exoharness/src/daytona.rs
+++ b/crates/exoharness/src/daytona.rs
@@ -1,0 +1,610 @@
+//! Daytona remote-container sandbox backend.
+//!
+//! Speaks Daytona's REST API directly via `reqwest`. State persistence is
+//! handled by Daytona itself: `stop` preserves the sandbox filesystem and the
+//! next `acquire` finds the same sandbox by label and `start`s it. Explicit
+//! `/snapshot` and `/rewind` go through [`SnapshotKind::DaytonaSnapshot`]
+//! payloads whose bytes are a small JSON manifest pointing at a named snapshot
+//! in Daytona's registry.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow, bail};
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::future::BoxFuture;
+use futures::io::Cursor;
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::sandbox::{
+    DEFAULT_SANDBOX_IMAGE, ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand,
+    SandboxCommandOutput, SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotKind,
+    SnapshotPayload, WARM_SANDBOX_KEY_LABEL, WARM_SANDBOX_SPEC_HASH_LABEL, sandbox_spec_hash,
+};
+
+pub const DEFAULT_DAYTONA_API_URL: &str = "https://app.daytona.io/api";
+
+/// Per-sandbox operations (exec, fs) go through Daytona's toolbox proxy rather
+/// than the control-plane API. The two have different base hosts.
+pub const DEFAULT_DAYTONA_TOOLBOX_URL: &str = "https://proxy.app.daytona.io";
+
+#[derive(Debug, Clone)]
+pub struct DaytonaConfig {
+    pub api_key: String,
+    pub api_url: String,
+    pub toolbox_url: String,
+    /// Optional region target (`eu` / `us`). Passed through to Daytona on
+    /// sandbox creation when set.
+    pub target: Option<String>,
+    /// Organization ID to scope requests to. Sent as the
+    /// `X-Daytona-Organization-ID` header. API keys can belong to multiple
+    /// organizations; without this, Daytona may default to a "personal" org
+    /// that isn't the one with credit / the one the user expects.
+    pub organization_id: Option<String>,
+}
+
+impl DaytonaConfig {
+    pub fn from_env() -> Result<Self> {
+        let api_key = std::env::var("DAYTONA_API_KEY")
+            .map_err(|_| anyhow!("DAYTONA_API_KEY is not set; required for the Daytona sandbox backend"))?;
+        let api_url =
+            std::env::var("DAYTONA_API_URL").unwrap_or_else(|_| DEFAULT_DAYTONA_API_URL.to_string());
+        let toolbox_url = std::env::var("DAYTONA_TOOLBOX_URL")
+            .unwrap_or_else(|_| DEFAULT_DAYTONA_TOOLBOX_URL.to_string());
+        let target = std::env::var("DAYTONA_TARGET").ok();
+        let organization_id = std::env::var("DAYTONA_ORGANIZATION_ID").ok();
+        Ok(Self {
+            api_key,
+            api_url,
+            toolbox_url,
+            target,
+            organization_id,
+        })
+    }
+}
+
+/// JSON payload persisted alongside a `SnapshotKind::DaytonaSnapshot`. The
+/// canonical filesystem bytes live in Daytona — we only persist enough
+/// metadata to ask Daytona to create a sandbox from the same snapshot later.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DaytonaSnapshotManifest {
+    /// Name of the snapshot in Daytona's snapshot registry.
+    snapshot_name: String,
+    /// Image the snapshotted sandbox was originally created from. Used as a
+    /// fallback if the snapshot itself doesn't carry enough info to recreate.
+    base_image: String,
+}
+
+pub struct DaytonaSandboxBackend {
+    client: reqwest::Client,
+    api_url: String,
+    toolbox_url: String,
+    target: Option<String>,
+}
+
+impl DaytonaSandboxBackend {
+    pub fn new(config: DaytonaConfig) -> Result<Self> {
+        let mut headers = HeaderMap::new();
+        let mut auth = HeaderValue::from_str(&format!("Bearer {}", config.api_key))
+            .context("DAYTONA_API_KEY contains characters that aren't valid in an HTTP header")?;
+        auth.set_sensitive(true);
+        headers.insert(AUTHORIZATION, auth);
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        if let Some(org_id) = config.organization_id.as_deref() {
+            let value = HeaderValue::from_str(org_id).context(
+                "DAYTONA_ORGANIZATION_ID contains characters that aren't valid in an HTTP header",
+            )?;
+            headers.insert("X-Daytona-Organization-ID", value);
+        }
+        let client = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()
+            .context("building Daytona HTTP client")?;
+        Ok(Self {
+            client,
+            api_url: config.api_url.trim_end_matches('/').to_string(),
+            toolbox_url: config.toolbox_url.trim_end_matches('/').to_string(),
+            target: config.target,
+        })
+    }
+
+    fn api_endpoint(&self, path: &str) -> String {
+        format!("{}{}", self.api_url, path)
+    }
+
+    fn toolbox_endpoint(&self, path: &str) -> String {
+        format!("{}{}", self.toolbox_url, path)
+    }
+
+    async fn find_sandbox_by_labels(
+        &self,
+        key_label: &str,
+        spec_hash: &str,
+    ) -> Result<Option<DaytonaSandbox>> {
+        // Daytona expects `labels` as a single query parameter whose value is a
+        // JSON-encoded object. Both label keys go into the same object so a
+        // spec change yields a fresh sandbox (matching the CLI backend's
+        // "evict on spec change" semantics).
+        let labels_filter = serde_json::json!({
+            WARM_SANDBOX_KEY_LABEL: key_label,
+            WARM_SANDBOX_SPEC_HASH_LABEL: spec_hash,
+        });
+        let response = self
+            .client
+            .get(self.api_endpoint("/sandbox"))
+            .query(&[("labels", labels_filter.to_string())])
+            .send()
+            .await
+            .context("listing Daytona sandboxes")?
+            .error_for_status()
+            .context("Daytona list sandboxes returned an error status")?;
+        let list: DaytonaSandboxList = response
+            .json()
+            .await
+            .context("decoding Daytona sandbox list response")?;
+        let mut sandboxes = list.items;
+        // If Daytona returned more than one match (e.g. concurrent creates),
+        // keep the most recent and let the rest age out via auto-stop /
+        // auto-archive. The prototype doesn't try to GC duplicates.
+        sandboxes.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(sandboxes.into_iter().next())
+    }
+
+    async fn create_sandbox(
+        &self,
+        request: &SandboxRequest,
+        spec_hash: &str,
+        snapshot_name: Option<&str>,
+    ) -> Result<DaytonaSandbox> {
+        let mut labels = HashMap::new();
+        labels.insert(WARM_SANDBOX_KEY_LABEL.to_string(), request.key.to_string());
+        labels.insert(WARM_SANDBOX_SPEC_HASH_LABEL.to_string(), spec_hash.to_string());
+
+        let auto_stop_minutes = request
+            .lifecycle
+            .idle_ttl
+            .map(|ttl| idle_ttl_to_minutes(ttl))
+            // 0 disables auto-stop in Daytona; we don't want that — pick a
+            // conservative default that matches Daytona's own (15 min).
+            .unwrap_or(15);
+
+        // `snapshot` on Daytona refers to a named, pre-registered snapshot in
+        // the user's account — not an arbitrary docker image ref. For fresh
+        // creates we omit it so Daytona falls back to its default base image;
+        // only the snapshot-restore path passes a name through. Honouring
+        // `spec.image` against Daytona would require registering it as a
+        // Daytona snapshot first; that's a follow-up.
+        let body = DaytonaCreateRequest {
+            snapshot: snapshot_name.map(str::to_string),
+            target: self.target.clone(),
+            labels,
+            env: HashMap::new(),
+            auto_stop_interval: auto_stop_minutes,
+            // Daytona's default auto-archive is one week; leave it alone.
+            network_block_all: matches!(request.spec.network, SandboxNetworkPolicy::Disabled),
+        };
+
+        let response = self
+            .client
+            .post(self.api_endpoint("/sandbox"))
+            .json(&body)
+            .send()
+            .await
+            .context("creating Daytona sandbox")?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            bail!("Daytona create-sandbox failed ({status}): {text}");
+        }
+        let sandbox: DaytonaSandbox = response
+            .json()
+            .await
+            .context("decoding Daytona create-sandbox response")?;
+        Ok(sandbox)
+    }
+
+    async fn start_sandbox(&self, id: &str) -> Result<()> {
+        let response = self
+            .client
+            .post(self.api_endpoint(&format!("/sandbox/{id}/start")))
+            .send()
+            .await
+            .with_context(|| format!("starting Daytona sandbox {id}"))?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            bail!("Daytona start-sandbox failed ({status}): {text}");
+        }
+        Ok(())
+    }
+
+}
+
+#[async_trait]
+impl ManagedSandboxBackend for DaytonaSandboxBackend {
+    async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
+        reject_host_mounts(&request)?;
+        let spec_hash = sandbox_spec_hash(&request.spec);
+        // `acquire` is "create fresh." The harness calls `try_resume` first
+        // when it wants to reuse an existing sandbox; once we're in `acquire`
+        // the contract is to mint a new one. Daytona's label-based lookup of
+        // existing sandboxes lives in `try_resume`.
+        let sandbox = self.create_sandbox(&request, &spec_hash, None).await?;
+        Ok(Arc::new(DaytonaSandboxHandle {
+            id: format!("daytona:{}", request.key),
+            sandbox_id: sandbox.id,
+            request,
+            backend: self.handle_backend()?,
+        }))
+    }
+
+    async fn try_resume(
+        &self,
+        request: SandboxRequest,
+    ) -> Result<Option<Arc<dyn ManagedSandboxHandle>>> {
+        reject_host_mounts(&request)?;
+        let spec_hash = sandbox_spec_hash(&request.spec);
+        let key_label = request.key.to_string();
+
+        let Some(existing) = self.find_sandbox_by_labels(&key_label, &spec_hash).await? else {
+            return Ok(None);
+        };
+        // Daytona preserves filesystem state across stop/start, so a
+        // labelled sandbox we find here always carries the previous
+        // session's writes. Start it if the auto-stop timer has fired.
+        if !existing.is_running() {
+            self.start_sandbox(&existing.id).await?;
+        }
+        Ok(Some(Arc::new(DaytonaSandboxHandle {
+            id: format!("daytona:{}", request.key),
+            sandbox_id: existing.id,
+            request,
+            backend: self.handle_backend()?,
+        })))
+    }
+
+    async fn acquire_from_snapshot(
+        &self,
+        request: SandboxRequest,
+        payload: SnapshotPayload,
+    ) -> Result<Arc<dyn ManagedSandboxHandle>> {
+        reject_host_mounts(&request)?;
+        if !matches!(payload.kind, SnapshotKind::DaytonaSnapshot) {
+            bail!(
+                "Daytona sandbox backend can only restore from SnapshotKind::DaytonaSnapshot, \
+                 got {:?}",
+                payload.kind
+            );
+        }
+        let manifest: DaytonaSnapshotManifest = serde_json::from_slice(&payload.bytes)
+            .context("decoding DaytonaSnapshot manifest")?;
+        let spec_hash = sandbox_spec_hash(&request.spec);
+        let sandbox = self
+            .create_sandbox(&request, &spec_hash, Some(&manifest.snapshot_name))
+            .await?;
+        Ok(Arc::new(DaytonaSandboxHandle {
+            id: format!("daytona-restored:{}", request.key),
+            sandbox_id: sandbox.id,
+            request,
+            backend: self.handle_backend()?,
+        }))
+    }
+}
+
+impl DaytonaSandboxBackend {
+    /// Clone the backend's HTTP state into a value the handle can hold. We
+    /// can't hand out `Arc<Self>` from `&self` without making the backend's
+    /// internals `Arc`-shared at construction; instead the handle holds its
+    /// own clone of the (cheap) client + URL + target.
+    fn handle_backend(&self) -> Result<DaytonaBackendHandle> {
+        Ok(DaytonaBackendHandle {
+            client: self.client.clone(),
+            api_url: self.api_url.clone(),
+            toolbox_url: self.toolbox_url.clone(),
+            target: self.target.clone(),
+        })
+    }
+}
+
+#[derive(Clone)]
+struct DaytonaBackendHandle {
+    client: reqwest::Client,
+    api_url: String,
+    toolbox_url: String,
+    #[allow(dead_code)] // available for future per-handle operations that re-target.
+    target: Option<String>,
+}
+
+impl DaytonaBackendHandle {
+    fn api_endpoint(&self, path: &str) -> String {
+        format!("{}{}", self.api_url, path)
+    }
+
+    fn toolbox_endpoint(&self, path: &str) -> String {
+        format!("{}{}", self.toolbox_url, path)
+    }
+}
+
+struct DaytonaSandboxHandle {
+    id: String,
+    sandbox_id: String,
+    request: SandboxRequest,
+    backend: DaytonaBackendHandle,
+}
+
+#[async_trait]
+impl ManagedSandboxHandle for DaytonaSandboxHandle {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    async fn exec(&self, command: &SandboxCommand) -> Result<SandboxCommandOutput> {
+        // Delegate to a free function so the backend struct doesn't need to
+        // be re-borrowed; the handle owns everything it needs.
+        exec_in_sandbox(&self.backend, &self.sandbox_id, &self.request.spec, command).await
+    }
+
+    async fn start_process(&self, command: &SandboxCommand) -> Result<crate::SandboxProcessParts> {
+        // Daytona's exec endpoint is request/response, not streaming. Run the
+        // command synchronously, then hand the caller a SandboxProcessParts
+        // whose stdout/stderr/wait are already populated. stdin goes to a
+        // sink — Daytona's exec doesn't accept piped input on this endpoint.
+        let output = exec_in_sandbox(
+            &self.backend,
+            &self.sandbox_id,
+            &self.request.spec,
+            command,
+        )
+        .await?;
+        let exit_code = output.exit_code.unwrap_or(0);
+        let stdout = Cursor::new(output.stdout.into_bytes());
+        let stderr = Cursor::new(output.stderr.into_bytes());
+        let stdin = futures::io::sink();
+        let wait: BoxFuture<'static, crate::Result<i32>> =
+            Box::pin(async move { Ok(exit_code) });
+        Ok(crate::SandboxProcessParts {
+            stdout: Box::pin(stdout),
+            stderr: Box::pin(stderr),
+            stdin: Box::pin(stdin),
+            wait,
+        })
+    }
+
+    async fn stop(&self) -> Result<()> {
+        // Stop, do NOT delete. Daytona preserves filesystem state across stop;
+        // the next acquire() for the same SandboxKey will find this sandbox by
+        // label and start() it back up. Auto-archive / auto-delete on the
+        // Daytona side eventually GCs sandboxes nobody comes back for.
+        stop_via_backend(&self.backend, &self.sandbox_id).await
+    }
+
+    async fn snapshot(&self) -> Result<SnapshotPayload> {
+        save_as_snapshot_via_backend(
+            &self.backend,
+            &self.sandbox_id,
+            resolve_image(&self.request.spec),
+        )
+        .await
+    }
+}
+
+async fn exec_in_sandbox(
+    backend: &DaytonaBackendHandle,
+    id: &str,
+    spec: &SandboxSpec,
+    command: &SandboxCommand,
+) -> Result<SandboxCommandOutput> {
+    if command.argv.is_empty() {
+        bail!("sandbox command requires at least one argv entry");
+    }
+    let cwd = command
+        .cwd
+        .clone()
+        .unwrap_or_else(|| spec.default_workdir.clone());
+    let body = DaytonaExecRequest {
+        command: render_shell_command(&command.argv),
+        cwd: Some(cwd.clone()),
+        env: command.env.clone(),
+        timeout: command.timeout.map(|t| t.as_secs()),
+    };
+    let response = backend
+        .client
+        .post(backend.toolbox_endpoint(&format!("/toolbox/{id}/process/execute")))
+        .json(&body)
+        .send()
+        .await
+        .with_context(|| format!("exec in Daytona sandbox {id}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        let text = response.text().await.unwrap_or_default();
+        bail!("Daytona exec failed ({status}): {text}");
+    }
+    let response: DaytonaExecResponse = response
+        .json()
+        .await
+        .context("decoding Daytona exec response")?;
+    Ok(SandboxCommandOutput {
+        ok: response.exit_code == 0,
+        exit_code: Some(response.exit_code),
+        stdout: response.result.unwrap_or_default(),
+        stderr: String::new(),
+        command: command
+            .display_argv
+            .clone()
+            .unwrap_or_else(|| command.argv.clone()),
+        cwd,
+    })
+}
+
+async fn stop_via_backend(backend: &DaytonaBackendHandle, id: &str) -> Result<()> {
+    let response = backend
+        .client
+        .post(backend.api_endpoint(&format!("/sandbox/{id}/stop")))
+        .send()
+        .await
+        .with_context(|| format!("stopping Daytona sandbox {id}"))?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        bail!("Daytona stop-sandbox failed ({status}): {text}");
+    }
+    Ok(())
+}
+
+async fn save_as_snapshot_via_backend(
+    backend: &DaytonaBackendHandle,
+    id: &str,
+    base_image: String,
+) -> Result<SnapshotPayload> {
+    let snapshot_name = format!("exo-snap-{}", Uuid::new_v4().simple());
+    let body = DaytonaSnapshotRequest {
+        name: snapshot_name.clone(),
+    };
+    let response = backend
+        .client
+        .post(backend.api_endpoint(&format!("/sandbox/{id}/snapshot")))
+        .json(&body)
+        .send()
+        .await
+        .with_context(|| format!("snapshotting Daytona sandbox {id}"))?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        bail!("Daytona snapshot failed ({status}): {text}");
+    }
+    let manifest = DaytonaSnapshotManifest {
+        snapshot_name,
+        base_image,
+    };
+    let bytes = serde_json::to_vec(&manifest)
+        .context("serializing Daytona snapshot manifest")?;
+    Ok(SnapshotPayload {
+        kind: SnapshotKind::DaytonaSnapshot,
+        bytes: Bytes::from(bytes),
+    })
+}
+
+fn reject_host_mounts(request: &SandboxRequest) -> Result<()> {
+    if request.spec.mounts.is_empty() {
+        return Ok(());
+    }
+    bail!(
+        "Daytona sandbox backend does not support host bind-mounts; \
+         remove conversation mounts or switch to --sandbox-backend docker. \
+         A remote-workspace provisioner (git clone / Daytona Volume) is planned as a follow-up."
+    )
+}
+
+fn resolve_image(spec: &SandboxSpec) -> String {
+    if spec.image.trim().is_empty() {
+        DEFAULT_SANDBOX_IMAGE.to_string()
+    } else {
+        spec.image.clone()
+    }
+}
+
+fn idle_ttl_to_minutes(ttl: Duration) -> u32 {
+    // Daytona auto-stop is in minutes with 0 meaning "disabled". Round up
+    // so we never expire earlier than the caller asked for, and floor at 1
+    // so the smallest meaningful TTL still produces an active timer.
+    let secs = ttl.as_secs();
+    let minutes = secs.div_ceil(60);
+    minutes.clamp(1, u32::MAX as u64) as u32
+}
+
+fn render_shell_command(argv: &[String]) -> String {
+    // Daytona's execute endpoint takes a single command string interpreted by
+    // a shell. Quote each argv element so spaces / metacharacters survive.
+    argv.iter()
+        .map(|arg| shell_quote(arg))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn shell_quote(arg: &str) -> String {
+    if !arg.is_empty()
+        && arg
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | '/' | ':' | '=' | ','))
+    {
+        return arg.to_string();
+    }
+    let mut quoted = String::with_capacity(arg.len() + 2);
+    quoted.push('\'');
+    for c in arg.chars() {
+        if c == '\'' {
+            quoted.push_str("'\\''");
+        } else {
+            quoted.push(c);
+        }
+    }
+    quoted.push('\'');
+    quoted
+}
+
+#[derive(Debug, Serialize)]
+struct DaytonaCreateRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    snapshot: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target: Option<String>,
+    labels: HashMap<String, String>,
+    env: HashMap<String, String>,
+    #[serde(rename = "autoStopInterval")]
+    auto_stop_interval: u32,
+    #[serde(rename = "networkBlockAll")]
+    network_block_all: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct DaytonaExecRequest {
+    command: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cwd: Option<String>,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    env: HashMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    timeout: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DaytonaExecResponse {
+    #[serde(rename = "exitCode", alias = "exit_code")]
+    exit_code: i32,
+    #[serde(default)]
+    result: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct DaytonaSnapshotRequest {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DaytonaSandboxList {
+    #[serde(default)]
+    items: Vec<DaytonaSandbox>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DaytonaSandbox {
+    id: String,
+    state: String,
+    #[serde(default, rename = "createdAt", alias = "created_at")]
+    created_at: Option<String>,
+}
+
+impl DaytonaSandbox {
+    fn is_running(&self) -> bool {
+        // Daytona's state strings vary by API version; treat anything that
+        // looks like an active state as running, and anything else as
+        // requiring a `start` call. The conservative call is "if I'm not sure
+        // it's running, ask Daytona to start it" — `start` is a no-op on an
+        // already-running sandbox.
+        matches!(self.state.as_str(), "started" | "running")
+    }
+}

--- a/crates/exoharness/src/daytona.rs
+++ b/crates/exoharness/src/daytona.rs
@@ -49,10 +49,11 @@ pub struct DaytonaConfig {
 
 impl DaytonaConfig {
     pub fn from_env() -> Result<Self> {
-        let api_key = std::env::var("DAYTONA_API_KEY")
-            .map_err(|_| anyhow!("DAYTONA_API_KEY is not set; required for the Daytona sandbox backend"))?;
-        let api_url =
-            std::env::var("DAYTONA_API_URL").unwrap_or_else(|_| DEFAULT_DAYTONA_API_URL.to_string());
+        let api_key = std::env::var("DAYTONA_API_KEY").map_err(|_| {
+            anyhow!("DAYTONA_API_KEY is not set; required for the Daytona sandbox backend")
+        })?;
+        let api_url = std::env::var("DAYTONA_API_URL")
+            .unwrap_or_else(|_| DEFAULT_DAYTONA_API_URL.to_string());
         let toolbox_url = std::env::var("DAYTONA_TOOLBOX_URL")
             .unwrap_or_else(|_| DEFAULT_DAYTONA_TOOLBOX_URL.to_string());
         let target = std::env::var("DAYTONA_TARGET").ok();
@@ -116,10 +117,6 @@ impl DaytonaSandboxBackend {
         format!("{}{}", self.api_url, path)
     }
 
-    fn toolbox_endpoint(&self, path: &str) -> String {
-        format!("{}{}", self.toolbox_url, path)
-    }
-
     async fn find_sandbox_by_labels(
         &self,
         key_label: &str,
@@ -162,12 +159,15 @@ impl DaytonaSandboxBackend {
     ) -> Result<DaytonaSandbox> {
         let mut labels = HashMap::new();
         labels.insert(WARM_SANDBOX_KEY_LABEL.to_string(), request.key.to_string());
-        labels.insert(WARM_SANDBOX_SPEC_HASH_LABEL.to_string(), spec_hash.to_string());
+        labels.insert(
+            WARM_SANDBOX_SPEC_HASH_LABEL.to_string(),
+            spec_hash.to_string(),
+        );
 
         let auto_stop_minutes = request
             .lifecycle
             .idle_ttl
-            .map(|ttl| idle_ttl_to_minutes(ttl))
+            .map(idle_ttl_to_minutes)
             // 0 disables auto-stop in Daytona; we don't want that — pick a
             // conservative default that matches Daytona's own (15 min).
             .unwrap_or(15);
@@ -221,7 +221,6 @@ impl DaytonaSandboxBackend {
         }
         Ok(())
     }
-
 }
 
 #[async_trait]
@@ -280,8 +279,8 @@ impl ManagedSandboxBackend for DaytonaSandboxBackend {
                 payload.kind
             );
         }
-        let manifest: DaytonaSnapshotManifest = serde_json::from_slice(&payload.bytes)
-            .context("decoding DaytonaSnapshot manifest")?;
+        let manifest: DaytonaSnapshotManifest =
+            serde_json::from_slice(&payload.bytes).context("decoding DaytonaSnapshot manifest")?;
         let spec_hash = sandbox_spec_hash(&request.spec);
         let sandbox = self
             .create_sandbox(&request, &spec_hash, Some(&manifest.snapshot_name))
@@ -353,19 +352,13 @@ impl ManagedSandboxHandle for DaytonaSandboxHandle {
         // command synchronously, then hand the caller a SandboxProcessParts
         // whose stdout/stderr/wait are already populated. stdin goes to a
         // sink — Daytona's exec doesn't accept piped input on this endpoint.
-        let output = exec_in_sandbox(
-            &self.backend,
-            &self.sandbox_id,
-            &self.request.spec,
-            command,
-        )
-        .await?;
+        let output =
+            exec_in_sandbox(&self.backend, &self.sandbox_id, &self.request.spec, command).await?;
         let exit_code = output.exit_code.unwrap_or(0);
         let stdout = Cursor::new(output.stdout.into_bytes());
         let stderr = Cursor::new(output.stderr.into_bytes());
         let stdin = futures::io::sink();
-        let wait: BoxFuture<'static, crate::Result<i32>> =
-            Box::pin(async move { Ok(exit_code) });
+        let wait: BoxFuture<'static, crate::Result<i32>> = Box::pin(async move { Ok(exit_code) });
         Ok(crate::SandboxProcessParts {
             stdout: Box::pin(stdout),
             stderr: Box::pin(stderr),
@@ -480,8 +473,7 @@ async fn save_as_snapshot_via_backend(
         snapshot_name,
         base_image,
     };
-    let bytes = serde_json::to_vec(&manifest)
-        .context("serializing Daytona snapshot manifest")?;
+    let bytes = serde_json::to_vec(&manifest).context("serializing Daytona snapshot manifest")?;
     Ok(SnapshotPayload {
         kind: SnapshotKind::DaytonaSnapshot,
         bytes: Bytes::from(bytes),
@@ -527,9 +519,9 @@ fn render_shell_command(argv: &[String]) -> String {
 
 fn shell_quote(arg: &str) -> String {
     if !arg.is_empty()
-        && arg
-            .chars()
-            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | '/' | ':' | '=' | ','))
+        && arg.chars().all(|c| {
+            c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | '/' | ':' | '=' | ',')
+        })
     {
         return arg.to_string();
     }

--- a/crates/exoharness/src/e2b.rs
+++ b/crates/exoharness/src/e2b.rs
@@ -1,0 +1,757 @@
+//! E2B remote sandbox backend.
+//!
+//! Uses E2B's platform REST API (`api.e2b.app`) for lifecycle and the per-sandbox
+//! envd Connect API for command execution. Cross-process resume uses sandbox
+//! `metadata` (same keys as Docker/Daytona labels). Snapshots are bytes-by-reference
+//! via [`SnapshotKind::E2bSnapshot`] manifests pointing at an E2B snapshot template id.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow, bail};
+use async_trait::async_trait;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use bytes::Bytes;
+use futures::future::BoxFuture;
+use futures::io::Cursor;
+use reqwest::header::{HeaderMap, HeaderValue};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::sandbox::{
+    DEFAULT_SANDBOX_IMAGE, ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand,
+    SandboxCommandOutput, SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotKind,
+    SnapshotPayload, WARM_SANDBOX_KEY_LABEL, WARM_SANDBOX_SPEC_HASH_LABEL, sandbox_spec_hash,
+};
+
+pub const DEFAULT_E2B_API_URL: &str = "https://api.e2b.app";
+pub const DEFAULT_E2B_ENVD_PORT: u16 = 49_983;
+
+/// Connect envelope flag: payload is gzip-compressed (unsupported here).
+const CONNECT_FLAG_COMPRESSED: u8 = 0x01;
+/// Connect envelope flag: final message carrying stream status / errors.
+const CONNECT_FLAG_END_STREAM: u8 = 0x02;
+const CONNECT_MAX_ENVELOPE_BYTES: usize = 16 * 1024 * 1024;
+
+#[derive(Debug, Clone)]
+pub struct E2bConfig {
+    pub api_key: String,
+    pub api_url: String,
+    pub template_id: String,
+    pub envd_port: u16,
+    /// When set (tests), envd requests go to this base URL instead of `{port}-{sandboxID}.e2b.app`.
+    pub envd_base_url: Option<String>,
+    /// When false, envd endpoints do not require `X-Access-Token` (E2B default for SDK is true).
+    pub secure: bool,
+}
+
+impl E2bConfig {
+    pub fn from_env() -> Result<Self> {
+        let api_key = std::env::var("E2B_API_KEY").map_err(|_| {
+            anyhow!("E2B_API_KEY is not set; required for the E2B sandbox backend")
+        })?;
+        let api_url =
+            std::env::var("E2B_API_URL").unwrap_or_else(|_| DEFAULT_E2B_API_URL.to_string());
+        let template_id = std::env::var("E2B_TEMPLATE_ID").unwrap_or_else(|_| "base".into());
+        let envd_port = std::env::var("E2B_ENVD_PORT")
+            .ok()
+            .and_then(|raw| raw.parse().ok())
+            .unwrap_or(DEFAULT_E2B_ENVD_PORT);
+        let secure = std::env::var("E2B_SECURE")
+            .ok()
+            .map(|raw| matches!(raw.as_str(), "1" | "true" | "yes"))
+            .unwrap_or(false);
+        let envd_base_url = std::env::var("E2B_ENVD_BASE_URL").ok();
+        Ok(Self {
+            api_key,
+            api_url,
+            template_id,
+            envd_port,
+            envd_base_url,
+            secure,
+        })
+    }
+}
+
+/// JSON persisted for [`SnapshotKind::E2bSnapshot`]. Filesystem state lives in E2B;
+/// we only store the snapshot template id returned by `POST /sandboxes/{id}/snapshots`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct E2bSnapshotManifest {
+    snapshot_id: String,
+    base_template: String,
+}
+
+pub struct E2bSandboxBackend {
+    client: reqwest::Client,
+    api_url: String,
+    template_id: String,
+    envd_port: u16,
+    envd_base_url: Option<String>,
+    secure: bool,
+}
+
+impl E2bSandboxBackend {
+    pub fn new(config: E2bConfig) -> Result<Self> {
+        let mut headers = HeaderMap::new();
+        let api_key = HeaderValue::from_str(&config.api_key)
+            .context("E2B_API_KEY contains characters that aren't valid in an HTTP header")?;
+        headers.insert("X-API-Key", api_key);
+        let client = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()
+            .context("building E2B HTTP client")?;
+        Ok(Self {
+            client,
+            api_url: config.api_url.trim_end_matches('/').to_string(),
+            template_id: config.template_id,
+            envd_port: config.envd_port,
+            envd_base_url: config.envd_base_url,
+            secure: config.secure,
+        })
+    }
+
+    fn api_endpoint(&self, path: &str) -> String {
+        format!("{}{}", self.api_url, path)
+    }
+
+    async fn find_sandbox_by_metadata(
+        &self,
+        key_label: &str,
+        spec_hash: &str,
+    ) -> Result<Option<E2bListedSandbox>> {
+        let metadata = metadata_filter_query(key_label, spec_hash);
+        // OpenAPI `state` uses style=form, explode=false → `state=running,paused`.
+        // Two `state=` query params are not accepted reliably by the API.
+        if let Some(found) = self
+            .list_sandboxes_with_metadata(&metadata, true)
+            .await?
+        {
+            return Ok(Some(found));
+        }
+        // Fallback: metadata only (e.g. API ignores unknown state serialization).
+        self.list_sandboxes_with_metadata(&metadata, false).await
+    }
+
+    async fn list_sandboxes_with_metadata(
+        &self,
+        metadata: &str,
+        with_state_filter: bool,
+    ) -> Result<Option<E2bListedSandbox>> {
+        let mut query: Vec<(&str, &str)> = vec![("metadata", metadata)];
+        if with_state_filter {
+            query.push(("state", "running,paused"));
+        }
+        let response = self
+            .client
+            .get(self.api_endpoint("/v2/sandboxes"))
+            .query(&query)
+            .send()
+            .await
+            .context("listing E2B sandboxes")?
+            .error_for_status()
+            .context("E2B list sandboxes returned an error status")?;
+        let mut sandboxes: Vec<E2bListedSandbox> = response
+            .json()
+            .await
+            .context("decoding E2B sandbox list response")?;
+        sandboxes.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+        Ok(sandboxes.into_iter().next())
+    }
+
+    async fn create_sandbox(
+        &self,
+        request: &SandboxRequest,
+        spec_hash: &str,
+        template_id: &str,
+    ) -> Result<E2bSandboxCreated> {
+        let mut metadata = HashMap::new();
+        metadata.insert(WARM_SANDBOX_KEY_LABEL.to_string(), request.key.to_string());
+        metadata.insert(
+            WARM_SANDBOX_SPEC_HASH_LABEL.to_string(),
+            spec_hash.to_string(),
+        );
+
+        let (timeout_secs, auto_pause) = idle_ttl_to_e2b_lifecycle(&request.lifecycle.idle_ttl);
+
+        let body = E2bCreateRequest {
+            template_id: template_id.to_string(),
+            timeout: timeout_secs,
+            auto_pause,
+            secure: self.secure,
+            allow_internet_access: !matches!(request.spec.network, SandboxNetworkPolicy::Disabled),
+            metadata,
+        };
+
+        let response = self
+            .client
+            .post(self.api_endpoint("/sandboxes"))
+            .json(&body)
+            .send()
+            .await
+            .context("creating E2B sandbox")?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            bail!("E2B create-sandbox failed ({status}): {text}");
+        }
+        let sandbox: E2bSandboxCreated = response
+            .json()
+            .await
+            .context("decoding E2B create-sandbox response")?;
+        Ok(sandbox)
+    }
+
+    async fn connect_sandbox(
+        &self,
+        sandbox_id: &str,
+        timeout_secs: u32,
+    ) -> Result<E2bSandboxCreated> {
+        let body = E2bConnectRequest {
+            timeout: timeout_secs,
+        };
+        let response = self
+            .client
+            .post(self.api_endpoint(&format!("/sandboxes/{sandbox_id}/connect")))
+            .json(&body)
+            .send()
+            .await
+            .with_context(|| format!("connecting to E2B sandbox {sandbox_id}"))?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            bail!("E2B connect-sandbox failed ({status}): {text}");
+        }
+        response
+            .json()
+            .await
+            .context("decoding E2B connect-sandbox response")
+    }
+
+    fn handle_backend(&self) -> E2bBackendHandle {
+        E2bBackendHandle {
+            client: self.client.clone(),
+            api_url: self.api_url.clone(),
+            template_id: self.template_id.clone(),
+            envd_port: self.envd_port,
+            envd_base_url: self.envd_base_url.clone(),
+            secure: self.secure,
+        }
+    }
+}
+
+#[async_trait]
+impl ManagedSandboxBackend for E2bSandboxBackend {
+    async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
+        reject_host_mounts(&request)?;
+        let spec_hash = sandbox_spec_hash(&request.spec);
+        let template_id = resolve_template_id(&request.spec, &self.template_id);
+        let sandbox = self
+            .create_sandbox(&request, &spec_hash, &template_id)
+            .await?;
+        Ok(Arc::new(E2bSandboxHandle {
+            id: format!("e2b:{}", request.key),
+            sandbox_id: sandbox.sandbox_id,
+            envd_access_token: sandbox.envd_access_token,
+            request,
+            backend: self.handle_backend(),
+        }))
+    }
+
+    async fn try_resume(
+        &self,
+        request: SandboxRequest,
+    ) -> Result<Option<Arc<dyn ManagedSandboxHandle>>> {
+        reject_host_mounts(&request)?;
+        let spec_hash = sandbox_spec_hash(&request.spec);
+        let key_label = request.key.to_string();
+
+        let Some(existing) = self.find_sandbox_by_metadata(&key_label, &spec_hash).await?
+        else {
+            return Ok(None);
+        };
+
+        let mut envd_access_token = None;
+        if existing.state == "paused" {
+            let timeout_secs = idle_ttl_to_e2b_lifecycle(&request.lifecycle.idle_ttl).0;
+            let connected = self
+                .connect_sandbox(&existing.sandbox_id, timeout_secs)
+                .await?;
+            envd_access_token = connected.envd_access_token;
+        }
+
+        Ok(Some(Arc::new(E2bSandboxHandle {
+            id: format!("e2b:{}", request.key),
+            sandbox_id: existing.sandbox_id,
+            envd_access_token,
+            request,
+            backend: self.handle_backend(),
+        })))
+    }
+
+    async fn acquire_from_snapshot(
+        &self,
+        request: SandboxRequest,
+        payload: SnapshotPayload,
+    ) -> Result<Arc<dyn ManagedSandboxHandle>> {
+        reject_host_mounts(&request)?;
+        if !matches!(payload.kind, SnapshotKind::E2bSnapshot) {
+            bail!(
+                "E2B sandbox backend can only restore from SnapshotKind::E2bSnapshot, got {:?}",
+                payload.kind
+            );
+        }
+        let manifest: E2bSnapshotManifest =
+            serde_json::from_slice(&payload.bytes).context("decoding E2bSnapshot manifest")?;
+        let spec_hash = sandbox_spec_hash(&request.spec);
+        let sandbox = self
+            .create_sandbox(&request, &spec_hash, &manifest.snapshot_id)
+            .await?;
+        Ok(Arc::new(E2bSandboxHandle {
+            id: format!("e2b-restored:{}", request.key),
+            sandbox_id: sandbox.sandbox_id,
+            envd_access_token: sandbox.envd_access_token,
+            request,
+            backend: self.handle_backend(),
+        }))
+    }
+}
+
+#[derive(Clone)]
+struct E2bBackendHandle {
+    client: reqwest::Client,
+    api_url: String,
+    template_id: String,
+    envd_port: u16,
+    envd_base_url: Option<String>,
+    secure: bool,
+}
+
+impl E2bBackendHandle {
+    fn api_endpoint(&self, path: &str) -> String {
+        format!("{}{}", self.api_url, path)
+    }
+
+    fn envd_endpoint(&self, sandbox_id: &str, path: &str) -> String {
+        envd_endpoint_url(self.envd_base_url.as_deref(), self.envd_port, sandbox_id, path)
+    }
+}
+
+fn envd_endpoint_url(
+    envd_base_url: Option<&str>,
+    envd_port: u16,
+    sandbox_id: &str,
+    path: &str,
+) -> String {
+    if let Some(base) = envd_base_url {
+        format!("{}{}", base.trim_end_matches('/'), path)
+    } else {
+        format!("https://{envd_port}-{sandbox_id}.e2b.app{path}")
+    }
+}
+
+struct E2bSandboxHandle {
+    id: String,
+    sandbox_id: String,
+    envd_access_token: Option<String>,
+    request: SandboxRequest,
+    backend: E2bBackendHandle,
+}
+
+#[async_trait]
+impl ManagedSandboxHandle for E2bSandboxHandle {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    async fn exec(&self, command: &SandboxCommand) -> Result<SandboxCommandOutput> {
+        exec_in_sandbox(
+            &self.backend,
+            &self.sandbox_id,
+            self.envd_access_token.as_deref(),
+            &self.request.spec,
+            command,
+        )
+        .await
+    }
+
+    async fn start_process(&self, command: &SandboxCommand) -> Result<crate::SandboxProcessParts> {
+        let output = exec_in_sandbox(
+            &self.backend,
+            &self.sandbox_id,
+            self.envd_access_token.as_deref(),
+            &self.request.spec,
+            command,
+        )
+        .await?;
+        let exit_code = output.exit_code.unwrap_or(0);
+        let stdout = Cursor::new(output.stdout.into_bytes());
+        let stderr = Cursor::new(output.stderr.into_bytes());
+        let stdin = futures::io::sink();
+        let wait: BoxFuture<'static, crate::Result<i32>> = Box::pin(async move { Ok(exit_code) });
+        Ok(crate::SandboxProcessParts {
+            stdout: Box::pin(stdout),
+            stderr: Box::pin(stderr),
+            stdin: Box::pin(stdin),
+            wait,
+        })
+    }
+
+    async fn stop(&self) -> Result<()> {
+        pause_via_backend(&self.backend, &self.sandbox_id).await
+    }
+
+    async fn snapshot(&self) -> Result<SnapshotPayload> {
+        let base_template =
+            resolve_template_id(&self.request.spec, &self.backend.template_id);
+        save_snapshot_via_backend(&self.backend, &self.sandbox_id, base_template).await
+    }
+}
+
+async fn exec_in_sandbox(
+    backend: &E2bBackendHandle,
+    sandbox_id: &str,
+    envd_access_token: Option<&str>,
+    spec: &SandboxSpec,
+    command: &SandboxCommand,
+) -> Result<SandboxCommandOutput> {
+    if command.argv.is_empty() {
+        bail!("sandbox command requires at least one argv entry");
+    }
+    let (cmd, args) = command.argv.split_first().expect("checked non-empty");
+    let cwd = command
+        .cwd
+        .clone()
+        .unwrap_or_else(|| spec.default_workdir.clone());
+
+    let start_request = serde_json::json!({
+        "process": {
+            "cmd": cmd,
+            "args": args,
+            "envs": command.env,
+            "cwd": cwd,
+        },
+        "stdin": false,
+    });
+    let request_payload = serde_json::to_vec(&start_request).context("encoding E2B StartRequest")?;
+    let request_body = connect_encode_envelope(0, &request_payload)?;
+
+    let mut request = backend
+        .client
+        .post(backend.envd_endpoint(sandbox_id, "/process.Process/Start"))
+        .header("Connect-Protocol-Version", "1")
+        .header("Content-Type", "application/connect+json")
+        .body(request_body);
+    if backend.secure {
+        let token = envd_access_token.ok_or_else(|| {
+            anyhow!(
+                "E2B sandbox {sandbox_id} requires envdAccessToken for command execution \
+                 (create with secure: false via E2B_SECURE=0, or reconnect to refresh the token)"
+            )
+        })?;
+        request = request.header("X-Access-Token", token);
+    }
+
+    let response = request
+        .send()
+        .await
+        .with_context(|| format!("exec in E2B sandbox {sandbox_id}"))?;
+    let status = response.status();
+    let bytes = response.bytes().await.context("reading E2B exec response")?;
+    if !status.is_success() {
+        bail!(
+            "E2B exec failed ({status}): {}",
+            String::from_utf8_lossy(&bytes)
+        );
+    }
+
+    let (stdout, stderr, exit_code) = parse_connect_start_response(&bytes)?;
+    Ok(SandboxCommandOutput {
+        ok: exit_code == 0,
+        exit_code: Some(exit_code),
+        stdout,
+        stderr,
+        command: command
+            .display_argv
+            .clone()
+            .unwrap_or_else(|| command.argv.clone()),
+        cwd,
+    })
+}
+
+/// Wrap a JSON payload in a Connect binary envelope (1-byte flags + 4-byte BE length).
+fn connect_encode_envelope(flags: u8, payload: &[u8]) -> Result<Vec<u8>> {
+    if payload.len() > CONNECT_MAX_ENVELOPE_BYTES {
+        bail!(
+            "connect envelope payload is {} bytes (max {CONNECT_MAX_ENVELOPE_BYTES})",
+            payload.len()
+        );
+    }
+    let mut out = Vec::with_capacity(5 + payload.len());
+    out.push(flags);
+    out.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+    out.extend_from_slice(payload);
+    Ok(out)
+}
+
+fn connect_decode_envelopes(bytes: &[u8]) -> Result<Vec<(u8, Vec<u8>)>> {
+    let mut remaining = bytes;
+    let mut envelopes = Vec::new();
+    while !remaining.is_empty() {
+        if remaining.len() < 5 {
+            bail!("truncated Connect envelope header");
+        }
+        let flags = remaining[0];
+        let len = u32::from_be_bytes(remaining[1..5].try_into().expect("four length bytes")) as usize;
+        remaining = &remaining[5..];
+        if len > CONNECT_MAX_ENVELOPE_BYTES {
+            bail!("connect envelope length {len} exceeds max {CONNECT_MAX_ENVELOPE_BYTES}");
+        }
+        if remaining.len() < len {
+            bail!(
+                "truncated Connect envelope payload: expected {len} bytes, got {}",
+                remaining.len()
+            );
+        }
+        let payload = remaining[..len].to_vec();
+        remaining = &remaining[len..];
+        if flags & CONNECT_FLAG_COMPRESSED != 0 {
+            bail!("compressed Connect envelopes are not supported");
+        }
+        envelopes.push((flags, payload));
+    }
+    Ok(envelopes)
+}
+
+/// Parse a Connect server-streaming `application/connect+json` body into stdout/stderr/exit.
+fn parse_connect_start_response(bytes: &[u8]) -> Result<(String, String, i32)> {
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    let mut exit_code = 0i32;
+
+    for (flags, payload) in connect_decode_envelopes(bytes)? {
+        if flags & CONNECT_FLAG_END_STREAM != 0 {
+            let end: serde_json::Value =
+                serde_json::from_slice(&payload).context("decoding Connect end-stream message")?;
+            if let Some(err) = end.get("error") {
+                let code = err
+                    .get("code")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown");
+                let message = err
+                    .get("message")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown error");
+                bail!("E2B process stream error ({code}): {message}");
+            }
+            continue;
+        }
+
+        let message: serde_json::Value =
+            serde_json::from_slice(&payload).context("decoding Connect stream message")?;
+        let Some(event) = message.get("event") else {
+            continue;
+        };
+        if let Some(data) = event.get("data") {
+            if let Some(chunk) = data.get("stdout").and_then(|v| v.as_str()) {
+                stdout.push_str(&decode_process_bytes(chunk));
+            }
+            if let Some(chunk) = data.get("stderr").and_then(|v| v.as_str()) {
+                stderr.push_str(&decode_process_bytes(chunk));
+            }
+        }
+        if let Some(end) = event.get("end") {
+            exit_code = parse_exit_code(end);
+        }
+    }
+
+    Ok((stdout, stderr, exit_code))
+}
+
+#[cfg(test)]
+mod connect_tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_envelope_header() {
+        let payload = br#"{"event":{"data":{"stdout":"hi"}}}"#;
+        let encoded = connect_encode_envelope(0, payload).unwrap();
+        let decoded = connect_decode_envelopes(&encoded).unwrap();
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].0, 0);
+        assert_eq!(decoded[0].1, payload);
+    }
+
+    #[test]
+    fn decode_process_bytes_handles_base64_stdout() {
+        assert_eq!(
+            super::decode_process_bytes("ZXhvLWUyYi1saXZlCg=="),
+            "exo-e2b-live\n"
+        );
+    }
+}
+
+/// E2B envd encodes stdout/stderr chunks as standard base64 in Connect JSON events.
+fn decode_process_bytes(raw: &str) -> String {
+    if let Ok(decoded) = BASE64.decode(raw.trim().as_bytes()) {
+        if let Ok(text) = String::from_utf8(decoded) {
+            return text;
+        }
+    }
+    raw.to_string()
+}
+
+fn parse_exit_code(end: &serde_json::Value) -> i32 {
+    if let Some(code) = end.get("exitCode").and_then(|v| v.as_i64()) {
+        return code as i32;
+    }
+    if let Some(status) = end.get("status").and_then(|v| v.as_str()) {
+        if let Some(rest) = status.strip_prefix("exit status ") {
+            if let Ok(code) = rest.trim().parse::<i32>() {
+                return code;
+            }
+        }
+    }
+    0
+}
+
+async fn pause_via_backend(backend: &E2bBackendHandle, sandbox_id: &str) -> Result<()> {
+    let response = backend
+        .client
+        .post(backend.api_endpoint(&format!("/sandboxes/{sandbox_id}/pause")))
+        .send()
+        .await
+        .with_context(|| format!("pausing E2B sandbox {sandbox_id}"))?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        bail!("E2B pause-sandbox failed ({status}): {text}");
+    }
+    Ok(())
+}
+
+async fn save_snapshot_via_backend(
+    backend: &E2bBackendHandle,
+    sandbox_id: &str,
+    base_template: String,
+) -> Result<SnapshotPayload> {
+    let snapshot_name = format!("exo-snap-{}", Uuid::new_v4().simple());
+    let body = E2bSnapshotCreateRequest {
+        name: Some(snapshot_name),
+    };
+    let response = backend
+        .client
+        .post(backend.api_endpoint(&format!("/sandboxes/{sandbox_id}/snapshots")))
+        .json(&body)
+        .send()
+        .await
+        .with_context(|| format!("snapshotting E2B sandbox {sandbox_id}"))?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        bail!("E2B snapshot failed ({status}): {text}");
+    }
+    let info: E2bSnapshotInfo = response
+        .json()
+        .await
+        .context("decoding E2B snapshot response")?;
+    let manifest = E2bSnapshotManifest {
+        snapshot_id: info.snapshot_id,
+        base_template,
+    };
+    let bytes = serde_json::to_vec(&manifest).context("serializing E2bSnapshot manifest")?;
+    Ok(SnapshotPayload {
+        kind: SnapshotKind::E2bSnapshot,
+        bytes: Bytes::from(bytes),
+    })
+}
+
+fn reject_host_mounts(request: &SandboxRequest) -> Result<()> {
+    if request.spec.mounts.is_empty() {
+        return Ok(());
+    }
+    bail!(
+        "E2B sandbox backend does not support host bind-mounts; \
+         remove conversation mounts or switch to --sandbox-backend docker. \
+         A remote-workspace provisioner is planned as a follow-up."
+    )
+}
+
+fn resolve_template_id(spec: &SandboxSpec, default_template: &str) -> String {
+    if spec.image.trim().is_empty() {
+        if default_template.is_empty() {
+            DEFAULT_SANDBOX_IMAGE.to_string()
+        } else {
+            default_template.to_string()
+        }
+    } else {
+        spec.image.clone()
+    }
+}
+
+/// Builds the `metadata` query value for `GET /v2/sandboxes`.
+///
+/// E2B expects `key=value&key2=value2` with URL encoding applied once at the
+/// HTTP layer. Pre-encoding here and then passing through reqwest's `.query()`
+/// double-encodes colons (`%253A`), so list filters never match created sandboxes.
+fn metadata_filter_query(key_label: &str, spec_hash: &str) -> String {
+    format!(
+        "{}={}&{}={}",
+        WARM_SANDBOX_KEY_LABEL, key_label, WARM_SANDBOX_SPEC_HASH_LABEL, spec_hash,
+    )
+}
+
+fn idle_ttl_to_e2b_lifecycle(idle_ttl: &Option<Duration>) -> (u32, bool) {
+    let Some(ttl) = idle_ttl else {
+        return (300, false);
+    };
+    let secs = ttl.as_secs().clamp(1, u32::MAX as u64) as u32;
+    (secs, true)
+}
+
+#[derive(Debug, Serialize)]
+struct E2bCreateRequest {
+    #[serde(rename = "templateID")]
+    template_id: String,
+    timeout: u32,
+    #[serde(rename = "autoPause")]
+    auto_pause: bool,
+    secure: bool,
+    allow_internet_access: bool,
+    metadata: HashMap<String, String>,
+}
+
+#[derive(Debug, Serialize)]
+struct E2bConnectRequest {
+    timeout: u32,
+}
+
+#[derive(Debug, Serialize)]
+struct E2bSnapshotCreateRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct E2bSandboxCreated {
+    #[serde(rename = "sandboxID")]
+    sandbox_id: String,
+    #[serde(default, rename = "envdAccessToken")]
+    envd_access_token: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct E2bListedSandbox {
+    #[serde(rename = "sandboxID")]
+    sandbox_id: String,
+    state: String,
+    #[serde(default, rename = "startedAt")]
+    started_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct E2bSnapshotInfo {
+    #[serde(rename = "snapshotID")]
+    snapshot_id: String,
+}

--- a/crates/exoharness/src/lib.rs
+++ b/crates/exoharness/src/lib.rs
@@ -4,6 +4,7 @@ mod basic;
 mod basic_tests;
 #[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
 mod daytona;
+mod e2b;
 mod error;
 pub mod protocol;
 #[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
@@ -21,6 +22,7 @@ mod uuid7;
 pub use basic::*;
 #[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
 pub use daytona::{DEFAULT_DAYTONA_API_URL, DaytonaConfig, DaytonaSandboxBackend};
+pub use e2b::{DEFAULT_E2B_API_URL, E2bConfig, E2bSandboxBackend};
 pub use error::*;
 #[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
 pub use sandbox::*;

--- a/crates/exoharness/src/lib.rs
+++ b/crates/exoharness/src/lib.rs
@@ -6,6 +6,7 @@ mod basic_tests;
 mod daytona;
 mod e2b;
 mod error;
+mod sprites;
 pub mod protocol;
 #[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
 mod sandbox;
@@ -23,6 +24,7 @@ pub use basic::*;
 #[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
 pub use daytona::{DEFAULT_DAYTONA_API_URL, DaytonaConfig, DaytonaSandboxBackend};
 pub use e2b::{DEFAULT_E2B_API_URL, E2bConfig, E2bSandboxBackend};
+pub use sprites::{DEFAULT_SPRITES_API_URL, SpritesConfig, SpritesSandboxBackend};
 pub use error::*;
 #[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
 pub use sandbox::*;

--- a/crates/exoharness/src/lib.rs
+++ b/crates/exoharness/src/lib.rs
@@ -2,6 +2,8 @@
 mod basic;
 #[cfg(all(test, not(target_arch = "wasm32"), feature = "basic-backend"))]
 mod basic_tests;
+#[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
+mod daytona;
 mod error;
 pub mod protocol;
 #[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
@@ -17,6 +19,8 @@ mod uuid7;
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
 pub use basic::*;
+#[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
+pub use daytona::{DEFAULT_DAYTONA_API_URL, DaytonaConfig, DaytonaSandboxBackend};
 pub use error::*;
 #[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
 pub use sandbox::*;

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -120,6 +120,9 @@ pub enum SnapshotKind {
     /// Daytona. Bytes-by-reference, not bytes-by-value — restoring is a
     /// `POST /sandbox { snapshot: <name> }` call, not a tarball load.
     DaytonaSnapshot,
+    /// Reference to an E2B snapshot template id. Payload bytes are a small JSON
+    /// manifest; restoring is `POST /sandboxes { templateID: <snapshot_id> }`.
+    E2bSnapshot,
 }
 
 #[async_trait]
@@ -543,6 +546,10 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
             (_, SnapshotKind::DaytonaSnapshot) => bail!(
                 "DaytonaSnapshot payloads can only be restored by the Daytona sandbox backend; \
                  switch to --sandbox-backend daytona to rewind this snapshot"
+            ),
+            (_, SnapshotKind::E2bSnapshot) => bail!(
+                "E2bSnapshot payloads can only be restored by the E2B sandbox backend; \
+                 switch to --sandbox-backend e2b to rewind this snapshot"
             ),
             (ContainerCliFlavor::AppleContainer, _) => bail!(
                 "restore-from-snapshot is not yet implemented for the apple-container backend"

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -133,7 +133,30 @@ pub trait ManagedSandboxHandle: Send + Sync {
 
 #[async_trait]
 pub trait ManagedSandboxBackend: Send + Sync {
+    /// Bring up a sandbox for `request.key`. Backends that warm-pool
+    /// (Docker, Apple container) reuse a matching warm sandbox if one is
+    /// already cached *in this process*; cross-process reuse goes through
+    /// [`Self::try_resume`] instead. Always able to satisfy the request:
+    /// on a miss, creates fresh from `request.spec.image`.
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>>;
+
+    /// Try to attach to a sandbox previously created for `request.key`
+    /// whose lifetime survives this process (e.g. a stopped Docker
+    /// container labelled with `exo.sandbox.key`, or a Daytona sandbox
+    /// known to the remote control plane). Starts the sandbox if it's
+    /// stopped, attaches if it's running, and returns the handle.
+    ///
+    /// Returns `Ok(None)` if no matching sandbox exists — the caller
+    /// then decides whether to restore from a snapshot or create fresh.
+    /// Returns `Err` only when the lookup itself fails (network error,
+    /// daemon unavailable, etc.).
+    ///
+    /// Backends that have no notion of cross-process identity (e.g. the
+    /// local-process backend) simply return `Ok(None)`.
+    async fn try_resume(
+        &self,
+        request: SandboxRequest,
+    ) -> Result<Option<Arc<dyn ManagedSandboxHandle>>>;
 
     /// Acquire a sandbox initialised from a previously-captured snapshot.
     /// The request is honoured for mounts, network, lifecycle, etc., but the
@@ -351,6 +374,10 @@ impl CliContainerSandboxBackend {
 
 impl Drop for CliContainerSandboxBackend {
     fn drop(&mut self) {
+        // Process is going away. Stop — but don't delete — every warm
+        // container so the next exo invocation can `try_resume` them by
+        // label. True cleanup happens via the cross-process idle-TTL
+        // check in `try_resume`, or via explicit `stop_sandbox` calls.
         let Ok(mut warm_sandboxes) = self.warm_sandboxes.try_lock() else {
             return;
         };
@@ -359,7 +386,7 @@ impl Drop for CliContainerSandboxBackend {
             .map(|(_, entry)| entry.name)
             .collect::<Vec<_>>();
         for name in names {
-            cleanup_named_container_blocking(&self.container_bin, self.cli, &name);
+            stop_named_container_blocking(&self.container_bin, self.cli, &name);
         }
     }
 }
@@ -420,6 +447,81 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
             request,
             warm_sandboxes: Arc::clone(&self.warm_sandboxes),
         }))
+    }
+
+    async fn try_resume(
+        &self,
+        request: SandboxRequest,
+    ) -> Result<Option<Arc<dyn ManagedSandboxHandle>>> {
+        let request = self.prepare_request(request).await?;
+
+        // Warm-pool-less sandboxes have no cross-process identity.
+        let Some(idle_ttl) = request.lifecycle.idle_ttl else {
+            return Ok(None);
+        };
+
+        // In-process warm pool first — this is the fast path and the
+        // common case during a single REPL session.
+        {
+            let warm_sandboxes = self.warm_sandboxes.lock().await;
+            if let Some(entry) = warm_sandboxes.get(&request.key)
+                && entry.request.spec == request.spec
+            {
+                return Ok(Some(Arc::new(WarmSandboxHandle {
+                    id: format!("warm:{}", request.key),
+                    cli: self.cli,
+                    container_bin: self.container_bin.clone(),
+                    request,
+                    warm_sandboxes: Arc::clone(&self.warm_sandboxes),
+                })));
+            }
+        }
+
+        // Cross-process: look for a labelled container the daemon still
+        // knows about. Drops any with mismatched spec hashes (the spec
+        // moved out from under them) so the caller can create fresh.
+        let spec_hash = sandbox_spec_hash(&request.spec);
+        let key_str = request.key.to_string();
+        let Some(existing) =
+            find_resumable_container(&self.container_bin, self.cli, &key_str, &spec_hash).await?
+        else {
+            return Ok(None);
+        };
+
+        // TTL: if the container has been stopped longer than the idle TTL,
+        // treat it as expired — delete it and report no match.
+        if !existing.is_running
+            && let Some(finished_at) = existing.finished_at
+            && let Ok(idle_for) = SystemTime::now().duration_since(finished_at)
+            && idle_for > idle_ttl
+        {
+            cleanup_named_container(&self.container_bin, self.cli, &existing.name).await?;
+            return Ok(None);
+        }
+
+        if !existing.is_running {
+            start_named_container(&self.container_bin, self.cli, &existing.name).await?;
+        }
+
+        {
+            let mut warm_sandboxes = self.warm_sandboxes.lock().await;
+            warm_sandboxes.insert(
+                request.key.clone(),
+                WarmSandboxEntry {
+                    name: existing.name.clone(),
+                    request: request.clone(),
+                    last_used_at: Instant::now(),
+                },
+            );
+        }
+
+        Ok(Some(Arc::new(WarmSandboxHandle {
+            id: format!("warm:{}", request.key),
+            cli: self.cli,
+            container_bin: self.container_bin.clone(),
+            request,
+            warm_sandboxes: Arc::clone(&self.warm_sandboxes),
+        })))
     }
 
     async fn acquire_from_snapshot(
@@ -619,6 +721,16 @@ impl ManagedSandboxBackend for LocalProcessSandboxBackend {
             id: format!("local:{}", request.key),
             request,
         }))
+    }
+
+    async fn try_resume(
+        &self,
+        _request: SandboxRequest,
+    ) -> Result<Option<Arc<dyn ManagedSandboxHandle>>> {
+        // Local-process "sandboxes" are just child processes; nothing
+        // outlives an exo invocation, so there is never anything to
+        // resume across processes.
+        Ok(None)
     }
 
     async fn acquire_from_snapshot(
@@ -1222,16 +1334,17 @@ fn owner_pid_is_alive(pid: &str) -> bool {
         .is_ok_and(|status| status.success())
 }
 
-fn cleanup_named_container_blocking(container_bin: &Path, cli: ContainerCliFlavor, name: &str) {
-    match cli {
-        ContainerCliFlavor::AppleContainer => {
-            run_container_admin_command_blocking(container_bin, ["stop", name]);
-            run_container_admin_command_blocking(container_bin, ["delete", name]);
-        }
-        ContainerCliFlavor::Docker => {
-            run_container_admin_command_blocking(container_bin, ["rm", "-f", name]);
-        }
-    }
+/// Stop a warm container without deleting it. Used from `Drop` so the
+/// container's filesystem persists across exo process exit and the next
+/// process can `try_resume` it. For destructive cleanup (TTL expiry,
+/// explicit user stop, spec change) call `cleanup_named_container`
+/// instead — it deletes.
+fn stop_named_container_blocking(container_bin: &Path, cli: ContainerCliFlavor, name: &str) {
+    let _ = cli; // both flavors accept `stop <name>`
+    // `-t 0` on Docker = SIGKILL immediately, no SIGTERM grace; we don't
+    // want our exit to block 10s per warm container. Apple's CLI ignores
+    // the flag.
+    run_container_admin_command_blocking(container_bin, ["stop", "-t", "0", name]);
 }
 
 fn schedule_cleanup_named_container(container_bin: PathBuf, cli: ContainerCliFlavor, name: String) {
@@ -1292,6 +1405,226 @@ fn is_missing_container_error(stderr: &str) -> bool {
     let lower = stderr.to_ascii_lowercase();
     lower.contains("not found") || lower.contains("no such")
 }
+
+/// What [`find_resumable_container`] returns when a labelled container
+/// matching a given `SandboxKey` survived from a previous exo process.
+#[derive(Debug)]
+struct ResumableContainerInfo {
+    /// Container name (the `--name` flag we set at creation).
+    name: String,
+    /// Currently running on the daemon. If false, we'll need to
+    /// [`start_named_container`] before exec'ing.
+    is_running: bool,
+    /// When the container stopped, if known. `None` for running
+    /// containers or backends that don't expose this. Used to enforce
+    /// cross-process idle TTL.
+    finished_at: Option<SystemTime>,
+}
+
+/// Cross-process container lookup: ask the daemon for any container
+/// labelled with this `SandboxKey`. If found with a matching spec hash,
+/// returns its info. Stale containers (same key, different spec) are
+/// reaped on the way out — they can never satisfy a resume.
+async fn find_resumable_container(
+    container_bin: &Path,
+    cli: ContainerCliFlavor,
+    key: &str,
+    spec_hash: &str,
+) -> Result<Option<ResumableContainerInfo>> {
+    match cli {
+        ContainerCliFlavor::Docker => find_docker_resumable(container_bin, key, spec_hash).await,
+        ContainerCliFlavor::AppleContainer => {
+            find_apple_resumable(container_bin, key, spec_hash).await
+        }
+    }
+}
+
+async fn find_docker_resumable(
+    container_bin: &Path,
+    key: &str,
+    spec_hash: &str,
+) -> Result<Option<ResumableContainerInfo>> {
+    // `docker ps -a --filter label=...` already does an exact-match on
+    // the key label server-side. We still pull every candidate so we can
+    // pick the most recent if there are duplicates (concurrent races)
+    // and reap any whose spec hash has drifted.
+    let key_filter = format!("label={WARM_SANDBOX_KEY_LABEL}={key}");
+    let format_arg = format!(
+        "{{{{.Names}}}}\t{{{{.Label \"{WARM_SANDBOX_SPEC_HASH_LABEL}\"}}}}\t{{{{.State}}}}\t{{{{.CreatedAt}}}}"
+    );
+    let mut command = Command::new(container_bin);
+    command
+        .arg("ps")
+        .arg("-a")
+        .arg("--filter")
+        .arg(&key_filter)
+        .arg("--format")
+        .arg(&format_arg)
+        .kill_on_drop(true);
+    let output = match time::timeout(WARM_SANDBOX_CLEANUP_TIMEOUT, command.output()).await {
+        Ok(out) => out?,
+        Err(_) => return Err(anyhow!("docker ps timed out while listing resumable containers")),
+    };
+    if !output.status.success() {
+        return Err(anyhow!(
+            "docker ps failed while listing resumable containers: {}",
+            render_command_error(&output.stderr)
+        ));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut matches: Vec<(String, String, String)> = Vec::new();
+    let mut stale_names: Vec<String> = Vec::new();
+    for line in stdout.lines() {
+        let mut parts = line.splitn(4, '\t');
+        let (Some(name), Some(hash), Some(state), Some(created)) =
+            (parts.next(), parts.next(), parts.next(), parts.next())
+        else {
+            continue;
+        };
+        if hash == spec_hash {
+            matches.push((name.to_string(), state.to_string(), created.to_string()));
+        } else {
+            stale_names.push(name.to_string());
+        }
+    }
+    for name in stale_names {
+        if let Err(err) =
+            cleanup_named_container(container_bin, ContainerCliFlavor::Docker, &name).await
+        {
+            eprintln!("failed to reap container {name} with stale spec hash: {err}");
+        }
+    }
+    // Prefer the most-recent entry (Docker's CreatedAt sorts
+    // lexicographically as ISO-8601-ish text).
+    matches.sort_by(|a, b| b.2.cmp(&a.2));
+    let Some((name, state, _created)) = matches.into_iter().next() else {
+        return Ok(None);
+    };
+    let is_running = state.eq_ignore_ascii_case("running");
+    let finished_at = if !is_running {
+        docker_container_finished_at(container_bin, &name).await?
+    } else {
+        None
+    };
+    Ok(Some(ResumableContainerInfo {
+        name,
+        is_running,
+        finished_at,
+    }))
+}
+
+async fn docker_container_finished_at(
+    container_bin: &Path,
+    name: &str,
+) -> Result<Option<SystemTime>> {
+    let mut command = Command::new(container_bin);
+    command
+        .arg("inspect")
+        .arg("--format")
+        .arg("{{.State.FinishedAt}}")
+        .arg(name)
+        .kill_on_drop(true);
+    let output = match time::timeout(WARM_SANDBOX_CLEANUP_TIMEOUT, command.output()).await {
+        Ok(out) => out?,
+        Err(_) => return Ok(None),
+    };
+    if !output.status.success() {
+        // Container disappeared between list and inspect — treat as
+        // unknown, the caller will create fresh.
+        return Ok(None);
+    }
+    let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    // "0001-01-01T00:00:00Z" is Docker's "never finished" sentinel.
+    if s.is_empty() || s.starts_with("0001-01-01") {
+        return Ok(None);
+    }
+    Ok(parse_rfc3339_to_system_time(&s))
+}
+
+fn parse_rfc3339_to_system_time(s: &str) -> Option<SystemTime> {
+    let dt = chrono::DateTime::parse_from_rfc3339(s).ok()?;
+    let nanos = dt.timestamp_nanos_opt()?;
+    if nanos < 0 {
+        return None;
+    }
+    Some(SystemTime::UNIX_EPOCH + Duration::from_nanos(nanos as u64))
+}
+
+async fn find_apple_resumable(
+    container_bin: &Path,
+    key: &str,
+    spec_hash: &str,
+) -> Result<Option<ResumableContainerInfo>> {
+    // Apple's `container` CLI doesn't expose a label filter; we list
+    // everything and match in-process.
+    let output =
+        run_container_admin_command(container_bin, WARM_SANDBOX_CLEANUP_TIMEOUT, ["list", "--format", "json"])
+            .await?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "container list failed: {}",
+            render_command_error(&output.stderr)
+        ));
+    }
+    let containers: Vec<ContainerListItem> = serde_json::from_slice(&output.stdout)?;
+    let mut chosen: Option<ResumableContainerInfo> = None;
+    let mut stale_names: Vec<String> = Vec::new();
+    for c in containers {
+        let labels = &c.configuration.labels;
+        let Some(matched_key) = labels.get(WARM_SANDBOX_KEY_LABEL) else {
+            continue;
+        };
+        if matched_key != key {
+            continue;
+        }
+        let hash_matches = labels
+            .get(WARM_SANDBOX_SPEC_HASH_LABEL)
+            .map(|s| s == spec_hash)
+            .unwrap_or(false);
+        if !hash_matches {
+            stale_names.push(c.configuration.id);
+            continue;
+        }
+        // We don't have a portable finished-at signal from the apple
+        // CLI's list output; trust the status field for run-state and
+        // leave finished_at as None (the TTL guard simply skips its
+        // staleness check when finished_at is unknown).
+        let is_running = c.status.as_deref() == Some("running");
+        chosen = Some(ResumableContainerInfo {
+            name: c.configuration.id,
+            is_running,
+            finished_at: None,
+        });
+    }
+    for name in stale_names {
+        if let Err(err) =
+            cleanup_named_container(container_bin, ContainerCliFlavor::AppleContainer, &name).await
+        {
+            eprintln!("failed to reap apple-container {name} with stale spec hash: {err}");
+        }
+    }
+    Ok(chosen)
+}
+
+async fn start_named_container(
+    container_bin: &Path,
+    cli: ContainerCliFlavor,
+    name: &str,
+) -> Result<()> {
+    let _ = cli; // both flavors take `start <name>`
+    let output =
+        run_container_admin_command(container_bin, WARM_SANDBOX_CLEANUP_TIMEOUT, ["start", name])
+            .await?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "failed to start container {name}: {}",
+            render_command_error(&output.stderr)
+        ));
+    }
+    Ok(())
+}
+
 
 fn is_already_exists_error(message: &str) -> bool {
     let lower = message.to_ascii_lowercase();

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -1439,6 +1439,24 @@ async fn find_resumable_container(
     }
 }
 
+/// One row of `docker ps --format '{{json .}}'`.
+#[derive(Debug, Deserialize)]
+struct DockerPsItem {
+    #[serde(rename = "Names")]
+    names: String,
+    /// `"k1=v1,k2=v2"`; parse with [`parse_docker_labels`].
+    #[serde(rename = "Labels")]
+    labels: String,
+    #[serde(rename = "State")]
+    state: String,
+    #[serde(rename = "CreatedAt")]
+    created_at: String,
+}
+
+fn parse_docker_labels(raw: &str) -> HashMap<&str, &str> {
+    raw.split(',').filter_map(|kv| kv.split_once('=')).collect()
+}
+
 async fn find_docker_resumable(
     container_bin: &Path,
     key: &str,
@@ -1449,9 +1467,6 @@ async fn find_docker_resumable(
     // pick the most recent if there are duplicates (concurrent races)
     // and reap any whose spec hash has drifted.
     let key_filter = format!("label={WARM_SANDBOX_KEY_LABEL}={key}");
-    let format_arg = format!(
-        "{{{{.Names}}}}\t{{{{.Label \"{WARM_SANDBOX_SPEC_HASH_LABEL}\"}}}}\t{{{{.State}}}}\t{{{{.CreatedAt}}}}"
-    );
     let mut command = Command::new(container_bin);
     command
         .arg("ps")
@@ -1459,7 +1474,7 @@ async fn find_docker_resumable(
         .arg("--filter")
         .arg(&key_filter)
         .arg("--format")
-        .arg(&format_arg)
+        .arg("{{json .}}")
         .kill_on_drop(true);
     let output = match time::timeout(WARM_SANDBOX_CLEANUP_TIMEOUT, command.output()).await {
         Ok(out) => out?,
@@ -1476,20 +1491,23 @@ async fn find_docker_resumable(
         ));
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stdout = std::str::from_utf8(&output.stdout).context("docker ps output is not utf-8")?;
     let mut matches: Vec<(String, String, String)> = Vec::new();
     let mut stale_names: Vec<String> = Vec::new();
     for line in stdout.lines() {
-        let mut parts = line.splitn(4, '\t');
-        let (Some(name), Some(hash), Some(state), Some(created)) =
-            (parts.next(), parts.next(), parts.next(), parts.next())
-        else {
+        if line.is_empty() {
             continue;
-        };
+        }
+        let item: DockerPsItem = serde_json::from_str(line)
+            .with_context(|| format!("decoding docker ps json line: {line}"))?;
+        let hash = parse_docker_labels(&item.labels)
+            .get(WARM_SANDBOX_SPEC_HASH_LABEL)
+            .copied()
+            .unwrap_or("");
         if hash == spec_hash {
-            matches.push((name.to_string(), state.to_string(), created.to_string()));
+            matches.push((item.names, item.state, item.created_at));
         } else {
-            stale_names.push(name.to_string());
+            stale_names.push(item.names);
         }
     }
     for name in stale_names {
@@ -1787,4 +1805,18 @@ async fn docker_load_image(container_bin: &Path, payload: &Bytes) -> Result<Stri
         }
     }
     bail!("docker load completed but no image reference found in output: {stdout}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_docker_labels_handles_empty_and_multi() {
+        assert!(!parse_docker_labels("").contains_key("anything"));
+        let labels =
+            parse_docker_labels("exo.sandbox.key=conversation:c1:s1,exo.sandbox.spec-hash=abc123");
+        assert_eq!(labels.get("exo.sandbox.key"), Some(&"conversation:c1:s1"));
+        assert_eq!(labels.get("exo.sandbox.spec-hash"), Some(&"abc123"));
+    }
 }

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -123,6 +123,9 @@ pub enum SnapshotKind {
     /// Reference to an E2B snapshot template id. Payload bytes are a small JSON
     /// manifest; restoring is `POST /sandboxes { templateID: <snapshot_id> }`.
     E2bSnapshot,
+    /// Reference to a Sprites checkpoint id on a named sprite. Payload bytes are
+    /// a small JSON manifest; restoring is `POST .../checkpoints/{id}/restore`.
+    SpritesSnapshot,
 }
 
 #[async_trait]
@@ -550,6 +553,10 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
             (_, SnapshotKind::E2bSnapshot) => bail!(
                 "E2bSnapshot payloads can only be restored by the E2B sandbox backend; \
                  switch to --sandbox-backend e2b to rewind this snapshot"
+            ),
+            (_, SnapshotKind::SpritesSnapshot) => bail!(
+                "SpritesSnapshot payloads can only be restored by the Sprites sandbox backend; \
+                 switch to --sandbox-backend sprites to rewind this snapshot"
             ),
             (ContainerCliFlavor::AppleContainer, _) => bail!(
                 "restore-from-snapshot is not yet implemented for the apple-container backend"

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -114,6 +114,12 @@ pub enum SnapshotKind {
     /// `docker save` output: a tar of OCI image layers + manifest, loadable
     /// with `docker load`.
     DockerImageTar,
+    /// Reference to a named snapshot held inside Daytona's own snapshot
+    /// registry. The payload bytes are a small JSON manifest pointing at
+    /// the Daytona snapshot name; the actual filesystem state stays on
+    /// Daytona. Bytes-by-reference, not bytes-by-value — restoring is a
+    /// `POST /sandbox { snapshot: <name> }` call, not a tarball load.
+    DaytonaSnapshot,
 }
 
 #[async_trait]
@@ -198,8 +204,8 @@ const WARM_SANDBOX_KEEPALIVE_ARGV: &[&str] = &["sleep", "infinity"];
 const WARM_SANDBOX_HEALTHCHECK_TIMEOUT: Duration = Duration::from_secs(3);
 const WARM_SANDBOX_CLEANUP_TIMEOUT: Duration = Duration::from_secs(5);
 const ORPHANED_WARM_SANDBOX_MIN_AGE: Duration = Duration::from_secs(60 * 60);
-const WARM_SANDBOX_KEY_LABEL: &str = "exo.sandbox.key";
-const WARM_SANDBOX_SPEC_HASH_LABEL: &str = "exo.sandbox.spec-hash";
+pub(crate) const WARM_SANDBOX_KEY_LABEL: &str = "exo.sandbox.key";
+pub(crate) const WARM_SANDBOX_SPEC_HASH_LABEL: &str = "exo.sandbox.spec-hash";
 const WARM_SANDBOX_OWNER_PID_LABEL: &str = "exo.sandbox.owner-pid";
 const APPLE_ABSOLUTE_TIME_UNIX_OFFSET_SECONDS: f64 = 978_307_200.0;
 
@@ -534,6 +540,10 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
         }
         match (self.cli, payload.kind) {
             (ContainerCliFlavor::Docker, SnapshotKind::DockerImageTar) => {}
+            (_, SnapshotKind::DaytonaSnapshot) => bail!(
+                "DaytonaSnapshot payloads can only be restored by the Daytona sandbox backend; \
+                 switch to --sandbox-backend daytona to rewind this snapshot"
+            ),
             (ContainerCliFlavor::AppleContainer, _) => bail!(
                 "restore-from-snapshot is not yet implemented for the apple-container backend"
             ),
@@ -1655,7 +1665,7 @@ fn is_already_exists_error(message: &str) -> bool {
     lower.contains("already exists")
 }
 
-fn sandbox_spec_hash(spec: &SandboxSpec) -> String {
+pub(crate) fn sandbox_spec_hash(spec: &SandboxSpec) -> String {
     let mut hasher = DefaultHasher::new();
     spec.hash(&mut hasher);
     format!("{:016x}", hasher.finish())

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -1463,7 +1463,11 @@ async fn find_docker_resumable(
         .kill_on_drop(true);
     let output = match time::timeout(WARM_SANDBOX_CLEANUP_TIMEOUT, command.output()).await {
         Ok(out) => out?,
-        Err(_) => return Err(anyhow!("docker ps timed out while listing resumable containers")),
+        Err(_) => {
+            return Err(anyhow!(
+                "docker ps timed out while listing resumable containers"
+            ));
+        }
     };
     if !output.status.success() {
         return Err(anyhow!(
@@ -1558,9 +1562,12 @@ async fn find_apple_resumable(
 ) -> Result<Option<ResumableContainerInfo>> {
     // Apple's `container` CLI doesn't expose a label filter; we list
     // everything and match in-process.
-    let output =
-        run_container_admin_command(container_bin, WARM_SANDBOX_CLEANUP_TIMEOUT, ["list", "--format", "json"])
-            .await?;
+    let output = run_container_admin_command(
+        container_bin,
+        WARM_SANDBOX_CLEANUP_TIMEOUT,
+        ["list", "--format", "json"],
+    )
+    .await?;
     if !output.status.success() {
         return Err(anyhow!(
             "container list failed: {}",
@@ -1624,7 +1631,6 @@ async fn start_named_container(
     }
     Ok(())
 }
-
 
 fn is_already_exists_error(message: &str) -> bool {
     let lower = message.to_ascii_lowercase();

--- a/crates/exoharness/src/sprites.rs
+++ b/crates/exoharness/src/sprites.rs
@@ -1,0 +1,568 @@
+//! Sprites.dev remote sandbox backend.
+//!
+//! Uses the Sprites platform REST API (`api.sprites.dev`) for lifecycle, HTTP
+//! exec, and checkpoint/restore snapshots. Cross-process resume uses a
+//! deterministic sprite name derived from [`SandboxKey`] + spec hash (same role
+//! as Docker labels / E2B metadata). Snapshots are bytes-by-reference via
+//! [`SnapshotKind::SpritesSnapshot`] manifests pointing at a checkpoint id.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use anyhow::{Context, Result, anyhow, bail};
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::future::BoxFuture;
+use futures::io::Cursor;
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
+use serde::{Deserialize, Serialize};
+
+use crate::sandbox::{
+    ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand, SandboxCommandOutput,
+    SandboxRequest, SandboxSpec, SnapshotKind, SnapshotPayload, sandbox_spec_hash,
+};
+
+pub const DEFAULT_SPRITES_API_URL: &str = "https://api.sprites.dev";
+
+#[derive(Debug, Clone)]
+pub struct SpritesConfig {
+    pub token: String,
+    pub api_url: String,
+}
+
+impl SpritesConfig {
+    pub fn from_env() -> Result<Self> {
+        let token = std::env::var("SPRITES_TOKEN")
+            .or_else(|_| std::env::var("SPRITE_TOKEN"))
+            .map_err(|_| {
+                anyhow!(
+                    "SPRITES_TOKEN (or SPRITE_TOKEN) is not set; required for the Sprites sandbox backend"
+                )
+            })?;
+        let api_url = std::env::var("SPRITES_API_URL")
+            .unwrap_or_else(|_| DEFAULT_SPRITES_API_URL.to_string());
+        Ok(Self { token, api_url })
+    }
+}
+
+/// JSON persisted for [`SnapshotKind::SpritesSnapshot`]. Filesystem state lives on
+/// the sprite; we only store the checkpoint id and sprite name.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SpritesSnapshotManifest {
+    checkpoint_id: String,
+    sprite_name: String,
+}
+
+pub struct SpritesSandboxBackend {
+    client: reqwest::Client,
+    api_url: String,
+}
+
+impl SpritesSandboxBackend {
+    pub fn new(config: SpritesConfig) -> Result<Self> {
+        let mut headers = HeaderMap::new();
+        let mut auth = HeaderValue::from_str(&format!("Bearer {}", config.token)).context(
+            "SPRITES_TOKEN contains characters that aren't valid in an HTTP header",
+        )?;
+        auth.set_sensitive(true);
+        headers.insert(AUTHORIZATION, auth);
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        let client = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()
+            .context("building Sprites HTTP client")?;
+        Ok(Self {
+            client,
+            api_url: config.api_url.trim_end_matches('/').to_string(),
+        })
+    }
+
+    fn api_endpoint(&self, path: &str) -> String {
+        format!("{}{}", self.api_url, path)
+    }
+
+    async fn get_sprite(&self, name: &str) -> Result<Option<()>> {
+        let response = self
+            .client
+            .get(self.api_endpoint(&format!("/v1/sprites/{name}")))
+            .send()
+            .await
+            .with_context(|| format!("fetching Sprites sprite {name}"))?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            bail!("Sprites get-sprite failed ({status}): {text}");
+        }
+        Ok(Some(()))
+    }
+
+    async fn create_sprite(&self, name: &str) -> Result<()> {
+        let body = SpritesCreateRequest { name: name.to_string() };
+        let response = self
+            .client
+            .post(self.api_endpoint("/v1/sprites"))
+            .json(&body)
+            .send()
+            .await
+            .context("creating Sprites sprite")?;
+        if response.status().is_success() {
+            return Ok(());
+        }
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        if status == reqwest::StatusCode::CONFLICT
+            || (status == reqwest::StatusCode::BAD_REQUEST && text.contains("exists"))
+        {
+            return Ok(());
+        }
+        bail!("Sprites create-sprite failed ({status}): {text}");
+    }
+
+    async fn ensure_sprite(&self, name: &str) -> Result<()> {
+        if self.get_sprite(name).await?.is_some() {
+            return Ok(());
+        }
+        self.create_sprite(name).await
+    }
+
+    fn handle_backend(&self) -> SpritesBackendHandle {
+        SpritesBackendHandle {
+            client: self.client.clone(),
+            api_url: self.api_url.clone(),
+        }
+    }
+}
+
+#[async_trait]
+impl ManagedSandboxBackend for SpritesSandboxBackend {
+    async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
+        reject_host_mounts(&request)?;
+        let sprite_name = sprite_name_for_request(&request);
+        self.ensure_sprite(&sprite_name).await?;
+        Ok(Arc::new(SpritesSandboxHandle {
+            id: format!("sprites:{}", request.key),
+            sprite_name,
+            request,
+            backend: self.handle_backend(),
+        }))
+    }
+
+    async fn try_resume(
+        &self,
+        request: SandboxRequest,
+    ) -> Result<Option<Arc<dyn ManagedSandboxHandle>>> {
+        reject_host_mounts(&request)?;
+        let sprite_name = sprite_name_for_request(&request);
+        if self.get_sprite(&sprite_name).await?.is_none() {
+            return Ok(None);
+        }
+        Ok(Some(Arc::new(SpritesSandboxHandle {
+            id: format!("sprites:{}", request.key),
+            sprite_name,
+            request,
+            backend: self.handle_backend(),
+        })))
+    }
+
+    async fn acquire_from_snapshot(
+        &self,
+        request: SandboxRequest,
+        payload: SnapshotPayload,
+    ) -> Result<Arc<dyn ManagedSandboxHandle>> {
+        reject_host_mounts(&request)?;
+        if !matches!(payload.kind, SnapshotKind::SpritesSnapshot) {
+            bail!(
+                "Sprites sandbox backend can only restore from SnapshotKind::SpritesSnapshot, \
+                 got {:?}",
+                payload.kind
+            );
+        }
+        let manifest: SpritesSnapshotManifest =
+            serde_json::from_slice(&payload.bytes).context("decoding SpritesSnapshot manifest")?;
+        let sprite_name = sprite_name_for_request(&request);
+        if manifest.sprite_name != sprite_name {
+            bail!(
+                "Sprites snapshot belongs to sprite {}, but this sandbox key maps to {}",
+                manifest.sprite_name,
+                sprite_name
+            );
+        }
+        self.ensure_sprite(&sprite_name).await?;
+        restore_checkpoint_via_backend(
+            &self.handle_backend(),
+            &sprite_name,
+            &manifest.checkpoint_id,
+        )
+        .await?;
+        Ok(Arc::new(SpritesSandboxHandle {
+            id: format!("sprites-restored:{}", request.key),
+            sprite_name,
+            request,
+            backend: self.handle_backend(),
+        }))
+    }
+}
+
+#[derive(Clone)]
+struct SpritesBackendHandle {
+    client: reqwest::Client,
+    api_url: String,
+}
+
+impl SpritesBackendHandle {
+    fn api_endpoint(&self, path: &str) -> String {
+        format!("{}{}", self.api_url, path)
+    }
+}
+
+struct SpritesSandboxHandle {
+    id: String,
+    sprite_name: String,
+    request: SandboxRequest,
+    backend: SpritesBackendHandle,
+}
+
+#[async_trait]
+impl ManagedSandboxHandle for SpritesSandboxHandle {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    async fn exec(&self, command: &SandboxCommand) -> Result<SandboxCommandOutput> {
+        exec_in_sprite(
+            &self.backend,
+            &self.sprite_name,
+            &self.request.spec,
+            command,
+        )
+        .await
+    }
+
+    async fn start_process(&self, command: &SandboxCommand) -> Result<crate::SandboxProcessParts> {
+        let output = exec_in_sprite(
+            &self.backend,
+            &self.sprite_name,
+            &self.request.spec,
+            command,
+        )
+        .await?;
+        let exit_code = output.exit_code.unwrap_or(0);
+        let stdout = Cursor::new(output.stdout.into_bytes());
+        let stderr = Cursor::new(output.stderr.into_bytes());
+        let stdin = futures::io::sink();
+        let wait: BoxFuture<'static, crate::Result<i32>> = Box::pin(async move { Ok(exit_code) });
+        Ok(crate::SandboxProcessParts {
+            stdout: Box::pin(stdout),
+            stderr: Box::pin(stderr),
+            stdin: Box::pin(stdin),
+            wait,
+        })
+    }
+
+    async fn stop(&self) -> Result<()> {
+        // Sprites hibernate when idle; do not DELETE — the next session resumes the
+        // same sprite by deterministic name via `try_resume`.
+        Ok(())
+    }
+
+    async fn snapshot(&self) -> Result<SnapshotPayload> {
+        save_checkpoint_via_backend(&self.backend, &self.sprite_name).await
+    }
+}
+
+async fn exec_in_sprite(
+    backend: &SpritesBackendHandle,
+    sprite_name: &str,
+    spec: &SandboxSpec,
+    command: &SandboxCommand,
+) -> Result<SandboxCommandOutput> {
+    if command.argv.is_empty() {
+        bail!("sandbox command requires at least one argv entry");
+    }
+    let cwd = command
+        .cwd
+        .clone()
+        .unwrap_or_else(|| spec.default_workdir.clone());
+
+    let mut query: Vec<(&str, String)> = Vec::new();
+    for arg in &command.argv {
+        query.push(("cmd", arg.clone()));
+    }
+    query.push(("stdin", "false".to_string()));
+    if !cwd.is_empty() {
+        query.push(("dir", cwd.clone()));
+    }
+    for (key, value) in &command.env {
+        query.push(("env", format!("{key}={value}")));
+    }
+
+    let response = backend
+        .client
+        .post(backend.api_endpoint(&format!("/v1/sprites/{sprite_name}/exec")))
+        .query(&query)
+        .send()
+        .await
+        .with_context(|| format!("exec in Sprites sprite {sprite_name}"))?;
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .context("reading Sprites exec response body")?;
+    if !status.is_success() {
+        bail!("Sprites exec failed ({status}): {body}");
+    }
+
+    let (exit_code, stdout, stderr) = parse_exec_response(&body)?;
+    Ok(SandboxCommandOutput {
+        ok: exit_code == 0,
+        exit_code: Some(exit_code),
+        stdout,
+        stderr,
+        command: command
+            .display_argv
+            .clone()
+            .unwrap_or_else(|| command.argv.clone()),
+        cwd,
+    })
+}
+
+fn parse_exec_response(body: &str) -> Result<(i32, String, String)> {
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return Ok((0, String::new(), String::new()));
+    }
+
+    // Some deployments return a single JSON object; others stream NDJSON or raw stdout.
+    if trimmed.starts_with('{') && !trimmed.contains('\n') {
+        if let Ok(parsed) = serde_json::from_str::<SpritesHttpExecResponse>(trimmed) {
+            return Ok(parsed.into_parts());
+        }
+    }
+
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    let mut exit_code = None;
+    let mut parsed_stream_event = false;
+    let mut raw_lines = String::new();
+
+    for line in trimmed.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(event) = serde_json::from_str::<SpritesStreamEvent>(line) else {
+            raw_lines.push_str(line);
+            raw_lines.push('\n');
+            continue;
+        };
+        parsed_stream_event = true;
+        match event.event_type.as_str() {
+            "stdout" => {
+                if let Some(data) = event.data {
+                    stdout.push_str(&data);
+                }
+            }
+            "stderr" => {
+                if let Some(data) = event.data {
+                    stderr.push_str(&data);
+                }
+            }
+            "complete" | "exit" => {
+                if let Some(code) = event.exit_code {
+                    exit_code = Some(code);
+                }
+            }
+            "error" => {
+                let message = event
+                    .error
+                    .or(event.message)
+                    .unwrap_or_else(|| "Sprites exec stream error".into());
+                bail!("{message}");
+            }
+            _ => {}
+        }
+    }
+
+    if parsed_stream_event {
+        return Ok((exit_code.unwrap_or(0), stdout, stderr));
+    }
+
+    if !raw_lines.is_empty() {
+        return Ok((exit_code.unwrap_or(0), raw_lines, stderr));
+    }
+
+    // Plain-text body (common for simple HTTP exec, e.g. `curl ... | python`).
+    Ok((exit_code.unwrap_or(0), trimmed.to_string(), stderr))
+}
+
+async fn save_checkpoint_via_backend(
+    backend: &SpritesBackendHandle,
+    sprite_name: &str,
+) -> Result<SnapshotPayload> {
+    let body = serde_json::json!({ "comment": "exo snapshot" });
+    let response = backend
+        .client
+        .post(backend.api_endpoint(&format!("/v1/sprites/{sprite_name}/checkpoint")))
+        .json(&body)
+        .send()
+        .await
+        .with_context(|| format!("creating Sprites checkpoint for {sprite_name}"))?;
+    let status = response.status();
+    let text = response
+        .text()
+        .await
+        .context("reading Sprites checkpoint response")?;
+    if !status.is_success() {
+        bail!("Sprites checkpoint failed ({status}): {text}");
+    }
+    let checkpoint_id = parse_checkpoint_id_from_stream(&text)?;
+    let manifest = SpritesSnapshotManifest {
+        checkpoint_id,
+        sprite_name: sprite_name.to_string(),
+    };
+    let bytes =
+        serde_json::to_vec(&manifest).context("serializing Sprites snapshot manifest")?;
+    Ok(SnapshotPayload {
+        kind: SnapshotKind::SpritesSnapshot,
+        bytes: Bytes::from(bytes),
+    })
+}
+
+async fn restore_checkpoint_via_backend(
+    backend: &SpritesBackendHandle,
+    sprite_name: &str,
+    checkpoint_id: &str,
+) -> Result<()> {
+    let response = backend
+        .client
+        .post(backend.api_endpoint(&format!(
+            "/v1/sprites/{sprite_name}/checkpoints/{checkpoint_id}/restore"
+        )))
+        .send()
+        .await
+        .with_context(|| {
+            format!("restoring Sprites checkpoint {checkpoint_id} on {sprite_name}")
+        })?;
+    let status = response.status();
+    let text = response
+        .text()
+        .await
+        .context("reading Sprites restore response")?;
+    if !status.is_success() {
+        bail!("Sprites checkpoint restore failed ({status}): {text}");
+    }
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let event: SpritesStreamEvent =
+            serde_json::from_str(line).context("decoding Sprites restore NDJSON line")?;
+        if event.event_type == "error" {
+            let message = event
+                .error
+                .or(event.message)
+                .unwrap_or_else(|| "Sprites restore stream error".into());
+            bail!("{message}");
+        }
+    }
+    Ok(())
+}
+
+fn parse_checkpoint_id_from_stream(body: &str) -> Result<String> {
+    let mut checkpoint_id = None;
+    for line in body.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let event: SpritesStreamEvent =
+            serde_json::from_str(line).context("decoding Sprites checkpoint NDJSON line")?;
+        if event.event_type == "error" {
+            let message = event
+                .error
+                .or(event.message)
+                .unwrap_or_else(|| "Sprites checkpoint stream error".into());
+            bail!("{message}");
+        }
+        if let Some(data) = event.data {
+            if let Some(id) = data.strip_prefix("  ID: ") {
+                checkpoint_id = Some(id.trim().to_string());
+            }
+            if let Some(rest) = data.strip_prefix("Checkpoint ") {
+                if let Some(id) = rest.split_whitespace().next() {
+                    checkpoint_id = Some(id.to_string());
+                }
+            }
+        }
+    }
+    checkpoint_id.ok_or_else(|| anyhow!("Sprites checkpoint stream did not report a checkpoint id"))
+}
+
+/// Deterministic sprite name for a sandbox key + spec. Sprites names must be unique
+/// per organization; hashing the exo key and spec hash gives stable cross-process resume.
+fn sprite_name_for_request(request: &SandboxRequest) -> String {
+    let spec_hash = sandbox_spec_hash(&request.spec);
+    let mut hasher = DefaultHasher::new();
+    request.key.hash(&mut hasher);
+    spec_hash.hash(&mut hasher);
+    format!("exo-{:016x}", hasher.finish())
+}
+
+fn reject_host_mounts(request: &SandboxRequest) -> Result<()> {
+    if request.spec.mounts.is_empty() {
+        return Ok(());
+    }
+    bail!(
+        "Sprites sandbox backend does not support host bind-mounts; \
+         remove conversation mounts or switch to --sandbox-backend docker. \
+         A remote-workspace provisioner is planned as a follow-up."
+    )
+}
+
+#[derive(Debug, Serialize)]
+struct SpritesCreateRequest {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SpritesHttpExecResponse {
+    #[serde(default, alias = "exitCode")]
+    exit_code: Option<i32>,
+    #[serde(default)]
+    stdout: String,
+    #[serde(default)]
+    stderr: String,
+    #[serde(default)]
+    output: String,
+}
+
+impl SpritesHttpExecResponse {
+    fn into_parts(self) -> (i32, String, String) {
+        let exit_code = self.exit_code.unwrap_or(0);
+        let stdout = if self.stdout.is_empty() {
+            self.output
+        } else {
+            self.stdout
+        };
+        (exit_code, stdout, self.stderr)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SpritesStreamEvent {
+    #[serde(rename = "type")]
+    event_type: String,
+    #[serde(default)]
+    data: Option<String>,
+    #[serde(default)]
+    message: Option<String>,
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(default, alias = "exitCode")]
+    exit_code: Option<i32>,
+}

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -151,6 +151,32 @@ pub struct EventQuery {
     pub types: Option<Vec<EventKind>>,
 }
 
+/// Return the first event of `kind` (in `direction` order) for which
+/// `extract` yields `Some`. `limit` caps the scan; set it generously
+/// when `extract` may filter most candidates out.
+pub async fn first_matching_event<T>(
+    conversation: &dyn ConversationHandle,
+    kind: EventKind,
+    direction: EventQueryDirection,
+    limit: u32,
+    mut extract: impl FnMut(EventData) -> Option<T>,
+) -> Result<Option<T>> {
+    let result = conversation
+        .get_events(Some(EventQuery {
+            cursor: None,
+            direction: Some(direction),
+            limit: Some(limit),
+            session_id: None,
+            turn_id: None,
+            types: Some(vec![kind]),
+        }))
+        .await?;
+    Ok(result
+        .events
+        .into_iter()
+        .find_map(|event| extract(event.data)))
+}
+
 /// Tag identifying an `EventData` variant — used by `EventQuery::types` to
 /// filter events by kind without stringly comparing snake_case names. The
 /// constants below cover every built-in variant; `EventKind::custom(name)`


### PR DESCRIPTION
# Sprites sandbox backend

## Summary

Adds a [Sprites.dev](https://sprites.dev) sandbox backend so exo can provision and reuse remote sandboxes the same way it does for Daytona (#22) and E2B (#36). The backend implements `ManagedSandboxBackend` and plugs into the existing harness path (`ensure_shell_sandbox`, `run_in_sandbox` → `try_resume`, snapshot restore). 

## What is included

- `crates/exoharness/src/sprites.rs` — `SpritesSandboxBackend`, lifecycle (`POST/GET /v1/sprites`), HTTP exec (`POST .../exec`), checkpoints (`SnapshotKind::SpritesSnapshot`).
- Wiring in `basic.rs`, `sandbox.rs`, `executor`, and CLI (`--sandbox-backend sprites`).
- Tests:
  - `crates/cli/tests/sprites_backend.rs` — wiremock coverage of create, resume, exec, checkpoint/restore, mount rejection, wrong snapshot kind.

Cross-process identity uses a **deterministic sprite name** derived from `SandboxKey` + spec hash (`exo-{hash}`), not E2B/Daytona-style metadata labels. Host bind mounts are rejected; use docker or local backends if you need mounts.

## How this differs from Daytona and E2B

All three backends sit behind the same exo abstractions. The differences are what each product exposes:


| Concern           | Daytona (#22)                                          | E2B                                               | Sprites (this PR)                                                |
| ----------------- | ------------------------------------------------------ | ------------------------------------------------- | ---------------------------------------------------------------- |
| Control plane     | REST on `DAYTONA_API_URL`                              | REST on `api.e2b.app`                             | REST on `api.sprites.dev`                                        |
| Run command       | REST JSON on toolbox (`/toolbox/{id}/process/execute`) | Connect RPC on per-VM envd                        | HTTP `POST /v1/sprites/{name}/exec` (query `cmd=...`)            |
| Identity / resume | Labels (`exo.sandbox.key`, `exo.sandbox.spec-hash`)    | Sandbox metadata on list API                      | Fixed sprite **name** per key + spec hash                        |
| Stop / reuse      | `stop` preserves VM; resume by labels                  | `pause`; resume by metadata + `connect` if paused | `stop` is a no-op (sprite hibernates); resume by `GET` same name |
| Snapshots         | `DaytonaSnapshot` (named snapshot in Daytona)          | `E2bSnapshot` (snapshot template id)              | `SpritesSnapshot` (checkpoint id on that sprite)                 |
| `sandbox_image`   | Daytona snapshot registry                              | E2B template id (e.g. `base`)                     | Not used (Sprites default environment)                           |


Sprites uses a single REST surface for lifecycle and exec (no separate toolbox or envd host). Exec responses may be JSON, NDJSON streams, or plain stdout; the backend accepts all three.

## Usage

Build with Rust 1.95+ (same as the rest of the repo).

Environment:

```bash
export SPRITES_TOKEN=...          # or SPRITE_TOKEN
# optional:
# SPRITES_API_URL=https://api.sprites.dev
```

Run exo with the Sprites backend (on macOS you must pass this explicitly; the default is still apple-container):

```bash
exo --sandbox-backend sprites --root "$EXO_ROOT" repl --agent <agent> --conversation <slug>
```

**Shell tools:** The default `exo repl` path auto-creates a conversation and disables the shell tool (plain chat). For sandbox commands, either:

1. Create the conversation first, then enable shell:

```bash
exo --sandbox-backend sprites --root "$EXO_ROOT" \
  conversation create <agent> --slug <conv>

exo --sandbox-backend sprites --root "$EXO_ROOT" \
  conversation update <agent> <conv> \
  --shell-program /bin/bash --networking enabled

exo --sandbox-backend sprites --root "$EXO_ROOT" repl --agent <agent> --conversation <conv>
```

1. Or use `conversation update` on an existing conversation before chatting.

Networking for installs/downloads follows **conversation** `enable_networking` (set via `conversation update` or agent defaults as wired today).

Verify resume across a REPL exit: write a file in the sandbox, `/quit`, reconnect with the same `--root`, agent, and conversation; exo should `try_resume` the same sprite by name (no second create if resume succeeds). Use a **new conversation slug** for a clean test so old `sandbox_created` events from failed runs do not confuse the check.

Manual smoke (Sprites API):

```bash
curl -s -H "Authorization: Bearer $SPRITES_TOKEN" https://api.sprites.dev/v1/sprites | head
```

Tests:

```bash
cargo +1.95.0 test --package exo --test sprites_backend
```

There is no `sprites_live.rs` yet; optional live tests behind `#[ignore]` (like `e2b_live.rs`) can follow in a follow-up.

## Relation to #22 and E2B

This PR assumes the shared sandbox integration from #22 is already in the tree: `ManagedSandboxBackend`, `try_resume`, the executor/harness shell sandbox lifecycle, and CLI `--sandbox-backend`. No new harness-level concepts are introduced.

If this branch stacks on the E2B work, you get both `--sandbox-backend e2b` and `--sandbox-backend sprites` as separate choices.

Dependencies are the same class as Daytona/E2B remote backends: `reqwest` on `exoharness` (via `basic-backend`). There is no Sprites SDK crate; the backend speaks HTTP directly, matching `daytona.rs` and `e2b.rs`.

## Notes for reviewers

- Deterministic sprite names mean a spec change (different `exo.sandbox.spec-hash`) maps to a **new** sprite; that matches Docker/Daytona “new sandbox on spec change” semantics.
- Checkpoint restore in `acquire_from_snapshot` requires the manifest’s `sprite_name` to match the name for the current `SandboxKey` (checkpoints are per-sprite, not global templates like E2B snapshot ids).
- Do not assume Debian/`apt` on the sprite; prefer `python3 --version` style checks when smoke-testing.

