### PR TITLE
exoharness: fix find_running_warm_sandbox to work on Docker (Linux)

### DIFF
--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -397,13 +397,14 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
             schedule_cleanup_named_container(self.container_bin.clone(), self.cli, entry.name);
         }
 
-        let (name, owned) = match find_running_warm_sandbox(&self.container_bin, &request).await? {
-            Some(name) => (name, false),
-            None => (
-                create_unique_warm_sandbox(&self.container_bin, &request).await?,
-                true,
-            ),
-        };
+        let (name, owned) =
+            match find_running_warm_sandbox(&self.container_bin, self.cli, &request).await? {
+                Some(name) => (name, false),
+                None => (
+                    create_unique_warm_sandbox(&self.container_bin, &request).await?,
+                    true,
+                ),
+            };
 
         {
             let mut warm_sandboxes = self.warm_sandboxes.lock().await;
@@ -791,6 +792,21 @@ async fn create_unique_warm_sandbox(
 
 async fn find_running_warm_sandbox(
     container_bin: &Path,
+    cli: ContainerCliFlavor,
+    request: &SandboxRequest,
+) -> Result<Option<String>> {
+    match cli {
+        ContainerCliFlavor::AppleContainer => {
+            find_running_warm_sandbox_apple(container_bin, request).await
+        }
+        ContainerCliFlavor::Docker => {
+            find_running_warm_sandbox_docker(container_bin, request).await
+        }
+    }
+}
+
+async fn find_running_warm_sandbox_apple(
+    container_bin: &Path,
     request: &SandboxRequest,
 ) -> Result<Option<String>> {
     let output = run_container_admin_command(
@@ -823,6 +839,58 @@ async fn find_running_warm_sandbox(
     }))
 }
 
+/// One row of `docker ps --format '{{json .}}'`. We only read `Names`;
+/// server-side `--filter`s narrow to running containers with the right key
+/// and spec hash, so no label parsing is needed.
+#[derive(Debug, Deserialize)]
+struct DockerPsItem {
+    #[serde(rename = "Names")]
+    names: String,
+}
+
+async fn find_running_warm_sandbox_docker(
+    container_bin: &Path,
+    request: &SandboxRequest,
+) -> Result<Option<String>> {
+    let key_filter = format!("label={WARM_SANDBOX_KEY_LABEL}={}", request.key);
+    let spec_hash = sandbox_spec_hash(&request.spec);
+    let spec_filter = format!("label={WARM_SANDBOX_SPEC_HASH_LABEL}={spec_hash}");
+    let output = run_container_admin_command(
+        container_bin,
+        WARM_SANDBOX_CLEANUP_TIMEOUT,
+        [
+            "ps",
+            "--filter",
+            "status=running",
+            "--filter",
+            &key_filter,
+            "--filter",
+            &spec_filter,
+            "--format",
+            "{{json .}}",
+        ],
+    )
+    .await?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "failed to list warm sandboxes for {}: {}",
+            request.key,
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+
+    let stdout = std::str::from_utf8(&output.stdout).context("docker ps output is not utf-8")?;
+    for line in stdout.lines() {
+        if line.is_empty() {
+            continue;
+        }
+        let item: DockerPsItem = serde_json::from_str(line)
+            .with_context(|| format!("decoding docker ps json line: {line}"))?;
+        return Ok(Some(item.names));
+    }
+    Ok(None)
+}
+
 async fn ensure_warm_sandbox_ready(
     container_bin: &Path,
     cli: ContainerCliFlavor,
@@ -850,7 +918,8 @@ async fn ensure_warm_sandbox_ready(
             if stale.owned {
                 schedule_cleanup_named_container(container_bin.to_path_buf(), cli, stale.name);
             }
-            let (name, owned) = match find_running_warm_sandbox(container_bin, request).await? {
+            let (name, owned) = match find_running_warm_sandbox(container_bin, cli, request).await?
+            {
                 Some(name) => (name, false),
                 None => (
                     create_unique_warm_sandbox(container_bin, request).await?,
@@ -869,7 +938,8 @@ async fn ensure_warm_sandbox_ready(
             return Ok(name);
         }
         None => {
-            let (name, owned) = match find_running_warm_sandbox(container_bin, request).await? {
+            let (name, owned) = match find_running_warm_sandbox(container_bin, cli, request).await?
+            {
                 Some(name) => (name, false),
                 None => (
                     create_unique_warm_sandbox(container_bin, request).await?,
@@ -897,13 +967,14 @@ async fn ensure_warm_sandbox_ready(
         return Ok(current_name);
     }
 
-    let (replacement_name, owned) = match find_running_warm_sandbox(container_bin, request).await? {
-        Some(name) => (name, false),
-        None => (
-            create_unique_warm_sandbox(container_bin, request).await?,
-            true,
-        ),
-    };
+    let (replacement_name, owned) =
+        match find_running_warm_sandbox(container_bin, cli, request).await? {
+            Some(name) => (name, false),
+            None => (
+                create_unique_warm_sandbox(container_bin, request).await?,
+                true,
+            ),
+        };
     warm_sandboxes.insert(
         request.key.clone(),
         WarmSandboxEntry {


### PR DESCRIPTION
`find_running_warm_sandbox` unconditionally called

    <bin> list --format json

which is Apple Container CLI syntax. On Docker (the Linux default), `list` isn't a subcommand and the call fails with `unknown flag: --format`, which surfaces as `failed to list warm sandboxes` on the first sandbox provision attempt. Linux Docker users can't run agents that touch a sandbox without working around it.

## Fix

Dispatch `find_running_warm_sandbox` on `ContainerCliFlavor`:

- **Apple path** — unchanged, extracted into `find_running_warm_sandbox_apple`.
- **Docker path** — `find_running_warm_sandbox_docker` uses `docker ps` with three server-side filters (`status=running`, key label, spec-hash label) plus `--format '{{json .}}'`. Each output line is a JSON object; we deserialize into a 1-field `DockerPsItem { names }` and return the first. No client-side label parsing required.
- Uses the existing `run_container_admin_command` helper for the subprocess spawn + timeout, matching the Apple sibling.

## Test plan

- `cargo check --all-targets` ✅
- `cargo clippy --all-targets -- -D warnings` ✅
- `cargo fmt --check` ✅
- End-to-end verified locally on Linux: with `sandbox_provider: docker` on an agent, sending a message triggers `docker run` for a fresh warm sandbox, the shell tool executes inside it (`echo linux-docker-fixed`), and the result returns through to the assistant. Before this change the same flow erroored with `failed to list warm sandboxes: unknown flag: --format` before any container was provisioned.