### PR TITLE
Daytona Snapshot/Rewind + Teleportation support

### DIFF
--- a/crates/cli/src/tui.rs
+++ b/crates/cli/src/tui.rs
@@ -8,8 +8,8 @@ use std::time::Duration;
 use anyhow::Result;
 use executor::{
     ConversationHandle, EventData, EventId, EventKind, EventQuery, EventQueryDirection,
-    ExecutionStreamEvent, HarnessAgent, HarnessConversation, SandboxId, SendRequest, SessionId,
-    SnapshotId, StartSandboxRequest,
+    ExecutionStreamEvent, HarnessAgent, HarnessConversation, SandboxId, SandboxProvider,
+    SendRequest, SessionId, SnapshotId, StartSandboxRequest,
 };
 use lingua::universal::{UserContent, UserContentPart};
 use lingua::{Message, UniversalStreamChunk};
@@ -540,6 +540,25 @@ impl ChatRepl {
                             }
                             Err(error) => println!("listing snapshots failed: {error:#}"),
                         },
+                        "/teleport" => {
+                            println!("usage: /teleport <provider> (e.g. /teleport daytona)");
+                        }
+                        other if other.starts_with("/teleport ") => {
+                            let arg = other
+                                .strip_prefix("/teleport ")
+                                .expect("prefix checked")
+                                .trim();
+                            if arg.is_empty() || arg.contains(char::is_whitespace) {
+                                println!("usage: /teleport <provider> (e.g. /teleport daytona)");
+                            } else {
+                                match self.teleport_sandbox(arg).await {
+                                    Ok((sandbox_id, provider)) => {
+                                        println!("sandbox {sandbox_id} teleported to {provider}");
+                                    }
+                                    Err(error) => println!("teleport failed: {error:#}"),
+                                }
+                            }
+                        }
                         other if other.starts_with("/rewind ") => {
                             let arg = other
                                 .strip_prefix("/rewind ")
@@ -602,6 +621,38 @@ impl ChatRepl {
         list_snapshots(self.conversation.as_ref()).await
     }
 
+    /// Teleport the conversation's live sandbox to another provider: snapshot
+    /// it where it runs now, then restore that snapshot under the target
+    /// provider. The sandbox id is stable across the move; only the backend
+    /// (and the machine actually running the container) changes.
+    async fn teleport_sandbox(&self, provider_str: &str) -> Result<(SandboxId, SandboxProvider)> {
+        let provider = provider_str
+            .parse::<SandboxProvider>()
+            .map_err(|error| anyhow::anyhow!("invalid provider `{provider_str}`: {error}"))?;
+        let sandbox_id = latest_sandbox_id(self.conversation.as_ref())
+            .await?
+            .ok_or_else(|| {
+                anyhow::anyhow!("no sandbox has been created in this conversation yet")
+            })?;
+        println!("snapshotting sandbox {sandbox_id}...");
+        let snapshot_id = self
+            .conversation
+            .exoharness_handle()
+            .snapshot_sandbox(sandbox_id.clone())
+            .await?;
+        println!("snapshot {snapshot_id} captured; restoring on {provider}...");
+        self.conversation
+            .exoharness_handle()
+            .start_sandbox(StartSandboxRequest {
+                id: sandbox_id.clone(),
+                snapshot_id,
+                idle_seconds: None,
+                provider: Some(provider),
+            })
+            .await?;
+        Ok((sandbox_id, provider))
+    }
+
     /// Restore the conversation's sandbox to a previously-taken snapshot.
     /// Stops the current container, decodes the snapshot payload, and starts
     /// a fresh container from that state.
@@ -620,6 +671,7 @@ impl ChatRepl {
                 id: sandbox_id,
                 snapshot_id,
                 idle_seconds: None,
+                provider: None,
             })
             .await?;
         Ok(())
@@ -908,6 +960,8 @@ fn print_help() {
     println!("                       (defaults to the latest one if no id is given)");
     println!("  /snapshots           list snapshots taken in this conversation");
     println!("  /rewind <id>         restore the sandbox to a previous snapshot");
+    println!("  /teleport <provider> move the live sandbox to another provider");
+    println!("                       (e.g. /teleport daytona: snapshot + restore there)");
     println!("  /help                show this message");
 }
 

--- a/crates/cli/src/tui.rs
+++ b/crates/cli/src/tui.rs
@@ -533,9 +533,15 @@ impl ChatRepl {
                                 println!("no snapshots yet for this conversation");
                             }
                             Ok(snapshots) => {
-                                println!("SNAPSHOT\tSANDBOX");
+                                println!("SNAPSHOT\tTAKEN\tSANDBOX");
                                 for (snapshot_id, sandbox_id) in snapshots {
-                                    println!("{snapshot_id}\t{sandbox_id}");
+                                    // Snapshot ids are uuid7, so creation time
+                                    // is embedded in the id itself.
+                                    let taken = snapshot_id
+                                        .timestamp()
+                                        .map(|t| t.format("%Y-%m-%d %H:%M:%S UTC").to_string())
+                                        .unwrap_or_else(|| "-".to_string());
+                                    println!("{snapshot_id}\t{taken}\t{sandbox_id}");
                                 }
                             }
                             Err(error) => println!("listing snapshots failed: {error:#}"),

--- a/crates/cli/tests/daytona_backend.rs
+++ b/crates/cli/tests/daytona_backend.rs
@@ -397,10 +397,10 @@ async fn stop_calls_stop_endpoint_not_delete() {
     );
 }
 
-// ─────────────────────── snapshot (unimplemented) ───────────────────────
+// ─────────────────────── snapshot ───────────────────────
 
 #[tokio::test]
-async fn snapshot_is_unimplemented() {
+async fn snapshot_returns_daytona_snapshot_payload_with_manifest() {
     let server = MockServer::start().await;
     let backend = backend_for_mock(&server);
 
@@ -410,52 +410,190 @@ async fn snapshot_is_unimplemented() {
         .respond_with(ResponseTemplate::new(200).set_body_json(sandbox_json("sb-snap", "started")))
         .mount(&server)
         .await;
+    Mock::given(method("POST"))
+        .and(path("/sandbox/sb-snap/snapshot"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+    // snapshot() polls the sandbox until it leaves `snapshotting`...
     mount_get_started(&server).await;
+    // ...then waits for the snapshot resource itself to reach `active`.
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/snapshots/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "state": "active" })))
+        .mount(&server)
+        .await;
 
     let handle = backend
         .acquire(make_request("conv-8", "sandbox-8"))
         .await
         .unwrap();
+    let payload = handle
+        .snapshot()
+        .await
+        .expect("snapshot should succeed against the mock");
+
+    assert!(
+        matches!(payload.kind, SnapshotKind::DaytonaSnapshot),
+        "kind should be DaytonaSnapshot, got {:?}",
+        payload.kind
+    );
+
+    let manifest: Value =
+        serde_json::from_slice(&payload.bytes).expect("payload should be a JSON manifest");
+    assert!(
+        manifest
+            .get("snapshot_name")
+            .and_then(Value::as_str)
+            .is_some_and(|n| n.starts_with("exo-snap-")),
+        "manifest should carry a snapshot_name with the exo-snap- prefix: {manifest:?}"
+    );
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let snap_call = requests
+        .iter()
+        .find(|r| r.url.path() == "/sandbox/sb-snap/snapshot")
+        .expect("snapshot endpoint should have been called");
+    let body: Value = serde_json::from_slice(&snap_call.body).unwrap();
+    let name = body
+        .get("name")
+        .and_then(Value::as_str)
+        .expect("snapshot request body must contain `name`");
+    assert!(name.starts_with("exo-snap-"));
+}
+
+#[tokio::test]
+async fn snapshot_surfaces_feature_flag_error_on_403() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    mount_find(&server, Vec::new()).await;
+    Mock::given(method("POST"))
+        .and(path("/sandbox"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sandbox_json("sb-flag", "started")))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/sandbox/sb-flag/snapshot"))
+        .respond_with(ResponseTemplate::new(403).set_body_json(json!({
+            "statusCode": 403,
+            "error": "Forbidden",
+            "message": "Required feature flags are not enabled"
+        })))
+        .mount(&server)
+        .await;
+
+    mount_get_started(&server).await;
+
+    let handle = backend
+        .acquire(make_request("conv-flag", "sandbox-flag"))
+        .await
+        .unwrap();
     let error = match handle.snapshot().await {
-        Ok(_) => panic!("Daytona snapshots are not implemented"),
-        Err(e) => e,
+        Ok(_) => panic!("snapshot should fail when the feature flag is off"),
+        Err(e) => format!("{e:#}").to_lowercase(),
     };
     assert!(
-        format!("{error:#}")
-            .to_lowercase()
-            .contains("not implemented"),
-        "error should say snapshots are not implemented: {error:#}"
+        error.contains("feature") && error.contains("enable"),
+        "403 should surface an actionable feature-flag message: {error}"
     );
 }
 
 #[tokio::test]
-async fn acquire_from_snapshot_is_unimplemented() {
+async fn acquire_from_snapshot_passes_snapshot_name_in_create_body() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    // acquire_from_snapshot creates directly (no find step).
+    Mock::given(method("POST"))
+        .and(path("/sandbox"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(sandbox_json("sb-restored", "started")),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let manifest = json!({ "snapshot_name": "exo-snap-canonical-fixture" });
+    let payload = SnapshotPayload {
+        kind: SnapshotKind::DaytonaSnapshot,
+        bytes: Bytes::from(serde_json::to_vec(&manifest).unwrap()),
+    };
+
+    mount_get_started(&server).await;
+
+    let request = make_request("conv-9", "sandbox-9");
+    backend
+        .acquire_from_snapshot(request, payload)
+        .await
+        .expect("acquire_from_snapshot should succeed against a 200 mock");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let create = requests
+        .iter()
+        .find(|r| r.url.path() == "/sandbox" && r.method.to_string().to_uppercase() == "POST")
+        .expect("POST /sandbox should have been called");
+    let body: Value = serde_json::from_slice(&create.body).unwrap();
+    assert_eq!(
+        body.get("snapshot").and_then(Value::as_str),
+        Some("exo-snap-canonical-fixture"),
+        "create-from-snapshot must pass the manifest's snapshot_name to Daytona: {body:?}"
+    );
+}
+
+#[tokio::test]
+async fn acquire_from_snapshot_rejects_foreign_kinds() {
     let server = MockServer::start().await;
     let backend = backend_for_mock(&server);
 
     let payload = SnapshotPayload {
-        kind: SnapshotKind::DaytonaSnapshot,
+        kind: SnapshotKind::E2bSnapshot,
         bytes: Bytes::from_static(b"{}"),
     };
-    let error = match backend
-        .acquire_from_snapshot(make_request("conv-9", "sandbox-9"), payload)
-        .await
-    {
-        Ok(_) => panic!("restoring a Daytona snapshot is not implemented"),
+    let request = make_request("conv-10", "sandbox-10");
+    let error = match backend.acquire_from_snapshot(request, payload).await {
+        Ok(_) => panic!("Daytona backend must reject an E2bSnapshot payload"),
         Err(e) => e,
     };
+    let msg = format!("{error:#}").to_lowercase();
     assert!(
-        format!("{error:#}")
-            .to_lowercase()
-            .contains("not implemented"),
-        "error should say restore is not implemented: {error:#}"
+        msg.contains("daytona") && msg.contains("e2bsnapshot"),
+        "error should explain the kind mismatch: {msg}"
+    );
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert_eq!(requests.len(), 0, "kind-mismatch must not reach the API");
+}
+
+#[tokio::test]
+async fn acquire_from_snapshot_bridges_docker_tar_but_fails_on_garbage() {
+    // A DockerImageTar payload is accepted (that's the teleport bridge), but the
+    // bytes here aren't a real `docker save` tarball, so the local `docker load`
+    // step fails before anything reaches the Daytona API.
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    let payload = SnapshotPayload {
+        kind: SnapshotKind::DockerImageTar,
+        bytes: Bytes::from_static(b"\x00not-a-real-tar"),
+    };
+    let request = make_request("conv-11", "sandbox-11");
+    let error = match backend.acquire_from_snapshot(request, payload).await {
+        Ok(_) => panic!("garbage tar bytes must not restore"),
+        Err(e) => e,
+    };
+    let msg = format!("{error:#}").to_lowercase();
+    assert!(
+        msg.contains("docker"),
+        "error should point at the docker bridge step: {msg}"
     );
 
     let requests = server.received_requests().await.unwrap_or_default();
     assert_eq!(
         requests.len(),
         0,
-        "unimplemented restore must not reach the API"
+        "a failed bridge import must not reach the API"
     );
 }
 

--- a/crates/cli/tests/snapshot_round_trip.rs
+++ b/crates/cli/tests/snapshot_round_trip.rs
@@ -161,6 +161,7 @@ async fn filesystem_snapshot_and_rewind_round_trip() {
             id: sandbox_id.clone(),
             snapshot_id,
             idle_seconds: None,
+            provider: None,
         })
         .await
         .expect("start_sandbox (rewind) should succeed");

--- a/crates/cli/tests/snapshot_round_trip_daytona.rs
+++ b/crates/cli/tests/snapshot_round_trip_daytona.rs
@@ -1,0 +1,175 @@
+//! Live native Daytona snapshot + rewind round-trip, through the harness API.
+//! The Daytona analog of `snapshot_round_trip.rs` (Docker): create a Daytona
+//! sandbox, write a file, `snapshot_sandbox` (native checkpoint), mutate,
+//! `start_sandbox` to rewind, and confirm the filesystem reverted.
+//!
+//! Ignored by default. Requires `DAYTONA_API_KEY` (+ optional
+//! `DAYTONA_ORGANIZATION_ID` / `DAYTONA_TARGET`; sandbox snapshots are
+//! available in the shared `us` region). Run with:
+//!
+//! ```bash
+//! cargo test -p exo --test snapshot_round_trip_daytona -- --ignored --nocapture
+//! ```
+
+use exoharness::{
+    BasicExoHarness, BasicExoHarnessConfig, ConversationHandle, CreateSandboxRequest,
+    DaytonaBackendSpec, ExoHarness, NewAgentRequest, NewConversationRequest, PutSecretRequest,
+    RunInSandboxRequest, SandboxBackendRegistration, SandboxId, SandboxProvider, Secret,
+    SecretBackendChoice, StartSandboxRequest,
+};
+use futures::io::AsyncReadExt;
+use tempfile::TempDir;
+
+#[tokio::test]
+#[ignore = "live: needs DAYTONA_API_KEY (snapshots available in the shared `us` region)"]
+async fn daytona_snapshot_and_rewind_round_trip() {
+    let Ok(api_key) = std::env::var("DAYTONA_API_KEY") else {
+        eprintln!("skipping: DAYTONA_API_KEY not set");
+        return;
+    };
+
+    let root = TempDir::new().expect("tempdir");
+    let harness = BasicExoHarness::new(BasicExoHarnessConfig {
+        root: root.path().to_path_buf(),
+        secret_backend: SecretBackendChoice::Static([7u8; 32]),
+        sandbox_default: SandboxProvider::Daytona,
+        sandbox_backends: vec![SandboxBackendRegistration::daytona(
+            DaytonaBackendSpec::with_conventional_secrets(),
+        )],
+    })
+    .await
+    .expect("harness");
+
+    seed_secret(&harness, "DAYTONA_API_KEY", &api_key).await;
+    if let Ok(v) = std::env::var("DAYTONA_ORGANIZATION_ID") {
+        seed_secret(&harness, "DAYTONA_ORGANIZATION_ID", &v).await;
+    }
+    if let Ok(v) = std::env::var("DAYTONA_TARGET") {
+        seed_secret(&harness, "DAYTONA_TARGET", &v).await;
+    }
+
+    let agent = harness
+        .new_agent(NewAgentRequest {
+            slug: "daysnap".into(),
+            name: "daysnap".into(),
+        })
+        .await
+        .expect("agent");
+    let conv = agent
+        .new_conversation(NewConversationRequest {
+            slug: Some("daysnap-conv".into()),
+            name: Some("daysnap".into()),
+        })
+        .await
+        .expect("conversation");
+
+    // Phase 1: create a Daytona sandbox and write v1.
+    let sandbox_id = conv
+        .create_sandbox(CreateSandboxRequest {
+            name: None,
+            provider: SandboxProvider::Daytona,
+            image: String::new(),
+            default_workdir: Some("/".into()),
+            file_system_mounts: None,
+            durable_file_systems: None,
+            enable_networking: Some(true),
+            idle_seconds: Some(300),
+        })
+        .await
+        .expect("create daytona sandbox");
+    let (rc, _, _) = exec_shell(
+        conv.as_ref(),
+        &sandbox_id,
+        "echo 'version 1' > /tmp/demo.txt",
+    )
+    .await;
+    assert_eq!(rc, 0, "writing v1 should succeed");
+
+    // Phase 2: snapshot (native Daytona checkpoint).
+    let snapshot_id = conv
+        .snapshot_sandbox(sandbox_id.clone())
+        .await
+        .expect("snapshot_sandbox");
+
+    // Phase 3: mutate after the snapshot.
+    let (rc, _, _) = exec_shell(
+        conv.as_ref(),
+        &sandbox_id,
+        "echo 'version 2' > /tmp/demo.txt && touch /tmp/post-snapshot.txt",
+    )
+    .await;
+    assert_eq!(rc, 0);
+    let (_, stdout, _) = exec_shell(conv.as_ref(), &sandbox_id, "cat /tmp/demo.txt").await;
+    assert_eq!(
+        stdout.trim(),
+        "version 2",
+        "before rewind, file should be v2"
+    );
+
+    // Phase 4: rewind to the snapshot.
+    conv.start_sandbox(StartSandboxRequest {
+        id: sandbox_id.clone(),
+        snapshot_id,
+        idle_seconds: None,
+        provider: None,
+    })
+    .await
+    .expect("start_sandbox (rewind)");
+
+    // Phase 5: prove the rewind landed.
+    let (_, stdout, _) = exec_shell(conv.as_ref(), &sandbox_id, "cat /tmp/demo.txt").await;
+    eprintln!("after rewind, /tmp/demo.txt = {stdout:?}");
+    assert_eq!(
+        stdout.trim(),
+        "version 1",
+        "after rewind, /tmp/demo.txt should be 'version 1' again"
+    );
+    let (rc, _, _) = exec_shell(conv.as_ref(), &sandbox_id, "test -f /tmp/post-snapshot.txt").await;
+    assert_ne!(rc, 0, "after rewind, the post-snapshot file should be gone");
+
+    let _ = conv.stop_sandbox(sandbox_id).await;
+}
+
+async fn seed_secret(harness: &BasicExoHarness, name: &str, value: &str) {
+    harness
+        .put_secret(PutSecretRequest {
+            name: name.into(),
+            secret: Secret::Key {
+                value: value.into(),
+            },
+        })
+        .await
+        .expect("put secret");
+}
+
+async fn exec_shell(
+    conversation: &dyn ConversationHandle,
+    sandbox_id: &SandboxId,
+    cmd: &str,
+) -> (i32, String, String) {
+    let process = conversation
+        .run_in_sandbox(RunInSandboxRequest {
+            id: sandbox_id.clone(),
+            command: vec!["/bin/bash".into(), "-c".into(), cmd.into()],
+            env: Default::default(),
+        })
+        .await
+        .unwrap_or_else(|error| panic!("run_in_sandbox({cmd:?}) failed: {error:#}"));
+    let mut parts = process.into_parts();
+    drop(parts.stdin);
+    let mut stdout_bytes = Vec::new();
+    let mut stderr_bytes = Vec::new();
+    let (stdout_result, stderr_result, wait_result) = tokio::join!(
+        parts.stdout.read_to_end(&mut stdout_bytes),
+        parts.stderr.read_to_end(&mut stderr_bytes),
+        parts.wait,
+    );
+    stdout_result.expect("read stdout");
+    stderr_result.expect("read stderr");
+    let exit_code = wait_result.expect("wait on sandbox process");
+    (
+        exit_code,
+        String::from_utf8_lossy(&stdout_bytes).into_owned(),
+        String::from_utf8_lossy(&stderr_bytes).into_owned(),
+    )
+}

--- a/crates/cli/tests/teleport_docker_to_daytona.rs
+++ b/crates/cli/tests/teleport_docker_to_daytona.rs
@@ -11,9 +11,8 @@
 //!   4. exec on the same sandbox id — now running on Daytona — and read the
 //!      marker file back
 //!
-//! Ignored by default — requires a local Docker daemon, the `daytona` CLI on
-//! PATH, and `DAYTONA_API_KEY` (+ optional `DAYTONA_ORGANIZATION_ID` /
-//! `DAYTONA_TARGET`). Run with:
+//! Ignored by default — requires a local Docker daemon and `DAYTONA_API_KEY`
+//! (+ optional `DAYTONA_ORGANIZATION_ID` / `DAYTONA_TARGET`). Run with:
 //!
 //! ```bash
 //! cargo test -p exo --test teleport_docker_to_daytona -- --ignored --nocapture
@@ -31,7 +30,7 @@ use futures::io::AsyncReadExt;
 use tempfile::TempDir;
 
 #[tokio::test]
-#[ignore = "live: needs docker, the daytona CLI, and DAYTONA_API_KEY"]
+#[ignore = "live: needs docker and DAYTONA_API_KEY"]
 async fn teleport_docker_sandbox_to_daytona_keeps_files() {
     let Ok(api_key) = std::env::var("DAYTONA_API_KEY") else {
         eprintln!("skipping: DAYTONA_API_KEY not set");

--- a/crates/cli/tests/teleport_docker_to_daytona.rs
+++ b/crates/cli/tests/teleport_docker_to_daytona.rs
@@ -23,9 +23,9 @@ use std::process::Command;
 
 use exoharness::{
     BasicExoHarness, BasicExoHarnessConfig, ConversationHandle, CreateSandboxRequest,
-    DaytonaBackendSpec, ExoHarness, NewAgentRequest, NewConversationRequest, PutSecretRequest,
-    RunInSandboxRequest, SandboxBackendRegistration, SandboxId, SandboxProvider, Secret,
-    SecretBackendChoice, StartSandboxRequest,
+    DaytonaBackendSpec, ExoHarness, FileSystemMount, FileSystemMountMode, NewAgentRequest,
+    NewConversationRequest, PutSecretRequest, RunInSandboxRequest, SandboxBackendRegistration,
+    SandboxId, SandboxProvider, Secret, SecretBackendChoice, StartSandboxRequest,
 };
 use futures::io::AsyncReadExt;
 use tempfile::TempDir;
@@ -135,6 +135,56 @@ async fn teleport_docker_sandbox_to_daytona_keeps_files() {
     );
 
     let _ = conv.stop_sandbox(sandbox_id).await;
+
+    // 5. Make-before-break: a teleport that fails must leave the source
+    //    sandbox running. Host mounts are rejected by the Daytona backend
+    //    inside acquire_from_snapshot, which makes the failure deterministic
+    //    (and local — nothing reaches the Daytona API).
+    let mount_dir = TempDir::new().expect("mount dir");
+    let mounted_id = conv
+        .create_sandbox(CreateSandboxRequest {
+            name: None,
+            provider: SandboxProvider::Docker,
+            image: "docker.io/library/ubuntu:24.04".into(),
+            default_workdir: Some("/".into()),
+            file_system_mounts: Some(vec![FileSystemMount {
+                host_path: mount_dir.path().display().to_string(),
+                mount_path: "/mnt/host".into(),
+                mode: FileSystemMountMode::ReadOnly,
+                internal: None,
+            }]),
+            durable_file_systems: None,
+            enable_networking: Some(false),
+            idle_seconds: Some(300),
+        })
+        .await
+        .expect("create mounted docker sandbox");
+    let (rc, _, _) = exec_shell(conv.as_ref(), &mounted_id, "echo alive > /still-here.txt").await;
+    assert_eq!(rc, 0);
+
+    let snapshot_id = conv
+        .snapshot_sandbox(mounted_id.clone())
+        .await
+        .expect("snapshot mounted docker sandbox");
+    let error = conv
+        .start_sandbox(StartSandboxRequest {
+            id: mounted_id.clone(),
+            snapshot_id,
+            idle_seconds: None,
+            provider: Some(SandboxProvider::Daytona),
+        })
+        .await
+        .expect_err("teleporting a mounted sandbox to daytona must fail");
+    eprintln!("failed teleport (expected): {error:#}");
+
+    let (rc, stdout, _) = exec_shell(conv.as_ref(), &mounted_id, "cat /still-here.txt").await;
+    assert_eq!(
+        rc, 0,
+        "the source sandbox must still be running after a failed teleport"
+    );
+    assert_eq!(stdout.trim(), "alive");
+
+    let _ = conv.stop_sandbox(mounted_id).await;
 }
 
 async fn seed_secret(harness: &BasicExoHarness, name: &str, value: &str) {

--- a/crates/cli/tests/teleport_docker_to_daytona.rs
+++ b/crates/cli/tests/teleport_docker_to_daytona.rs
@@ -1,0 +1,191 @@
+//! Live teleport test: a sandbox running on local Docker is snapshotted and
+//! moved to Daytona — the SAME sandbox id, resumed remotely with its files
+//! intact. Drives the harness API (not just the backend), i.e. the exact code
+//! path behind the REPL's `/teleport daytona` command:
+//!
+//!   1. create a sandbox on Docker, write a marker file
+//!   2. `snapshot_sandbox` (-> DockerImageTar payload in exoharness storage)
+//!   3. `start_sandbox` with `provider: Some(Daytona)` — the cross-provider
+//!      override routes the restore through the Daytona backend's Docker
+//!      bridge (`docker load` -> `daytona snapshot push` -> create)
+//!   4. exec on the same sandbox id — now running on Daytona — and read the
+//!      marker file back
+//!
+//! Ignored by default — requires a local Docker daemon, the `daytona` CLI on
+//! PATH, and `DAYTONA_API_KEY` (+ optional `DAYTONA_ORGANIZATION_ID` /
+//! `DAYTONA_TARGET`). Run with:
+//!
+//! ```bash
+//! cargo test -p exo --test teleport_docker_to_daytona -- --ignored --nocapture
+//! ```
+
+use std::process::Command;
+
+use exoharness::{
+    BasicExoHarness, BasicExoHarnessConfig, ConversationHandle, CreateSandboxRequest,
+    DaytonaBackendSpec, ExoHarness, NewAgentRequest, NewConversationRequest, PutSecretRequest,
+    RunInSandboxRequest, SandboxBackendRegistration, SandboxId, SandboxProvider, Secret,
+    SecretBackendChoice, StartSandboxRequest,
+};
+use futures::io::AsyncReadExt;
+use tempfile::TempDir;
+
+#[tokio::test]
+#[ignore = "live: needs docker, the daytona CLI, and DAYTONA_API_KEY"]
+async fn teleport_docker_sandbox_to_daytona_keeps_files() {
+    let Ok(api_key) = std::env::var("DAYTONA_API_KEY") else {
+        eprintln!("skipping: DAYTONA_API_KEY not set");
+        return;
+    };
+    if !docker_available() {
+        eprintln!("skipping: docker not available");
+        return;
+    }
+
+    let root = TempDir::new().expect("tempdir");
+    let harness = BasicExoHarness::new(BasicExoHarnessConfig {
+        root: root.path().to_path_buf(),
+        secret_backend: SecretBackendChoice::Static([7u8; 32]),
+        sandbox_default: SandboxProvider::Docker,
+        sandbox_backends: vec![
+            SandboxBackendRegistration::docker(),
+            SandboxBackendRegistration::daytona(DaytonaBackendSpec::with_conventional_secrets()),
+        ],
+    })
+    .await
+    .expect("harness");
+
+    // Daytona credentials live in the secret store (resolved lazily on first use).
+    seed_secret(&harness, "DAYTONA_API_KEY", &api_key).await;
+    if let Ok(v) = std::env::var("DAYTONA_ORGANIZATION_ID") {
+        seed_secret(&harness, "DAYTONA_ORGANIZATION_ID", &v).await;
+    }
+    if let Ok(v) = std::env::var("DAYTONA_TARGET") {
+        seed_secret(&harness, "DAYTONA_TARGET", &v).await;
+    }
+
+    let agent = harness
+        .new_agent(NewAgentRequest {
+            slug: "teleport".into(),
+            name: "teleport".into(),
+        })
+        .await
+        .expect("agent");
+    let conv = agent
+        .new_conversation(NewConversationRequest {
+            slug: Some("teleport-conv".into()),
+            name: Some("teleport".into()),
+        })
+        .await
+        .expect("conversation");
+
+    // 1. Create a Docker sandbox and write a marker file.
+    let sandbox_id = conv
+        .create_sandbox(CreateSandboxRequest {
+            name: None,
+            provider: SandboxProvider::Docker,
+            image: "docker.io/library/ubuntu:24.04".into(),
+            default_workdir: Some("/".into()),
+            file_system_mounts: None,
+            durable_file_systems: None,
+            enable_networking: Some(false),
+            idle_seconds: Some(300),
+        })
+        .await
+        .expect("create docker sandbox");
+    let (rc, _, _) = exec_shell(
+        conv.as_ref(),
+        &sandbox_id,
+        "echo teleport-marker > /exo-teleport.txt",
+    )
+    .await;
+    assert_eq!(rc, 0, "writing the marker on docker should succeed");
+
+    // 2. Snapshot the Docker sandbox (-> DockerImageTar in exoharness storage).
+    let snapshot_id = conv
+        .snapshot_sandbox(sandbox_id.clone())
+        .await
+        .expect("snapshot docker sandbox");
+
+    // 3. Restore under Daytona via the provider override (-> bridge).
+    conv.start_sandbox(StartSandboxRequest {
+        id: sandbox_id.clone(),
+        snapshot_id,
+        idle_seconds: None,
+        provider: Some(SandboxProvider::Daytona),
+    })
+    .await
+    .expect("start_sandbox on daytona from the docker snapshot");
+
+    // 4. The file written on Docker is present on the Daytona sandbox.
+    let (rc, stdout, _) = exec_shell(
+        conv.as_ref(),
+        &sandbox_id,
+        "cat /exo-teleport.txt && echo --- && hostname",
+    )
+    .await;
+    eprintln!("after teleport, daytona sees:\n{stdout}");
+    assert_eq!(
+        rc, 0,
+        "exec on the teleported daytona sandbox should succeed"
+    );
+    assert!(
+        stdout.contains("teleport-marker"),
+        "file should survive the docker->daytona teleport: {stdout:?}"
+    );
+
+    let _ = conv.stop_sandbox(sandbox_id).await;
+}
+
+async fn seed_secret(harness: &BasicExoHarness, name: &str, value: &str) {
+    harness
+        .put_secret(PutSecretRequest {
+            name: name.into(),
+            secret: Secret::Key {
+                value: value.into(),
+            },
+        })
+        .await
+        .expect("put secret");
+}
+
+fn docker_available() -> bool {
+    Command::new("docker")
+        .arg("info")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+async fn exec_shell(
+    conversation: &dyn ConversationHandle,
+    sandbox_id: &SandboxId,
+    cmd: &str,
+) -> (i32, String, String) {
+    let process = conversation
+        .run_in_sandbox(RunInSandboxRequest {
+            id: sandbox_id.clone(),
+            command: vec!["/bin/bash".into(), "-c".into(), cmd.into()],
+            env: Default::default(),
+        })
+        .await
+        .unwrap_or_else(|error| panic!("run_in_sandbox({cmd:?}) failed: {error:#}"));
+
+    let mut parts = process.into_parts();
+    drop(parts.stdin);
+    let mut stdout_bytes = Vec::new();
+    let mut stderr_bytes = Vec::new();
+    let (stdout_result, stderr_result, wait_result) = tokio::join!(
+        parts.stdout.read_to_end(&mut stdout_bytes),
+        parts.stderr.read_to_end(&mut stderr_bytes),
+        parts.wait,
+    );
+    stdout_result.expect("read stdout");
+    stderr_result.expect("read stderr");
+    let exit_code = wait_result.expect("wait on sandbox process");
+    (
+        exit_code,
+        String::from_utf8_lossy(&stdout_bytes).into_owned(),
+        String::from_utf8_lossy(&stderr_bytes).into_owned(),
+    )
+}

--- a/crates/executor/src/harness_tool.rs
+++ b/crates/executor/src/harness_tool.rs
@@ -578,6 +578,7 @@ async fn execute_rewind_sandbox_tool(
                     id: handle.sandbox_id.clone(),
                     snapshot_id,
                     idle_seconds: Some(spec.idle_seconds),
+                    provider: None,
                 })
                 .await?;
             turn.add_events(vec![EventData::SandboxStarted {
@@ -609,6 +610,7 @@ async fn execute_rewind_sandbox_tool(
                 id: sandbox_id.clone(),
                 snapshot_id,
                 idle_seconds: Some(spec.idle_seconds),
+                provider: None,
             })
             .await?;
             record_current_sandbox_snapshot(

--- a/crates/executor/src/local_sandbox.rs
+++ b/crates/executor/src/local_sandbox.rs
@@ -295,6 +295,7 @@ impl SnapshotHandle for LocalSandboxAgent {
                 id: local_id,
                 snapshot_id: request.snapshot_id,
                 idle_seconds: request.idle_seconds,
+                provider: request.provider,
             })
             .await
     }
@@ -784,6 +785,7 @@ impl SnapshotHandle for LocalSandboxConversation {
                 id: local_id,
                 snapshot_id: request.snapshot_id,
                 idle_seconds: request.idle_seconds,
+                provider: request.provider,
             })
             .await?;
         self.append_remote_sandbox_events(vec![EventData::SandboxStarted {
@@ -960,6 +962,7 @@ impl SnapshotHandle for LocalSandboxTurnHandle {
             id: local_id,
             snapshot_id: request.snapshot_id,
             idle_seconds: request.idle_seconds,
+            provider: request.provider,
         })
         .await?;
         self.remote

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -2630,27 +2630,65 @@ async fn start_sandbox_side_effect(
     // teleport a Docker snapshot up to Daytona). Set before routing so the
     // restore targets the new backend and the new provider is persisted;
     // unsupported providers / snapshot kinds error in the calls below.
+    let previous_provider = sandbox.provider;
     if let Some(provider) = request.provider {
         sandbox.provider = provider;
     }
+    let cross_provider = sandbox.provider != previous_provider;
 
-    // Remote work before the write lock: stop any previous handle, then boot
-    // the restored sandbox.
-    let previous_handle = harness
-        .inner
-        .running_sandboxes
-        .lock()
-        .await
-        .remove(&request.id);
-    if let Some(previous_handle) = previous_handle {
-        previous_handle.stop().await?;
-    }
-    let sandbox_handle = harness
-        .inner
-        .sandbox_backend_for_provider(sandbox.provider)
-        .await?
-        .acquire_from_snapshot(sandbox_request(owner, &request.id, &sandbox, None), payload)
-        .await?;
+    // Remote work before the write lock. Two orders, chosen by whether the
+    // restore changes providers:
+    //   - Cross-provider (teleport): make-before-break. Boot the new sandbox
+    //     first and stop the old one only once it's up, so a failed restore
+    //     leaves the source sandbox running and serving. Safe because the two
+    //     handles live on different backends and can't collide.
+    //   - Same provider: stop-then-boot. The backend replaces the warm
+    //     container for this key itself during restore, and stopping the old
+    //     handle after the new one exists would tear down the new container's
+    //     warm-cache entry (both handles share the same SandboxKey).
+    let sandbox_handle = if cross_provider {
+        let sandbox_handle = harness
+            .inner
+            .sandbox_backend_for_provider(sandbox.provider)
+            .await?
+            .acquire_from_snapshot(sandbox_request(owner, &request.id, &sandbox, None), payload)
+            .await?;
+        let previous_handle = harness
+            .inner
+            .running_sandboxes
+            .lock()
+            .await
+            .remove(&request.id);
+        if let Some(previous_handle) = previous_handle
+            && let Err(error) = previous_handle.stop().await
+        {
+            // The new sandbox is authoritative at this point; a failure to
+            // reap the source shouldn't fail the restore.
+            tracing::warn!(
+                sandbox_id = %request.id,
+                previous_provider = %previous_provider,
+                error = format!("{error:#}"),
+                "failed to stop the source sandbox after a cross-provider restore"
+            );
+        }
+        sandbox_handle
+    } else {
+        let previous_handle = harness
+            .inner
+            .running_sandboxes
+            .lock()
+            .await
+            .remove(&request.id);
+        if let Some(previous_handle) = previous_handle {
+            previous_handle.stop().await?;
+        }
+        harness
+            .inner
+            .sandbox_backend_for_provider(sandbox.provider)
+            .await?
+            .acquire_from_snapshot(sandbox_request(owner, &request.id, &sandbox, None), payload)
+            .await?
+    };
 
     let _guard = harness.inner.write_lock.lock().await;
     harness

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -2626,6 +2626,13 @@ async fn start_sandbox_side_effect(
     if let Some(idle_seconds) = request.idle_seconds {
         sandbox.idle_seconds = idle_seconds;
     }
+    // Optional provider override: restore under a different backend (e.g.
+    // teleport a Docker snapshot up to Daytona). Set before routing so the
+    // restore targets the new backend and the new provider is persisted;
+    // unsupported providers / snapshot kinds error in the calls below.
+    if let Some(provider) = request.provider {
+        sandbox.provider = provider;
+    }
 
     // Remote work before the write lock: stop any previous handle, then boot
     // the restored sandbox.

--- a/crates/exoharness/src/http_tests.rs
+++ b/crates/exoharness/src/http_tests.rs
@@ -366,6 +366,7 @@ async fn http_exoharness_supports_turn_scoped_sandbox_snapshot_and_start() {
         id: sandbox_id.clone(),
         snapshot_id,
         idle_seconds: Some(60),
+        provider: None,
     })
     .await
     .expect("turn start from snapshot");

--- a/crates/exoharness/src/sandbox_provider/daytona.rs
+++ b/crates/exoharness/src/sandbox_provider/daytona.rs
@@ -2,8 +2,12 @@
 //! `reqwest`. API reference: <https://www.daytona.io/docs/en/tools/api/>.
 //!
 //! Daytona persists state itself: `stop` keeps the filesystem and the next
-//! `acquire` finds the sandbox by label and `start`s it. Snapshot/restore is
-//! not implemented yet.
+//! `acquire` finds the sandbox by label and `start`s it. Snapshots use
+//! [`SnapshotKind::DaytonaSnapshot`] payloads — a JSON manifest naming a
+//! snapshot in Daytona's registry, not the bytes themselves. A
+//! [`SnapshotKind::DockerImageTar`] payload (the Docker backend's snapshot
+//! format) can also be restored here, which is how a sandbox teleports from
+//! local Docker up to Daytona.
 
 const DEFAULT_DAYTONA_IMAGE: &str = "daytonaio/sandbox:0.8.0";
 
@@ -17,6 +21,7 @@ use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, anyhow, bail};
 use async_trait::async_trait;
+use bytes::Bytes;
 use futures::future::BoxFuture;
 use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
 use serde::{Deserialize, Serialize};
@@ -27,8 +32,8 @@ use uuid::Uuid;
 
 use crate::sandbox::{
     ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand, SandboxCommandOutput,
-    SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotPayload, WARM_SANDBOX_KEY_LABEL,
-    WARM_SANDBOX_SPEC_HASH_LABEL, sandbox_spec_hash,
+    SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotKind, SnapshotPayload,
+    WARM_SANDBOX_KEY_LABEL, WARM_SANDBOX_SPEC_HASH_LABEL, sandbox_spec_hash,
 };
 use crate::sandbox_provider::shell_quote;
 
@@ -40,6 +45,8 @@ pub const DEFAULT_DAYTONA_TOOLBOX_URL: &str = "https://proxy.app.daytona.io";
 
 const START_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const START_TIMEOUT: Duration = Duration::from_secs(120);
+const SNAPSHOT_POLL_INTERVAL: Duration = Duration::from_secs(2);
+const SNAPSHOT_WAIT_TIMEOUT: Duration = Duration::from_secs(180);
 const PROCESS_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const PROCESS_PIPE_BUFFER_SIZE: usize = 64 * 1024;
 const PROCESS_ENV_END_MARKER: &str = "__EXO_ENV_END__";
@@ -51,7 +58,7 @@ pub struct DaytonaConfig {
     pub api_key: String,
     pub api_url: String,
     pub toolbox_url: String,
-    /// Region target (`eu` / `us`), passed through on create when set.
+    /// Region target (e.g. `us`), passed through on create when set.
     pub target: Option<String>,
     /// Scopes requests via `X-Daytona-Organization-ID`; without it Daytona may
     /// default to a "personal" org that lacks credit.
@@ -63,6 +70,9 @@ pub struct DaytonaSandboxBackend {
     api_url: String,
     toolbox_url: String,
     target: Option<String>,
+    /// Kept (beyond the baked-in auth header) so the cross-backend bridge can
+    /// authenticate the `daytona` CLI for `snapshot push`.
+    api_key: String,
 }
 
 impl DaytonaSandboxBackend {
@@ -88,6 +98,7 @@ impl DaytonaSandboxBackend {
             api_url: config.api_url.trim_end_matches('/').to_string(),
             toolbox_url: config.toolbox_url.trim_end_matches('/').to_string(),
             target: config.target,
+            api_key: config.api_key,
         })
     }
 
@@ -269,11 +280,39 @@ impl ManagedSandboxBackend for DaytonaSandboxBackend {
 
     async fn acquire_from_snapshot(
         &self,
-        _request: SandboxRequest,
-        _payload: SnapshotPayload,
+        request: SandboxRequest,
+        payload: SnapshotPayload,
     ) -> Result<Arc<dyn ManagedSandboxHandle>> {
-        // Restoring needs snapshot-readiness handling that isn't in place yet.
-        bail!("restoring a Daytona sandbox from a snapshot is not implemented yet");
+        reject_unsupported_mounts(&request)?;
+        let snapshot_name = match payload.kind {
+            SnapshotKind::DaytonaSnapshot => {
+                let manifest: DaytonaSnapshotManifest = serde_json::from_slice(&payload.bytes)
+                    .context("decoding DaytonaSnapshot manifest")?;
+                manifest.snapshot_name
+            }
+            // PROTOTYPE cross-backend bridge: resume a sandbox snapshotted on the
+            // Docker backend (a `docker save` tarball) here on Daytona. This is
+            // the teleport path: local container -> snapshot -> remote Daytona.
+            SnapshotKind::DockerImageTar => {
+                import_docker_image_tar(&self.handle_backend(), &payload.bytes).await?
+            }
+            SnapshotKind::E2bSnapshot | SnapshotKind::SpritesSnapshot => bail!(
+                "the Daytona backend cannot restore a {:?} payload; \
+                 select the provider that produced the snapshot",
+                payload.kind
+            ),
+        };
+        let spec_hash = sandbox_spec_hash(&request.spec);
+        let sandbox = self
+            .create_sandbox(&request, &spec_hash, Some(&snapshot_name))
+            .await?;
+        self.wait_until_started(&sandbox.id).await?;
+        Ok(Arc::new(DaytonaSandboxHandle {
+            id: format!("daytona-restored:{}", request.key),
+            sandbox_id: sandbox.id,
+            request,
+            backend: self.handle_backend(),
+        }))
     }
 }
 
@@ -285,6 +324,8 @@ impl DaytonaSandboxBackend {
             client: self.client.clone(),
             api_url: self.api_url.clone(),
             toolbox_url: self.toolbox_url.clone(),
+            api_key: self.api_key.clone(),
+            target: self.target.clone(),
         }
     }
 }
@@ -294,6 +335,11 @@ struct DaytonaBackendHandle {
     client: reqwest::Client,
     api_url: String,
     toolbox_url: String,
+    api_key: String,
+    /// Region target; the bridge must push its snapshot into the same region
+    /// sandboxes are created in, or create-from-snapshot 400s with
+    /// "not available in region".
+    target: Option<String>,
 }
 
 impl DaytonaBackendHandle {
@@ -303,6 +349,88 @@ impl DaytonaBackendHandle {
 
     fn toolbox_endpoint(&self, path: &str) -> String {
         format!("{}{}", self.toolbox_url, path)
+    }
+
+    /// `None` until the snapshot is registered: a freshly-captured snapshot 404s
+    /// for a few seconds before it appears, so callers poll through that window.
+    async fn get_snapshot(&self, name: &str) -> Result<Option<DaytonaSnapshotInfo>> {
+        let response = self
+            .client
+            .get(self.api_endpoint(&format!("/snapshots/{name}")))
+            .send()
+            .await
+            .with_context(|| format!("fetching Daytona snapshot {name}"))?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        response
+            .error_for_status()
+            .with_context(|| format!("Daytona get-snapshot {name} returned an error status"))?
+            .json()
+            .await
+            .map(Some)
+            .with_context(|| format!("decoding Daytona snapshot {name}"))
+    }
+
+    /// Snapshot capture is asynchronous (404 -> Pending -> Building/Pulling ->
+    /// Active); only `active` snapshots can be used to create sandboxes, so block
+    /// until it reaches that state before returning.
+    async fn wait_for_snapshot_active(&self, name: &str) -> Result<()> {
+        let deadline = Instant::now() + SNAPSHOT_WAIT_TIMEOUT;
+        loop {
+            if let Some(info) = self.get_snapshot(name).await? {
+                match info.state.to_ascii_lowercase().as_str() {
+                    "active" => return Ok(()),
+                    "error" | "build_failed" => {
+                        bail!("Daytona snapshot {name} failed (state={})", info.state)
+                    }
+                    _ => {}
+                }
+            }
+            if Instant::now() >= deadline {
+                bail!(
+                    "Daytona snapshot {name} did not become active within {}s",
+                    SNAPSHOT_WAIT_TIMEOUT.as_secs()
+                );
+            }
+            tokio::time::sleep(SNAPSHOT_POLL_INTERVAL).await;
+        }
+    }
+
+    async fn get_sandbox(&self, id: &str) -> Result<DaytonaSandbox> {
+        self.client
+            .get(self.api_endpoint(&format!("/sandbox/{id}")))
+            .send()
+            .await
+            .with_context(|| format!("fetching Daytona sandbox {id}"))?
+            .error_for_status()
+            .with_context(|| format!("Daytona get-sandbox {id} returned an error status"))?
+            .json()
+            .await
+            .with_context(|| format!("decoding Daytona sandbox {id}"))
+    }
+
+    /// A native `POST /sandbox/{id}/snapshot` runs asynchronously: the sandbox
+    /// enters `snapshotting` and returns to its prior state once the source is
+    /// quiesced. This only tracks the *sandbox* side; the snapshot resource
+    /// becomes usable a little later (see `wait_for_snapshot_active`).
+    async fn wait_until_snapshot_complete(&self, id: &str) -> Result<()> {
+        let deadline = Instant::now() + SNAPSHOT_WAIT_TIMEOUT;
+        loop {
+            if !matches!(
+                self.get_sandbox(id).await?.state,
+                DaytonaSandboxState::Snapshotting
+            ) {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                bail!(
+                    "Daytona snapshot for {id} did not finish within {}s",
+                    SNAPSHOT_WAIT_TIMEOUT.as_secs()
+                );
+            }
+            tokio::time::sleep(SNAPSHOT_POLL_INTERVAL).await;
+        }
     }
 }
 
@@ -334,9 +462,7 @@ impl ManagedSandboxHandle for DaytonaSandboxHandle {
     }
 
     async fn snapshot(&self) -> Result<SnapshotPayload> {
-        // Capturing a snapshot reliably needs readiness handling that isn't in
-        // place yet.
-        bail!("Daytona sandbox snapshots are not implemented yet");
+        save_as_snapshot_via_backend(&self.backend, &self.sandbox_id).await
     }
 }
 
@@ -927,6 +1053,154 @@ async fn stop_via_backend(backend: &DaytonaBackendHandle, id: &str) -> Result<()
     Ok(())
 }
 
+// Snapshot the running sandbox (`POST /sandbox/{id}/snapshot`); restore later
+// via `create_sandbox(snapshot = <name>)`. Daytona's docs disagree on whether
+// this captures fs+memory ("checkpoint") or fs only — verify empirically.
+//
+// TODO(snapshot-modes): exoharness's snapshot API is mode-less, so it can't
+// distinguish a memory checkpoint from a disk snapshot; a follow-up should add
+// `SnapshotMode { Disk, Checkpoint }`.
+//
+// Available in the shared `us` region (verified live 2026-07). Orgs without
+// the feature get a 403 ("feature flags not enabled"), surfaced below.
+async fn save_as_snapshot_via_backend(
+    backend: &DaytonaBackendHandle,
+    id: &str,
+) -> Result<SnapshotPayload> {
+    let snapshot_name = format!("exo-snap-{}", Uuid::new_v4().simple());
+    let body = DaytonaSnapshotRequest {
+        name: snapshot_name.clone(),
+    };
+    let response = backend
+        .client
+        .post(backend.api_endpoint(&format!("/sandbox/{id}/snapshot")))
+        .json(&body)
+        .send()
+        .await
+        .with_context(|| format!("snapshotting Daytona sandbox {id}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        let text = response.text().await.unwrap_or_default();
+        if status == reqwest::StatusCode::FORBIDDEN {
+            bail!(
+                "Daytona sandbox snapshots are not enabled for this organization \
+                 (HTTP 403: {text}). Enable the feature in the Daytona dashboard or \
+                 request it from Daytona support."
+            );
+        }
+        bail!("Daytona snapshot failed ({status}): {text}");
+    }
+    // Capture is asynchronous on two fronts: the source sandbox sits in
+    // `snapshotting`, and the snapshot resource itself is built in the background
+    // (404 -> Pending -> Active). The sandbox leaves `snapshotting` *before* the
+    // snapshot is Active, and creating from a not-yet-Active snapshot fails with
+    // "Sandbox failed to start: internal error" — so wait for both.
+    backend.wait_until_snapshot_complete(id).await?;
+    backend.wait_for_snapshot_active(&snapshot_name).await?;
+
+    let manifest = DaytonaSnapshotManifest { snapshot_name };
+    let bytes = serde_json::to_vec(&manifest).context("serializing Daytona snapshot manifest")?;
+    Ok(SnapshotPayload {
+        kind: SnapshotKind::DaytonaSnapshot,
+        bytes: Bytes::from(bytes),
+    })
+}
+
+// PROTOTYPE cross-backend bridge: import a `docker save` tarball (the Docker
+// backend's snapshot format) into Daytona as a snapshot and return its name, so
+// a sandbox snapshotted on local Docker can be teleported to Daytona with its
+// files intact.
+//
+// Caveats (fine for a prototype, not production):
+//   - Requires `docker` and the `daytona` CLI on the harness host.
+//   - Disk/filesystem only -- a docker image carries no memory/process state.
+//   - The image must be linux/amd64 to run on Daytona.
+// A production version would push to Daytona's registry via the API rather than
+// shelling out, and wouldn't need a local docker daemon.
+async fn import_docker_image_tar(backend: &DaytonaBackendHandle, tar: &[u8]) -> Result<String> {
+    let snapshot_name = format!("exo-bridge-{}", Uuid::new_v4().simple());
+    let tar_path = std::env::temp_dir().join(format!("{snapshot_name}.tar"));
+    tokio::fs::write(&tar_path, tar)
+        .await
+        .with_context(|| format!("writing docker image tar to {}", tar_path.display()))?;
+
+    let load = tokio::process::Command::new("docker")
+        .arg("load")
+        .arg("-i")
+        .arg(&tar_path)
+        .output()
+        .await
+        .context("running `docker load` (is docker installed on the harness host?)")?;
+    let _ = tokio::fs::remove_file(&tar_path).await;
+    if !load.status.success() {
+        bail!(
+            "docker load failed: {}",
+            String::from_utf8_lossy(&load.stderr)
+        );
+    }
+    let image_ref = String::from_utf8_lossy(&load.stdout)
+        .lines()
+        .find_map(|line| line.strip_prefix("Loaded image: ").map(str::trim))
+        .map(str::to_string)
+        .context("could not parse an image ref from `docker load` output")?;
+
+    // Re-tag to a specific version: Daytona rejects the `latest` tag that the
+    // Docker backend's snapshots carry.
+    let versioned_ref = format!("{snapshot_name}:1");
+    let tag = tokio::process::Command::new("docker")
+        .args(["tag", &image_ref, &versioned_ref])
+        .output()
+        .await
+        .context("running `docker tag`")?;
+    if !tag.status.success() {
+        bail!(
+            "docker tag failed: {}",
+            String::from_utf8_lossy(&tag.stderr)
+        );
+    }
+
+    // Authenticate the CLI with the same API key, then push the image as a
+    // Daytona snapshot (the CLI handles the registry push + snapshot
+    // registration). Push into the backend's region — sandboxes are created
+    // there, and a snapshot in another region 400s on create.
+    run_daytona_cli(&["login", "--api-key", &backend.api_key]).await?;
+    let mut push_args = vec!["snapshot", "push", &versioned_ref, "--name", &snapshot_name];
+    if let Some(target) = backend.target.as_deref() {
+        push_args.extend(["--region", target]);
+    }
+    run_daytona_cli(&push_args).await?;
+    for image in [&image_ref, &versioned_ref] {
+        let _ = tokio::process::Command::new("docker")
+            .args(["image", "rm", image])
+            .output()
+            .await;
+    }
+
+    backend.wait_for_snapshot_active(&snapshot_name).await?;
+    Ok(snapshot_name)
+}
+
+async fn run_daytona_cli(args: &[&str]) -> Result<()> {
+    let output = tokio::process::Command::new("daytona")
+        .args(args)
+        .output()
+        .await
+        .with_context(|| {
+            format!(
+                "running `daytona {}` (is the daytona CLI installed on the harness host?)",
+                args.first().copied().unwrap_or_default()
+            )
+        })?;
+    if !output.status.success() {
+        bail!(
+            "`daytona {}` failed: {}",
+            args.first().copied().unwrap_or_default(),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(())
+}
+
 fn reject_unsupported_mounts(request: &SandboxRequest) -> Result<()> {
     if !request.spec.mounts.is_empty() {
         bail!(
@@ -1012,8 +1286,15 @@ fn wrap_session_command_with_exit_status(
     } else {
         String::new()
     };
+    // Two zsh landmines here, hit live on daemon v0.193 (the session shell in
+    // the default sandbox image is zsh):
+    //   - `status` is a read-only zsh special variable; assigning it aborts the
+    //     whole command line with 126, so the variable is exo-prefixed.
+    //   - a trailing `exit` kills the persistent session shell and the daemon
+    //     never reports completion, so the exit code travels via the status
+    //     file only.
     format!(
-        "set -e; {env_prelude}set +e; {command}; status=$?; printf '%s\\n' \"$status\" > {}; exit \"$status\"",
+        "set -e; {env_prelude}set +e; {command}; exo_exit_status=$?; printf '%s\\n' \"$exo_exit_status\" > {}",
         shell_quote(exit_status_path)
     )
 }
@@ -1180,6 +1461,24 @@ struct DaytonaSessionCommandInputRequest {
     data: String,
 }
 
+/// Persisted alongside a `SnapshotKind::DaytonaSnapshot`: a Daytona snapshot is
+/// self-contained, so the registered name is all we need to recreate it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DaytonaSnapshotManifest {
+    snapshot_name: String,
+}
+
+#[derive(Debug, Serialize)]
+struct DaytonaSnapshotRequest {
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct DaytonaSnapshotInfo {
+    #[serde(default)]
+    state: String,
+}
+
 #[derive(Debug, Deserialize)]
 struct DaytonaSandboxList {
     #[serde(default)]
@@ -1203,6 +1502,7 @@ enum DaytonaSandboxState {
     Starting,
     #[serde(alias = "running")]
     Started,
+    Snapshotting,
     Stopping,
     Stopped,
     Archiving,

--- a/crates/exoharness/src/sandbox_provider/daytona.rs
+++ b/crates/exoharness/src/sandbox_provider/daytona.rs
@@ -327,9 +327,6 @@ struct DaytonaBackendHandle {
     client: reqwest::Client,
     api_url: String,
     toolbox_url: String,
-    /// Region target; the bridge must register its snapshot in the same region
-    /// sandboxes are created in, or create-from-snapshot 400s with
-    /// "not available in region".
     target: Option<String>,
 }
 
@@ -1080,7 +1077,7 @@ async fn stop_via_backend(backend: &DaytonaBackendHandle, id: &str) -> Result<()
 }
 
 // Snapshot the running sandbox (`POST /sandbox/{id}/snapshot`); can later be restored
-// via `create_sandbox(snapshot = <name>)`. 
+// via `create_sandbox(snapshot = <name>)`.
 async fn save_as_snapshot_via_backend(
     backend: &DaytonaBackendHandle,
     id: &str,
@@ -1123,15 +1120,11 @@ async fn save_as_snapshot_via_backend(
 // Cross-backend bridge: import a `docker save` tarball (the Docker backend's
 // snapshot format) into Daytona as a snapshot and return its name, so a
 // sandbox snapshotted on local Docker can be teleported to Daytona with its
-// files intact. The registry push runs against Daytona's transient registry
-// with short-lived credentials from the API; no daytona CLI involved.
+// files intact.
 //
-// Caveats:
-//   - Requires a `docker` daemon on the harness host (used for load/tag/push;
-//     pushing the tarball's layers straight from memory with an OCI registry
-//     client would drop that too).
-//   - Disk/filesystem only -- a docker image carries no memory/process state.
-//   - The image must be linux/amd64 to run on Daytona.
+// Note: requires a `docker` daemon on the harness host (used for load/tag/push).
+// The resulting snapshot is disk/filesystem-only, i.e. not CRIU (no memory/process
+// state). The image *must* be linux/amd64 to run on Daytona.
 async fn import_docker_image_tar(backend: &DaytonaBackendHandle, tar: &[u8]) -> Result<String> {
     let snapshot_name = format!("exo-bridge-{}", Uuid::new_v4().simple());
     let tar_path = std::env::temp_dir().join(format!("{snapshot_name}.tar"));
@@ -1159,9 +1152,6 @@ async fn import_docker_image_tar(backend: &DaytonaBackendHandle, tar: &[u8]) -> 
         .map(str::to_string)
         .context("could not parse an image ref from `docker load` output")?;
 
-    // Fetch short-lived push credentials for Daytona's transient registry and
-    // re-tag the image into it. (Also sidesteps the `latest` tag that the
-    // Docker backend's snapshots carry, which Daytona rejects.)
     let push_access = backend.get_registry_push_access().await?;
     let remote_ref = format!(
         "{}/{}/{snapshot_name}:1",
@@ -1179,10 +1169,6 @@ async fn import_docker_image_tar(backend: &DaytonaBackendHandle, tar: &[u8]) -> 
         );
     }
 
-    // Push with a throwaway docker config dir so the temp credentials never
-    // touch the host user's ~/.docker/config.json, then register the pushed
-    // image as a Daytona snapshot in the backend's region — sandboxes are
-    // created there, and a snapshot in another region 400s on create.
     let push_result = docker_push_with_credentials(&push_access, &remote_ref).await;
     for image in [&image_ref, &remote_ref] {
         let _ = tokio::process::Command::new("docker")
@@ -1208,6 +1194,9 @@ async fn docker_push_with_credentials(
 ) -> Result<()> {
     use tokio::process::Command;
 
+    // We create a temp docker config dir so that the credentials are not written to the host
+    // user's docker config. The temp dir is removed after the push. Note, these are the (1-hour
+    // temporary) credentials provided by the Daytona backend, not the host user's docker credentials.
     let config_dir = std::env::temp_dir().join(format!("exo-docker-config-{}", Uuid::new_v4()));
     tokio::fs::create_dir_all(&config_dir)
         .await
@@ -1353,13 +1342,6 @@ fn wrap_session_command_with_exit_status(
     } else {
         String::new()
     };
-    // Two zsh landmines here, hit live on daemon v0.193 (the session shell in
-    // the default sandbox image is zsh):
-    //   - `status` is a read-only zsh special variable; assigning it aborts the
-    //     whole command line with 126, so the variable is exo-prefixed.
-    //   - a trailing `exit` kills the persistent session shell and the daemon
-    //     never reports completion, so the exit code travels via the status
-    //     file only.
     format!(
         "set -e; {env_prelude}set +e; {command}; exo_exit_status=$?; printf '%s\\n' \"$exo_exit_status\" > {}",
         shell_quote(exit_status_path)

--- a/crates/exoharness/src/sandbox_provider/daytona.rs
+++ b/crates/exoharness/src/sandbox_provider/daytona.rs
@@ -58,7 +58,7 @@ pub struct DaytonaConfig {
     pub api_key: String,
     pub api_url: String,
     pub toolbox_url: String,
-    /// Region target (e.g. `us`), passed through on create when set.
+    /// Region target (e.g. `eu`, `us`), passed through on create when set.
     pub target: Option<String>,
     /// Scopes requests via `X-Daytona-Organization-ID`; without it Daytona may
     /// default to a "personal" org that lacks credit.
@@ -70,9 +70,6 @@ pub struct DaytonaSandboxBackend {
     api_url: String,
     toolbox_url: String,
     target: Option<String>,
-    /// Kept (beyond the baked-in auth header) so the cross-backend bridge can
-    /// authenticate the `daytona` CLI for `snapshot push`.
-    api_key: String,
 }
 
 impl DaytonaSandboxBackend {
@@ -98,7 +95,6 @@ impl DaytonaSandboxBackend {
             api_url: config.api_url.trim_end_matches('/').to_string(),
             toolbox_url: config.toolbox_url.trim_end_matches('/').to_string(),
             target: config.target,
-            api_key: config.api_key,
         })
     }
 
@@ -290,9 +286,6 @@ impl ManagedSandboxBackend for DaytonaSandboxBackend {
                     .context("decoding DaytonaSnapshot manifest")?;
                 manifest.snapshot_name
             }
-            // PROTOTYPE cross-backend bridge: resume a sandbox snapshotted on the
-            // Docker backend (a `docker save` tarball) here on Daytona. This is
-            // the teleport path: local container -> snapshot -> remote Daytona.
             SnapshotKind::DockerImageTar => {
                 import_docker_image_tar(&self.handle_backend(), &payload.bytes).await?
             }
@@ -308,7 +301,7 @@ impl ManagedSandboxBackend for DaytonaSandboxBackend {
             .await?;
         self.wait_until_started(&sandbox.id).await?;
         Ok(Arc::new(DaytonaSandboxHandle {
-            id: format!("daytona-restored:{}", request.key),
+            id: format!("daytona:{}", request.key),
             sandbox_id: sandbox.id,
             request,
             backend: self.handle_backend(),
@@ -324,7 +317,6 @@ impl DaytonaSandboxBackend {
             client: self.client.clone(),
             api_url: self.api_url.clone(),
             toolbox_url: self.toolbox_url.clone(),
-            api_key: self.api_key.clone(),
             target: self.target.clone(),
         }
     }
@@ -335,8 +327,7 @@ struct DaytonaBackendHandle {
     client: reqwest::Client,
     api_url: String,
     toolbox_url: String,
-    api_key: String,
-    /// Region target; the bridge must push its snapshot into the same region
+    /// Region target; the bridge must register its snapshot in the same region
     /// sandboxes are created in, or create-from-snapshot 400s with
     /// "not available in region".
     target: Option<String>,
@@ -349,6 +340,45 @@ impl DaytonaBackendHandle {
 
     fn toolbox_endpoint(&self, path: &str) -> String {
         format!("{}{}", self.toolbox_url, path)
+    }
+
+    /// Short-lived push credentials for Daytona's transient registry, used by
+    /// the Docker bridge (`GET /docker-registry/registry-push-access`).
+    async fn get_registry_push_access(&self) -> Result<DaytonaRegistryPushAccess> {
+        self.client
+            .get(self.api_endpoint("/docker-registry/registry-push-access"))
+            .send()
+            .await
+            .context("fetching Daytona registry push access")?
+            .error_for_status()
+            .context("Daytona registry-push-access returned an error status")?
+            .json()
+            .await
+            .context("decoding Daytona registry push access")
+    }
+
+    /// Register a pushed transient-registry image as a Daytona snapshot in the
+    /// backend's region (`POST /snapshots`). The snapshot builds asynchronously
+    /// (pending -> active); see `wait_for_snapshot_active`.
+    async fn register_snapshot(&self, name: &str, image_name: &str) -> Result<()> {
+        let body = DaytonaCreateSnapshotRequest {
+            name: name.to_string(),
+            image_name: image_name.to_string(),
+            region_id: self.target.clone(),
+        };
+        let response = self
+            .client
+            .post(self.api_endpoint("/snapshots"))
+            .json(&body)
+            .send()
+            .await
+            .with_context(|| format!("registering Daytona snapshot {name}"))?;
+        let status = response.status();
+        if !status.is_success() {
+            let text = response.text().await.unwrap_or_default();
+            bail!("Daytona snapshot registration failed ({status}): {text}");
+        }
+        Ok(())
     }
 
     /// `None` until the snapshot is registered: a freshly-captured snapshot 404s
@@ -410,10 +440,6 @@ impl DaytonaBackendHandle {
             .with_context(|| format!("decoding Daytona sandbox {id}"))
     }
 
-    /// A native `POST /sandbox/{id}/snapshot` runs asynchronously: the sandbox
-    /// enters `snapshotting` and returns to its prior state once the source is
-    /// quiesced. This only tracks the *sandbox* side; the snapshot resource
-    /// becomes usable a little later (see `wait_for_snapshot_active`).
     async fn wait_until_snapshot_complete(&self, id: &str) -> Result<()> {
         let deadline = Instant::now() + SNAPSHOT_WAIT_TIMEOUT;
         loop {
@@ -1053,16 +1079,8 @@ async fn stop_via_backend(backend: &DaytonaBackendHandle, id: &str) -> Result<()
     Ok(())
 }
 
-// Snapshot the running sandbox (`POST /sandbox/{id}/snapshot`); restore later
-// via `create_sandbox(snapshot = <name>)`. Daytona's docs disagree on whether
-// this captures fs+memory ("checkpoint") or fs only — verify empirically.
-//
-// TODO(snapshot-modes): exoharness's snapshot API is mode-less, so it can't
-// distinguish a memory checkpoint from a disk snapshot; a follow-up should add
-// `SnapshotMode { Disk, Checkpoint }`.
-//
-// Available in the shared `us` region (verified live 2026-07). Orgs without
-// the feature get a 403 ("feature flags not enabled"), surfaced below.
+// Snapshot the running sandbox (`POST /sandbox/{id}/snapshot`); can later be restored
+// via `create_sandbox(snapshot = <name>)`. 
 async fn save_as_snapshot_via_backend(
     backend: &DaytonaBackendHandle,
     id: &str,
@@ -1090,11 +1108,7 @@ async fn save_as_snapshot_via_backend(
         }
         bail!("Daytona snapshot failed ({status}): {text}");
     }
-    // Capture is asynchronous on two fronts: the source sandbox sits in
-    // `snapshotting`, and the snapshot resource itself is built in the background
-    // (404 -> Pending -> Active). The sandbox leaves `snapshotting` *before* the
-    // snapshot is Active, and creating from a not-yet-Active snapshot fails with
-    // "Sandbox failed to start: internal error" — so wait for both.
+    // Capture is async for both the sandbox and the snapshot resource itself, wait for both.
     backend.wait_until_snapshot_complete(id).await?;
     backend.wait_for_snapshot_active(&snapshot_name).await?;
 
@@ -1106,17 +1120,18 @@ async fn save_as_snapshot_via_backend(
     })
 }
 
-// PROTOTYPE cross-backend bridge: import a `docker save` tarball (the Docker
-// backend's snapshot format) into Daytona as a snapshot and return its name, so
-// a sandbox snapshotted on local Docker can be teleported to Daytona with its
-// files intact.
+// Cross-backend bridge: import a `docker save` tarball (the Docker backend's
+// snapshot format) into Daytona as a snapshot and return its name, so a
+// sandbox snapshotted on local Docker can be teleported to Daytona with its
+// files intact. The registry push runs against Daytona's transient registry
+// with short-lived credentials from the API; no daytona CLI involved.
 //
-// Caveats (fine for a prototype, not production):
-//   - Requires `docker` and the `daytona` CLI on the harness host.
+// Caveats:
+//   - Requires a `docker` daemon on the harness host (used for load/tag/push;
+//     pushing the tarball's layers straight from memory with an OCI registry
+//     client would drop that too).
 //   - Disk/filesystem only -- a docker image carries no memory/process state.
 //   - The image must be linux/amd64 to run on Daytona.
-// A production version would push to Daytona's registry via the API rather than
-// shelling out, and wouldn't need a local docker daemon.
 async fn import_docker_image_tar(backend: &DaytonaBackendHandle, tar: &[u8]) -> Result<String> {
     let snapshot_name = format!("exo-bridge-{}", Uuid::new_v4().simple());
     let tar_path = std::env::temp_dir().join(format!("{snapshot_name}.tar"));
@@ -1144,11 +1159,16 @@ async fn import_docker_image_tar(backend: &DaytonaBackendHandle, tar: &[u8]) -> 
         .map(str::to_string)
         .context("could not parse an image ref from `docker load` output")?;
 
-    // Re-tag to a specific version: Daytona rejects the `latest` tag that the
-    // Docker backend's snapshots carry.
-    let versioned_ref = format!("{snapshot_name}:1");
+    // Fetch short-lived push credentials for Daytona's transient registry and
+    // re-tag the image into it. (Also sidesteps the `latest` tag that the
+    // Docker backend's snapshots carry, which Daytona rejects.)
+    let push_access = backend.get_registry_push_access().await?;
+    let remote_ref = format!(
+        "{}/{}/{snapshot_name}:1",
+        push_access.registry_url, push_access.project
+    );
     let tag = tokio::process::Command::new("docker")
-        .args(["tag", &image_ref, &versioned_ref])
+        .args(["tag", &image_ref, &remote_ref])
         .output()
         .await
         .context("running `docker tag`")?;
@@ -1159,46 +1179,93 @@ async fn import_docker_image_tar(backend: &DaytonaBackendHandle, tar: &[u8]) -> 
         );
     }
 
-    // Authenticate the CLI with the same API key, then push the image as a
-    // Daytona snapshot (the CLI handles the registry push + snapshot
-    // registration). Push into the backend's region — sandboxes are created
-    // there, and a snapshot in another region 400s on create.
-    run_daytona_cli(&["login", "--api-key", &backend.api_key]).await?;
-    let mut push_args = vec!["snapshot", "push", &versioned_ref, "--name", &snapshot_name];
-    if let Some(target) = backend.target.as_deref() {
-        push_args.extend(["--region", target]);
-    }
-    run_daytona_cli(&push_args).await?;
-    for image in [&image_ref, &versioned_ref] {
+    // Push with a throwaway docker config dir so the temp credentials never
+    // touch the host user's ~/.docker/config.json, then register the pushed
+    // image as a Daytona snapshot in the backend's region — sandboxes are
+    // created there, and a snapshot in another region 400s on create.
+    let push_result = docker_push_with_credentials(&push_access, &remote_ref).await;
+    for image in [&image_ref, &remote_ref] {
         let _ = tokio::process::Command::new("docker")
             .args(["image", "rm", image])
             .output()
             .await;
     }
+    push_result?;
+    backend
+        .register_snapshot(&snapshot_name, &remote_ref)
+        .await?;
 
     backend.wait_for_snapshot_active(&snapshot_name).await?;
     Ok(snapshot_name)
 }
 
-async fn run_daytona_cli(args: &[&str]) -> Result<()> {
-    let output = tokio::process::Command::new("daytona")
-        .args(args)
-        .output()
+/// `docker login` + `docker push` against an isolated `--config` directory:
+/// the temp registry credentials are fed over stdin and written only to the
+/// throwaway config, never to the host user's docker config or process argv.
+async fn docker_push_with_credentials(
+    push_access: &DaytonaRegistryPushAccess,
+    remote_ref: &str,
+) -> Result<()> {
+    use tokio::process::Command;
+
+    let config_dir = std::env::temp_dir().join(format!("exo-docker-config-{}", Uuid::new_v4()));
+    tokio::fs::create_dir_all(&config_dir)
         .await
-        .with_context(|| {
-            format!(
-                "running `daytona {}` (is the daytona CLI installed on the harness host?)",
-                args.first().copied().unwrap_or_default()
-            )
-        })?;
-    if !output.status.success() {
-        bail!(
-            "`daytona {}` failed: {}",
-            args.first().copied().unwrap_or_default(),
-            String::from_utf8_lossy(&output.stderr)
-        );
+        .with_context(|| format!("creating temp docker config {}", config_dir.display()))?;
+
+    let result = async {
+        let mut login = Command::new("docker")
+            .arg("--config")
+            .arg(&config_dir)
+            .args([
+                "login",
+                &push_access.registry_url,
+                "--username",
+                &push_access.username,
+                "--password-stdin",
+            ])
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .context("running `docker login` for the Daytona transient registry")?;
+        let mut stdin = login
+            .stdin
+            .take()
+            .context("opening stdin for `docker login`")?;
+        stdin
+            .write_all(push_access.secret.as_bytes())
+            .await
+            .context("writing registry credentials to `docker login`")?;
+        drop(stdin);
+        let login = login.wait_with_output().await.context("`docker login`")?;
+        if !login.status.success() {
+            bail!(
+                "docker login to {} failed: {}",
+                push_access.registry_url,
+                String::from_utf8_lossy(&login.stderr)
+            );
+        }
+
+        let push = Command::new("docker")
+            .arg("--config")
+            .arg(&config_dir)
+            .args(["push", remote_ref])
+            .output()
+            .await
+            .context("running `docker push` to the Daytona transient registry")?;
+        if !push.status.success() {
+            bail!(
+                "docker push {remote_ref} failed: {}",
+                String::from_utf8_lossy(&push.stderr)
+            );
+        }
+        Ok(())
     }
-    Ok(())
+    .await;
+
+    let _ = tokio::fs::remove_dir_all(&config_dir).await;
+    result
 }
 
 fn reject_unsupported_mounts(request: &SandboxRequest) -> Result<()> {
@@ -1477,6 +1544,26 @@ struct DaytonaSnapshotRequest {
 struct DaytonaSnapshotInfo {
     #[serde(default)]
     state: String,
+}
+
+/// Temporary robot-account credentials for the transient registry; expire
+/// after about an hour, so they're fetched per-push and never persisted.
+#[derive(Deserialize)]
+struct DaytonaRegistryPushAccess {
+    username: String,
+    secret: String,
+    #[serde(rename = "registryUrl")]
+    registry_url: String,
+    project: String,
+}
+
+#[derive(Debug, Serialize)]
+struct DaytonaCreateSnapshotRequest {
+    name: String,
+    #[serde(rename = "imageName")]
+    image_name: String,
+    #[serde(rename = "regionId", skip_serializing_if = "Option::is_none")]
+    region_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -593,10 +593,9 @@ pub struct StartSandboxRequest {
     pub id: SandboxId,
     pub snapshot_id: SnapshotId,
     pub idle_seconds: Option<u64>,
-    /// Restore under a different provider than the sandbox was created with
-    /// (e.g. teleport a Docker snapshot up to Daytona). `None` keeps the
-    /// sandbox's current provider. The target provider must be supported by the
-    /// harness and able to restore the snapshot's kind.
+    // If unspecified, starts sandbox where it was last run. If specified, will attempt to
+    // start the sandbox on the specified provider, if supported. If successful, the
+    // sandbox will start there going forward. 
     #[serde(default)]
     pub provider: Option<SandboxProvider>,
 }
@@ -836,8 +835,7 @@ pub enum SandboxProviderConfig {
     Daytona {
         /// Secret-store id of the API key.
         api_key_secret_id: SecretId,
-        /// Daytona `target` region (e.g. `us` / `eu`). Sandbox snapshots are
-        /// available in the shared `us` region (verified 2026-07).
+        /// Daytona `target` region (e.g. `us` / `eu`).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         region: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -595,7 +595,7 @@ pub struct StartSandboxRequest {
     pub idle_seconds: Option<u64>,
     // If unspecified, starts sandbox where it was last run. If specified, will attempt to
     // start the sandbox on the specified provider, if supported. If successful, the
-    // sandbox will start there going forward. 
+    // sandbox will start there going forward.
     #[serde(default)]
     pub provider: Option<SandboxProvider>,
 }

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -593,6 +593,12 @@ pub struct StartSandboxRequest {
     pub id: SandboxId,
     pub snapshot_id: SnapshotId,
     pub idle_seconds: Option<u64>,
+    /// Restore under a different provider than the sandbox was created with
+    /// (e.g. teleport a Docker snapshot up to Daytona). `None` keeps the
+    /// sandbox's current provider. The target provider must be supported by the
+    /// harness and able to restore the snapshot's kind.
+    #[serde(default)]
+    pub provider: Option<SandboxProvider>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -830,7 +836,8 @@ pub enum SandboxProviderConfig {
     Daytona {
         /// Secret-store id of the API key.
         api_key_secret_id: SecretId,
-        /// Daytona `target` (`us` / `eu` / `experimental`; Note: CRIU snapshot support requires `experimental` as of 6/5/2026).
+        /// Daytona `target` region (e.g. `us` / `eu`). Sandbox snapshots are
+        /// available in the shared `us` region (verified 2026-07).
         #[serde(default, skip_serializing_if = "Option::is_none")]
         region: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/docs/sandbox-snapshots.md
+++ b/docs/sandbox-snapshots.md
@@ -184,7 +184,7 @@ matrix cell that supports docker. The test self-skips on cells that don't
 
 Two live Daytona analogs (both `#[ignore]`d; they need `DAYTONA_API_KEY`
 — snapshots are available in Daytona's shared `us` region — and, for the
-teleport, a local docker daemon plus the `daytona` CLI on PATH):
+teleport, a local docker daemon):
 
 ```
 # native Daytona snapshot + rewind

--- a/docs/sandbox-snapshots.md
+++ b/docs/sandbox-snapshots.md
@@ -1,7 +1,8 @@
 # Sandbox Snapshots
 
-Status: implemented for the Docker sandbox backend; stubs in place for the
-other backends.
+Status: implemented for the Docker, E2B, Sprites, and Daytona sandbox
+backends; stubs in place for the others. Daytona can additionally restore a
+Docker snapshot (the cross-provider "teleport" bridge).
 
 ## Summary
 
@@ -22,8 +23,13 @@ it, and the restore path that actually consumes it.
 - `ConversationHandle::start_sandbox(StartSandboxRequest { id, snapshot_id, .. })`
   starts a fresh container whose filesystem is sourced from the snapshot,
   preserving the original sandbox's mounts, network policy, and lifecycle.
-- A chat-REPL slash-command surface — `/snapshot`, `/snapshots`, `/rewind <id>`
-  — that drives the round-trip without leaving the conversation.
+- A chat-REPL slash-command surface — `/snapshot`, `/snapshots`, `/rewind <id>`,
+  `/teleport <provider>` — that drives the round-trip without leaving the
+  conversation.
+- **Teleportation**: `start_sandbox` accepts an optional `provider` override,
+  so a snapshot taken on one backend can be restored under another. The
+  flagship path is local Docker → Daytona: the same sandbox id, resumed
+  remotely with its filesystem intact.
 
 ## What this is not
 
@@ -150,6 +156,9 @@ Inside the chat REPL (`exo chat repl <agent> <conv>`):
 /snapshots          list snapshots taken in this conversation
 /rewind <id>        stop the current sandbox, start a fresh one from the
                     named snapshot
+/teleport <provider> snapshot the live sandbox and restore it under another
+                    provider (e.g. `/teleport daytona` moves a local Docker
+                    sandbox up to Daytona)
 /help               show command list
 ```
 
@@ -172,6 +181,18 @@ EXO_TEST_SANDBOX_BACKEND=docker cargo test --package exo \
 The CI integration workflow runs it on push to `main` against each Linux
 matrix cell that supports docker. The test self-skips on cells that don't
 (`local-process`) so they don't false-fail.
+
+Two live Daytona analogs (both `#[ignore]`d; they need `DAYTONA_API_KEY`
+— snapshots are available in Daytona's shared `us` region — and, for the
+teleport, a local docker daemon plus the `daytona` CLI on PATH):
+
+```
+# native Daytona snapshot + rewind
+cargo test -p exo --test snapshot_round_trip_daytona -- --ignored --nocapture
+
+# teleport: local Docker sandbox snapshotted and resumed on Daytona
+cargo test -p exo --test teleport_docker_to_daytona -- --ignored --nocapture
+```
 
 ## Extending to another sandbox backend
 


### PR DESCRIPTION
Excited to have (1) Daytona snapshot, (2) Daytona teleport, *and* (3) Docker -> Daytona teleportation working!

Note, there is not a clear path for Daytona -> Docker teleportation (returning back to local). I have asked in the Daytona Slack for some guidance. 

This PR adds...

- **`/teleport <provider>` REPL command** — snapshot the conversation's live sandbox and restore it under another provider in one step (`/teleport daytona` moves the local Docker sandbox up to Daytona).
- **Provider override on `start_sandbox`** — `StartSandboxRequest.provider: Option<SandboxProvider>` (serde-default, wire-compatible). The restore routes to the new backend and the new provider is persisted on the stored sandbox, so subsequent execs hit Daytona.
- **Daytona native `snapshot()`** — `POST /sandbox/{id}/snapshot`, then waits for the sandbox to leave `snapshotting` **and** the snapshot resource to reach `active` (creating from a not-yet-active snapshot 400s — hit live). Returns a `DaytonaSnapshot` manifest payload.
- **Daytona `acquire_from_snapshot()`** — restores a `DaytonaSnapshot` (create-from-named-snapshot) or bridges a `DockerImageTar`: `docker load` → fetch short-lived robot creds from `GET /docker-registry/registry-push-access` → `docker push` against a throwaway `--config` dir (secret over stdin) → `POST /snapshots {name, imageName, regionId}`.


Additional misc fix: daytona session exec was broken on the default image...the live round-trip exposed a pre-existing bug in `wrap_session_command_with_exit_status`: on daemon v0.193 the session shell in the default `daytonaio/sandbox` image is **zsh**, where `status` is a read-only special variable — `status=$?` aborts the whole command line with exit 126, the exit-status file never lands, and the harness poller (which only trusts the file) hangs forever. A trailing `exit "$status"` additionally kills the persistent session shell so the daemon never reports completion. Fixed by renaming the variable (`exo_exit_status`) and dropping the trailing `exit`; every `start_process`/`run_in_sandbox` on Daytona with the default image was affected, not just snapshots.

## Failure semantics: make-before-break

A cross-provider restore boots the new sandbox **before** stopping the source, so a failed teleport leaves the original container running and serving (stop of the source after success is best-effort). Same-provider rewinds keep stop-then-boot — the backend replaces the warm container for the key itself, and stopping the old handle after the swap would tear down the new container's warm-cache entry. The stored provider only flips after a successful restore.

## Tests

- Wiremock (`daytona_backend.rs`, hermetic): native snapshot manifest + wire contract, 403 feature-flag surfacing, restore passes `snapshot` name in the create body, foreign-kind rejection, garbage-tar bridge failure never reaches the API.
- Live, `#[ignore]`d:
  - `teleport_docker_to_daytona` — the headline: Docker sandbox → `snapshot_sandbox` → `start_sandbox(provider: Daytona)` → file readable on Daytona.
  - `snapshot_round_trip_daytona` — native Daytona snapshot + rewind.
  - The teleport test also covers the failure path: a bind-mounted Docker sandbox fails Daytona's restore and the source keeps serving.

Tested this driving exo myself with some teleportation, snapshotting, and rewinding.

```bash
DAYTONA_API_KEY=... cargo test -p exo --test teleport_docker_to_daytona -- --ignored --nocapture
```

## Verification

- `cargo build --workspace` / `cargo clippy --workspace --tests` clean; full non-ignored workspace suite passes.
- **Live** (`us` region, API v0.193): teleport passes in ~24s — the teleported sandbox serves the marker file written on local Docker; the native round-trip passes in ~15s — filesystem reverts after rewind.

## Known prototype caveats

- The Docker→Daytona bridge needs a `docker` daemon on the harness host (load/tag/push); pushing the tarball's layers directly with an OCI registry client would drop that too.
- Filesystem only — no process/memory state (same contract as all exoharness snapshots).