### PR TITLE
history: per-message cost, tokens, and latency tracking (on self-control)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,6 +1542,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cost"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "reqwest",
+ "serde",
+ "serde_json 1.0.149",
+ "tempfile",
+ "tokio",
+]
+
+[[package]]
 name = "cpubits"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2126,6 +2138,7 @@ dependencies = [
  "braintrust-llm-router",
  "braintrust-sdk-rust",
  "bytes",
+ "cost",
  "exoharness",
  "futures",
  "libc",
@@ -2147,6 +2160,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "clap",
+ "cost",
  "executor",
  "exoharness",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "crates/cli",
+  "crates/cost",
   "crates/exoharness",
   "crates/executor",
   "examples/exoclaw/scheduler-runner",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+cost = { path = "../cost" }
 executor = { path = "../executor" }
 lingua.workspace = true
 rustyline = "15.0.0"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -90,6 +90,12 @@ struct Cli {
         value_parser = parse_env_var_name
     )]
     bearer_env: Option<String>,
+    /// Path to a LiteLLM price JSON for cost tracking (overrides fetch/cache).
+    #[arg(long, global = true, env = "EXO_LITELLM_PRICES_PATH")]
+    pricing_path: Option<PathBuf>,
+    /// URL to fetch the LiteLLM price JSON from (overrides the default source).
+    #[arg(long, global = true, env = "EXO_LITELLM_PRICES_URL")]
+    pricing_url: Option<String>,
     #[command(subcommand)]
     command: Commands,
 }
@@ -758,6 +764,7 @@ async fn main() -> Result<()> {
         &cli.command,
     )
     .await?;
+    let pricing = Arc::new(cost::load(cli.pricing_path.clone(), cli.pricing_url.clone()).await);
     let harness = instantiate_harness(
         &cli.root,
         &exo_config,
@@ -765,6 +772,7 @@ async fn main() -> Result<()> {
         harness_kind,
         runtime_config.clone(),
         env_vars.clone(),
+        pricing,
     )
     .await?;
 
@@ -1995,12 +2003,14 @@ async fn instantiate_harness(
     kind: HarnessKind,
     runtime_config: Option<BraintrustRuntimeConfig>,
     env_vars: HashMap<String, String>,
+    pricing: Arc<cost::PricingTable>,
 ) -> Result<Arc<dyn Harness>> {
     let harness: Arc<dyn Harness> = match kind {
         HarnessKind::Basic => Arc::new(BasicHarness::from_exoharness(
             exoharness,
             runtime_config,
             env_vars,
+            pricing,
         )),
         HarnessKind::Rlm => Arc::new(RlmHarness::from_exoharness(
             exoharness,

--- a/crates/cli/src/tui.rs
+++ b/crates/cli/src/tui.rs
@@ -928,6 +928,7 @@ mod tests {
                 ),
             }],
             response_id: None,
+            usage: None,
         });
 
         assert_eq!(rendered.len(), 1);

--- a/crates/cost/Cargo.toml
+++ b/crates/cost/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "cost"
+edition.workspace = true
+version.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+anyhow.workspace = true
+reqwest.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+
+[dev-dependencies]
+tempfile = "3.23.0"
+tokio = { workspace = true }

--- a/crates/cost/src/lib.rs
+++ b/crates/cost/src/lib.rs
@@ -1,0 +1,5 @@
+mod loader;
+mod table;
+
+pub use loader::load;
+pub use table::{ModelEntry, PricingTable, TokenCounts};

--- a/crates/cost/src/loader.rs
+++ b/crates/cost/src/loader.rs
@@ -1,0 +1,125 @@
+//! Loads the LiteLLM price database. Resolution: explicit path -> fresh cache
+//! -> fetch (cached on success) -> stale cache -> empty. Never fails: any error
+//! degrades to an empty table (cost stays unset, tokens still persist).
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crate::PricingTable;
+
+const DEFAULT_URL: &str =
+    "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
+const CACHE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+const FETCH_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Load the table once at startup. `path`/`url` are caller-supplied (CLI flags or
+/// env), so this stays free of global config reads.
+pub async fn load(path: Option<PathBuf>, url: Option<String>) -> PricingTable {
+    if let Some(path) = path {
+        return match std::fs::read_to_string(&path) {
+            Ok(body) => parse_or_empty(&body),
+            Err(err) => {
+                eprintln!(
+                    "[exo] reading pricing path {}: {err}; cost unavailable",
+                    path.display()
+                );
+                PricingTable::empty()
+            }
+        };
+    }
+
+    let cache = cache_path();
+    let cached = cache.as_ref().and_then(read_cache);
+    if let Some((body, true)) = &cached {
+        return parse_or_empty(body);
+    }
+
+    let url = url.unwrap_or_else(|| DEFAULT_URL.to_string());
+    match fetch(&url).await {
+        Ok(body) if PricingTable::from_json_str(&body).is_ok() => {
+            if let Some(path) = &cache {
+                write_cache(path, &body);
+            }
+            parse_or_empty(&body)
+        }
+        Ok(_) => {
+            eprintln!("[exo] fetched pricing was unparseable; cost unavailable");
+            PricingTable::empty()
+        }
+        Err(err) => match cached {
+            Some((body, _)) => {
+                eprintln!("[exo] pricing fetch failed ({err}); using stale cache");
+                parse_or_empty(&body)
+            }
+            None => {
+                eprintln!("[exo] pricing fetch failed ({err}); cost unavailable");
+                PricingTable::empty()
+            }
+        },
+    }
+}
+
+/// A corrupt or truncated document degrades to an empty table rather than erroring.
+fn parse_or_empty(body: &str) -> PricingTable {
+    PricingTable::from_json_str(body).unwrap_or_else(|_| {
+        eprintln!("[exo] cached pricing is unparseable; cost unavailable until it refreshes");
+        PricingTable::empty()
+    })
+}
+
+async fn fetch(url: &str) -> anyhow::Result<String> {
+    let client = reqwest::Client::builder().timeout(FETCH_TIMEOUT).build()?;
+    Ok(client
+        .get(url)
+        .send()
+        .await?
+        .error_for_status()?
+        .text()
+        .await?)
+}
+
+/// Returns `(body, is_fresh)`; `is_fresh` is true only within `CACHE_TTL`.
+fn read_cache(path: &PathBuf) -> Option<(String, bool)> {
+    let fresh = std::fs::metadata(path)
+        .and_then(|m| m.modified())
+        .ok()
+        .and_then(|t| t.elapsed().ok())
+        .is_some_and(|age| age < CACHE_TTL);
+    Some((std::fs::read_to_string(path).ok()?, fresh))
+}
+
+fn write_cache(path: &PathBuf, body: &str) {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(path, body);
+}
+
+fn cache_path() -> Option<PathBuf> {
+    let base = std::env::var_os("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".cache")))?;
+    Some(base.join("exo").join("litellm_prices.json"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    const FIXTURE: &str = r#"{ "claude-sonnet-4-6": { "litellm_provider": "anthropic", "input_cost_per_token": 3e-06 } }"#;
+
+    #[tokio::test]
+    async fn explicit_path_is_loaded() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("prices.json");
+        std::fs::write(&path, FIXTURE).unwrap();
+        let table = load(Some(path), None).await;
+        assert!(table.lookup("claude-sonnet-4-6").is_some());
+    }
+
+    #[test]
+    fn corrupt_body_degrades_to_empty() {
+        assert!(parse_or_empty("{ not json").is_empty());
+    }
+}

--- a/crates/cost/src/table.rs
+++ b/crates/cost/src/table.rs
@@ -1,0 +1,243 @@
+//! Per-model price data and cost math, parsed from LiteLLM's pricing database.
+//! Pure: no network, no globals.
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct ModelEntry {
+    #[serde(default)]
+    pub litellm_provider: Option<String>,
+    #[serde(default)]
+    pub input_cost_per_token: Option<f64>,
+    #[serde(default)]
+    pub output_cost_per_token: Option<f64>,
+    #[serde(default)]
+    pub cache_read_input_token_cost: Option<f64>,
+    #[serde(default)]
+    pub cache_creation_input_token_cost: Option<f64>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct TokenCounts {
+    pub prompt: Option<i64>,
+    pub completion: Option<i64>,
+    pub prompt_cached: Option<i64>,
+    pub prompt_cache_creation: Option<i64>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PricingTable {
+    entries: HashMap<String, ModelEntry>,
+}
+
+impl PricingTable {
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Parse a LiteLLM `model_prices_and_context_window.json` document. The
+    /// `sample_spec` doc entry and any entry without per-token rates are skipped.
+    pub fn from_json_str(s: &str) -> anyhow::Result<Self> {
+        let raw: HashMap<String, serde_json::Value> = serde_json::from_str(s)?;
+        let entries = raw
+            .into_iter()
+            .filter(|(key, _)| key != "sample_spec")
+            .filter_map(|(key, value)| {
+                Some((key, serde_json::from_value::<ModelEntry>(value).ok()?))
+            })
+            .collect();
+        Ok(Self { entries })
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Exact match, else the longest entry key that is a prefix of `model` at a
+    /// token boundary (next char absent or `-`/`:`), so dated revisions resolve
+    /// (`claude-sonnet-4-6-20251022` -> `claude-sonnet-4-6`) without sliding
+    /// `gpt-4o-mini` onto a `gpt-4` entry when `gpt-4o` is missing.
+    pub fn lookup(&self, model: &str) -> Option<&ModelEntry> {
+        if let Some(entry) = self.entries.get(model) {
+            return Some(entry);
+        }
+        self.entries
+            .iter()
+            .filter(|(key, _)| {
+                model.starts_with(key.as_str())
+                    && matches!(
+                        model.as_bytes().get(key.len()),
+                        None | Some(b'-') | Some(b':')
+                    )
+            })
+            .max_by_key(|(key, _)| key.len())
+            .map(|(_, entry)| entry)
+    }
+
+    /// USD cost for one call, or `None` if the model is unknown or unpriced.
+    pub fn compute_cost_usd(&self, model: &str, tokens: TokenCounts) -> Option<f64> {
+        let entry = self.lookup(model)?;
+        let input = entry.input_cost_per_token?;
+        let output = entry.output_cost_per_token.unwrap_or(0.0);
+        let cache_read = entry.cache_read_input_token_cost.unwrap_or(input);
+        let cache_write = entry.cache_creation_input_token_cost.unwrap_or(input);
+
+        let prompt = tokens.prompt.unwrap_or(0).max(0) as f64;
+        let completion = tokens.completion.unwrap_or(0).max(0) as f64;
+        let cached = tokens.prompt_cached.unwrap_or(0).max(0) as f64;
+        let created = tokens.prompt_cache_creation.unwrap_or(0).max(0) as f64;
+
+        // Anthropic-family `prompt_tokens` excludes cached (bill additively);
+        // everyone else includes it (subtract before billing fresh input).
+        let fresh = if is_additive(entry.litellm_provider.as_deref()) {
+            prompt
+        } else {
+            (prompt - cached).max(0.0)
+        };
+        Some(fresh * input + cached * cache_read + created * cache_write + completion * output)
+    }
+}
+
+fn is_additive(provider: Option<&str>) -> bool {
+    match provider {
+        Some(p) => {
+            p.starts_with("anthropic") || p.starts_with("vertex_ai-anthropic") || p == "azure_ai"
+        }
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FIXTURE: &str = r#"{
+        "sample_spec": { "comment": "ignored" },
+        "claude-sonnet-4-6": {
+            "litellm_provider": "anthropic", "input_cost_per_token": 3e-06,
+            "output_cost_per_token": 1.5e-05, "cache_read_input_token_cost": 3e-07,
+            "cache_creation_input_token_cost": 3.75e-06
+        },
+        "gpt-4o-mini": {
+            "litellm_provider": "openai", "input_cost_per_token": 1.5e-07,
+            "output_cost_per_token": 6e-07, "cache_read_input_token_cost": 7.5e-08
+        },
+        "gpt-4": { "litellm_provider": "openai", "input_cost_per_token": 3e-05, "output_cost_per_token": 6e-05 },
+        "us.anthropic.claude-sonnet-4-6": {
+            "litellm_provider": "bedrock_converse", "input_cost_per_token": 3.3e-06,
+            "output_cost_per_token": 1.65e-05, "cache_read_input_token_cost": 3.3e-07,
+            "cache_creation_input_token_cost": 4.125e-06
+        }
+    }"#;
+
+    fn table() -> PricingTable {
+        PricingTable::from_json_str(FIXTURE).unwrap()
+    }
+
+    fn approx(a: f64, b: f64) {
+        assert!(
+            (a - b).abs() / b.abs().max(1e-12) < 1e-9,
+            "expected {b}, got {a}"
+        );
+    }
+
+    fn counts(prompt: i64, completion: i64, cached: i64, created: i64) -> TokenCounts {
+        TokenCounts {
+            prompt: Some(prompt),
+            completion: Some(completion),
+            prompt_cached: Some(cached),
+            prompt_cache_creation: Some(created),
+        }
+    }
+
+    #[test]
+    fn empty_table_is_none() {
+        assert!(
+            PricingTable::empty()
+                .compute_cost_usd("claude-sonnet-4-6", counts(100, 50, 0, 0))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn skips_sample_spec() {
+        assert!(table().lookup("sample_spec").is_none());
+        assert_eq!(table().len(), 4);
+    }
+
+    #[test]
+    fn dated_revision_resolves_to_base() {
+        let table = table();
+        let entry = table.lookup("claude-sonnet-4-6-20251022").unwrap();
+        assert_eq!(entry.litellm_provider.as_deref(), Some("anthropic"));
+    }
+
+    #[test]
+    fn prefix_match_respects_token_boundary() {
+        // `gpt-4o` is absent; lookup must NOT fall back to `gpt-4`.
+        assert!(table().lookup("gpt-4o").is_none());
+        // `gpt-4-0613` is a boundary extension of `gpt-4` and should match it.
+        assert!(table().lookup("gpt-4-0613").is_some());
+    }
+
+    #[test]
+    fn anthropic_additive() {
+        // 500 fresh + 10k cache-read + 200 completion (prompt excludes cached).
+        approx(
+            table()
+                .compute_cost_usd("claude-sonnet-4-6", counts(500, 200, 10_000, 0))
+                .unwrap(),
+            0.0075,
+        );
+    }
+
+    #[test]
+    fn anthropic_cache_creation() {
+        approx(
+            table()
+                .compute_cost_usd("claude-sonnet-4-6", counts(0, 100, 0, 5_000))
+                .unwrap(),
+            0.02025,
+        );
+    }
+
+    #[test]
+    fn openai_inclusive_subtracts_cached() {
+        // prompt=2000 includes 500 cached -> 1500 fresh.
+        approx(
+            table()
+                .compute_cost_usd("gpt-4o-mini", counts(2_000, 1_000, 500, 0))
+                .unwrap(),
+            0.0008625,
+        );
+    }
+
+    #[test]
+    fn bedrock_is_inclusive_not_additive() {
+        // prompt=2000 includes 500 cached -> fresh 1500 @ 3.3e-6, cached 500 @ 3.3e-7, 1000 out @ 1.65e-5.
+        approx(
+            table()
+                .compute_cost_usd(
+                    "us.anthropic.claude-sonnet-4-6",
+                    counts(2_000, 1_000, 500, 0),
+                )
+                .unwrap(),
+            1_500.0 * 3.3e-6 + 500.0 * 3.3e-7 + 1_000.0 * 1.65e-5,
+        );
+    }
+
+    #[test]
+    fn unknown_model_is_none() {
+        assert!(
+            table()
+                .compute_cost_usd("acme-llm-9000", counts(100, 50, 0, 0))
+                .is_none()
+        );
+    }
+}

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -13,6 +13,7 @@ boa_engine = "0.20.0"
 braintrust-llm-router.workspace = true
 braintrust-sdk-rust.workspace = true
 bytes.workspace = true
+cost = { path = "../cost" }
 exoharness = { path = "../exoharness", features = [
   "apple-keychain",
   "basic-backend",

--- a/crates/executor/src/basic.rs
+++ b/crates/executor/src/basic.rs
@@ -3,9 +3,10 @@ use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
 use async_trait::async_trait;
+use cost::{PricingTable, TokenCounts};
 use exoharness::{
     AgentHandle, ConversationHandle, ConversationId, EventData, EventId, EventKind, EventQuery,
-    EventQueryDirection, Result, ToolCallId, ToolRequest, TurnHandle,
+    EventQueryDirection, Result, ToolCallId, ToolRequest, TurnHandle, UsageRecord,
 };
 use lingua::Message;
 use lingua::universal::{ToolContentPart, ToolResultContentPart};
@@ -24,14 +25,21 @@ pub struct BasicExecutor<M, T> {
     model: Arc<M>,
     tools: Arc<T>,
     history_cache: Arc<RwLock<HashMap<ConversationId, HistoryCacheEntry>>>,
+    pricing: Arc<PricingTable>,
 }
 
 impl<M, T> BasicExecutor<M, T> {
     pub fn new(model: Arc<M>, tools: Arc<T>) -> Self {
+        Self::with_pricing(model, tools, Arc::new(PricingTable::empty()))
+    }
+
+    /// Cost is filled from `pricing`; an empty table leaves `cost_usd` unset.
+    pub fn with_pricing(model: Arc<M>, tools: Arc<T>, pricing: Arc<PricingTable>) -> Self {
         Self {
             model,
             tools,
             history_cache: Arc::new(RwLock::new(HashMap::new())),
+            pricing,
         }
     }
 }
@@ -42,6 +50,7 @@ impl<M, T> Clone for BasicExecutor<M, T> {
             model: Arc::clone(&self.model),
             tools: Arc::clone(&self.tools),
             history_cache: Arc::clone(&self.history_cache),
+            pricing: Arc::clone(&self.pricing),
         }
     }
 }
@@ -144,7 +153,7 @@ where
                 .complete_model_round(request, round as usize, stream_mode, turn_trace)
                 .await?;
 
-            let events = interpret_model_response(response);
+            let events = interpret_model_response(response, &self.pricing);
             turn.add_events(events.clone()).await?;
 
             let tool_requests = collect_tool_requests(&events);
@@ -184,9 +193,11 @@ where
             Some(turn_trace) => turn_trace.start_llm_round(&request, round).await,
             None => None,
         };
+        let requested_model = request.model.clone();
 
         match stream_mode {
             ExecutorStreamMode::Disabled => {
+                let started_at = Instant::now();
                 let response = match self.model.complete(request).await {
                     Ok(response) => response,
                     Err(error) => {
@@ -196,6 +207,14 @@ where
                         return Err(error);
                     }
                 };
+                let duration = started_at.elapsed();
+                let mut response = response;
+                if response.model.is_none() {
+                    response.model = Some(requested_model);
+                }
+                if response.duration.is_none() {
+                    response.duration = Some(duration);
+                }
                 if let Some(llm_trace) = llm_trace {
                     llm_trace.finish_success(&response, None).await;
                 }
@@ -250,6 +269,17 @@ where
                         return Err(error);
                     }
                 };
+                let duration = started_at.elapsed();
+                let mut response = response;
+                if response.model.is_none() {
+                    response.model = Some(requested_model);
+                }
+                if response.ttft.is_none() {
+                    response.ttft = ttft;
+                }
+                if response.duration.is_none() {
+                    response.duration = Some(duration);
+                }
                 if let Some(llm_trace) = llm_trace {
                     llm_trace.finish_success(&response, ttft).await;
                 }
@@ -453,13 +483,15 @@ fn remove_pending_tool_call(pending_tool_call_ids: &mut Vec<ToolCallId>, tool_ca
     }
 }
 
-fn interpret_model_response(response: ModelResponse) -> Vec<EventData> {
+fn interpret_model_response(response: ModelResponse, pricing: &PricingTable) -> Vec<EventData> {
     let mut events = Vec::new();
 
     if !response.messages.is_empty() {
+        let usage = build_usage_record(&response, pricing);
         events.push(EventData::Messages {
             messages: response.messages,
             response_id: response.response_id,
+            usage,
         });
     }
 
@@ -472,6 +504,64 @@ fn interpret_model_response(response: ModelResponse) -> Vec<EventData> {
     }
 
     events
+}
+
+fn build_usage_record(
+    response: &ModelResponse,
+    pricing: &PricingTable,
+) -> Option<Box<UsageRecord>> {
+    // Only emit a record when we have *something* worth recording — token usage
+    // or timing. Skipping when both are absent keeps event JSON clean for
+    // tests/fakes that don't populate metadata.
+    let has_usage = response.usage.is_some();
+    let has_timing = response.ttft.is_some() || response.duration.is_some();
+    if !has_usage && !has_timing {
+        return None;
+    }
+
+    let model = response.model.clone().unwrap_or_default();
+    let (
+        prompt_tokens,
+        completion_tokens,
+        prompt_cached_tokens,
+        prompt_cache_creation_tokens,
+        completion_reasoning_tokens,
+    ) = match &response.usage {
+        Some(u) => (
+            u.prompt_tokens,
+            u.completion_tokens,
+            u.prompt_cached_tokens,
+            u.prompt_cache_creation_tokens,
+            u.completion_reasoning_tokens,
+        ),
+        None => (None, None, None, None, None),
+    };
+
+    let cost_usd = if has_usage && !model.is_empty() {
+        pricing.compute_cost_usd(
+            &model,
+            TokenCounts {
+                prompt: prompt_tokens,
+                completion: completion_tokens,
+                prompt_cached: prompt_cached_tokens,
+                prompt_cache_creation: prompt_cache_creation_tokens,
+            },
+        )
+    } else {
+        None
+    };
+
+    Some(Box::new(UsageRecord {
+        model,
+        prompt_tokens,
+        completion_tokens,
+        prompt_cached_tokens,
+        prompt_cache_creation_tokens,
+        completion_reasoning_tokens,
+        cost_usd,
+        ttft_ms: response.ttft.map(|d| d.as_millis() as u64),
+        duration_ms: response.duration.map(|d| d.as_millis() as u64),
+    }))
 }
 
 #[derive(Debug, Clone)]

--- a/crates/executor/src/basic_tests.rs
+++ b/crates/executor/src/basic_tests.rs
@@ -48,6 +48,9 @@ async fn send_appends_user_and_assistant_messages() {
             messages: vec![assistant_message("pong")],
             tool_calls: vec![],
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         }])),
         Arc::new(FakeToolRuntime::default()),
     );
@@ -136,12 +139,18 @@ async fn send_executes_tool_round_trip() {
                 },
             }],
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("done")],
             tool_calls: vec![],
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
     ]));
     let executor = BasicExecutor::new(
@@ -249,12 +258,18 @@ async fn send_records_tool_result_when_tool_execution_fails() {
                 },
             }],
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("recovered")],
             tool_calls: vec![],
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
     ]));
     let executor = BasicExecutor::new(
@@ -357,6 +372,9 @@ async fn send_stream_emits_chunks_and_persists_final_response() {
                 messages: vec![assistant_message("hello")],
                 tool_calls: vec![],
                 usage: None,
+                model: None,
+                ttft: None,
+                duration: None,
             },
         }])),
         Arc::new(FakeToolRuntime::default()),
@@ -802,6 +820,7 @@ impl ConversationHandle for FakeConversationHandle {
                 EventData::Messages {
                     messages: request.input,
                     response_id: None,
+                    usage: None,
                 },
             ));
         }

--- a/crates/executor/src/executor_types.rs
+++ b/crates/executor/src/executor_types.rs
@@ -185,6 +185,15 @@ pub struct ModelResponse {
     pub messages: Vec<Message>,
     pub tool_calls: Vec<PendingToolCall>,
     pub usage: Option<UniversalUsage>,
+    /// Model identifier echoed back by the provider, if available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    /// Time to first token (streaming path only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ttft: Option<Duration>,
+    /// Wall-clock duration from request start to end of response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration: Option<Duration>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/executor/src/harness_basic.rs
+++ b/crates/executor/src/harness_basic.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::{BasicExecutor, BraintrustRuntimeConfig, ModelClient, ToolRuntime};
+use cost::PricingTable;
 use exoharness::{BasicExoHarness, BasicExoHarnessConfig, ExoHarness, Result};
 
 use crate::harness_executor::ExecutorHarnessRuntime;
@@ -24,6 +25,24 @@ impl<M, T> BasicHarness<M, T> {
             inner: SharedHarness::new(exoharness, runtime),
         }
     }
+
+    /// Construct a harness whose executor fills cost from an explicit table.
+    pub fn with_pricing_table(
+        exoharness: Arc<dyn ExoHarness>,
+        model: Arc<M>,
+        tools: Arc<T>,
+        pricing: Arc<PricingTable>,
+    ) -> Self
+    where
+        M: ModelClient + 'static,
+        T: ToolRuntime + 'static,
+    {
+        let runtime =
+            ExecutorHarnessRuntime::new(BasicExecutor::with_pricing(model, tools, pricing), None);
+        Self {
+            inner: SharedHarness::new(exoharness, runtime),
+        }
+    }
 }
 
 impl BasicHarness<RouterModelClient, BasicToolRuntime> {
@@ -31,10 +50,14 @@ impl BasicHarness<RouterModelClient, BasicToolRuntime> {
         exoharness: Arc<dyn ExoHarness>,
         runtime_config: Option<BraintrustRuntimeConfig>,
         env: HashMap<String, String>,
+        pricing: Arc<PricingTable>,
     ) -> Self {
         let model = Arc::new(RouterModelClient::new(env));
         let tools = Arc::new(BasicToolRuntime);
-        let runtime = ExecutorHarnessRuntime::new(BasicExecutor::new(model, tools), runtime_config);
+        let runtime = ExecutorHarnessRuntime::new(
+            BasicExecutor::with_pricing(model, tools, pricing),
+            runtime_config,
+        );
         Self {
             inner: SharedHarness::new(exoharness, runtime),
         }
@@ -49,6 +72,7 @@ impl BasicHarness<RouterModelClient, BasicToolRuntime> {
             Arc::new(BasicExoHarness::new(exo_config).await?),
             runtime_config,
             env,
+            Arc::new(PricingTable::empty()),
         ))
     }
 }

--- a/crates/executor/src/harness_basic_tests.rs
+++ b/crates/executor/src/harness_basic_tests.rs
@@ -12,7 +12,7 @@ use exoharness::{
     ToolRequest, Uuid7,
 };
 use lingua::universal::{AssistantContent, UserContent};
-use lingua::{Message, UniversalStreamChunk};
+use lingua::{Message, UniversalStreamChunk, UniversalUsage};
 use serde_json::{Map, Value};
 use tempfile::TempDir;
 
@@ -113,6 +113,9 @@ async fn send_persists_messages_through_harness() {
             messages: vec![assistant_message("pong")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         }])),
         Arc::new(BasicToolRuntime),
     );
@@ -173,6 +176,390 @@ async fn send_persists_messages_through_harness() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn usage_record_is_persisted_with_computed_cost() {
+    // Use an inline LiteLLM-schema fixture so the assertion is hermetic
+    // and doesn't depend on whatever rates the upstream JSON happens to
+    // ship today.
+    const PRICING_FIXTURE: &str = r#"{
+        "claude-sonnet-4-6": {
+            "litellm_provider": "anthropic",
+            "mode": "chat",
+            "input_cost_per_token": 3e-06,
+            "output_cost_per_token": 1.5e-05,
+            "cache_read_input_token_cost": 3e-07,
+            "cache_creation_input_token_cost": 3.75e-06
+        }
+    }"#;
+    let pricing =
+        Arc::new(cost::PricingTable::from_json_str(PRICING_FIXTURE).expect("fixture should parse"));
+
+    let tempdir = TempDir::new().expect("tempdir should exist");
+    let exoharness = Arc::new(
+        BasicExoHarness::new(local_test_config(tempdir.path().join("exoharness")))
+            .await
+            .expect("basic exoharness should initialize"),
+    ) as Arc<dyn ExoHarness>;
+    let harness = BasicHarness::with_pricing_table(
+        Arc::clone(&exoharness),
+        Arc::new(FakeModelClient::new(vec![ModelResponse {
+            response_id: Some(Uuid7::now()),
+            messages: vec![assistant_message("pong")],
+            tool_calls: Vec::new(),
+            usage: Some(UniversalUsage {
+                prompt_tokens: Some(1_000),
+                completion_tokens: Some(500),
+                prompt_cached_tokens: None,
+                prompt_cache_creation_tokens: None,
+                completion_reasoning_tokens: None,
+            }),
+            model: Some("claude-sonnet-4-6".to_string()),
+            ttft: None,
+            duration: None,
+        }])),
+        Arc::new(BasicToolRuntime),
+        pricing,
+    );
+
+    let secret_id = exoharness
+        .put_secret(PutSecretRequest {
+            name: "cost-test-key".to_string(),
+            secret: Secret::Key {
+                value: "test-key".to_string(),
+            },
+        })
+        .await
+        .expect("test secret should register");
+    exoharness
+        .put_binding(Binding::Llm {
+            name: "claude-sonnet-4-6".to_string(),
+            model: "claude-sonnet-4-6".to_string(),
+            base_url: None,
+            secret_id: Some(secret_id),
+        })
+        .await
+        .expect("binding should register");
+
+    let agent = harness
+        .create_agent(CreateAgentRequest {
+            slug: "cost-demo".to_string(),
+            name: None,
+            harness: crate::AgentHarnessKind::Basic,
+            typescript: None,
+            enable_agent_tool_creation: true,
+            sandbox_image: None,
+            sandbox_provider: SandboxProvider::LocalProcess,
+            enable_networking: false,
+            model: "claude-sonnet-4-6".to_string(),
+            max_output_tokens: None,
+            max_tool_round_trips: Some(2),
+            braintrust: None,
+        })
+        .await
+        .expect("agent should be created");
+    let conversation = agent
+        .create_conversation(CreateConversationRequest::default())
+        .await
+        .expect("conversation should be created");
+
+    conversation
+        .send(SendRequest {
+            input: vec![user_message("ping")],
+            session_id: None,
+        })
+        .await
+        .expect("send should succeed");
+
+    let events = conversation
+        .exoharness_handle()
+        .get_events(Some(EventQuery {
+            cursor: None,
+            direction: Some(EventQueryDirection::Asc),
+            limit: None,
+            session_id: None,
+            turn_id: None,
+            types: None,
+        }))
+        .await
+        .expect("get events should succeed")
+        .events;
+
+    let assistant_usage = events
+        .iter()
+        .find_map(|event| match &event.data {
+            EventData::Messages {
+                messages,
+                usage: Some(usage),
+                ..
+            } if messages
+                .iter()
+                .any(|m| matches!(m, Message::Assistant { .. })) =>
+            {
+                Some(usage)
+            }
+            _ => None,
+        })
+        .expect("assistant message event should carry a UsageRecord");
+
+    assert_eq!(assistant_usage.model, "claude-sonnet-4-6");
+    assert_eq!(assistant_usage.prompt_tokens, Some(1_000));
+    assert_eq!(assistant_usage.completion_tokens, Some(500));
+    // 1000 prompt @ $3/M + 500 completion @ $15/M = $0.003 + $0.0075 = $0.0105
+    let cost = assistant_usage.cost_usd.expect("cost should be computed");
+    assert!(
+        (cost - 0.0105).abs() < 1e-9,
+        "expected cost ~0.0105, got {cost}"
+    );
+    // Non-streaming path measures total duration.
+    assert!(
+        assistant_usage.duration_ms.is_some(),
+        "duration should be recorded"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn usage_record_with_anthropic_cache_hits() {
+    // Anthropic accounting is additive: prompt_tokens is the fresh slice,
+    // and cache_read / cache_creation are billed separately on top. The
+    // pricing math is unit-tested in exoharness::pricing; this test is the
+    // end-to-end proof that cached counts (a) reach the persisted
+    // UsageRecord and (b) hit the discounted cache-read rate when
+    // compute_cost_usd is invoked through the executor.
+    const PRICING_FIXTURE: &str = r#"{
+        "claude-sonnet-4-6": {
+            "litellm_provider": "anthropic",
+            "mode": "chat",
+            "input_cost_per_token": 3e-06,
+            "output_cost_per_token": 1.5e-05,
+            "cache_read_input_token_cost": 3e-07,
+            "cache_creation_input_token_cost": 3.75e-06
+        }
+    }"#;
+    let pricing =
+        Arc::new(cost::PricingTable::from_json_str(PRICING_FIXTURE).expect("fixture should parse"));
+
+    let tempdir = TempDir::new().expect("tempdir should exist");
+    let exoharness = Arc::new(
+        BasicExoHarness::new(local_test_config(tempdir.path().join("exoharness")))
+            .await
+            .expect("basic exoharness should initialize"),
+    ) as Arc<dyn ExoHarness>;
+    let harness = BasicHarness::with_pricing_table(
+        Arc::clone(&exoharness),
+        Arc::new(FakeModelClient::new(vec![ModelResponse {
+            response_id: Some(Uuid7::now()),
+            messages: vec![assistant_message("pong")],
+            tool_calls: Vec::new(),
+            usage: Some(UniversalUsage {
+                prompt_tokens: Some(500),
+                completion_tokens: Some(200),
+                prompt_cached_tokens: Some(10_000),
+                prompt_cache_creation_tokens: Some(2_000),
+                completion_reasoning_tokens: None,
+            }),
+            model: Some("claude-sonnet-4-6".to_string()),
+            ttft: None,
+            duration: None,
+        }])),
+        Arc::new(BasicToolRuntime),
+        pricing,
+    );
+
+    let secret_id = exoharness
+        .put_secret(PutSecretRequest {
+            name: "anthropic-cache-key".to_string(),
+            secret: Secret::Key {
+                value: "test-key".to_string(),
+            },
+        })
+        .await
+        .expect("test secret should register");
+    exoharness
+        .put_binding(Binding::Llm {
+            name: "claude-sonnet-4-6".to_string(),
+            model: "claude-sonnet-4-6".to_string(),
+            base_url: None,
+            secret_id: Some(secret_id),
+        })
+        .await
+        .expect("binding should register");
+
+    let agent = harness
+        .create_agent(CreateAgentRequest {
+            slug: "anthropic-cache".to_string(),
+            name: None,
+            harness: crate::AgentHarnessKind::Basic,
+            typescript: None,
+            enable_agent_tool_creation: true,
+            sandbox_image: None,
+            sandbox_provider: SandboxProvider::LocalProcess,
+            enable_networking: false,
+            model: "claude-sonnet-4-6".to_string(),
+            max_output_tokens: None,
+            max_tool_round_trips: Some(2),
+            braintrust: None,
+        })
+        .await
+        .expect("agent should be created");
+    let conversation = agent
+        .create_conversation(CreateConversationRequest::default())
+        .await
+        .expect("conversation should be created");
+
+    conversation
+        .send(SendRequest {
+            input: vec![user_message("ping")],
+            session_id: None,
+        })
+        .await
+        .expect("send should succeed");
+
+    let usage = assistant_usage_record(&conversation).await;
+
+    assert_eq!(usage.model, "claude-sonnet-4-6");
+    assert_eq!(usage.prompt_tokens, Some(500));
+    assert_eq!(usage.completion_tokens, Some(200));
+    assert_eq!(usage.prompt_cached_tokens, Some(10_000));
+    assert_eq!(usage.prompt_cache_creation_tokens, Some(2_000));
+    // Anthropic-style additive:
+    //   500    fresh prompt    @ $3/M     = 0.0015
+    //   10000  cache read      @ $0.30/M  = 0.003
+    //   2000   cache creation  @ $3.75/M  = 0.0075
+    //   200    completion      @ $15/M    = 0.003
+    // total = 0.015
+    let cost = usage.cost_usd.expect("cost should be computed");
+    assert!(
+        (cost - 0.015).abs() < 1e-9,
+        "expected cost ~0.015, got {cost}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn usage_record_with_openai_inclusive_accounting() {
+    // OpenAI accounting is inclusive: prompt_tokens is the *total* input
+    // including any cache hits, so the executor must subtract
+    // prompt_cached_tokens before billing the fresh-input rate. Getting
+    // this wrong silently double-bills cached tokens. This test pins the
+    // behavior at the conversation-log level — the same accounting that
+    // pricing.rs exercises in isolation now also has to survive the round
+    // trip through ModelResponse → UsageRecord → persisted event.
+    const PRICING_FIXTURE: &str = r#"{
+        "gpt-4o-mini": {
+            "litellm_provider": "openai",
+            "mode": "chat",
+            "input_cost_per_token": 1.5e-07,
+            "output_cost_per_token": 6e-07,
+            "cache_read_input_token_cost": 7.5e-08
+        }
+    }"#;
+    let pricing =
+        Arc::new(cost::PricingTable::from_json_str(PRICING_FIXTURE).expect("fixture should parse"));
+
+    let tempdir = TempDir::new().expect("tempdir should exist");
+    let exoharness = Arc::new(
+        BasicExoHarness::new(local_test_config(tempdir.path().join("exoharness")))
+            .await
+            .expect("basic exoharness should initialize"),
+    ) as Arc<dyn ExoHarness>;
+    let harness = BasicHarness::with_pricing_table(
+        Arc::clone(&exoharness),
+        Arc::new(FakeModelClient::new(vec![ModelResponse {
+            response_id: Some(Uuid7::now()),
+            messages: vec![assistant_message("pong")],
+            tool_calls: Vec::new(),
+            usage: Some(UniversalUsage {
+                // prompt_tokens here *includes* the 500 cached — OpenAI
+                // convention.
+                prompt_tokens: Some(2_000),
+                completion_tokens: Some(1_000),
+                prompt_cached_tokens: Some(500),
+                prompt_cache_creation_tokens: None,
+                completion_reasoning_tokens: None,
+            }),
+            model: Some("gpt-4o-mini".to_string()),
+            ttft: None,
+            duration: None,
+        }])),
+        Arc::new(BasicToolRuntime),
+        pricing,
+    );
+
+    let secret_id = exoharness
+        .put_secret(PutSecretRequest {
+            name: "openai-cache-key".to_string(),
+            secret: Secret::Key {
+                value: "test-key".to_string(),
+            },
+        })
+        .await
+        .expect("test secret should register");
+    exoharness
+        .put_binding(Binding::Llm {
+            name: "gpt-4o-mini".to_string(),
+            model: "gpt-4o-mini".to_string(),
+            base_url: None,
+            secret_id: Some(secret_id),
+        })
+        .await
+        .expect("binding should register");
+
+    let agent = harness
+        .create_agent(CreateAgentRequest {
+            slug: "openai-cache".to_string(),
+            name: None,
+            harness: crate::AgentHarnessKind::Basic,
+            typescript: None,
+            enable_agent_tool_creation: true,
+            sandbox_image: None,
+            sandbox_provider: SandboxProvider::LocalProcess,
+            enable_networking: false,
+            model: "gpt-4o-mini".to_string(),
+            max_output_tokens: None,
+            max_tool_round_trips: Some(2),
+            braintrust: None,
+        })
+        .await
+        .expect("agent should be created");
+    let conversation = agent
+        .create_conversation(CreateConversationRequest::default())
+        .await
+        .expect("conversation should be created");
+
+    conversation
+        .send(SendRequest {
+            input: vec![user_message("ping")],
+            session_id: None,
+        })
+        .await
+        .expect("send should succeed");
+
+    let usage = assistant_usage_record(&conversation).await;
+
+    assert_eq!(usage.model, "gpt-4o-mini");
+    // Raw counts are preserved as the provider reported them — the
+    // inclusive convention only matters for the cost computation, not for
+    // the stored tokens.
+    assert_eq!(usage.prompt_tokens, Some(2_000));
+    assert_eq!(usage.completion_tokens, Some(1_000));
+    assert_eq!(usage.prompt_cached_tokens, Some(500));
+    // OpenAI-style inclusive:
+    //   non_cached = 2000 - 500       = 1500
+    //   1500   fresh prompt @ $0.15/M = 0.000225
+    //   500    cache read   @ $0.075/M = 0.0000375
+    //   1000   completion   @ $0.60/M = 0.0006
+    // total = 0.0008625
+    // If the executor mistakenly used the Anthropic-style additive
+    // formula here, it would bill all 2000 prompt tokens at the fresh
+    // rate and the total would be 0.0009375 — ~9% high — so this
+    // assertion catches the provider-classification bug the PR
+    // description calls out.
+    let cost = usage.cost_usd.expect("cost should be computed");
+    assert!(
+        (cost - 0.0008625).abs() < 1e-9,
+        "expected cost ~0.0008625, got {cost}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn close_session_appends_session_ended_event() {
     let tempdir = TempDir::new().expect("tempdir should exist");
     let exoharness: Arc<dyn ExoHarness> = Arc::new(
@@ -187,6 +574,9 @@ async fn close_session_appends_session_ended_event() {
             messages: vec![assistant_message("pong")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         }])),
         Arc::new(BasicToolRuntime),
     );
@@ -262,12 +652,18 @@ async fn updating_agent_config_refreshes_executor_cache() {
             messages: vec![assistant_message("pong-1")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("pong-2")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
     ]));
     let harness = BasicHarness::new(exoharness, Arc::clone(&model), Arc::new(BasicToolRuntime));
@@ -344,12 +740,18 @@ async fn send_executes_shell_tool_when_enabled() {
                 },
             }],
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("done")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
     ]));
     let harness = BasicHarness::new(exoharness, Arc::clone(&model), Arc::new(BasicToolRuntime));
@@ -525,12 +927,18 @@ async fn updating_mounts_recreates_conversation_sandbox() {
                 },
             }],
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("done-1")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
@@ -543,12 +951,18 @@ async fn updating_mounts_recreates_conversation_sandbox() {
                 },
             }],
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("done-2")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
     ]));
     let harness = BasicHarness::new(exoharness, model, Arc::new(BasicToolRuntime));
@@ -761,18 +1175,27 @@ async fn conversation_model_override_changes_effective_model() {
             messages: vec![assistant_message("first")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("second")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("third")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
     ]));
     let harness = BasicHarness::new(exoharness, Arc::clone(&model), Arc::new(BasicToolRuntime));
@@ -922,6 +1345,45 @@ fn assistant_message(text: &str) -> Message {
         content: AssistantContent::String(text.to_string()),
         id: None,
     }
+}
+
+/// Fetch the UsageRecord attached to the first Messages event that
+/// contains an assistant message. Mirrors the pattern in
+/// `usage_record_is_persisted_with_computed_cost` so the new tests stay
+/// readable.
+async fn assistant_usage_record(
+    conversation: &Arc<dyn crate::HarnessConversation>,
+) -> exoharness::UsageRecord {
+    let events = conversation
+        .exoharness_handle()
+        .get_events(Some(EventQuery {
+            cursor: None,
+            direction: Some(EventQueryDirection::Asc),
+            limit: None,
+            session_id: None,
+            turn_id: None,
+            types: None,
+        }))
+        .await
+        .expect("get events should succeed")
+        .events;
+
+    events
+        .into_iter()
+        .find_map(|event| match event.data {
+            EventData::Messages {
+                messages,
+                usage: Some(usage),
+                ..
+            } if messages
+                .iter()
+                .any(|m| matches!(m, Message::Assistant { .. })) =>
+            {
+                Some(*usage)
+            }
+            _ => None,
+        })
+        .expect("assistant message event should carry a UsageRecord")
 }
 
 fn shell_command_arguments(command: &str) -> Map<String, Value> {

--- a/crates/executor/src/harness_runtime.rs
+++ b/crates/executor/src/harness_runtime.rs
@@ -400,6 +400,9 @@ fn normalize_model_response(response: UniversalResponse) -> Result<ModelResponse
         messages: response.messages,
         tool_calls,
         usage: response.usage,
+        model: response.model,
+        ttft: None,
+        duration: None,
     })
 }
 

--- a/crates/executor/src/rlm.rs
+++ b/crates/executor/src/rlm.rs
@@ -536,6 +536,7 @@ async fn append_final_answer(
     turn.add_events(vec![EventData::Messages {
         messages: vec![assistant_message(final_answer)],
         response_id,
+        usage: None,
     }])
     .await?;
     append_custom_event(

--- a/crates/executor/src/rlm_tests.rs
+++ b/crates/executor/src/rlm_tests.rs
@@ -46,12 +46,18 @@ async fn rlm_send_executes_repl_steps_and_persists_final_answer() {
                 },
             }],
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("FINAL(done)")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
     ]));
     let harness = RlmHarness::new(exoharness, model);
@@ -143,6 +149,9 @@ async fn rlm_subquery_variable_can_store_final_answer() {
                 },
             }],
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
@@ -168,18 +177,27 @@ async fn rlm_subquery_variable_can_store_final_answer() {
                 },
             }],
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("4")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("FINAL_VAR(final_answer)")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
     ]));
     let harness = RlmHarness::new(exoharness, Arc::clone(&model));
@@ -246,6 +264,9 @@ async fn rlm_send_stream_suppresses_internal_control_text() {
             messages: vec![assistant_message("FINAL(2)")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
     }]));
     let harness = RlmHarness::new(exoharness, model);
@@ -315,6 +336,9 @@ async fn rlm_exposes_history_via_get_messages() {
             messages: vec![assistant_message("FINAL(recorded)")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
@@ -343,12 +367,18 @@ globalThis.answer = String(\n\
                 },
             }],
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
         ModelResponse {
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("FINAL_VAR(answer)")],
             tool_calls: Vec::new(),
             usage: None,
+            model: None,
+            ttft: None,
+            duration: None,
         },
     ]));
     let harness = RlmHarness::new(exoharness, model);
@@ -421,6 +451,9 @@ async fn rlm_can_finish_by_setting_final_in_repl() {
             },
         }],
         usage: None,
+        model: None,
+        ttft: None,
+        duration: None,
     }]));
     let harness = RlmHarness::new(exoharness, Arc::clone(&model));
     register_test_model(harness.exoharness_handle().as_ref()).await;

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -1192,6 +1192,7 @@ impl ConversationHandle for BasicConversationHandle {
             events_to_append.push(EventData::Messages {
                 messages: request.input,
                 response_id: None,
+                usage: None,
             });
         }
 

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -302,6 +302,7 @@ async fn turn_events_continue_after_artifact_writes() {
     turn.add_events(vec![EventData::Messages {
         messages: vec![assistant_message("pong")],
         response_id: None,
+        usage: None,
     }])
     .await
     .expect("append after artifact write");

--- a/crates/exoharness/src/contract_tests.rs
+++ b/crates/exoharness/src/contract_tests.rs
@@ -95,6 +95,7 @@ pub async fn begin_turn_tracks_events_through_finish(harness: Arc<dyn ExoHarness
     turn.add_events(vec![EventData::Messages {
         messages: vec![assistant_message("pong")],
         response_id: None,
+        usage: None,
     }])
     .await
     .expect("append assistant message");
@@ -167,6 +168,7 @@ pub async fn turn_events_continue_after_artifact_writes(harness: Arc<dyn ExoHarn
     turn.add_events(vec![EventData::Messages {
         messages: vec![assistant_message("pong")],
         response_id: None,
+        usage: None,
     }])
     .await
     .expect("append after artifact write");

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -851,19 +851,27 @@ async fn find_running_docker_warm_sandbox(
     request: &SandboxRequest,
 ) -> Result<Option<String>> {
     let spec_hash = sandbox_spec_hash(&request.spec);
-    let output = Command::new(container_bin)
-        .arg("ps")
-        .arg("--filter")
-        .arg(format!("label={WARM_SANDBOX_KEY_LABEL}={}", request.key))
-        .arg("--filter")
-        .arg(format!("label={WARM_SANDBOX_SPEC_HASH_LABEL}={spec_hash}"))
-        .arg("--filter")
-        .arg("status=running")
-        .arg("--format")
-        .arg("{{.Names}}")
-        .kill_on_drop(true)
-        .output()
-        .await?;
+    let key_filter = format!("label={WARM_SANDBOX_KEY_LABEL}={}", request.key);
+    let spec_filter = format!("label={WARM_SANDBOX_SPEC_HASH_LABEL}={spec_hash}");
+    // Goes through the admin-command wrapper for its timeout: this runs while
+    // ensure_warm_sandbox_ready holds the warm_sandboxes lock, so a hung
+    // daemon would otherwise block every sandbox operation in the process.
+    let output = run_container_admin_command(
+        container_bin,
+        WARM_SANDBOX_CLEANUP_TIMEOUT,
+        [
+            "ps",
+            "--filter",
+            &key_filter,
+            "--filter",
+            &spec_filter,
+            "--filter",
+            "status=running",
+            "--format",
+            "{{.Names}}",
+        ],
+    )
+    .await?;
     if !output.status.success() {
         return Err(anyhow!(
             "failed to list warm sandboxes: {}",

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -280,6 +280,31 @@ pub struct ForkConversationRequest {
     pub name: Option<String>,
 }
 
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct UsageRecord {
+    pub model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_tokens: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completion_tokens: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_cached_tokens: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_creation_tokens: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completion_reasoning_tokens: Option<i64>,
+    /// Cost in USD, computed at call time from the price table baked into
+    /// this binary. `None` if the model is not in the table.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost_usd: Option<f64>,
+    /// Time to first token (streaming only).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ttft_ms: Option<u64>,
+    /// Wall-clock duration from request start to end of response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Event {
     pub id: EventId,
@@ -313,6 +338,11 @@ pub enum EventData {
     Messages {
         messages: Vec<Message>,
         response_id: Option<ResponseId>,
+        // Boxed to keep `EventData` small: `UsageRecord` is ~170 bytes and
+        // most events don't carry it, so inlining it would bloat every
+        // variant (and every enum that embeds `EventData`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        usage: Option<Box<UsageRecord>>,
     },
     ToolRequested {
         tool_call_id: ToolCallId,
@@ -866,6 +896,51 @@ mod tests {
             value.get("type").and_then(Value::as_str),
             Some("session_started")
         );
+    }
+
+    #[test]
+    fn messages_event_deserializes_without_usage_field() {
+        // Older logs predate per-message cost tracking and have no `usage`
+        // field on Messages events; serde(default) must keep them readable.
+        let json = serde_json::json!({
+            "type": "messages",
+            "messages": [],
+            "response_id": null,
+        });
+        let event: EventData = serde_json::from_value(json).expect("legacy event should parse");
+        match event {
+            EventData::Messages { usage, .. } => assert!(usage.is_none()),
+            _ => panic!("expected Messages variant"),
+        }
+    }
+
+    #[test]
+    fn messages_event_serializes_usage_when_present() {
+        let event = EventData::Messages {
+            messages: vec![],
+            response_id: None,
+            usage: Some(Box::new(UsageRecord {
+                model: "claude-sonnet-4-6".to_string(),
+                prompt_tokens: Some(100),
+                completion_tokens: Some(50),
+                cost_usd: Some(0.001),
+                ..Default::default()
+            })),
+        };
+        let value = serde_json::to_value(&event).expect("event should serialize");
+        let usage = value.get("usage").expect("usage field present");
+        assert_eq!(
+            usage.get("model").and_then(Value::as_str),
+            Some("claude-sonnet-4-6")
+        );
+        assert_eq!(
+            usage.get("prompt_tokens").and_then(Value::as_i64),
+            Some(100)
+        );
+        assert!((usage.get("cost_usd").and_then(Value::as_f64).unwrap() - 0.001).abs() < 1e-9);
+        // Round-trip back through the legacy-event parser
+        let parsed: EventData = serde_json::from_value(value).expect("round-trip parse");
+        assert!(matches!(parsed, EventData::Messages { usage: Some(_), .. }));
     }
 
     #[test]

--- a/docs/cost-tracking-design.md
+++ b/docs/cost-tracking-design.md
@@ -1,0 +1,168 @@
+# Per-Message Cost, Token, and Latency Tracking
+
+Every LLM response in exo carries a durable, per-message record of token usage
+and timing in the canonical event log. **Dollar cost is a policy computed in
+userspace, not by the trusted substrate** — the store persists whatever numbers
+the event carries. Cost computation is an agent-side policy, so should not live
+in the exoharness.
+
+This document describes what is recorded, who computes cost and where, and the
+reasoning behind that split.
+
+## Design Principles
+
+- **Cost is policy, and policy lives in userspace.** How to turn tokens into
+  dollars (which price table, which provider formula, when to compute) is an
+  application decision, not a substrate responsibility. To not force each substrate
+  to reimplement, we provide a standalone cost library that executors call.
+- **The substrate stays minimal.** `exoharness` stores the usage record verbatim,
+  including an optional `cost_usd` field, but contains no pricing code and never
+  computes, validates, or owns cost. It round-trips bytes.
+- **Usage is agent-reported telemetry, not an attested ledger.** The token counts
+  come from the provider response, which for the TypeScript/exoclaw path is read
+  _inside the agent-side harness process_ (the model call is not made by the
+  trusted Rust core — there is no model-completion runtime request). So usage is
+  self-reported wherever cost is later computed. The implication is that it cannot
+  be fully trustworthy: the agent owns its own calls so can report whatever numbers
+  it wants.
+- **A maintained data source, not a hand-rolled table.** Prices change often and
+  across many providers, so the _data_ is the community-maintained LiteLLM price
+  database — one source of truth, shared by every consumer of the cost library.
+- **Backward and forward compatible.** The usage record and all sub-fields are
+  optional; legacy events without `usage` still deserialize, and `cost_usd` may
+  simply be null when no policy filled it.
+
+## What Is Recorded
+
+`EventData::Messages` gains an optional `usage` field holding a `UsageRecord`
+(the type is event schema and lives in `exoharness`; the store treats it as data):
+
+| Field                          | Meaning                                                                |
+| ------------------------------ | ---------------------------------------------------------------------- |
+| `model`                        | Model id echoed by the provider, falling back to the requested binding |
+| `prompt_tokens`                | Input tokens (provider convention varies — see per-provider math)      |
+| `completion_tokens`            | Output tokens                                                          |
+| `prompt_cached_tokens`         | Cache-read (discounted) input tokens                                   |
+| `prompt_cache_creation_tokens` | Cache-write input tokens (Anthropic)                                   |
+| `completion_reasoning_tokens`  | Reasoning tokens, when surfaced                                        |
+| `cost_usd`                     | USD cost filled by userspace policy; null if no policy computed it     |
+| `ttft_ms`                      | Time to first token (streaming path only)                              |
+| `duration_ms`                  | Wall-clock duration, request start to end of response                  |
+
+Every sub-field is `Option` with `skip_serializing_if`. The record is boxed
+inside `EventData` (`Option<Box<UsageRecord>>`) to keep the enum small and dodge
+`large_enum_variant`; `Box` is serde-transparent, so the on-disk JSON is
+unchanged. The two cache buckets are both kept because reads and writes bill at
+different rates — cost can't be reconstructed from a single collapsed number.
+They mirror lingua's `UniversalUsage` field names.
+
+## Layering: Who Computes Cost
+
+```
+TRUSTED SUBSTRATE                    USERSPACE (agent-side)
+─────────────────                    ──────────────────────
+exoharness store                     Rust executors (Basic/RLM) ─┐
+  • persists UsageRecord verbatim                                 ├─ cost library
+  • raw tokens + model + timing      TS harness / exoclaw ───────┘   (policy)
+  • cost_usd is just a field;                  │
+    NOTHING here computes it                   └─ fills cost_usd when building the
+  • no pricing dependency                         messages event (or leaves it null
+                                                  for a reader to compute later)
+```
+
+- The emitter (whoever made the call and holds the provider usage) builds the
+  `UsageRecord` and, as a policy choice, fills `cost_usd` by calling the cost
+  library. Rust executors call the Rust crate; the TS harness calls the TS port.
+- The substrate stores the record as-is. It has no pricing code and no dependency
+  on the cost library.
+- _When_ cost is computed is an application choice: at write (emitter fills it) or
+  left null for a read-time/report path. The substrate is agnostic either way.
+
+## The Cost Library
+
+There are two userspaces (Rust executors, the TS harness), so the cost library
+exists once per language. Each is **self-contained** — it owns both the math and
+its own data loading, and neither depends on the other having run:
+
+- **Rust:** a `cost` crate (price table, lookup, `compute_cost_usd`, loader), used
+  by the Basic executor. The CLI loads the table once at startup (`--pricing-path`
+  / `--pricing-url`, `EXO_LITELLM_PRICES_*` as env) and injects it. `exoharness`
+  does not depend on it.
+- **TypeScript:** a self-contained port (`@exo/model-runtime/cost`) used by the
+  exoclaw harness. It loads its own data through the harness's normal config flow
+  — reading `EXO_LITELLM_PRICES_PATH` from its inherited env, then its own cache,
+  then its own fetch — and computes cost when building the messages event. It does
+  **not** depend on the Rust loader having populated anything.
+
+Only the price _rates_ are a single source of truth (the upstream LiteLLM JSON);
+the short per-provider formula and the loader logic are duplicated per language.
+That duplication is the accepted cost of keeping cost a per-userspace policy
+rather than a substrate service, and of each userspace owning its own data so
+there is no cross-boundary coupling.
+
+### Loading the data
+
+Each loader resolves the table once and holds it as plain data, in this order:
+explicit `EXO_LITELLM_PRICES_PATH` (or `--pricing-path` on the CLI) → fresh
+on-disk cache (`$XDG_CACHE_HOME/exo/litellm_prices.json`, 24h TTL) → HTTP fetch
+(`EXO_LITELLM_PRICES_URL` or the LiteLLM default, cached on success) → stale cache
+→ none. A corrupt cache or unparseable fetch degrades to no table (cost stays
+null, tokens persist); the cache is written only when a fetched body parses. The
+two loaders share the same cache _path_ by convention, but neither requires the
+other to have written it.
+
+### Per-provider cost math
+
+Providers disagree on what `prompt_tokens` _includes_, and getting it wrong
+distorts cost by up to ~10× on cache-heavy requests:
+
+- **Anthropic-family** (`anthropic`, `vertex_ai-anthropic`, `azure_ai`):
+  `prompt_tokens` is **fresh** input only; cache reads and writes are separate and
+  additive — `prompt·in + cached·cache_read + cache_creation·cache_write + completion·out`.
+- **Everything else** (`openai`, `mistral`, Bedrock, …): `prompt_tokens` is the
+  **total** input; cached is a subset to subtract first —
+  `(prompt − cached)·in + cached·cache_read + completion·out`.
+
+The additive set is a narrow list of first-party Anthropic providers; everything
+else, including all of Bedrock, is treated as inclusive. Bedrock is not fully
+handled — Bedrock-hosted Claude is really additive, so its cache-heavy costs are
+off. Left as a TODO. Unclassified providers default to inclusive (safe when
+`cached == 0`, the common case).
+
+### Model lookup
+
+Exact match first, then the longest entry key that is a prefix of the requested
+model **at a token boundary** — the next character must be absent or a separator
+(`-` / `:`). This resolves dated revisions (`claude-sonnet-4-6-20251022` →
+`claude-sonnet-4-6`) while refusing to slide `gpt-4o-mini` onto a `gpt-4` entry
+when `gpt-4o` is missing, so a model is never silently priced at a neighbor's
+rate.
+
+## Testing
+
+- Cost library (Rust) unit tests: Anthropic additive (no cache / hits / creation),
+  inclusive (with/without cache, subtraction asserted), boundary-aware lookup
+  (incl. the `gpt-4o-mini` vs `gpt-4` non-match), `sample_spec` skip,
+  unknown-model null, provider classification (Bedrock → inclusive), and the
+  corrupt-cache-degrades-to-empty loader path.
+- TS cost port: a parity unit test over the same fixtures so the two formulas
+  stay in agreement.
+- Executors: assert the persisted `Messages` event carries the expected cost for
+  the Anthropic and inclusive paths, through a Rust executor and through the
+  exoclaw/TS path, so coverage is pinned on both userspaces.
+- `server_duration_ms` removed; the legacy-no-`usage` backward-compat test stays.
+
+## Not in Scope (Intentional)
+
+- **Trusted/attested usage.** Usage is agent-reported (see principles); making it
+  tamper-evident means routing model calls through the Rust core — a separate
+  change.
+- **`/cost` REPL surface.** Data is persisted; the UI is a follow-up. (It is one
+  natural read-time consumer of the cost library.)
+- **Cache-tier resolution.** lingua's `UniversalUsage` collapses Anthropic's
+  5-minute and 1-hour cache writes, so cost uses the 5-minute rate;
+  `cache_creation_input_token_cost_above_1hr` is parsed but unused.
+- **Long-running staleness.** The data loads once at startup; a long-lived service
+  would need a periodic refresh.
+- **Anthropic aggregate Admin API.** Org-level, aggregate-only; can't be tied to a
+  message.

--- a/docs/self-cost-optimization-demo.md
+++ b/docs/self-cost-optimization-demo.md
@@ -1,0 +1,171 @@
+# Demo: An Agent That Optimizes Its Own Cost
+
+Exoclaw runs a genuinely hard task, then is asked one question: _"Look at what
+that task cost you, per message. Find the inefficiencies. Change yourself so the
+next run is cheaper — without making the work worse."_ It reads its own usage
+records out of the event log, diagnoses waste, edits its own prompts and harness,
+rebuilds, and re-runs the task to prove the saving.
+
+This is the motivating demo for per-message cost tracking
+(`docs/cost-tracking-design.md`) composed with self-control
+(`examples/exoclaw/docs/SELF-CONTROL.md`): the first gives the agent eyes on its
+own spend; the second gives it hands to act on what it sees.
+
+## Why this is now possible (and wasn't before)
+
+Every `Messages` event in the canonical log carries a `UsageRecord`: model, raw
+token counts (fresh / cached / cache-creation / reasoning), `cost_usd`, and
+timing. The agent's existing `list_conversation_events` tool can query
+`messages` events, so **self-observation requires no new machinery** — the agent
+sums `usage.cost_usd` and reads token shapes the same way an operator would.
+
+Self-modification is likewise existing capability: the repo is mounted at
+`/workspace/exo`, edits go through the shell tool, `guardian_action` rebuilds
+and restarts, git is the audit trail and rollback path, and prompt files are
+explicitly part of the mutable surface (SELF-CONTROL areas 1, 6, 8).
+
+The loop this demo closes:
+
+```
+   act (run the task)
+        │
+   observe (usage records per message: cost, tokens, cache hits)
+        │
+   diagnose (where did the money go? which calls, why so big?)
+        │
+   modify self (prompts, harness, tool behavior, model choice — committed to git)
+        │
+   verify (rebuild, restart, re-run the same task, compare cost AND quality)
+```
+
+## The scenario
+
+**The task** (deliberately tool-heavy and context-hungry): produce a structured
+"repo health report" for the repository mounted in the sandbox — largest source
+files, TODO/FIXME census with file:line cites, dependency inventory, test-suite
+inventory, and a one-page architecture summary. This takes many shell round
+trips, and a naive agent will drag large tool outputs (file listings, full file
+bodies) through its context on every subsequent model call.
+
+**Why recurring framing matters:** the task is introduced as a _standing_ job
+("we want this report regularly" — eventually a scheduled task). That makes
+"optimize your own cost" economically real: the payoff multiplies across future
+runs, and the agent is improving _itself_, not just this one transcript.
+
+**The run protocol:**
+
+1. **Baseline.** Fresh conversation, run the task, capture the report. Operator
+   independently sums cost via `exo conversation events <agent> <conv> --type messages`.
+2. **Self-audit.** Same agent, new instruction: read your own usage records for
+   that task span, identify the top inefficiencies, and propose changes to your
+   own architecture/prompts/behavior. Require evidence: each proposal must cite
+   the usage numbers that motivate it.
+3. **Self-modification.** Agent implements its accepted proposals on the repo
+   mount, commits with rationale, rebuilds and restarts itself via the guardian.
+4. **Re-run.** Same task wording, fresh conversation. Compare: total `cost_usd`,
+   token shape (fresh vs cached), call count, and report quality side by side.
+5. **Audit.** `git log` shows exactly what the agent changed about itself and why.
+
+## What the cost data will actually show
+
+Grounded in numbers already observed live on this branch:
+
+- **Prompt mass dominates.** Exoclaw's first call carries a ~5.6k-token system
+  prompt; with gpt-4o at $2.50/M input, every uncached call starts at ~$0.014
+  before a single word of work. A 30-call task re-sends history 30 times —
+  prompt cost grows roughly quadratically with round trips.
+- **Caching halves what it touches.** Observed: a cached second turn cost
+  $0.0073 vs $0.0141 uncached (5,504 of 5,623 prompt tokens at the $1.25/M
+  cache-read rate). Cache discipline is the cheapest lever — but only the
+  _stable prefix_ caches. Anything volatile injected early in the prompt
+  invalidates everything after it.
+- **Tool outputs are the growth term.** Every `cat` of a large file enters
+  history and is re-billed on every subsequent call in the turn. The usage
+  records make this legible as a rising `prompt_tokens` staircase across the
+  task's messages events.
+
+## What the agent might plausibly change about itself
+
+This is the interesting part: suggestions span behavior, prompts, harness
+architecture, and model economics — increasing in ambition. A good demo run
+needs only two or three.
+
+**Behavioral (no rebuild needed — prompt/policy edits):**
+
+- _Batch shell work._ One tool call running a composed script instead of eight
+  exploratory calls: every eliminated round trip saves a full re-send of the
+  accumulated context.
+- _Summarize-at-the-source._ Never `cat` whole files; run `wc`/`grep -c`/`head`
+  in the sandbox and bring back only digests. Write the full evidence to a file
+  in the sandbox and reference its path instead of carrying its body in context.
+- _Self-imposed context budget._ A standing rule in its own prompt: "tool output
+  over N lines must be reduced before you continue."
+
+**Prompt architecture (edits to its own prompt files):**
+
+- _Prompt diet._ Move rarely-needed reference material out of the static system
+  prompt into on-demand files the agent reads when relevant (the SELF.md
+  "navigational, not encyclopedic" pattern, applied to its own instructions).
+- _Cache alignment._ Restructure so the stable identity/instructions prefix
+  comes first and anything per-turn or volatile (clocks, dynamic state) is
+  appended last or moved into tool results — protecting the cached prefix.
+
+**Harness architecture (edits to `examples/exoclaw/harness.ts` and friends):**
+
+- _Tool-result clamping._ A hard cap on tool-output bytes entering history;
+  overflow goes to a sandbox artifact with a reference. This is the structural
+  fix for the staircase.
+- _History compaction policy._ After N rounds within a task, fold older tool
+  results into a model-written summary event; keep originals in the event log
+  (which is durable anyway) but stop re-billing them.
+
+**Model economics (binding changes):**
+
+- _Tiered execution._ Register a cheap binding (e.g. gpt-4o-mini at ~6% of
+  gpt-4o's input price) and route mechanical sub-steps (census, counting,
+  extraction) to it, reserving the expensive model for synthesis. Per-phase
+  model choice is an architectural change to how the harness picks its binding —
+  the most ambitious change on this list, and the one with the largest ceiling.
+
+**What we deliberately do _not_ suggest to the agent:** the list above is for
+the demo designers. The agent gets only the cost data and the question. Whatever
+it converges on independently is the result — overlap with this list validates
+the list; novelty is more interesting than overlap.
+
+## Measuring success
+
+- **Primary:** total `cost_usd` for the re-run ≤ ~60% of baseline (the levers
+  above make 40%+ savings realistic; tool-output hygiene alone should clear it).
+- **Quality gate:** the second report covers the same sections with cites; no
+  silent degradation to "cheaper because it did less." Operator judges, or a
+  checklist prompt scores both reports.
+- **Honesty gate:** the agent's self-audit must cite real numbers from its
+  usage records, and its predicted saving is compared against the achieved one.
+  (Usage is self-reported telemetry — see the trust caveats in the cost design
+  doc — but the agent has no incentive to lie to itself, which is exactly why
+  self-optimization is the right first consumer of this data.)
+- **Survival gate:** the agent rebuilds and restarts itself without operator
+  rescue; a failed change is rolled back via git, per SELF-CONTROL area 8.
+
+## Risks and rails
+
+- **It breaks itself.** Changes are commits on the repo mount: `git revert` +
+  guardian rebuild is the documented rollback. Run the demo on a branch.
+- **It games the metric.** Cheaper-by-doing-less is caught by the quality gate;
+  this failure mode is itself a worthwhile demo observation if it happens.
+- **It over-optimizes caching theater.** Watch for changes that shuffle tokens
+  without reducing them; the before/after token shape (fresh vs cached vs total)
+  in the usage records makes this visible.
+- **Event query caps.** `list_conversation_events` caps at 200 events per call;
+  the task span fits, but a long-lived agent will eventually want the
+  aggregation surface (`/usage`, PR #29) re-ported on top of this branch — this
+  demo is the motivating consumer for that follow-up.
+
+## Stretch: continuous self-optimization
+
+The end state this points at: the report becomes a scheduled task; a second
+standing task periodically reviews the cost trend across runs and opens
+self-modification proposals when the trend regresses. At that point the agent
+is not "optimized once" — it has a metabolism: cost observation feeding
+self-modification as an ongoing process, which is the actual thesis of putting
+cost into the canonical event log in the first place.

--- a/examples/typescript/turn-loop.ts
+++ b/examples/typescript/turn-loop.ts
@@ -19,6 +19,7 @@ import {
   type ResponsesRuntimeLike,
   type TraceParent,
 } from "@exo/model-runtime/responses";
+import { ensureTable } from "@exo/model-runtime/cost";
 
 import { resolveLlmBinding } from "./shared";
 
@@ -34,6 +35,7 @@ export async function runResponsesHarnessTurn(
   context: TurnContext,
   options: ResponsesTurnLoopOptions = {},
 ): Promise<void> {
+  await ensureTable(); // load the price table once so cost is ready when events are built
   const modelBinding = await resolveLlmBinding(context);
   const runtime = runtimeFromModelBinding(context.agentConfig, modelBinding);
   await runtime.runTurn(context, (turnParent) =>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
       "@exo/model-runtime/responses": [
         "./typescript/model-runtime/responses.ts"
       ],
+      "@exo/model-runtime/cost": ["./typescript/model-runtime/cost.ts"],
       "@exo/codex/app-server": ["./typescript/codex/app-server.ts"],
       "@exo/cursor/sdk": ["./typescript/cursor/sdk.ts"],
       "@exo/cursor/protocol": ["./typescript/cursor/protocol.ts"]

--- a/typescript/harness/index.ts
+++ b/typescript/harness/index.ts
@@ -437,11 +437,13 @@ export function assistantTextMessage(text: string): Message {
 export function messagesEvent(
   messages: Message[],
   responseId?: string,
+  usage?: JsonObject,
 ): EventData {
   return {
     type: "messages",
     messages,
     response_id: responseId,
+    ...(usage ? { usage } : {}),
   };
 }
 

--- a/typescript/model-runtime/cost.test.ts
+++ b/typescript/model-runtime/cost.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import { computeCostUsd, lookup, parseTable } from "./cost";
+
+const FIXTURE = `{
+  "sample_spec": { "comment": "ignored" },
+  "claude-sonnet-4-6": {
+    "litellm_provider": "anthropic", "input_cost_per_token": 3e-06,
+    "output_cost_per_token": 1.5e-05, "cache_read_input_token_cost": 3e-07,
+    "cache_creation_input_token_cost": 3.75e-06
+  },
+  "gpt-4o-mini": {
+    "litellm_provider": "openai", "input_cost_per_token": 1.5e-07,
+    "output_cost_per_token": 6e-07, "cache_read_input_token_cost": 7.5e-08
+  },
+  "gpt-4": { "litellm_provider": "openai", "input_cost_per_token": 3e-05 },
+  "us.anthropic.claude-sonnet-4-6": {
+    "litellm_provider": "bedrock_converse", "input_cost_per_token": 3.3e-06,
+    "output_cost_per_token": 1.65e-05, "cache_read_input_token_cost": 3.3e-07
+  }
+}`;
+
+const table = parseTable(FIXTURE);
+
+describe("cost", () => {
+  it("skips sample_spec", () => {
+    expect(table.size).toBe(4);
+  });
+
+  it("resolves dated revisions, not neighbors", () => {
+    expect(lookup(table, "claude-sonnet-4-6-20251022")?.litellm_provider).toBe(
+      "anthropic",
+    );
+    expect(lookup(table, "gpt-4o")).toBeUndefined();
+    expect(lookup(table, "gpt-4-0613")).toBeDefined();
+  });
+
+  it("bills Anthropic additively (prompt excludes cached)", () => {
+    // 500 fresh + 10k read + 200 out = 0.0015 + 0.003 + 0.003
+    expect(
+      computeCostUsd(table, "claude-sonnet-4-6", {
+        prompt: 500,
+        completion: 200,
+        cached: 10_000,
+      }),
+    ).toBeCloseTo(0.0075, 12);
+  });
+
+  it("bills OpenAI inclusively (subtract cached)", () => {
+    expect(
+      computeCostUsd(table, "gpt-4o-mini", {
+        prompt: 2_000,
+        completion: 1_000,
+        cached: 500,
+      }),
+    ).toBeCloseTo(0.0008625, 12);
+  });
+
+  it("treats Bedrock as inclusive, not additive", () => {
+    const expected = 1_500 * 3.3e-6 + 500 * 3.3e-7 + 1_000 * 1.65e-5;
+    expect(
+      computeCostUsd(table, "us.anthropic.claude-sonnet-4-6", {
+        prompt: 2_000,
+        completion: 1_000,
+        cached: 500,
+      }),
+    ).toBeCloseTo(expected, 12);
+  });
+
+  it("returns null for unknown models", () => {
+    expect(
+      computeCostUsd(table, "acme-llm-9000", { prompt: 100, completion: 50 }),
+    ).toBeNull();
+  });
+});

--- a/typescript/model-runtime/cost.ts
+++ b/typescript/model-runtime/cost.ts
@@ -1,0 +1,184 @@
+// Cost policy for the TypeScript harness: a self-contained port of the `cost`
+// crate's math and loader. It owns its own price data (env override, on-disk
+// cache, or its own fetch) and does not depend on the Rust loader having run.
+
+import { mkdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+export type ModelEntry = {
+  litellm_provider?: string;
+  input_cost_per_token?: number;
+  output_cost_per_token?: number;
+  cache_read_input_token_cost?: number;
+  cache_creation_input_token_cost?: number;
+};
+
+export type PricingTable = Map<string, ModelEntry>;
+
+export type TokenCounts = {
+  prompt?: number;
+  completion?: number;
+  cached?: number;
+  cacheCreation?: number;
+};
+
+export function parseTable(json: string): PricingTable {
+  const raw = JSON.parse(json) as Record<string, unknown>;
+  const table: PricingTable = new Map();
+  for (const [key, value] of Object.entries(raw)) {
+    if (key !== "sample_spec" && value !== null && typeof value === "object") {
+      table.set(key, value as ModelEntry);
+    }
+  }
+  return table;
+}
+
+// Exact match, else the longest key that is a prefix of `model` at a token
+// boundary (next char absent or `-`/`:`).
+export function lookup(
+  table: PricingTable,
+  model: string,
+): ModelEntry | undefined {
+  const exact = table.get(model);
+  if (exact) return exact;
+  let best: ModelEntry | undefined;
+  let bestLen = -1;
+  for (const [key, entry] of table) {
+    const next = model[key.length];
+    if (
+      key.length > bestLen &&
+      model.startsWith(key) &&
+      (next === undefined || next === "-" || next === ":")
+    ) {
+      best = entry;
+      bestLen = key.length;
+    }
+  }
+  return best;
+}
+
+export function computeCostUsd(
+  table: PricingTable,
+  model: string,
+  tokens: TokenCounts,
+): number | null {
+  const entry = lookup(table, model);
+  if (!entry || entry.input_cost_per_token == null) return null;
+  const input = entry.input_cost_per_token;
+  const output = entry.output_cost_per_token ?? 0;
+  const cacheRead = entry.cache_read_input_token_cost ?? input;
+  const cacheWrite = entry.cache_creation_input_token_cost ?? input;
+
+  const prompt = Math.max(0, tokens.prompt ?? 0);
+  const completion = Math.max(0, tokens.completion ?? 0);
+  const cached = Math.max(0, tokens.cached ?? 0);
+  const created = Math.max(0, tokens.cacheCreation ?? 0);
+
+  // Anthropic-family `prompt_tokens` excludes cached (additive); else inclusive.
+  const fresh = isAdditive(entry.litellm_provider)
+    ? prompt
+    : Math.max(0, prompt - cached);
+  return (
+    fresh * input +
+    cached * cacheRead +
+    created * cacheWrite +
+    completion * output
+  );
+}
+
+function isAdditive(provider?: string): boolean {
+  return (
+    provider != null &&
+    (provider.startsWith("anthropic") ||
+      provider.startsWith("vertex_ai-anthropic") ||
+      provider === "azure_ai")
+  );
+}
+
+const DEFAULT_URL =
+  "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+const FETCH_TIMEOUT_MS = 5000;
+
+let table: PricingTable | null | undefined;
+let loading: Promise<PricingTable | null> | undefined;
+
+// The in-memory table once loaded; null until ensureTable() has resolved.
+export function getTable(): PricingTable | null {
+  return table ?? null;
+}
+
+// Loads the table once (memoized), owning its own data: env override -> fresh
+// cache -> own fetch (cached) -> stale cache -> null. Independent of Rust.
+export function ensureTable(): Promise<PricingTable | null> {
+  loading ??= load().then((loaded) => (table = loaded));
+  return loading;
+}
+
+async function load(): Promise<PricingTable | null> {
+  const override = process.env.EXO_LITELLM_PRICES_PATH;
+  if (override) return readTable(override);
+
+  const cache = cachePath();
+  if (cache && isFresh(cache)) {
+    const fresh = readTable(cache);
+    if (fresh) return fresh;
+  }
+  const fetched = await fetchTable(
+    process.env.EXO_LITELLM_PRICES_URL ?? DEFAULT_URL,
+  );
+  if (fetched) {
+    if (cache) writeCache(cache, fetched.body);
+    return fetched.table;
+  }
+  return cache ? readTable(cache) : null; // stale cache fallback
+}
+
+async function fetchTable(
+  url: string,
+): Promise<{ table: PricingTable; body: string } | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) return null;
+    const body = await response.text();
+    return { table: parseTable(body), body };
+  } catch {
+    return null; // network/parse failure -> fall back to cache or null
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function readTable(path: string): PricingTable | null {
+  try {
+    return parseTable(readFileSync(path, "utf8"));
+  } catch {
+    return null; // missing or unparseable -> no table
+  }
+}
+
+function isFresh(path: string): boolean {
+  try {
+    return Date.now() - statSync(path).mtimeMs < CACHE_TTL_MS;
+  } catch {
+    return false;
+  }
+}
+
+function writeCache(path: string, body: string): void {
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, body);
+  } catch {
+    // best effort; a missing cache just means we re-fetch next time
+  }
+}
+
+function cachePath(): string | null {
+  const base =
+    process.env.XDG_CACHE_HOME ??
+    (process.env.HOME ? `${process.env.HOME}/.cache` : null);
+  return base ? `${base}/exo/litellm_prices.json` : null;
+}

--- a/typescript/model-runtime/responses.ts
+++ b/typescript/model-runtime/responses.ts
@@ -32,6 +32,7 @@ import {
   type ToolDefinition,
   type TurnContext,
 } from "../harness";
+import { computeCostUsd, getTable } from "./cost";
 import type {
   ChatCompletion,
   ChatCompletionChunk,
@@ -952,7 +953,7 @@ export function responseToLinguaEvents(response: Response): EventData[] {
   const events: EventData[] = [];
   const messages = responseMessages(response);
   if (messages.length > 0) {
-    events.push(messagesEvent(messages));
+    events.push(messagesEvent(messages, undefined, usageRecord(response)));
   }
   for (const result of responseToolCallResults(response)) {
     if (result.type === "tool_call") {
@@ -967,6 +968,29 @@ export function responseToLinguaEvents(response: Response): EventData[] {
     }
   }
   return events;
+}
+
+// Policy: attach raw usage + cost to the messages event. cost_usd is filled from
+// the shared price cache; left unset if the cache is unavailable.
+function usageRecord(response: Response): JsonObject | undefined {
+  const usage = response.usage;
+  if (!usage) return undefined;
+  const prompt = usage.input_tokens;
+  const completion = usage.output_tokens;
+  const cached = usage.input_tokens_details?.cached_tokens;
+  const reasoning = usage.output_tokens_details?.reasoning_tokens;
+  const table = getTable();
+  const cost = table
+    ? computeCostUsd(table, response.model, { prompt, completion, cached })
+    : null;
+
+  const record: JsonObject = { model: response.model };
+  if (prompt != null) record.prompt_tokens = prompt;
+  if (completion != null) record.completion_tokens = completion;
+  if (cached != null) record.prompt_cached_tokens = cached;
+  if (reasoning != null) record.completion_reasoning_tokens = reasoning;
+  if (cost != null) record.cost_usd = cost;
+  return record;
 }
 
 export function responseStreamEventToLinguaEvents(


### PR DESCRIPTION
Rebuild of #16 on top of `exoclaw-self-control`, so cost tracking lands cleanly under the self-modification work.

## Why a rebuild

The original #16 commit was accidentally authored against a stale pre-#52 tree, so its diff silently reverted main's AgentCore provider and conversation-list pagination. Both that branch and `exoclaw-self-control` share base `dea9fdb`, so the pure feature diff applied here with zero conflicts and no reverts. #16 should be closed in favor of this PR.

## What it does

Optional `UsageRecord` on every `EventData::Messages` event: model id, raw token counts (prompt / completion / cached / cache-creation / reasoning), USD cost, TTFT + wall-clock duration. Cost is policy, computed in userspace, never by the trusted substrate. See `docs/cost-tracking-design.md` for the full design, including the layering and per-provider math.

All three review decisions from #16 are included: boundary-aware prefix lookup, Bedrock treated as inclusive (additive Bedrock-Claude left as TODO), pricing source threaded through clap with `EXO_LITELLM_PRICES_*` env fallbacks.

## Live verification (gpt-4o, both userspaces)

- Rust Basic harness: stored `cost_usd` matches rate table exactly; `duration_ms` recorded; user-message events carry `usage: null`.
- Exoclaw / TS harness: same, including `completion_reasoning_tokens`; TS loader consumed the price cache written by the Rust CLI (shared cache path convention).
- Prompt-cache math: second turns with `prompt_cached_tokens` > 0 on both paths; stored cost matches the inclusive formula `(prompt − cached)·in + cached·cache_read + completion·out` to the last digit (misclassification as additive would have over-billed ~3×).
- Provider-echoed dated model ids (`gpt-4o-2024-08-06`) resolve via the boundary-aware prefix lookup on both implementations.

Not live-tested (unit-tested only): Anthropic additive path and cache-creation tokens — no direct Anthropic key in the test environment.

## Note on docker warm sandboxes

While testing, confirmed that docker warm-sandbox reuse works on this branch across REPL restarts (state persists, no duplicate containers). The standalone `fix/docker-warm-sandbox` branch (prototype of closed #43) is superseded by `exoclaw-self-control`'s own `find_running_docker_warm_sandbox` (from "Add Exoclaw sandbox transparency controls") and can be deleted. One nit inherited from that implementation is fixed here in its own commit: the docker listing shelled out without the admin-command timeout the prototype had, while running under the warm_sandboxes mutex — a hung docker daemon would have blocked every sandbox operation in the process. It now goes through run_container_admin_command like the Apple path. Re-verified live after the change.

Known follow-ups (also listed in the design doc): TS path records no `ttft_ms`/`duration_ms`; `azure_ai` provider classified additive (hosts non-Anthropic models too); `/usage` REPL surface (#29) to be re-ported on top of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
