### PR TITLE
discord adapter: report worker failures and don't restart-loop on fatal closes

### DIFF
--- a/examples/exoclaw/adapters/discord/discord.test.ts
+++ b/examples/exoclaw/adapters/discord/discord.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  createResilienceHandlers,
+  describeCloseCode,
+  errorMessage,
+} from "./discord";
+
+describe("errorMessage", () => {
+  it("uses the message of an Error", () => {
+    expect(errorMessage(new Error("boom"))).toBe("boom");
+  });
+
+  it("stringifies non-error values", () => {
+    expect(errorMessage("plain")).toBe("plain");
+    expect(errorMessage(undefined)).toBe("undefined");
+    expect(errorMessage(42)).toBe("42");
+  });
+
+  it("never throws on values that cannot be stringified", () => {
+    const hostile = {
+      toString() {
+        throw new Error("nope");
+      },
+    };
+    expect(() => errorMessage(hostile)).not.toThrow();
+    expect(errorMessage(hostile)).toBe("unknown error");
+  });
+});
+
+describe("describeCloseCode", () => {
+  it("explains the unrecoverable configuration codes", () => {
+    expect(describeCloseCode(4004)).toContain("token is invalid");
+    expect(describeCloseCode(4014)).toContain("privileged intents");
+    expect(describeCloseCode(4014)).toContain("4014");
+  });
+
+  it("falls back for any other code", () => {
+    expect(describeCloseCode(1006)).toBe("gateway closed (code 1006)");
+  });
+});
+
+describe("createResilienceHandlers", () => {
+  it("exits after an unhandled rejection", () => {
+    const emit = vi.fn();
+    const exit = vi.fn();
+    createResilienceHandlers({ emit, exit }).onUnhandledRejection(
+      new Error("stray"),
+    );
+    expect(emit).toHaveBeenCalledWith({
+      type: "error",
+      message: "unhandled rejection: stray",
+    });
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("exits after an uncaught exception", () => {
+    const emit = vi.fn();
+    const exit = vi.fn();
+    createResilienceHandlers({ emit, exit }).onUncaughtException(
+      new Error("bad state"),
+    );
+    expect(emit).toHaveBeenCalledWith({
+      type: "error",
+      message: "uncaught exception: bad state",
+    });
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it("reports a shard disconnect without exiting into a restart loop", () => {
+    const emit = vi.fn();
+    const exit = vi.fn();
+    // 4014 (disallowed intents) is a config error a restart cannot fix; the
+    // worker must stay up rather than churn.
+    createResilienceHandlers({ emit, exit }).onShardDisconnect(4014);
+    expect(emit).toHaveBeenCalledWith({
+      type: "disconnected",
+      reason: expect.stringContaining("privileged intents"),
+    });
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it("keeps the worker alive on a shard error", () => {
+    const emit = vi.fn();
+    const exit = vi.fn();
+    createResilienceHandlers({ emit, exit }).onShardError(new Error("ws blip"));
+    expect(emit).toHaveBeenCalledWith({
+      type: "error",
+      message: "shard error: ws blip",
+    });
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it("exits when login fails", () => {
+    const emit = vi.fn();
+    const exit = vi.fn();
+    createResilienceHandlers({ emit, exit }).onLoginFailure(
+      new Error("invalid token"),
+    );
+    expect(emit).toHaveBeenCalledWith({
+      type: "error",
+      message: "discord login failed: invalid token",
+    });
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/examples/exoclaw/adapters/discord/discord.ts
+++ b/examples/exoclaw/adapters/discord/discord.ts
@@ -1,0 +1,101 @@
+import type { WorkerInboundEvent } from "../protocol";
+
+export function errorMessage(value: unknown): string {
+  if (value instanceof Error) {
+    return value.message;
+  }
+  try {
+    return String(value);
+  } catch {
+    return "unknown error";
+  }
+}
+
+// Gateway close codes discord.js will not reconnect from. Each is a
+// configuration problem that a worker restart cannot fix. discord.js emits the
+// Client "shardDisconnect" event only for these codes; every other close is
+// retried internally and surfaces as "shardReconnecting" instead.
+// https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-close-event-codes
+const UNRECOVERABLE_CLOSE_CODES = new Map<number, string>([
+  [4004, "authentication failed: the bot token is invalid"],
+  [4010, "invalid shard"],
+  [4011, "sharding required"],
+  [4012, "invalid gateway API version"],
+  [4013, "invalid gateway intents"],
+  [
+    4014,
+    "disallowed gateway intents: enable the privileged intents in the Discord developer portal",
+  ],
+]);
+
+export function describeCloseCode(code: number): string {
+  const detail = UNRECOVERABLE_CLOSE_CODES.get(code);
+  return detail ? `${detail} (code ${code})` : `gateway closed (code ${code})`;
+}
+
+export type ResilienceDeps = {
+  emit: (event: WorkerInboundEvent) => void;
+  exit: (code: number) => void;
+};
+
+export type ResilienceHandlers = {
+  onUnhandledRejection: (reason: unknown) => void;
+  onUncaughtException: (error: unknown) => void;
+  onShardDisconnect: (code: number) => void;
+  onShardError: (error: unknown) => void;
+  onLoginFailure: (error: unknown) => void;
+};
+
+// The worker is a child process the adapter runner restarts on every exit
+// (a fixed 5s delay, with no give-up). So it should exit only when a fresh
+// start can plausibly help; for a failure a restart cannot fix it stays up and
+// reports the cause rather than churning. The emit/exit side effects are
+// injected so the decisions can be unit-tested without a real process or
+// gateway.
+export function createResilienceHandlers(
+  deps: ResilienceDeps,
+): ResilienceHandlers {
+  return {
+    onUnhandledRejection(reason) {
+      // A rejection that escapes discord.js's own gateway recovery leaves the
+      // worker in an unknown state, so surface it and exit for a clean restart.
+      deps.emit({
+        type: "error",
+        message: `unhandled rejection: ${errorMessage(reason)}`,
+      });
+      deps.exit(1);
+    },
+    onUncaughtException(error) {
+      deps.emit({
+        type: "error",
+        message: `uncaught exception: ${errorMessage(error)}`,
+      });
+      deps.exit(1);
+    },
+    onShardDisconnect(code) {
+      // discord.js emits shardDisconnect only for close codes it will not
+      // reconnect from, and all of them are configuration errors. A restart
+      // cannot fix those and would just reconnect-storm Discord, so report the
+      // cause and stay up instead of exiting into a 5s restart loop.
+      deps.emit({ type: "disconnected", reason: describeCloseCode(code) });
+    },
+    onShardError(error) {
+      // Shard errors are transient; discord.js keeps reconnecting, so report
+      // the error without tearing the worker down.
+      deps.emit({
+        type: "error",
+        message: `shard error: ${errorMessage(error)}`,
+      });
+    },
+    onLoginFailure(error) {
+      // Login can fail transiently, in which case a restart may succeed, so
+      // surface the error and exit. A persistently bad token reports this on
+      // each retry.
+      deps.emit({
+        type: "error",
+        message: `discord login failed: ${errorMessage(error)}`,
+      });
+      deps.exit(1);
+    },
+  };
+}

--- a/examples/exoclaw/adapters/discord/worker.ts
+++ b/examples/exoclaw/adapters/discord/worker.ts
@@ -17,6 +17,7 @@ import {
   parseWorkerCommand,
   writeWorkerEvent,
 } from "../protocol";
+import { createResilienceHandlers } from "./discord";
 
 const SEND_TIMEOUT_MS = 60_000;
 
@@ -34,6 +35,19 @@ const allowBots = config.allowBots === true;
 if (trigger !== "all_messages" && trigger !== "mentions_only") {
   throw new Error("Discord trigger must be all_messages or mentions_only");
 }
+
+const resilience = createResilienceHandlers({
+  emit: writeWorkerEvent,
+  exit: (code) => process.exit(code),
+});
+
+process.on("unhandledRejection", (reason) => {
+  resilience.onUnhandledRejection(reason);
+});
+
+process.on("uncaughtException", (error) => {
+  resilience.onUncaughtException(error);
+});
 
 const client = new Client({
   intents: [
@@ -60,10 +74,11 @@ client.once("ready", () => {
 });
 
 client.on("shardDisconnect", (event) => {
-  writeWorkerEvent({
-    type: "disconnected",
-    reason: event.reason || String(event.code),
-  });
+  resilience.onShardDisconnect(event.code);
+});
+
+client.on("shardError", (error) => {
+  resilience.onShardError(error);
 });
 
 client.on("messageCreate", (message) => {
@@ -91,7 +106,11 @@ client.on("messageCreate", (message) => {
   });
 });
 
-await client.login(token);
+try {
+  await client.login(token);
+} catch (error) {
+  resilience.onLoginFailure(error);
+}
 
 const input = readline.createInterface({
   input: process.stdin,


### PR DESCRIPTION
## Summary

The Discord worker reports failures inconsistently. An unhandled rejection
crashes the process with a bare stderr stack trace, `shardDisconnect` records the
deprecated `CloseEvent.reason` (in discord.js 14 that is the literal string "the
reason property is deprecated, use the code property..."), and `shardError` is
dropped entirely.

This routes worker-level failures through structured worker events, and exits
only when a restart can actually help:

- `unhandledRejection` / `uncaughtException`: report the error, then `exit(1)`
  for a clean supervised restart (same as the irc and whatsapp adapters).
- `shardDisconnect`: report the cause derived from the close code, and stay up.
  discord.js emits this event only for the close codes it will not reconnect
  from, and all of them are configuration errors (a bad token, disallowed
  intents, and so on). Since the runner restarts the worker on every exit,
  exiting here would just reconnect-storm the gateway every 5s on a problem a
  restart cannot fix.
- `shardError`: report it. discord.js reconnects on its own, so no exit.
- failed `client.login`: report it and `exit(1)` so a transient failure recovers
  on the next start.

The decision logic moves into `discord.ts` with injected emit/exit so it is
unit-testable, following the irc adapter's split.

## Out of scope

- A persistently invalid token still loops on the 5s restart, reporting the login
  error each time. Stopping that needs the runner to give up after repeated
  failures, which is a separate change.
- `writeWorkerEvent` right before `process.exit` can drop the last line if stdout
  is mid-flush. That is the existing pattern in the irc and whatsapp workers,
  left as-is.

## Testing

- `pnpm typecheck` and `pnpm lint` clean.
- `pnpm test`, full suite green, including a new `discord.test.ts` covering
  `errorMessage`, the close-code messages, and each handler's report/exit
  behavior.
