### PR TITLE
Adapter target-scoped conversations (per-channel)

### DIFF
--- a/crates/executor/src/adapter/runtime.rs
+++ b/crates/executor/src/adapter/runtime.rs
@@ -10,15 +10,18 @@ use serde::Deserialize;
 use tokio::sync::Notify;
 use tokio::task::JoinSet;
 
-use super::store::AdapterStore;
-use super::types::{AdapterAttachment, AdapterConfig, AdapterEventType, AdapterRecord};
+use super::store::{AdapterStore, stable_target_key};
+use super::types::{
+    AdapterAttachment, AdapterConfig, AdapterEventType, AdapterRecord,
+    AdapterTargetConversationRecord, now_ms,
+};
 use super::worker::{WorkerCommand, WorkerEvent, run_worker_loop};
 use crate::conversation_events::{
     HOST_EVENT_ADAPTER_RUNNER_DRAINING, HOST_EVENT_ADAPTER_RUNNER_STARTED, HOST_EVENT_REBOOT,
     record_host_event,
 };
 use crate::conversation_wakeup::send_conversation_wakeup;
-use crate::{Harness, HarnessAgent, HarnessConversation};
+use crate::{CreateConversationRequest, Harness, HarnessAgent, HarnessConversation};
 
 const INITIAL_RESTART_DELAY: Duration = Duration::from_secs(5);
 const MAX_RESTART_DELAY: Duration = Duration::from_secs(300);
@@ -429,6 +432,7 @@ async fn run_adapter_loop(
     let outbound_notifier = register_adapter_outbound_notifier(&adapter.id);
     let event_store = store.clone();
     let event_adapter = adapter.clone();
+    let event_agent = std::sync::Arc::clone(&agent);
     let event_conversation = std::sync::Arc::clone(&conversation);
     let event_config = config.clone();
     let outbound_store = store.clone();
@@ -443,10 +447,19 @@ async fn run_adapter_loop(
         move |event| {
             let store = event_store.clone();
             let adapter = event_adapter.clone();
+            let agent = std::sync::Arc::clone(&event_agent);
             let conversation = std::sync::Arc::clone(&event_conversation);
             let config = event_config.clone();
             async move {
-                handle_worker_event(&store, conversation.as_ref(), &adapter, &config, event).await
+                handle_worker_event(
+                    &store,
+                    agent.as_ref(),
+                    conversation,
+                    &adapter,
+                    &config,
+                    event,
+                )
+                .await
             }
         },
         move || {
@@ -532,7 +545,8 @@ fn adapter_outbound_notifiers() -> &'static Mutex<HashMap<String, Weak<Notify>>>
 
 async fn handle_worker_event(
     store: &AdapterStore,
-    conversation: &dyn HarnessConversation,
+    agent: &dyn HarnessAgent,
+    root_conversation: Arc<dyn HarnessConversation>,
     adapter: &AdapterRecord,
     config: &AdapterConfig,
     event: WorkerEvent,
@@ -542,7 +556,7 @@ async fn handle_worker_event(
             store.mark_connected(&adapter.id).await?;
             record_worker_lifecycle(
                 store,
-                conversation,
+                root_conversation.as_ref(),
                 adapter,
                 config,
                 "connected",
@@ -557,9 +571,19 @@ async fn handle_worker_event(
             message_id,
             metadata,
         } => {
+            let conversation = resolve_message_conversation(
+                store,
+                agent,
+                root_conversation,
+                adapter,
+                config,
+                &target,
+                &metadata,
+            )
+            .await?;
             handle_worker_message(
                 store,
-                conversation,
+                conversation.as_ref(),
                 adapter,
                 config,
                 target,
@@ -571,7 +595,15 @@ async fn handle_worker_event(
             .await
         }
         WorkerEvent::Lifecycle { name, metadata } => {
-            record_worker_lifecycle(store, conversation, adapter, config, &name, metadata).await
+            record_worker_lifecycle(
+                store,
+                root_conversation.as_ref(),
+                adapter,
+                config,
+                &name,
+                metadata,
+            )
+            .await
         }
         WorkerEvent::Error { message } => {
             store.mark_error(&adapter.id, message.clone()).await?;
@@ -600,7 +632,7 @@ async fn handle_worker_event(
         WorkerEvent::Disconnected { reason } => {
             record_worker_lifecycle(
                 store,
-                conversation,
+                root_conversation.as_ref(),
                 adapter,
                 config,
                 "disconnected",
@@ -609,6 +641,88 @@ async fn handle_worker_event(
             .await
         }
     }
+}
+
+async fn resolve_message_conversation(
+    store: &AdapterStore,
+    agent: &dyn HarnessAgent,
+    root_conversation: Arc<dyn HarnessConversation>,
+    adapter: &AdapterRecord,
+    config: &AdapterConfig,
+    target: &str,
+    _metadata: &serde_json::Value,
+) -> Result<Arc<dyn HarnessConversation>> {
+    if !uses_target_conversation_scope(config) {
+        return Ok(root_conversation);
+    }
+    if let Some(record) = store.get_target_conversation(&adapter.id, target).await? {
+        if let Some(conversation) = agent.get_conversation(&record.conversation_id).await? {
+            return Ok(conversation);
+        }
+        tracing::warn!(
+            adapter_id = %adapter.id,
+            target,
+            conversation_id = %record.conversation_id,
+            "adapter target conversation mapping points to missing conversation; recreating"
+        );
+    }
+
+    let slug = target_conversation_slug(adapter, target);
+    let name = format!("{} target {}", adapter.name, target);
+    let conversation = match agent
+        .create_conversation(CreateConversationRequest {
+            slug: Some(slug.clone()),
+            name: Some(name),
+            ..Default::default()
+        })
+        .await
+    {
+        Ok(conversation) => conversation,
+        Err(error) => {
+            if let Some(conversation) = agent.get_conversation(&slug).await? {
+                conversation
+            } else {
+                return Err(error).with_context(|| {
+                    format!(
+                        "failed to create target-scoped conversation for adapter {} target {}",
+                        adapter.id, target
+                    )
+                });
+            }
+        }
+    };
+    let record = AdapterTargetConversationRecord::new(
+        adapter.id.clone(),
+        target.to_string(),
+        conversation.record().id.to_string(),
+        now_ms(),
+    )?;
+    store.put_target_conversation(&record).await?;
+    Ok(conversation)
+}
+
+fn uses_target_conversation_scope(config: &AdapterConfig) -> bool {
+    config
+        .initialization
+        .get("conversationScope")
+        .and_then(|value| value.as_str())
+        == Some("target")
+}
+
+fn target_conversation_slug(adapter: &AdapterRecord, target: &str) -> String {
+    format!(
+        "adapter-{}-{}",
+        short_slug_part(&adapter.id),
+        stable_target_key(target)
+    )
+}
+
+fn short_slug_part(value: &str) -> String {
+    value
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .take(12)
+        .collect()
 }
 
 async fn handle_worker_message(
@@ -801,5 +915,55 @@ mod tests {
         std::fs::write(&path, "not json").unwrap();
         assert!(claim_reboot_notice(Some(&path)).is_none());
         assert!(!path.exists(), "malformed notices are still consumed");
+    }
+
+    fn config_with_scope(scope: Option<&str>) -> AdapterConfig {
+        let initialization = match scope {
+            Some(scope) => serde_json::json!({ "conversationScope": scope }),
+            None => serde_json::json!({}),
+        };
+        AdapterConfig {
+            adapter_type: "discord".to_string(),
+            worker_command: vec!["node".to_string()],
+            initialization,
+            state_dir: None,
+            secret_env: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn target_scope_only_when_explicitly_set() {
+        assert!(uses_target_conversation_scope(&config_with_scope(Some(
+            "target"
+        ))));
+        // Default and explicit "adapter" both stay on the root conversation.
+        assert!(!uses_target_conversation_scope(&config_with_scope(None)));
+        assert!(!uses_target_conversation_scope(&config_with_scope(Some(
+            "adapter"
+        ))));
+    }
+
+    #[test]
+    fn target_conversation_slug_is_deterministic_and_target_specific() {
+        let adapter = AdapterRecord::new(
+            super::super::types::NewAdapter {
+                agent_id: "agent".to_string(),
+                conversation_id: "conversation".to_string(),
+                name: "discord-dev".to_string(),
+                source: super::super::types::AdapterSource::BuiltIn,
+                config: config_with_scope(Some("target")),
+            },
+            0,
+        )
+        .unwrap();
+
+        let a1 = target_conversation_slug(&adapter, "channel-A");
+        let a2 = target_conversation_slug(&adapter, "channel-A");
+        let b = target_conversation_slug(&adapter, "channel-B");
+        assert_eq!(a1, a2, "same target must yield the same slug");
+        assert_ne!(a1, b, "different targets must yield different slugs");
+        assert!(a1.starts_with("adapter-"));
+        // Slug must agree with the store's filename key for that target.
+        assert!(a1.ends_with(&stable_target_key("channel-A")));
     }
 }

--- a/crates/executor/src/adapter/store.rs
+++ b/crates/executor/src/adapter/store.rs
@@ -8,7 +8,8 @@ use tokio::io::AsyncWriteExt;
 
 use super::types::{
     AdapterAttachment, AdapterEventRecord, AdapterEventType, AdapterInboundMessageRecord,
-    AdapterOutboundMessageRecord, AdapterRecord, NewAdapter, now_ms,
+    AdapterOutboundMessageRecord, AdapterRecord, AdapterTargetConversationRecord, NewAdapter,
+    now_ms,
 };
 
 #[derive(Debug, Clone)]
@@ -122,6 +123,7 @@ impl AdapterStore {
         remove_dir_if_exists(self.outbox_dir(adapter_id)).await?;
         remove_dir_if_exists(self.inflight_dir(adapter_id)).await?;
         remove_dir_if_exists(self.inbound_seen_dir(adapter_id)).await?;
+        remove_dir_if_exists(self.target_conversations_dir(adapter_id)).await?;
         Ok(Some(adapter))
     }
 
@@ -339,6 +341,68 @@ impl AdapterStore {
         Ok(())
     }
 
+    pub async fn get_target_conversation(
+        &self,
+        adapter_id: &str,
+        target: &str,
+    ) -> Result<Option<AdapterTargetConversationRecord>> {
+        let path = self.target_conversation_path(adapter_id, target);
+        match fs::read(&path).await {
+            Ok(bytes) => Ok(Some(serde_json::from_slice::<
+                AdapterTargetConversationRecord,
+            >(&bytes)?)),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error).with_context(|| {
+                format!(
+                    "failed to read adapter target conversation {}",
+                    path.display()
+                )
+            }),
+        }
+    }
+
+    pub async fn put_target_conversation(
+        &self,
+        record: &AdapterTargetConversationRecord,
+    ) -> Result<()> {
+        let dir = self.target_conversations_dir(&record.adapter_id);
+        fs::create_dir_all(&dir).await?;
+        let path = self.target_conversation_path(&record.adapter_id, &record.target);
+        write_json_file(&path, record).await
+    }
+
+    pub async fn list_target_conversations(
+        &self,
+        adapter_id: &str,
+    ) -> Result<Vec<AdapterTargetConversationRecord>> {
+        let dir = self.target_conversations_dir(adapter_id);
+        match fs::metadata(&dir).await {
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("failed to stat target conversation dir {}", dir.display())
+                });
+            }
+        }
+        let mut records = Vec::new();
+        let mut entries = fs::read_dir(&dir).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            let path = entry.path();
+            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                continue;
+            }
+            let bytes = fs::read(&path).await.with_context(|| {
+                format!("failed to read target conversation {}", path.display())
+            })?;
+            records.push(serde_json::from_slice::<AdapterTargetConversationRecord>(
+                &bytes,
+            )?);
+        }
+        records.sort_by_key(|record| record.updated_at_ms);
+        Ok(records)
+    }
+
     pub async fn record_inbound_message_once(
         &self,
         adapter_id: &str,
@@ -411,6 +475,15 @@ impl AdapterStore {
             .join(format!("{message_id}.json"))
     }
 
+    fn target_conversations_dir(&self, adapter_id: &str) -> PathBuf {
+        self.root.join("target-conversations").join(adapter_id)
+    }
+
+    fn target_conversation_path(&self, adapter_id: &str, target: &str) -> PathBuf {
+        self.target_conversations_dir(adapter_id)
+            .join(format!("{}.json", stable_target_key(target)))
+    }
+
     fn inbound_seen_dir(&self, adapter_id: &str) -> PathBuf {
         self.root.join("inbound-seen").join(adapter_id)
     }
@@ -448,6 +521,17 @@ async fn remove_dir_if_exists(path: PathBuf) -> Result<()> {
             Err(error).with_context(|| format!("failed to delete directory {}", path.display()))
         }
     }
+}
+/// FNV-1a of an adapter target, used for both the target-conversation mapping
+/// filename and the derived conversation slug. `pub(crate)` so the runtime
+/// derives the same slug the store keys by — they must agree.
+pub(crate) fn stable_target_key(target: &str) -> String {
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in target.bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{hash:016x}")
 }
 
 fn stable_message_key(target: &str, message_id: &str) -> String {
@@ -517,6 +601,79 @@ mod tests {
         );
         assert!(store.delete_adapter(&adapter.id).await.unwrap().is_some());
         assert!(store.get_adapter(&adapter.id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn target_conversation_mapping_round_trips() {
+        use super::super::types::AdapterTargetConversationRecord;
+
+        let tempdir = TempDir::new().unwrap();
+        let store = AdapterStore::new(tempdir.path());
+        // A real adapter record so delete_adapter reaches the mapping cleanup.
+        let adapter = store
+            .create_adapter(NewAdapter {
+                agent_id: "agent".to_string(),
+                conversation_id: "root".to_string(),
+                name: "discord".to_string(),
+                source: AdapterSource::BuiltIn,
+                config: AdapterConfig {
+                    adapter_type: "discord".to_string(),
+                    worker_command: vec!["node".to_string()],
+                    initialization: serde_json::json!({}),
+                    state_dir: None,
+                    secret_env: Vec::new(),
+                },
+            })
+            .await
+            .unwrap();
+
+        // Missing mapping reads as None.
+        assert!(
+            store
+                .get_target_conversation(&adapter.id, "channel-A")
+                .await
+                .unwrap()
+                .is_none()
+        );
+
+        let rec_a = AdapterTargetConversationRecord::new(
+            adapter.id.clone(),
+            "channel-A".into(),
+            "conv-A".into(),
+            1,
+        )
+        .unwrap();
+        let rec_b = AdapterTargetConversationRecord::new(
+            adapter.id.clone(),
+            "channel-B".into(),
+            "conv-B".into(),
+            2,
+        )
+        .unwrap();
+        store.put_target_conversation(&rec_a).await.unwrap();
+        store.put_target_conversation(&rec_b).await.unwrap();
+
+        assert_eq!(
+            store
+                .get_target_conversation(&adapter.id, "channel-A")
+                .await
+                .unwrap(),
+            Some(rec_a.clone())
+        );
+        let listed = store.list_target_conversations(&adapter.id).await.unwrap();
+        assert_eq!(listed.len(), 2);
+        // Distinct targets must not collide on the hashed filename.
+        assert_ne!(rec_a.conversation_id, rec_b.conversation_id);
+
+        // Deleting the adapter removes its target-conversation mappings.
+        store.delete_adapter(&adapter.id).await.unwrap();
+        assert!(
+            store
+                .list_target_conversations(&adapter.id)
+                .await
+                .unwrap()
+                .is_empty()
+        );
     }
 
     #[tokio::test]

--- a/crates/executor/src/adapter/tools.rs
+++ b/crates/executor/src/adapter/tools.rs
@@ -136,6 +136,8 @@ struct DiscordAdapterCreationConfig {
     /// `openai` when voice is enabled and no id is given.
     #[serde(default)]
     openai_secret_id: Option<String>,
+    #[serde(default)]
+    conversation_scope: Option<AdapterConversationScope>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -204,6 +206,22 @@ enum ChatTrigger {
 enum DiscordTrigger {
     AllMessages,
     MentionsOnly,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum AdapterConversationScope {
+    Adapter,
+    Target,
+}
+
+impl AdapterConversationScope {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Adapter => "adapter",
+            Self::Target => "target",
+        }
+    }
 }
 
 fn default_irc_nick() -> String {
@@ -331,6 +349,10 @@ impl AdapterCreationConfig {
                         "allowedChannels": config.allowed_channels,
                         "allowBots": config.allow_bots,
                         "voice": config.voice,
+                        "conversationScope": config
+                            .conversation_scope
+                            .map(|scope| scope.as_str())
+                            .unwrap_or("adapter"),
                     }),
                     state_dir: None,
                     secret_env,
@@ -568,11 +590,11 @@ pub async fn execute_send_adapter_message_tool(
     let Some(adapter) = store.get_adapter(&args.adapter_id).await? else {
         return Ok(not_found());
     };
-    if adapter.agent_id != agent.record().id.to_string()
-        || adapter.conversation_id != conversation.record().id.to_string()
-    {
+    let Some(scoped_target) = adapter_access_target(store, agent, conversation, &adapter).await?
+    else {
         return Ok(not_found());
-    }
+    };
+    let target = resolve_send_target(scoped_target.as_deref(), args.target.as_deref())?;
     let attachments = args.attachments.unwrap_or_default();
     if !attachments.is_empty()
         && adapter.config.adapter_type != "whatsapp"
@@ -600,7 +622,7 @@ pub async fn execute_send_adapter_message_tool(
         store,
         &adapter,
         &args.text,
-        args.target.as_deref(),
+        target.as_deref(),
         attachments,
     )
     .await?;
@@ -609,6 +631,71 @@ pub async fn execute_send_adapter_message_tool(
         "adapterId": args.adapter_id,
         "sent": true,
     }))
+}
+
+/// Determine whether `conversation` may send through `adapter`, gathering the
+/// target-conversation mappings from the store and delegating the decision to
+/// the pure [`classify_adapter_access`]. The outer `Option` is authorization
+/// (None = denied); the inner `Option` is the send constraint (None = root
+/// conversation, any target allowed; `Some(target)` = scoped, that target only).
+async fn adapter_access_target(
+    store: &AdapterStore,
+    agent: &dyn AgentHandle,
+    conversation: &dyn ConversationHandle,
+    adapter: &super::types::AdapterRecord,
+) -> Result<Option<Option<String>>> {
+    let conversation_id = conversation.record().id.to_string();
+    let mappings = store.list_target_conversations(&adapter.id).await?;
+    Ok(classify_adapter_access(
+        &adapter.agent_id,
+        &adapter.conversation_id,
+        &agent.record().id.to_string(),
+        &conversation_id,
+        mappings
+            .iter()
+            .map(|m| (m.conversation_id.as_str(), m.target.as_str())),
+    ))
+}
+
+/// Pure authorization decision. `None`: this conversation may not use the
+/// adapter. `Some(None)`: the adapter's root conversation — may send to any
+/// target. `Some(Some(target))`: a target-scoped conversation — may send only
+/// to `target`.
+fn classify_adapter_access<'a>(
+    adapter_agent_id: &str,
+    adapter_root_conversation_id: &str,
+    agent_id: &str,
+    conversation_id: &str,
+    target_mappings: impl Iterator<Item = (&'a str, &'a str)>,
+) -> Option<Option<String>> {
+    if adapter_agent_id != agent_id {
+        return None;
+    }
+    if adapter_root_conversation_id == conversation_id {
+        return Some(None);
+    }
+    for (mapped_conversation, target) in target_mappings {
+        if mapped_conversation == conversation_id {
+            return Some(Some(target.to_string()));
+        }
+    }
+    None
+}
+
+/// Resolve the effective send target, enforcing that a target-scoped
+/// conversation may only send to its mapped target (a missing target defaults
+/// to it). A root conversation sends to whatever it requested.
+fn resolve_send_target(scoped: Option<&str>, requested: Option<&str>) -> Result<Option<String>> {
+    match scoped {
+        Some(scoped) => match requested {
+            Some(requested) if requested != scoped => {
+                bail!("target-scoped conversation may only send to mapped target {scoped}")
+            }
+            Some(requested) => Ok(Some(requested.to_string())),
+            None => Ok(Some(scoped.to_string())),
+        },
+        None => Ok(requested.map(str::to_string)),
+    }
 }
 
 async fn resolve_sandbox_attachments(
@@ -894,6 +981,59 @@ mod tests {
     use super::*;
     use crate::test_support::local_test_config;
     use crate::{AgentConfig, AgentHarnessKind, ConversationConfig};
+
+    #[test]
+    fn access_denied_for_other_agent() {
+        assert_eq!(
+            classify_adapter_access("agent-1", "root", "agent-2", "root", std::iter::empty()),
+            None
+        );
+    }
+
+    #[test]
+    fn root_conversation_may_send_to_any_target() {
+        // Some(None) => root conversation, no target constraint.
+        assert_eq!(
+            classify_adapter_access("a", "root", "a", "root", std::iter::empty()),
+            Some(None)
+        );
+    }
+
+    #[test]
+    fn scoped_conversation_is_constrained_to_its_mapped_target() {
+        let mappings = [("conv-A", "chan-A"), ("conv-B", "chan-B")];
+        assert_eq!(
+            classify_adapter_access("a", "root", "a", "conv-B", mappings.into_iter()),
+            Some(Some("chan-B".to_string()))
+        );
+        // A conversation with no mapping and not the root is denied.
+        assert_eq!(
+            classify_adapter_access("a", "root", "a", "conv-Z", mappings.into_iter()),
+            None
+        );
+    }
+
+    #[test]
+    fn resolve_send_target_enforces_scope() {
+        // Root (unscoped) passes the requested target through, or none.
+        assert_eq!(
+            resolve_send_target(None, Some("x")).unwrap(),
+            Some("x".into())
+        );
+        assert_eq!(resolve_send_target(None, None).unwrap(), None);
+        // Scoped: missing target defaults to the mapped one.
+        assert_eq!(
+            resolve_send_target(Some("chan-A"), None).unwrap(),
+            Some("chan-A".into())
+        );
+        // Scoped: matching target is allowed.
+        assert_eq!(
+            resolve_send_target(Some("chan-A"), Some("chan-A")).unwrap(),
+            Some("chan-A".into())
+        );
+        // Scoped: a different target is refused — the key cross-channel guard.
+        assert!(resolve_send_target(Some("chan-A"), Some("chan-B")).is_err());
+    }
 
     #[tokio::test]
     async fn create_and_list_adapter_tools_are_conversation_scoped() {

--- a/crates/executor/src/adapter/types.rs
+++ b/crates/executor/src/adapter/types.rs
@@ -118,11 +118,37 @@ pub enum AdapterEventType {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AdapterTargetConversationRecord {
+    pub adapter_id: String,
+    pub target: String,
+    pub conversation_id: String,
+    pub created_at_ms: u64,
+    pub updated_at_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AdapterInboundMessageRecord {
     pub adapter_id: String,
     pub target: String,
     pub message_id: String,
     pub first_seen_at_ms: u64,
+}
+
+impl AdapterTargetConversationRecord {
+    pub fn new(
+        adapter_id: String,
+        target: String,
+        conversation_id: String,
+        now_ms: u64,
+    ) -> Result<Self> {
+        Ok(Self {
+            adapter_id: non_empty("adapterId", adapter_id)?,
+            target: non_empty("target", target)?,
+            conversation_id: non_empty("conversationId", conversation_id)?,
+            created_at_ms: now_ms,
+            updated_at_ms: now_ms,
+        })
+    }
 }
 
 impl AdapterRecord {

--- a/examples/exoclaw/adapters/discord/README.md
+++ b/examples/exoclaw/adapters/discord/README.md
@@ -66,7 +66,8 @@ The setup prompt at `setup-prompt.md` asks Exoclaw to create a library adapter s
     "defaultChannelId": null,
     "trigger": "all_messages",
     "allowedChannels": null,
-    "allowBots": false
+    "allowBots": false,
+    "conversationScope": "adapter"
   }
 }
 ```
@@ -74,6 +75,8 @@ The setup prompt at `setup-prompt.md` asks Exoclaw to create a library adapter s
 Use `defaultChannelId` when you want outbound messages to go to one channel by default. Otherwise, pass the copied Discord channel id as `target` when calling `send_adapter_message`.
 
 Set `allowBots: true` if you want the adapter to wake on messages from other bot accounts (useful for bot-to-bot integrations). The adapter never wakes on its own messages regardless of this flag.
+
+Set `conversationScope: "target"` to wake a separate Exoclaw conversation per Discord channel id. The default, `"adapter"`, preserves the historical behavior where every channel for an adapter shares the adapter's root conversation.
 
 ### 5. Test It
 

--- a/examples/exoclaw/adapters/discord/setup-prompt.md
+++ b/examples/exoclaw/adapters/discord/setup-prompt.md
@@ -12,6 +12,7 @@ Create a library Discord adapter if one does not already exist for this conversa
 - allowBots: `false`
 - voice: `false` (set to `true` only if I ask for voice chat; when enabled also set `openaiSecretId: "openai"`, tell me to invite the bot with the `applications.commands` scope plus Connect/Speak permissions, and to store the OpenAI key with `exo secret set openai --env OPENAI_API_KEY`)
 - openaiSecretId: `null` (use `"openai"` only when voice is `true`)
+- conversationScope: `adapter`
 
 Do not block on secret inspection. The harness may not expose a secret-listing tool, so assume secret `discord-bot-token` exists and create the adapter. If the adapter later reports a missing Discord token, tell the user to create the secret with `exo secret set discord-bot-token --env DISCORD_BOT_TOKEN` after exporting a Discord bot token locally.
 

--- a/typescript/harness/adapter-tools.ts
+++ b/typescript/harness/adapter-tools.ts
@@ -391,6 +391,12 @@ function adapterConfigSchema(): ToolDefinition["parameters"] {
             description:
               'Secret id holding the OpenAI API key used for voice STT/TTS. Use "openai" when voice is true; null when voice is false.',
           },
+          conversationScope: {
+            type: "string",
+            enum: ["adapter", "target"],
+            description:
+              "Conversation routing mode. Use adapter to wake the adapter's root conversation for every message; use target to create and wake a separate conversation per Discord channel. Defaults to adapter.",
+          },
         },
         required: [
           "type",
@@ -401,6 +407,7 @@ function adapterConfigSchema(): ToolDefinition["parameters"] {
           "allowBots",
           "voice",
           "openaiSecretId",
+          "conversationScope",
         ],
       },
       {


### PR DESCRIPTION
Opt-in per-target conversation routing for adapters, off `exoclaw-self-control`.

## Problem
An adapter has one `conversation_id`, so every inbound message — every Discord channel, say — wakes one shared conversation. That bloats context and cost and bleeds history across channels.

## What it does
Adds `conversationScope: "adapter" | "target"` (default `adapter`, unchanged behavior). In `target` mode each external target (Discord channel id, etc.) routes to its own conversation:

- **types**: `AdapterTargetConversationRecord` (adapter_id, target, conversation_id, timestamps) with validation.
- **store**: get/put/list target-conversation mappings, keyed by an FNV hash of the target; cleaned up on adapter delete. `stable_target_key` is `pub(crate)` and shared so the runtime derives the same slug the store keys by.
- **runtime**: resolve-or-create the per-target conversation and wake it instead of the root; handles the create/slug race and a dangling mapping (recreates).
- **tools**: `send_adapter_message` authorization split into pure, tested functions — `classify_adapter_access` (root may send anywhere; a target-scoped conversation may use the adapter only if mapped) and `resolve_send_target` (a scoped conversation may send ONLY to its mapped target), preventing one channel's context from posting into another.
- **schema**: `conversationScope` added to the `create_adapter` Discord schema's `required[]` (OpenAI strict mode rejects a property absent from `required`).

## Tests
Store round-trip + delete cleanup; runtime slug/scope derivation (slug agrees with the store key); the authorization and target-restriction decisions including the cross-channel guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)