### PR TITLE
Reload agent and conversation config each turn instead of caching

### DIFF
--- a/crates/executor/src/basic_tests.rs
+++ b/crates/executor/src/basic_tests.rs
@@ -24,7 +24,9 @@ use serde_json::{Map, Value, json};
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
-use crate::harness_executor::{ExecutorStreamMode, HarnessExecutor};
+use crate::execution_tracing::TurnExecutionTrace;
+use crate::harness_executor::{ExecutorHarnessRuntime, ExecutorStreamMode, HarnessExecutor};
+use crate::harness_facade::HarnessRuntime;
 use crate::*;
 
 #[tokio::test(flavor = "current_thread")]
@@ -607,6 +609,7 @@ struct FakeExoHarness {
 struct FakeState {
     agent: AgentRecord,
     conversation: FakeConversationState,
+    agent_artifact: Option<(u64, String, Vec<u8>)>,
 }
 
 struct FakeConversationState {
@@ -632,6 +635,7 @@ impl FakeExoHarness {
                     },
                     events: Vec::new(),
                 },
+                agent_artifact: None,
             })),
         }
     }
@@ -769,16 +773,52 @@ impl AgentHandle for FakeAgentHandle {
         }))
     }
 
-    async fn write_artifact(&self, _request: WriteArtifactRequest) -> Result<ArtifactVersion> {
-        Err(anyhow!("not implemented"))
+    async fn write_artifact(&self, request: WriteArtifactRequest) -> Result<ArtifactVersion> {
+        let mut state = self.state.lock().expect("state poisoned");
+        let version = state.agent_artifact.as_ref().map_or(1, |(v, _, _)| v + 1);
+        let size_bytes = request.contents.len() as u64;
+        state.agent_artifact = Some((version, request.path.clone(), request.contents));
+        Ok(ArtifactVersion {
+            artifact_id: Uuid7::now(),
+            path: request.path,
+            version,
+            created_at: artifact_timestamp(),
+            size_bytes,
+        })
     }
 
     async fn read_artifact(&self, _request: ReadArtifactRequest) -> Result<Option<Artifact>> {
-        Ok(None)
+        let state = self.state.lock().expect("state poisoned");
+        Ok(state
+            .agent_artifact
+            .as_ref()
+            .map(|(version, path, contents)| Artifact {
+                version: ArtifactVersion {
+                    artifact_id: Uuid7::now(),
+                    path: path.clone(),
+                    version: *version,
+                    created_at: artifact_timestamp(),
+                    size_bytes: contents.len() as u64,
+                },
+                contents: contents.clone(),
+            }))
     }
 
     async fn list_artifacts(&self) -> Result<Vec<ArtifactVersion>> {
-        Ok(Vec::new())
+        let state = self.state.lock().expect("state poisoned");
+        Ok(state
+            .agent_artifact
+            .as_ref()
+            .map(|(version, path, contents)| {
+                vec![ArtifactVersion {
+                    artifact_id: Uuid7::now(),
+                    path: path.clone(),
+                    version: *version,
+                    created_at: artifact_timestamp(),
+                    size_bytes: contents.len() as u64,
+                }]
+            })
+            .unwrap_or_default())
     }
 }
 
@@ -1199,4 +1239,81 @@ fn default_agent_config() -> AgentConfig {
         max_tool_round_trips: Some(4),
         braintrust: None,
     }
+}
+
+fn artifact_timestamp() -> exoharness::DateTimeUtc {
+    exoharness::DateTimeUtc::from_timestamp(0, 0).expect("valid epoch timestamp")
+}
+
+#[derive(Clone)]
+struct NoopExecutor;
+
+#[async_trait]
+impl HarnessExecutor for NoopExecutor {
+    type Prepared = ();
+
+    fn prepare_request(&self, _request: &SendRequest) -> Result<Self::Prepared> {
+        Ok(())
+    }
+
+    async fn execute_turn(
+        &self,
+        _agent: &dyn AgentHandle,
+        _conversation: &dyn ConversationHandle,
+        _turn: Arc<dyn TurnHandle>,
+        _agent_config: &AgentConfig,
+        _conversation_config: &ConversationConfig,
+        _prepared: &Self::Prepared,
+        _stream_mode: ExecutorStreamMode<'_>,
+        _turn_trace: Option<&dyn TurnExecutionTrace>,
+    ) -> Result<()> {
+        unimplemented!("execute_turn is not exercised by get_agent_config")
+    }
+}
+
+async fn write_agent_config(agent: &dyn AgentHandle, config: &AgentConfig) {
+    agent
+        .write_artifact(WriteArtifactRequest {
+            path: "config/executor.json".to_string(),
+            contents: serde_json::to_vec(config).expect("serialize config"),
+        })
+        .await
+        .expect("write config artifact");
+}
+
+#[tokio::test]
+async fn get_agent_config_reflects_external_update_without_restart() {
+    let agent_id = Uuid7::now();
+    let conversation_id = Uuid7::now();
+    let harness = FakeExoHarness::new(agent_id, conversation_id);
+    let agent = harness
+        .get_agent(&agent_id)
+        .await
+        .expect("get_agent")
+        .expect("agent exists");
+    let runtime = ExecutorHarnessRuntime::new(NoopExecutor, None);
+
+    // Initial config, as written by `exo agent create`.
+    let mut config = default_agent_config();
+    config.enable_networking = false;
+    write_agent_config(agent.as_ref(), &config).await;
+    let loaded = runtime
+        .get_agent_config(agent.as_ref())
+        .await
+        .expect("load config");
+    assert!(!loaded.enable_networking);
+
+    // Rewrite the artifact out of band, as a concurrent `exo agent update` would.
+    config.enable_networking = true;
+    write_agent_config(agent.as_ref(), &config).await;
+
+    // The next turn must observe the new config without restarting the runner.
+    let reloaded = runtime
+        .get_agent_config(agent.as_ref())
+        .await
+        .expect("reload config");
+    assert!(
+        reloaded.enable_networking,
+        "config update should be picked up without a restart"
+    );
 }

--- a/crates/executor/src/harness_executor.rs
+++ b/crates/executor/src/harness_executor.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use exoharness::{AgentHandle, BeginTurnRequest, ConversationHandle, Result, TurnHandle};
@@ -12,11 +11,7 @@ use crate::harness_config::{
 };
 use crate::harness_facade::HarnessRuntime;
 use crate::harness_helpers::get_conversation_model_override;
-use crate::shared::{
-    AGENT_CONFIG_CACHE_NAME, CONVERSATION_CONFIG_CACHE_NAME, cache_agent_config,
-    cache_conversation_config, execute_prepared_turn, get_or_load_cached,
-    spawn_prepared_turn_stream,
-};
+use crate::shared::{execute_prepared_turn, spawn_prepared_turn_stream};
 use crate::{
     AgentConfig, ConversationConfig, ConversationModelConfig, ExecutionStreamEvent,
     ExecutionStreamHandle, SendRequest, SendResult,
@@ -60,8 +55,6 @@ pub(crate) trait HarnessExecutor: Send + Sync + Clone + 'static {
 pub(crate) struct ExecutorHarnessRuntime<E> {
     executor: E,
     tracer: Arc<dyn ExecutionTracer>,
-    agent_config_cache: Arc<RwLock<HashMap<exoharness::AgentId, AgentConfig>>>,
-    conversation_config_cache: Arc<RwLock<HashMap<exoharness::ConversationId, ConversationConfig>>>,
 }
 
 impl<E> ExecutorHarnessRuntime<E> {
@@ -69,8 +62,6 @@ impl<E> ExecutorHarnessRuntime<E> {
         Self {
             executor,
             tracer: Arc::new(BraintrustTracer::new(runtime_config)),
-            agent_config_cache: Arc::new(RwLock::new(HashMap::new())),
-            conversation_config_cache: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 }
@@ -83,8 +74,6 @@ where
         Self {
             executor: self.executor.clone(),
             tracer: Arc::clone(&self.tracer),
-            agent_config_cache: Arc::clone(&self.agent_config_cache),
-            conversation_config_cache: Arc::clone(&self.conversation_config_cache),
         }
     }
 }
@@ -106,35 +95,25 @@ where
     E: HarnessExecutor,
 {
     async fn get_agent_config(&self, agent: &dyn AgentHandle) -> Result<AgentConfig> {
-        let agent_id = agent.record().id;
-        get_or_load_cached(
-            &self.agent_config_cache,
-            agent_id,
-            AGENT_CONFIG_CACHE_NAME,
-            || load_agent_config(agent),
-        )
-        .await
+        // Read the latest config from the agent's artifact store every turn, so an
+        // external `exo agent update` (or the agent rewriting its own config) takes
+        // effect on the next turn without restarting the runner. No cache on
+        // purpose: the config is a tiny artifact and a turn is dominated by the
+        // model call, so a fresh read costs less than keeping a cache correct
+        // across outside writes (the stale-cache bug this replaces).
+        load_agent_config(agent).await
     }
 
     async fn put_agent_config(&self, agent: &dyn AgentHandle, config: AgentConfig) -> Result<()> {
-        let agent_id = agent.record().id;
-        store_agent_config(agent, &config).await?;
-        cache_agent_config(&self.agent_config_cache, agent_id, config);
-        Ok(())
+        store_agent_config(agent, &config).await
     }
 
     async fn get_conversation_config(
         &self,
         conversation: &dyn ConversationHandle,
     ) -> Result<ConversationConfig> {
-        let conversation_id = conversation.record().id;
-        get_or_load_cached(
-            &self.conversation_config_cache,
-            conversation_id,
-            CONVERSATION_CONFIG_CACHE_NAME,
-            || load_conversation_config(conversation),
-        )
-        .await
+        // Read fresh every turn, for the same reasons as get_agent_config.
+        load_conversation_config(conversation).await
     }
 
     async fn put_conversation_config(
@@ -142,10 +121,7 @@ where
         conversation: &dyn ConversationHandle,
         config: ConversationConfig,
     ) -> Result<()> {
-        let conversation_id = conversation.record().id;
-        store_conversation_config(conversation, &config).await?;
-        cache_conversation_config(&self.conversation_config_cache, conversation_id, config);
-        Ok(())
+        store_conversation_config(conversation, &config).await
     }
 
     async fn send(

--- a/crates/executor/src/shared.rs
+++ b/crates/executor/src/shared.rs
@@ -1,13 +1,9 @@
-use std::collections::HashMap;
 use std::future::Future;
-use std::hash::Hash;
 use std::pin::Pin;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 
 use anyhow::Error;
-use exoharness::{
-    AgentHandle, AgentId, ConversationHandle, ConversationId, EventId, Result, TurnHandle,
-};
+use exoharness::{AgentHandle, ConversationHandle, EventId, Result, TurnHandle};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
@@ -15,37 +11,6 @@ use crate::execution_tracing::{ExecutionTracer, TurnExecutionTrace};
 use crate::{AgentConfig, ExecutionStreamEvent, ExecutionStreamHandle, SendResult};
 
 pub(crate) type TurnFuture<'a> = Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
-
-pub(crate) fn cache_insert<K, V>(cache: &RwLock<HashMap<K, V>>, key: K, value: V, name: &str)
-where
-    K: Eq + Hash,
-{
-    cache.write().expect(name).insert(key, value);
-}
-
-pub(crate) async fn get_or_load_cached<K, V, Load, LoadFuture>(
-    cache: &RwLock<HashMap<K, V>>,
-    key: K,
-    name: &str,
-    load: Load,
-) -> Result<V>
-where
-    K: Eq + Hash + Clone,
-    V: Clone,
-    Load: FnOnce() -> LoadFuture,
-    LoadFuture: Future<Output = Result<V>>,
-{
-    {
-        let cache = cache.read().expect(name);
-        if let Some(value) = cache.get(&key) {
-            return Ok(value.clone());
-        }
-    }
-
-    let value = load().await?;
-    cache_insert(cache, key, value.clone(), name);
-    Ok(value)
-}
 
 pub(crate) async fn execute_prepared_turn<Run>(
     tracer: &dyn ExecutionTracer,
@@ -181,27 +146,4 @@ pub(crate) fn try_send_stream_error(
     if event_tx.send(Err(Error::msg(error.to_string()))).is_err() {}
 }
 
-pub(crate) const AGENT_CONFIG_CACHE_NAME: &str = "agent config cache poisoned";
-pub(crate) const CONVERSATION_CONFIG_CACHE_NAME: &str = "conversation config cache poisoned";
 pub(crate) const HISTORY_CACHE_NAME: &str = "history cache poisoned";
-
-pub(crate) fn cache_agent_config(
-    cache: &RwLock<HashMap<AgentId, AgentConfig>>,
-    agent_id: AgentId,
-    config: AgentConfig,
-) {
-    cache_insert(cache, agent_id, config, AGENT_CONFIG_CACHE_NAME);
-}
-
-pub(crate) fn cache_conversation_config(
-    cache: &RwLock<HashMap<ConversationId, crate::ConversationConfig>>,
-    conversation_id: ConversationId,
-    config: crate::ConversationConfig,
-) {
-    cache_insert(
-        cache,
-        conversation_id,
-        config,
-        CONVERSATION_CONFIG_CACHE_NAME,
-    );
-}


### PR DESCRIPTION
## Summary

Fixes #44. The harness runtime loaded an agent's `AgentConfig` (and a
conversation's `ConversationConfig`) once and cached it in process memory for the
runner's lifetime. An `exo agent update` in another process writes a new config
artifact to disk but does not invalidate that cache, so a long-running
`adapters run` keeps building sandboxes from the old config until it is restarted.

This drops the per-process config caches and reads the latest artifact from disk
on every turn. The read is one small artifact load, negligible next to running a
turn, and it removes a class of stale-config bugs across the runner (the same
cache also affected `exo conversation update`).

`get_agent_config` / `get_conversation_config` now call `load_agent_config` /
`load_conversation_config` directly, and `put_*` just writes the artifact. The
now-unused cache helpers (`get_or_load_cached`, `cache_insert`, and the
config-specific wrappers) are removed. Secrets are not affected: the runtime
never cached them.

## Testing

- New `get_agent_config_reflects_external_update_without_restart`: writes a
  config, reads it through the runtime, rewrites the artifact out of band (as a
  concurrent `exo agent update` would), and asserts the next read reflects the
  change. It fails against the old caching path.
- `cargo test --workspace` green (executor 49, exo 35, exoharness 29, daytona 11).
- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --check`
  clean.

The conversation-config cache is removed by the same change; the unit test covers
the agent path and the conversation path is the identical mechanism.
