### PR TITLE
Support durable filesystem mounts

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -611,6 +611,9 @@ struct ProviderConfigureArgs {
     runtime_arn: Option<String>,
     #[arg(long)]
     qualifier: Option<String>,
+    /// AgentCore managed session storage mount path configured on the runtime.
+    #[arg(long = "session-storage-mount-path")]
+    session_storage_mount_path: Option<String>,
     /// Default base image for sandboxes that don't request one.
     #[arg(long)]
     default_image: Option<String>,
@@ -1765,10 +1768,16 @@ async fn main() -> Result<()> {
                     api_url,
                     runtime_arn,
                     qualifier,
+                    session_storage_mount_path,
                     default_image,
                 } = *args;
                 let binding_name =
                     name.unwrap_or_else(|| SandboxProvider::from(provider).as_str().to_string());
+                if !matches!(provider, SandboxProviderArg::AwsAgentCore)
+                    && session_storage_mount_path.is_some()
+                {
+                    bail!("--session-storage-mount-path is only valid for aws-agentcore");
+                }
                 let config = match provider {
                     SandboxProviderArg::Daytona => {
                         let secret =
@@ -1821,6 +1830,7 @@ async fn main() -> Result<()> {
                             region,
                             qualifier,
                             endpoint_url: api_url,
+                            session_storage_mount_path,
                             default_image: default_image
                                 .unwrap_or_else(default_aws_agentcore_image),
                         }

--- a/crates/cli/tests/daytona_backend.rs
+++ b/crates/cli/tests/daytona_backend.rs
@@ -32,6 +32,7 @@ fn make_request(conversation_id: &str, sandbox_id: &str) -> SandboxRequest {
         spec: SandboxSpec {
             image: "docker.io/library/ubuntu:24.04".into(),
             mounts: Vec::new(),
+            durable_file_systems: Vec::new(),
             network: SandboxNetworkPolicy::Enabled,
             default_workdir: "/".into(),
         },

--- a/crates/cli/tests/snapshot_round_trip.rs
+++ b/crates/cli/tests/snapshot_round_trip.rs
@@ -75,6 +75,7 @@ async fn filesystem_snapshot_and_rewind_round_trip() {
             image: SANDBOX_IMAGE.into(),
             default_workdir: Some("/".into()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(false),
             idle_seconds: Some(60),
         })

--- a/crates/cli/tests/vercel_backend.rs
+++ b/crates/cli/tests/vercel_backend.rs
@@ -22,6 +22,7 @@ fn make_request(conversation_id: &str, sandbox_id: &str) -> SandboxRequest {
         spec: SandboxSpec {
             image: "node24".into(),
             mounts: Vec::new(),
+            durable_file_systems: Vec::new(),
             network: SandboxNetworkPolicy::Enabled,
             default_workdir: "/vercel/sandbox".into(),
         },

--- a/crates/executor/src/agent_sandbox.rs
+++ b/crates/executor/src/agent_sandbox.rs
@@ -70,6 +70,7 @@ pub(crate) async fn ensure_agent_sandbox(
             image: spec.image.clone(),
             default_workdir: Some(spec.default_workdir.clone()),
             file_system_mounts: Some(spec.file_system_mounts.clone()),
+            durable_file_systems: None,
             enable_networking: Some(spec.enable_networking),
             idle_seconds: Some(spec.idle_seconds),
         })

--- a/crates/executor/src/agent_sandbox.rs
+++ b/crates/executor/src/agent_sandbox.rs
@@ -26,6 +26,8 @@ struct AgentSandboxRecord {
     image: String,
     default_workdir: String,
     file_system_mounts: Vec<exoharness::FileSystemMount>,
+    #[serde(default)]
+    durable_file_systems: Vec<exoharness::DurableFileSystem>,
     enable_networking: bool,
     idle_seconds: u64,
 }
@@ -36,6 +38,7 @@ impl AgentSandboxRecord {
             && self.image == spec.image
             && self.default_workdir == spec.default_workdir
             && self.file_system_mounts == spec.file_system_mounts
+            && self.durable_file_systems == spec.durable_file_systems
             && self.enable_networking == spec.enable_networking
             && self.idle_seconds == spec.idle_seconds
     }
@@ -70,7 +73,7 @@ pub(crate) async fn ensure_agent_sandbox(
             image: spec.image.clone(),
             default_workdir: Some(spec.default_workdir.clone()),
             file_system_mounts: Some(spec.file_system_mounts.clone()),
-            durable_file_systems: None,
+            durable_file_systems: Some(spec.durable_file_systems.clone()),
             enable_networking: Some(spec.enable_networking),
             idle_seconds: Some(spec.idle_seconds),
         })
@@ -84,6 +87,7 @@ pub(crate) async fn ensure_agent_sandbox(
             image: spec.image,
             default_workdir: spec.default_workdir,
             file_system_mounts: spec.file_system_mounts,
+            durable_file_systems: spec.durable_file_systems,
             enable_networking: spec.enable_networking,
             idle_seconds: spec.idle_seconds,
         },

--- a/crates/executor/src/conversation_sandbox.rs
+++ b/crates/executor/src/conversation_sandbox.rs
@@ -15,6 +15,7 @@ pub(crate) struct ConversationSandboxInfo {
     pub(crate) image: String,
     pub(crate) default_workdir: String,
     pub(crate) file_system_mounts: Vec<FileSystemMount>,
+    pub(crate) durable_file_systems: Vec<exoharness::DurableFileSystem>,
     pub(crate) enable_networking: bool,
     pub(crate) idle_seconds: u64,
 }
@@ -25,6 +26,7 @@ impl ConversationSandboxInfo {
             && self.image == spec.image
             && self.default_workdir == spec.default_workdir
             && self.file_system_mounts == spec.file_system_mounts
+            && self.durable_file_systems == spec.durable_file_systems
             && self.enable_networking == spec.enable_networking
             && self.idle_seconds == spec.idle_seconds
     }
@@ -36,6 +38,7 @@ pub(crate) struct ConversationSandboxSpec {
     pub(crate) image: String,
     pub(crate) default_workdir: String,
     pub(crate) file_system_mounts: Vec<FileSystemMount>,
+    pub(crate) durable_file_systems: Vec<exoharness::DurableFileSystem>,
     pub(crate) enable_networking: bool,
     pub(crate) idle_seconds: u64,
 }
@@ -71,7 +74,7 @@ pub(crate) async fn create_conversation_sandbox(
             image: spec.image,
             default_workdir: Some(spec.default_workdir),
             file_system_mounts: Some(spec.file_system_mounts),
-            durable_file_systems: None,
+            durable_file_systems: Some(spec.durable_file_systems),
             enable_networking: Some(spec.enable_networking),
             idle_seconds: Some(spec.idle_seconds),
         })
@@ -101,6 +104,7 @@ pub(crate) async fn conversation_sandboxes(
             image,
             default_workdir,
             file_system_mounts,
+            durable_file_systems,
             enable_networking,
             idle_seconds,
             ..
@@ -112,6 +116,7 @@ pub(crate) async fn conversation_sandboxes(
                 image,
                 default_workdir,
                 file_system_mounts,
+                durable_file_systems,
                 enable_networking,
                 idle_seconds,
             });
@@ -135,8 +140,15 @@ pub(crate) fn conversation_sandbox_spec(
             .mounts
             .first()
             .map(|mount| mount.mount_path.clone())
+            .or_else(|| {
+                config
+                    .durable_file_systems
+                    .first()
+                    .map(|file_system| file_system.mount_path.clone())
+            })
             .unwrap_or_else(|| "/".to_string()),
         file_system_mounts: normalize_mounts(&config.mounts),
+        durable_file_systems: config.durable_file_systems.clone(),
         enable_networking: agent_config.enable_networking,
         idle_seconds: 300,
     }

--- a/crates/executor/src/conversation_sandbox.rs
+++ b/crates/executor/src/conversation_sandbox.rs
@@ -71,6 +71,7 @@ pub(crate) async fn create_conversation_sandbox(
             image: spec.image,
             default_workdir: Some(spec.default_workdir),
             file_system_mounts: Some(spec.file_system_mounts),
+            durable_file_systems: None,
             enable_networking: Some(spec.enable_networking),
             idle_seconds: Some(spec.idle_seconds),
         })

--- a/crates/executor/src/executor_types.rs
+++ b/crates/executor/src/executor_types.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use exoharness::{
-    AgentHandle, ConversationHandle, EventId, FileSystemMount, ResponseId, Result, SandboxProvider,
-    SessionId, ToolArguments, ToolCallId, ToolRequest, ToolResult, TurnId,
+    AgentHandle, ConversationHandle, DurableFileSystem, EventId, FileSystemMount, ResponseId,
+    Result, SandboxProvider, SessionId, ToolArguments, ToolCallId, ToolRequest, ToolResult, TurnId,
 };
 use lingua::{Message, UniversalStreamChunk, UniversalUsage};
 use serde::{Deserialize, Serialize};
@@ -68,6 +68,8 @@ pub struct ConversationConfig {
     #[serde(default)]
     pub mounts: Vec<FileSystemMount>,
     #[serde(default)]
+    pub durable_file_systems: Vec<DurableFileSystem>,
+    #[serde(default)]
     pub sandbox_scope: Option<SandboxScope>,
 }
 
@@ -104,6 +106,7 @@ impl Default for ConversationConfig {
             sandbox_provider: None,
             shell_program: Some("/bin/bash".to_string()),
             mounts: Vec::new(),
+            durable_file_systems: Vec::new(),
             sandbox_scope: None,
         }
     }

--- a/crates/executor/src/harness_facade.rs
+++ b/crates/executor/src/harness_facade.rs
@@ -247,6 +247,7 @@ where
                 .shell_program
                 .or(default_conversation_config.shell_program),
             mounts: default_conversation_config.mounts,
+            durable_file_systems: default_conversation_config.durable_file_systems,
             sandbox_scope: default_conversation_config.sandbox_scope,
         };
         self.runtime

--- a/crates/executor/src/harness_tool.rs
+++ b/crates/executor/src/harness_tool.rs
@@ -410,8 +410,15 @@ pub(crate) async fn ensure_shell_sandbox(
         .mounts
         .first()
         .map(|mount| mount.mount_path.clone())
+        .or_else(|| {
+            config
+                .durable_file_systems
+                .first()
+                .map(|file_system| file_system.mount_path.clone())
+        })
         .unwrap_or_else(|| "/".to_string());
     let desired_mounts = normalize_mounts(&config.mounts);
+    let desired_durable_file_systems = config.durable_file_systems.clone();
     let desired_provider = config.effective_sandbox_provider(agent_config);
     // Empty means "unspecified"; the harness fills the provider's default.
     let requested_image = config.effective_sandbox_image(agent_config);
@@ -425,6 +432,7 @@ pub(crate) async fn ensure_shell_sandbox(
         let config_matches = image_matches
             && sandbox.default_workdir == desired_default_workdir
             && sandbox.file_system_mounts == desired_mounts
+            && sandbox.durable_file_systems == desired_durable_file_systems
             && sandbox.enable_networking == desired_enable_networking
             && sandbox.idle_seconds == 300;
 
@@ -453,7 +461,7 @@ pub(crate) async fn ensure_shell_sandbox(
             image: desired_image,
             default_workdir: Some(desired_default_workdir),
             file_system_mounts: Some(desired_mounts),
-            durable_file_systems: None,
+            durable_file_systems: Some(desired_durable_file_systems),
             enable_networking: Some(desired_enable_networking),
             idle_seconds: Some(300),
         })
@@ -481,6 +489,7 @@ struct ShellSandboxInfo {
     image: String,
     default_workdir: String,
     file_system_mounts: Vec<FileSystemMount>,
+    durable_file_systems: Vec<exoharness::DurableFileSystem>,
     enable_networking: bool,
     idle_seconds: u64,
 }
@@ -511,6 +520,7 @@ async fn latest_shell_sandbox(
             image,
             default_workdir,
             file_system_mounts,
+            durable_file_systems,
             enable_networking,
             idle_seconds,
             ..
@@ -523,6 +533,7 @@ async fn latest_shell_sandbox(
                 image,
                 default_workdir,
                 file_system_mounts,
+                durable_file_systems,
                 enable_networking,
                 idle_seconds,
             }))

--- a/crates/executor/src/harness_tool.rs
+++ b/crates/executor/src/harness_tool.rs
@@ -453,6 +453,7 @@ pub(crate) async fn ensure_shell_sandbox(
             image: desired_image,
             default_workdir: Some(desired_default_workdir),
             file_system_mounts: Some(desired_mounts),
+            durable_file_systems: None,
             enable_networking: Some(desired_enable_networking),
             idle_seconds: Some(300),
         })

--- a/crates/executor/src/local_sandbox.rs
+++ b/crates/executor/src/local_sandbox.rs
@@ -443,6 +443,7 @@ impl ConversationHandle for LocalSandboxConversation {
                 image: request.image,
                 default_workdir: request.default_workdir.unwrap_or_default(),
                 file_system_mounts: request.file_system_mounts.unwrap_or_default(),
+                durable_file_systems: request.durable_file_systems.unwrap_or_default(),
                 enable_networking: request.enable_networking.unwrap_or(true),
                 idle_seconds: request.idle_seconds.unwrap_or(60),
             },
@@ -690,6 +691,7 @@ mod tests {
                 image: "local-image".to_string(),
                 default_workdir: Some("/workspace".to_string()),
                 file_system_mounts: Some(Vec::new()),
+                durable_file_systems: None,
                 enable_networking: Some(false),
                 idle_seconds: Some(120),
             })

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -34,17 +34,17 @@ use crate::{
     AddEventsRequest, AddEventsResult, AgentHandle, AgentId, AgentRecord, Artifact,
     ArtifactVersion, BeginTurnRequest, Binding, BindingId, BindingRecord, BindingType,
     BoxAsyncRead, BoxAsyncWrite, CancelSandboxProcessRequest, CloseSandboxProcessInputRequest,
-    ConversationHandle, ConversationId, ConversationRecord, CreateSandboxRequest, Event, EventData,
-    EventId, EventKind, EventQuery, EventQueryDirection, EventStream, ExoHarness, FileSystemMount,
-    ForkConversationRequest, GetEventsResult, GetSandboxProcessEventsResult,
-    ListConversationsRequest, ListConversationsResult, NewAgentRequest, NewConversationRequest,
-    PutSecretRequest, ReadArtifactRequest, Result, RunInSandboxRequest, SandboxId, SandboxProcess,
-    SandboxProcessEvent, SandboxProcessEventQuery, SandboxProcessId, SandboxProcessMode,
-    SandboxProcessParts, SandboxProcessRecord, SandboxProcessStatus, SandboxProcessStdin,
-    SandboxProvider, SandboxProviderConfig, Secret, SecretId, SecretMetadata, SecretType,
-    SessionId, SnapshotId, StartSandboxProcessRequest, StartSandboxRequest, TurnHandle, TurnId,
-    TurnRecord, Uuid7, WaitSandboxProcessRequest, WriteArtifactRequest,
-    WriteSandboxProcessInputRequest,
+    ConversationHandle, ConversationId, ConversationRecord, CreateSandboxRequest,
+    DurableFileSystem, Event, EventData, EventId, EventKind, EventQuery, EventQueryDirection,
+    EventStream, ExoHarness, FileSystemMount, ForkConversationRequest, GetEventsResult,
+    GetSandboxProcessEventsResult, ListConversationsRequest, ListConversationsResult,
+    NewAgentRequest, NewConversationRequest, PutSecretRequest, ReadArtifactRequest, Result,
+    RunInSandboxRequest, SandboxId, SandboxProcess, SandboxProcessEvent, SandboxProcessEventQuery,
+    SandboxProcessId, SandboxProcessMode, SandboxProcessParts, SandboxProcessRecord,
+    SandboxProcessStatus, SandboxProcessStdin, SandboxProvider, SandboxProviderConfig, Secret,
+    SecretId, SecretMetadata, SecretType, SessionId, SnapshotId, StartSandboxProcessRequest,
+    StartSandboxRequest, TurnHandle, TurnId, TurnRecord, Uuid7, WaitSandboxProcessRequest,
+    WriteArtifactRequest, WriteSandboxProcessInputRequest,
 };
 
 #[derive(Debug, Clone)]
@@ -148,6 +148,7 @@ pub struct BasicExoHarness {
 }
 
 struct BasicExoHarnessInner {
+    root: PathBuf,
     storage: BasicObjectStore,
     write_lock: AsyncMutex<()>,
     subscribers: Mutex<HashMap<ConversationId, Vec<mpsc::UnboundedSender<Result<Event>>>>>,
@@ -187,10 +188,14 @@ impl BasicExoHarnessInner {
         choice: &SandboxBackendChoice,
     ) -> Result<Arc<dyn ManagedSandboxBackend>> {
         let backend: Arc<dyn ManagedSandboxBackend> = match choice {
-            SandboxBackendChoice::AppleContainer => {
-                Arc::new(CliContainerSandboxBackend::apple_container())
-            }
-            SandboxBackendChoice::Docker => Arc::new(CliContainerSandboxBackend::docker()),
+            SandboxBackendChoice::AppleContainer => Arc::new(
+                CliContainerSandboxBackend::apple_container()
+                    .with_durable_file_system_root(self.root.join("durable-filesystems")),
+            ),
+            SandboxBackendChoice::Docker => Arc::new(
+                CliContainerSandboxBackend::docker()
+                    .with_durable_file_system_root(self.root.join("durable-filesystems")),
+            ),
             SandboxBackendChoice::LocalProcess => Arc::new(LocalProcessSandboxBackend::new()),
             SandboxBackendChoice::Daytona(spec) => {
                 // Prefer a root `Binding::Sandbox` for Daytona; fall back to the
@@ -537,6 +542,7 @@ impl BasicExoHarness {
             build_secret_cipher(secret_backend, root.to_string_lossy().to_string())?;
         Ok(Self {
             inner: Arc::new(BasicExoHarnessInner {
+                root,
                 storage,
                 write_lock: AsyncMutex::new(()),
                 subscribers: Mutex::new(HashMap::new()),
@@ -1121,6 +1127,7 @@ impl BasicConversationHandle {
             image,
             default_workdir: request.default_workdir,
             file_system_mounts: request.file_system_mounts.unwrap_or_default(),
+            durable_file_systems: request.durable_file_systems.unwrap_or_default(),
             enable_networking: request.enable_networking.unwrap_or(true),
             idle_seconds: request.idle_seconds.unwrap_or(60),
         })
@@ -1153,6 +1160,7 @@ impl BasicConversationHandle {
                 image,
                 default_workdir,
                 file_system_mounts,
+                durable_file_systems,
                 enable_networking,
                 idle_seconds,
                 ..
@@ -1171,6 +1179,7 @@ impl BasicConversationHandle {
                 || image != request.image
                 || default_workdir != request.default_workdir.clone().unwrap_or_default()
                 || file_system_mounts != request.file_system_mounts
+                || durable_file_systems != request.durable_file_systems
                 || enable_networking != request.enable_networking
                 || idle_seconds != request.idle_seconds
             {
@@ -1249,6 +1258,7 @@ impl BasicConversationHandle {
                     image: sandbox.image,
                     default_workdir: sandbox.default_workdir.unwrap_or_default(),
                     file_system_mounts: sandbox.file_system_mounts,
+                    durable_file_systems: sandbox.durable_file_systems,
                     enable_networking: sandbox.enable_networking,
                     idle_seconds: sandbox.idle_seconds,
                 },
@@ -2455,6 +2465,7 @@ struct StoredSandbox {
     image: String,
     default_workdir: Option<String>,
     file_system_mounts: Vec<FileSystemMount>,
+    durable_file_systems: Vec<DurableFileSystem>,
     enable_networking: bool,
     idle_seconds: u64,
     running: bool,
@@ -2468,6 +2479,7 @@ struct PreparedSandboxRequest {
     image: String,
     default_workdir: Option<String>,
     file_system_mounts: Vec<FileSystemMount>,
+    durable_file_systems: Vec<DurableFileSystem>,
     enable_networking: bool,
     idle_seconds: u64,
 }
@@ -2481,6 +2493,7 @@ impl PreparedSandboxRequest {
             image: self.image.clone(),
             default_workdir: self.default_workdir.clone(),
             file_system_mounts: self.file_system_mounts.clone(),
+            durable_file_systems: self.durable_file_systems.clone(),
             enable_networking: self.enable_networking,
             idle_seconds: self.idle_seconds,
             running: true,
@@ -2814,6 +2827,7 @@ fn sandbox_request(
             } else {
                 SandboxNetworkPolicy::Disabled
             },
+            durable_file_systems: sandbox.durable_file_systems.clone(),
             default_workdir: sandbox
                 .default_workdir
                 .clone()

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -426,32 +426,44 @@ impl BasicExoHarnessInner {
     #[cfg(feature = "aws-agentcore")]
     async fn aws_agentcore_config_from_binding(&self) -> Result<Option<crate::AwsAgentCoreConfig>> {
         let bindings = list_binding_records(&self.storage, Path::new("bindings")).await?;
-        let Some((runtime_arn, region, qualifier, endpoint_url)) = bindings
-            .into_iter()
-            .rev()
-            .find_map(|record| match record.binding {
-                Binding::Sandbox {
-                    config:
-                        SandboxProviderConfig::AwsAgentCore {
-                            runtime_arn,
-                            region,
-                            qualifier,
-                            endpoint_url,
-                            ..
-                        },
-                    ..
-                } => Some((runtime_arn, region, qualifier, endpoint_url)),
-                _ => None,
-            })
+        let Some((runtime_arn, region, qualifier, endpoint_url, session_storage_mount_path)) =
+            bindings
+                .into_iter()
+                .rev()
+                .find_map(|record| match record.binding {
+                    Binding::Sandbox {
+                        config:
+                            SandboxProviderConfig::AwsAgentCore {
+                                runtime_arn,
+                                region,
+                                qualifier,
+                                endpoint_url,
+                                session_storage_mount_path,
+                                ..
+                            },
+                        ..
+                    } => Some((
+                        runtime_arn,
+                        region,
+                        qualifier,
+                        endpoint_url,
+                        session_storage_mount_path,
+                    )),
+                    _ => None,
+                })
         else {
             return Ok(None);
         };
+        let session_storage_mount_path = session_storage_mount_path
+            .or_else(|| nonempty_env("AWS_AGENTCORE_SESSION_STORAGE_MOUNT_PATH"))
+            .or_else(|| nonempty_env("AGENTCORE_SESSION_STORAGE_MOUNT_PATH"));
         Ok(Some(crate::AwsAgentCoreConfig {
             runtime_arn,
             region,
             qualifier,
             endpoint_url,
             credentials: aws_agentcore_credentials_from_env(),
+            session_storage_mount_path,
         }))
     }
 
@@ -486,6 +498,14 @@ fn aws_agentcore_credentials_from_env() -> Option<crate::AwsAgentCoreCredentials
         secret_access_key,
         session_token,
     })
+}
+
+#[cfg(feature = "aws-agentcore")]
+fn nonempty_env(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
 }
 
 impl BasicExoHarness {

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -30,7 +30,7 @@ use crate::{
     WriteArtifactRequest, WriteSandboxProcessInputRequest,
 };
 
-const DURABLE_CONTRACT_MOUNT_PATH: &str = "/mnt/exo-durable";
+const DEFAULT_DURABLE_CONTRACT_MOUNT_PATH: &str = "/home/exo/workspace";
 
 #[tokio::test(flavor = "current_thread")]
 async fn basic_backend_supports_agent_and_conversation_crud() {
@@ -192,13 +192,14 @@ async fn docker_sandbox_contract_durable_file_system_survives_stop_and_reacquire
         crate::CliContainerSandboxBackend::docker()
             .with_durable_file_system_root(tempdir.path().join("durable-filesystems")),
     );
+    let mount_path = durable_contract_mount_path();
     crate::contract_tests::sandbox_backend_durable_file_system_survives_stop_and_reacquire(
         backend,
         durable_provider_contract_request(
             "docker",
             "durable-file-system",
             env_or("DOCKER_IMAGE", &crate::default_docker_image()),
-            "/",
+            &mount_path,
         ),
     )
     .await
@@ -213,13 +214,14 @@ async fn apple_container_sandbox_contract_durable_file_system_survives_stop_and_
         crate::CliContainerSandboxBackend::apple_container()
             .with_durable_file_system_root(tempdir.path().join("durable-filesystems")),
     );
+    let mount_path = durable_contract_mount_path();
     crate::contract_tests::sandbox_backend_durable_file_system_survives_stop_and_reacquire(
         backend,
         durable_provider_contract_request(
             "apple-container",
             "durable-file-system",
             env_or("APPLE_CONTAINER_IMAGE", &crate::default_docker_image()),
-            "/",
+            &mount_path,
         ),
     )
     .await
@@ -228,18 +230,19 @@ async fn apple_container_sandbox_contract_durable_file_system_survives_stop_and_
 
 #[cfg(feature = "aws-agentcore")]
 #[tokio::test(flavor = "current_thread")]
-#[ignore = "uses a real AgentCore runtime configured with managed session storage at /mnt/exo-durable; run this test explicitly"]
+#[ignore = "uses a real AgentCore runtime configured with managed session storage at EXO_DURABLE_CONTRACT_MOUNT_PATH or /home/exo/workspace; run this test explicitly"]
 async fn aws_agentcore_sandbox_contract_durable_file_system_survives_stop_and_reacquire() {
     let Some(backend) = aws_agentcore_contract_backend().await else {
         return;
     };
+    let mount_path = durable_contract_mount_path();
     crate::contract_tests::sandbox_backend_durable_file_system_survives_stop_and_reacquire(
         backend,
         durable_provider_contract_request(
             "aws-agentcore",
             "durable-file-system",
             env_or("AGENTCORE_IMAGE", &crate::default_aws_agentcore_image()),
-            "/",
+            &mount_path,
         ),
     )
     .await
@@ -347,9 +350,13 @@ async fn aws_agentcore_contract_backend() -> Option<Arc<dyn ManagedSandboxBacken
         );
         return None;
     };
-    let Some(region) = nonempty_env("AWS_REGION").or_else(|| nonempty_env("AWS_DEFAULT_REGION"))
+    let Some(region) = nonempty_env("AWS_AGENTCORE_REGION")
+        .or_else(|| nonempty_env("AWS_REGION"))
+        .or_else(|| nonempty_env("AWS_DEFAULT_REGION"))
     else {
-        eprintln!("skipping real AgentCore sandbox contract: AWS_REGION is not set");
+        eprintln!(
+            "skipping real AgentCore sandbox contract: AWS_AGENTCORE_REGION or AWS_REGION is not set"
+        );
         return None;
     };
     let credentials = match (
@@ -427,10 +434,17 @@ fn durable_provider_contract_request(
     let mut request = provider_contract_request(provider, contract, image, default_workdir);
     request.spec.durable_file_systems = vec![DurableFileSystem {
         name: "workspace".to_string(),
-        mount_path: DURABLE_CONTRACT_MOUNT_PATH.to_string(),
+        mount_path: durable_contract_mount_path(),
         mode: FileSystemMountMode::ReadWrite,
     }];
     request
+}
+
+fn durable_contract_mount_path() -> String {
+    env_or(
+        "EXO_DURABLE_CONTRACT_MOUNT_PATH",
+        DEFAULT_DURABLE_CONTRACT_MOUNT_PATH,
+    )
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -19,15 +19,18 @@ use tokio::time::{sleep, timeout};
 use crate::test_support::{local_test_config, local_test_config_with_daytona};
 use crate::{
     Artifact, ArtifactVersion, BasicExoHarness, BeginTurnRequest, Binding, BoxAsyncRead,
-    BoxAsyncWrite, CloseSandboxProcessInputRequest, CreateSandboxRequest, EventData, EventKind,
-    EventQuery, EventQueryDirection, ExoHarness, ForkConversationRequest, ManagedSandboxBackend,
-    ManagedSandboxHandle, NewAgentRequest, NewConversationRequest, PutSecretRequest,
-    RunInSandboxRequest, SandboxCommand, SandboxCommandOutput, SandboxKey, SandboxLifecycleConfig,
-    SandboxNetworkPolicy, SandboxProcessEvent, SandboxProcessEventQuery, SandboxProcessParts,
-    SandboxProcessStatus, SandboxProcessStdin, SandboxProvider, SandboxProviderConfig,
-    SandboxRequest, SandboxSpec, Secret, SnapshotPayload, StartSandboxProcessRequest, Uuid7,
-    WaitSandboxProcessRequest, WriteArtifactRequest, WriteSandboxProcessInputRequest,
+    BoxAsyncWrite, CloseSandboxProcessInputRequest, CreateSandboxRequest, DurableFileSystem,
+    EventData, EventKind, EventQuery, EventQueryDirection, ExoHarness, FileSystemMountMode,
+    ForkConversationRequest, ManagedSandboxBackend, ManagedSandboxHandle, NewAgentRequest,
+    NewConversationRequest, PutSecretRequest, RunInSandboxRequest, SandboxCommand,
+    SandboxCommandOutput, SandboxKey, SandboxLifecycleConfig, SandboxNetworkPolicy,
+    SandboxProcessEvent, SandboxProcessEventQuery, SandboxProcessParts, SandboxProcessStatus,
+    SandboxProcessStdin, SandboxProvider, SandboxProviderConfig, SandboxRequest, SandboxSpec,
+    Secret, SnapshotPayload, StartSandboxProcessRequest, Uuid7, WaitSandboxProcessRequest,
+    WriteArtifactRequest, WriteSandboxProcessInputRequest,
 };
+
+const DURABLE_CONTRACT_MOUNT_PATH: &str = "/mnt/exo-durable";
 
 #[tokio::test(flavor = "current_thread")]
 async fn basic_backend_supports_agent_and_conversation_crud() {
@@ -108,6 +111,32 @@ async fn local_process_sandbox_contract_start_process_long_running_protocol() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn local_process_sandbox_rejects_durable_file_systems() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let backend: Arc<dyn ManagedSandboxBackend> =
+        Arc::new(crate::LocalProcessSandboxBackend::new());
+    let result = backend
+        .acquire(durable_provider_contract_request(
+            "local-process",
+            "durable-file-system",
+            "local-process".to_string(),
+            &tempdir.path().display().to_string(),
+        ))
+        .await;
+    match result {
+        Ok(handle) => panic!(
+            "local-process unexpectedly acquired durable filesystem sandbox {}",
+            handle.id()
+        ),
+        Err(error) => assert!(
+            error
+                .to_string()
+                .contains("does not support durable file systems")
+        ),
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
 #[ignore = "uses a real Daytona sandbox; source sandbox-vars.sh and run this test explicitly"]
 async fn daytona_sandbox_contract_start_process_stdio_and_env() {
     let Some(handle) = daytona_contract_handle("stdio-and-env").await else {
@@ -155,6 +184,68 @@ async fn vercel_sandbox_contract_start_process_long_running_protocol() {
     .expect("Vercel sandbox long-running protocol contract");
 }
 
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "uses a real Docker sandbox; run this test explicitly"]
+async fn docker_sandbox_contract_durable_file_system_survives_stop_and_reacquire() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let backend: Arc<dyn ManagedSandboxBackend> = Arc::new(
+        crate::CliContainerSandboxBackend::docker()
+            .with_durable_file_system_root(tempdir.path().join("durable-filesystems")),
+    );
+    crate::contract_tests::sandbox_backend_durable_file_system_survives_stop_and_reacquire(
+        backend,
+        durable_provider_contract_request(
+            "docker",
+            "durable-file-system",
+            env_or("DOCKER_IMAGE", &crate::default_docker_image()),
+            "/",
+        ),
+    )
+    .await
+    .expect("Docker sandbox durable filesystem contract");
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "uses a real Apple container sandbox; run this test explicitly"]
+async fn apple_container_sandbox_contract_durable_file_system_survives_stop_and_reacquire() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let backend: Arc<dyn ManagedSandboxBackend> = Arc::new(
+        crate::CliContainerSandboxBackend::apple_container()
+            .with_durable_file_system_root(tempdir.path().join("durable-filesystems")),
+    );
+    crate::contract_tests::sandbox_backend_durable_file_system_survives_stop_and_reacquire(
+        backend,
+        durable_provider_contract_request(
+            "apple-container",
+            "durable-file-system",
+            env_or("APPLE_CONTAINER_IMAGE", &crate::default_docker_image()),
+            "/",
+        ),
+    )
+    .await
+    .expect("Apple container sandbox durable filesystem contract");
+}
+
+#[cfg(feature = "aws-agentcore")]
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "uses a real AgentCore runtime configured with managed session storage at /mnt/exo-durable; run this test explicitly"]
+async fn aws_agentcore_sandbox_contract_durable_file_system_survives_stop_and_reacquire() {
+    let Some(backend) = aws_agentcore_contract_backend().await else {
+        return;
+    };
+    crate::contract_tests::sandbox_backend_durable_file_system_survives_stop_and_reacquire(
+        backend,
+        durable_provider_contract_request(
+            "aws-agentcore",
+            "durable-file-system",
+            env_or("AGENTCORE_IMAGE", &crate::default_aws_agentcore_image()),
+            "/",
+        ),
+    )
+    .await
+    .expect("AgentCore sandbox durable filesystem contract");
+}
+
 async fn local_process_contract_handle(
     tempdir: &TempDir,
     sandbox_id: &str,
@@ -170,6 +261,7 @@ async fn local_process_contract_handle(
             spec: SandboxSpec {
                 image: "local-process".to_string(),
                 mounts: Vec::new(),
+                durable_file_systems: Vec::new(),
                 network: SandboxNetworkPolicy::Enabled,
                 default_workdir: tempdir.path().display().to_string(),
             },
@@ -245,6 +337,52 @@ async fn vercel_contract_handle(contract: &str) -> Option<Arc<dyn ManagedSandbox
     )
 }
 
+#[cfg(feature = "aws-agentcore")]
+async fn aws_agentcore_contract_backend() -> Option<Arc<dyn ManagedSandboxBackend>> {
+    let Some(runtime_arn) =
+        nonempty_env("AGENTCORE_RUNTIME_ARN").or_else(|| nonempty_env("AWS_AGENTCORE_RUNTIME_ARN"))
+    else {
+        eprintln!(
+            "skipping real AgentCore sandbox contract: AGENTCORE_RUNTIME_ARN or AWS_AGENTCORE_RUNTIME_ARN is not set"
+        );
+        return None;
+    };
+    let Some(region) = nonempty_env("AWS_REGION").or_else(|| nonempty_env("AWS_DEFAULT_REGION"))
+    else {
+        eprintln!("skipping real AgentCore sandbox contract: AWS_REGION is not set");
+        return None;
+    };
+    let credentials = match (
+        nonempty_env("AWS_ACCESS_KEY_ID"),
+        nonempty_env("AWS_SECRET_ACCESS_KEY"),
+    ) {
+        (Some(access_key_id), Some(secret_access_key)) => Some(crate::AwsAgentCoreCredentials {
+            access_key_id,
+            secret_access_key,
+            session_token: nonempty_env("AWS_SESSION_TOKEN"),
+        }),
+        (None, None) => None,
+        _ => {
+            eprintln!(
+                "skipping real AgentCore sandbox contract: set both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, or neither"
+            );
+            return None;
+        }
+    };
+    let backend = crate::AwsAgentCoreSandboxBackend::new(crate::AwsAgentCoreConfig {
+        runtime_arn,
+        region,
+        qualifier: nonempty_env("AGENTCORE_QUALIFIER")
+            .or_else(|| nonempty_env("AWS_AGENTCORE_QUALIFIER")),
+        endpoint_url: nonempty_env("AGENTCORE_ENDPOINT_URL")
+            .or_else(|| nonempty_env("AWS_AGENTCORE_ENDPOINT_URL")),
+        credentials,
+    })
+    .await
+    .expect("AwsAgentCoreSandboxBackend::new");
+    Some(Arc::new(backend))
+}
+
 fn nonempty_env(name: &str) -> Option<String> {
     env::var(name)
         .ok()
@@ -270,6 +408,7 @@ fn provider_contract_request(
         spec: SandboxSpec {
             image,
             mounts: Vec::new(),
+            durable_file_systems: Vec::new(),
             network: SandboxNetworkPolicy::Enabled,
             default_workdir: default_workdir.to_string(),
         },
@@ -277,6 +416,21 @@ fn provider_contract_request(
             idle_ttl: Some(Duration::from_secs(300)),
         },
     }
+}
+
+fn durable_provider_contract_request(
+    provider: &str,
+    contract: &str,
+    image: String,
+    default_workdir: &str,
+) -> SandboxRequest {
+    let mut request = provider_contract_request(provider, contract, image, default_workdir);
+    request.spec.durable_file_systems = vec![DurableFileSystem {
+        name: "workspace".to_string(),
+        mount_path: DURABLE_CONTRACT_MOUNT_PATH.to_string(),
+        mode: FileSystemMountMode::ReadWrite,
+    }];
+    request
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -722,6 +876,7 @@ async fn basic_backend_runs_commands_in_created_sandbox() {
             image: "basic-local-process".to_string(),
             default_workdir: Some(tempdir.path().display().to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })
@@ -781,6 +936,7 @@ async fn basic_backend_reuses_named_sandbox() {
         image: "basic-local-process".to_string(),
         default_workdir: Some(tempdir.path().display().to_string()),
         file_system_mounts: None,
+        durable_file_systems: None,
         enable_networking: Some(true),
         idle_seconds: Some(60),
     };
@@ -831,6 +987,7 @@ async fn basic_backend_reattaches_running_sandbox_in_new_harness_process() {
             image: "basic-local-process".to_string(),
             default_workdir: Some(tempdir.path().display().to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })
@@ -909,6 +1066,7 @@ async fn basic_backend_exposes_process_events_and_input() {
             image: "basic-local-process".to_string(),
             default_workdir: Some(tempdir.path().display().to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })
@@ -1033,6 +1191,7 @@ async fn basic_backend_records_process_name_metadata() {
             image: "basic-local-process".to_string(),
             default_workdir: Some(tempdir.path().display().to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })
@@ -1239,6 +1398,7 @@ async fn test_sandbox(conversation: &Arc<dyn crate::ConversationHandle>) -> Stri
             image: "test-sandbox".to_string(),
             default_workdir: Some("/".to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })
@@ -1285,6 +1445,7 @@ async fn basic_backend_rejects_daytona_provider() {
             image: "test-sandbox".to_string(),
             default_workdir: Some("/".to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })
@@ -1323,6 +1484,7 @@ async fn advertised_daytona_without_secret_errors_at_first_use() {
             image: "test-sandbox".to_string(),
             default_workdir: Some("/".to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -31,6 +31,8 @@ use crate::{
 };
 
 const DEFAULT_DURABLE_CONTRACT_MOUNT_PATH: &str = "/home/exo/workspace";
+#[cfg(feature = "aws-agentcore")]
+const DEFAULT_AGENTCORE_DURABLE_CONTRACT_MOUNT_PATH: &str = "/mnt/workspace";
 
 #[tokio::test(flavor = "current_thread")]
 async fn basic_backend_supports_agent_and_conversation_crud() {
@@ -230,12 +232,12 @@ async fn apple_container_sandbox_contract_durable_file_system_survives_stop_and_
 
 #[cfg(feature = "aws-agentcore")]
 #[tokio::test(flavor = "current_thread")]
-#[ignore = "uses a real AgentCore runtime configured with managed session storage at EXO_DURABLE_CONTRACT_MOUNT_PATH or /home/exo/workspace; run this test explicitly"]
+#[ignore = "uses a real AgentCore runtime configured with managed session storage at EXO_AGENTCORE_DURABLE_CONTRACT_MOUNT_PATH or /mnt/workspace; run this test explicitly"]
 async fn aws_agentcore_sandbox_contract_durable_file_system_survives_stop_and_reacquire() {
     let Some(backend) = aws_agentcore_contract_backend().await else {
         return;
     };
-    let mount_path = durable_contract_mount_path();
+    let mount_path = agentcore_durable_contract_mount_path();
     crate::contract_tests::sandbox_backend_durable_file_system_survives_stop_and_reacquire(
         backend,
         durable_provider_contract_request(
@@ -384,6 +386,7 @@ async fn aws_agentcore_contract_backend() -> Option<Arc<dyn ManagedSandboxBacken
         endpoint_url: nonempty_env("AGENTCORE_ENDPOINT_URL")
             .or_else(|| nonempty_env("AWS_AGENTCORE_ENDPOINT_URL")),
         credentials,
+        session_storage_mount_path: Some(agentcore_durable_contract_mount_path()),
     })
     .await
     .expect("AwsAgentCoreSandboxBackend::new");
@@ -429,12 +432,12 @@ fn durable_provider_contract_request(
     provider: &str,
     contract: &str,
     image: String,
-    default_workdir: &str,
+    mount_path: &str,
 ) -> SandboxRequest {
-    let mut request = provider_contract_request(provider, contract, image, default_workdir);
+    let mut request = provider_contract_request(provider, contract, image, mount_path);
     request.spec.durable_file_systems = vec![DurableFileSystem {
         name: "workspace".to_string(),
-        mount_path: durable_contract_mount_path(),
+        mount_path: mount_path.to_string(),
         mode: FileSystemMountMode::ReadWrite,
     }];
     request
@@ -445,6 +448,14 @@ fn durable_contract_mount_path() -> String {
         "EXO_DURABLE_CONTRACT_MOUNT_PATH",
         DEFAULT_DURABLE_CONTRACT_MOUNT_PATH,
     )
+}
+
+#[cfg(feature = "aws-agentcore")]
+fn agentcore_durable_contract_mount_path() -> String {
+    nonempty_env("EXO_AGENTCORE_DURABLE_CONTRACT_MOUNT_PATH")
+        .or_else(|| nonempty_env("AWS_AGENTCORE_SESSION_STORAGE_MOUNT_PATH"))
+        .or_else(|| nonempty_env("AGENTCORE_SESSION_STORAGE_MOUNT_PATH"))
+        .unwrap_or_else(|| DEFAULT_AGENTCORE_DURABLE_CONTRACT_MOUNT_PATH.to_string())
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/exoharness/src/contract_tests.rs
+++ b/crates/exoharness/src/contract_tests.rs
@@ -10,8 +10,8 @@ use tokio::time::timeout;
 use crate::{
     AddEventsRequest, BeginTurnRequest, Binding, EventData, EventKind, EventQuery,
     EventQueryDirection, ExoHarness, ForkConversationRequest, ListConversationsRequest,
-    ManagedSandboxHandle, NewAgentRequest, NewConversationRequest, SandboxCommand, Uuid7,
-    WriteArtifactRequest,
+    ManagedSandboxBackend, ManagedSandboxHandle, NewAgentRequest, NewConversationRequest,
+    SandboxCommand, SandboxRequest, Uuid7, WriteArtifactRequest,
 };
 
 pub async fn supports_agent_and_conversation_crud(harness: Arc<dyn ExoHarness>) {
@@ -388,6 +388,44 @@ pub async fn sandbox_handle_start_process_supports_long_running_request_response
     }
 }
 
+pub async fn sandbox_backend_durable_file_system_survives_stop_and_reacquire(
+    backend: Arc<dyn ManagedSandboxBackend>,
+    request: SandboxRequest,
+) -> crate::Result<()> {
+    let mount_path = request
+        .spec
+        .durable_file_systems
+        .first()
+        .context("durable filesystem contract requires a durable filesystem")?
+        .mount_path
+        .clone();
+    let marker = format!("durable-{}", Uuid7::now());
+
+    let first = backend
+        .acquire(request.clone())
+        .await
+        .context("acquire sandbox for durable filesystem write")?;
+    let write_result = write_durable_marker(Arc::clone(&first), &mount_path, &marker).await;
+    stop_after_contract(
+        first,
+        write_result,
+        "stop sandbox after durable filesystem write",
+    )
+    .await?;
+
+    let second = backend
+        .acquire(request)
+        .await
+        .context("reacquire sandbox for durable filesystem read")?;
+    let read_result = read_durable_marker(Arc::clone(&second), &mount_path, &marker).await;
+    stop_after_contract(
+        second,
+        read_result,
+        "stop sandbox after durable filesystem read",
+    )
+    .await
+}
+
 async fn sandbox_handle_start_process_supports_interactive_stdio_and_env_inner(
     handle: Arc<dyn ManagedSandboxHandle>,
 ) -> crate::Result<()> {
@@ -467,6 +505,95 @@ async fn sandbox_handle_start_process_supports_interactive_stdio_and_env_inner(
         bail!("unexpected stderr: {stderr:?}");
     }
     Ok(())
+}
+
+async fn write_durable_marker(
+    handle: Arc<dyn ManagedSandboxHandle>,
+    mount_path: &str,
+    marker: &str,
+) -> crate::Result<()> {
+    let mut env = std::collections::HashMap::new();
+    env.insert("EXO_DURABLE_MOUNT".to_string(), mount_path.to_string());
+    env.insert("EXO_DURABLE_MARKER".to_string(), marker.to_string());
+    let output = handle
+        .exec(&SandboxCommand {
+            argv: vec![
+                "/bin/sh".to_string(),
+                "-lc".to_string(),
+                "mkdir -p \"$EXO_DURABLE_MOUNT\" && printf '%s' \"$EXO_DURABLE_MARKER\" > \"$EXO_DURABLE_MOUNT/marker.txt\""
+                    .to_string(),
+            ],
+            env,
+            display_argv: None,
+            cwd: None,
+            timeout: Some(Duration::from_secs(30)),
+        })
+        .await
+        .context("write durable filesystem marker")?;
+    if !output.ok {
+        bail!(
+            "write durable filesystem marker failed with exit code {:?}: {}{}",
+            output.exit_code,
+            output.stdout,
+            output.stderr
+        );
+    }
+    Ok(())
+}
+
+async fn read_durable_marker(
+    handle: Arc<dyn ManagedSandboxHandle>,
+    mount_path: &str,
+    expected_marker: &str,
+) -> crate::Result<()> {
+    let mut env = std::collections::HashMap::new();
+    env.insert("EXO_DURABLE_MOUNT".to_string(), mount_path.to_string());
+    let output = handle
+        .exec(&SandboxCommand {
+            argv: vec![
+                "/bin/sh".to_string(),
+                "-lc".to_string(),
+                "cat \"$EXO_DURABLE_MOUNT/marker.txt\"".to_string(),
+            ],
+            env,
+            display_argv: None,
+            cwd: None,
+            timeout: Some(Duration::from_secs(30)),
+        })
+        .await
+        .context("read durable filesystem marker")?;
+    if !output.ok {
+        bail!(
+            "read durable filesystem marker failed with exit code {:?}: {}{}",
+            output.exit_code,
+            output.stdout,
+            output.stderr
+        );
+    }
+    if output.stdout != expected_marker {
+        bail!(
+            "durable filesystem marker mismatch: expected {:?}, got {:?}",
+            expected_marker,
+            output.stdout
+        );
+    }
+    Ok(())
+}
+
+async fn stop_after_contract(
+    handle: Arc<dyn ManagedSandboxHandle>,
+    result: crate::Result<()>,
+    context: &str,
+) -> crate::Result<()> {
+    let stop_result = handle.stop().await.with_context(|| context.to_string());
+    match (result, stop_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) => Err(error),
+        (Ok(()), Err(error)) => Err(error),
+        (Err(error), Err(stop_error)) => Err(anyhow!(
+            "{error:#}; also failed to stop sandbox after contract: {stop_error:#}"
+        )),
+    }
 }
 
 async fn sandbox_handle_start_process_supports_long_running_request_response_protocol_inner(

--- a/crates/exoharness/src/contract_tests.rs
+++ b/crates/exoharness/src/contract_tests.rs
@@ -520,7 +520,7 @@ async fn write_durable_marker(
             argv: vec![
                 "/bin/sh".to_string(),
                 "-lc".to_string(),
-                "mkdir -p \"$EXO_DURABLE_MOUNT\" && printf '%s' \"$EXO_DURABLE_MARKER\" > \"$EXO_DURABLE_MOUNT/marker.txt\""
+                "test \"$(pwd)\" = \"$EXO_DURABLE_MOUNT\" && mkdir -p .codex-smoke && printf '%s' \"$EXO_DURABLE_MARKER\" > .codex-smoke/marker.txt"
                     .to_string(),
             ],
             env,
@@ -553,7 +553,8 @@ async fn read_durable_marker(
             argv: vec![
                 "/bin/sh".to_string(),
                 "-lc".to_string(),
-                "cat \"$EXO_DURABLE_MOUNT/marker.txt\"".to_string(),
+                "test \"$(pwd)\" = \"$EXO_DURABLE_MOUNT\" && cat .codex-smoke/marker.txt"
+                    .to_string(),
             ],
             env,
             display_argv: None,

--- a/crates/exoharness/src/http_tests.rs
+++ b/crates/exoharness/src/http_tests.rs
@@ -111,6 +111,7 @@ async fn http_exoharness_runs_noninteractive_sandbox_commands() {
             image: "local".to_string(),
             default_workdir: Some("/".to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })
@@ -158,6 +159,7 @@ async fn http_exoharness_supports_sandbox_process_events() {
             image: "local".to_string(),
             default_workdir: Some("/".to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -18,6 +18,8 @@ use tokio::time;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use uuid::Uuid;
 
+use crate::DurableFileSystem;
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SandboxKey {
     ConversationSandbox {
@@ -66,6 +68,7 @@ pub enum SandboxNetworkPolicy {
 pub struct SandboxSpec {
     pub image: String,
     pub mounts: Vec<SandboxMount>,
+    pub durable_file_systems: Vec<DurableFileSystem>,
     pub network: SandboxNetworkPolicy,
     pub default_workdir: String,
 }
@@ -183,6 +186,7 @@ pub(crate) const WARM_SANDBOX_KEY_LABEL: &str = "exo.sandbox.key";
 pub(crate) const WARM_SANDBOX_SPEC_HASH_LABEL: &str = "exo.sandbox.spec-hash";
 const WARM_SANDBOX_OWNER_PID_LABEL: &str = "exo.sandbox.owner-pid";
 const APPLE_ABSOLUTE_TIME_UNIX_OFFSET_SECONDS: f64 = 978_307_200.0;
+const DURABLE_FILE_SYSTEM_ROOT_ENV: &str = "EXO_DURABLE_FILE_SYSTEM_ROOT";
 
 #[derive(Debug, Clone)]
 struct WarmSandboxEntry {
@@ -211,6 +215,7 @@ struct ContainerListConfiguration {
 pub struct CliContainerSandboxBackend {
     cli: ContainerCliFlavor,
     container_bin: PathBuf,
+    durable_file_system_root: Option<PathBuf>,
     system_started: Mutex<bool>,
     network_created: Mutex<bool>,
     warm_sandboxes: Arc<Mutex<HashMap<SandboxKey, WarmSandboxEntry>>>,
@@ -225,10 +230,16 @@ impl CliContainerSandboxBackend {
         Self::new(ContainerCliFlavor::Docker)
     }
 
+    pub fn with_durable_file_system_root(mut self, root: impl Into<PathBuf>) -> Self {
+        self.durable_file_system_root = Some(root.into());
+        self
+    }
+
     fn new(cli: ContainerCliFlavor) -> Self {
         Self {
             cli,
             container_bin: PathBuf::from(cli.default_binary()),
+            durable_file_system_root: None,
             system_started: Mutex::new(false),
             network_created: Mutex::new(false),
             warm_sandboxes: Arc::new(Mutex::new(HashMap::new())),
@@ -292,12 +303,16 @@ impl CliContainerSandboxBackend {
     }
 
     async fn prepare_request(&self, request: SandboxRequest) -> Result<SandboxRequest> {
+        validate_durable_file_system_mounts(
+            &request.spec.mounts,
+            &request.spec.durable_file_systems,
+        )?;
         self.ensure_system_started().await?;
         if matches!(request.spec.network, SandboxNetworkPolicy::Enabled) {
             self.ensure_default_network_created().await?;
         }
 
-        let mounts = request
+        let mut mounts = request
             .spec
             .mounts
             .into_iter()
@@ -312,6 +327,11 @@ impl CliContainerSandboxBackend {
                 Ok(SandboxMount { host_path, ..mount })
             })
             .collect::<Result<Vec<_>>>()?;
+        mounts.extend(materialize_durable_file_systems(
+            &request.key,
+            &request.spec.durable_file_systems,
+            self.durable_file_system_root.as_deref(),
+        )?);
 
         Ok(SandboxRequest {
             key: request.key,
@@ -322,6 +342,7 @@ impl CliContainerSandboxBackend {
                     request.spec.image
                 },
                 mounts,
+                durable_file_systems: request.spec.durable_file_systems,
                 network: request.spec.network,
                 default_workdir: request.spec.default_workdir,
             },
@@ -632,6 +653,9 @@ impl LocalProcessSandboxBackend {
 #[async_trait]
 impl ManagedSandboxBackend for LocalProcessSandboxBackend {
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
+        if !request.spec.durable_file_systems.is_empty() {
+            bail!("local-process sandbox backend does not support durable file systems");
+        }
         Ok(Arc::new(LocalProcessSandboxHandle {
             id: format!("local:{}", request.key),
             request,
@@ -721,6 +745,139 @@ fn resolve_local_workdir(spec: &SandboxSpec, cwd: &str) -> Option<PathBuf> {
         .iter()
         .find(|mount| mount.guest_path == cwd)
         .map(|mount| mount.host_path.clone())
+}
+
+fn materialize_durable_file_systems(
+    key: &SandboxKey,
+    file_systems: &[DurableFileSystem],
+    configured_root: Option<&Path>,
+) -> Result<Vec<SandboxMount>> {
+    if file_systems.is_empty() {
+        return Ok(Vec::new());
+    }
+    let root = durable_file_system_root(configured_root)?;
+    file_systems
+        .iter()
+        .map(|file_system| {
+            let host_path = root.join(stable_fnv1a_hex(&format!("{}\n{}", key, file_system.name)));
+            std::fs::create_dir_all(&host_path).with_context(|| {
+                format!(
+                    "creating durable file system {} at {}",
+                    file_system.name,
+                    host_path.display()
+                )
+            })?;
+            let host_path = std::fs::canonicalize(&host_path).with_context(|| {
+                format!(
+                    "canonicalizing durable file system {} at {}",
+                    file_system.name,
+                    host_path.display()
+                )
+            })?;
+            Ok(SandboxMount {
+                host_path,
+                guest_path: file_system.mount_path.clone(),
+                access: match file_system.mode {
+                    crate::FileSystemMountMode::ReadOnly => SandboxMountAccess::ReadOnly,
+                    crate::FileSystemMountMode::ReadWrite => SandboxMountAccess::ReadWrite,
+                },
+                internal: true,
+            })
+        })
+        .collect()
+}
+
+fn validate_durable_file_system_mounts(
+    mounts: &[SandboxMount],
+    file_systems: &[DurableFileSystem],
+) -> Result<()> {
+    validate_durable_file_systems(file_systems)?;
+    for mount in mounts {
+        for file_system in file_systems {
+            if mount.guest_path == file_system.mount_path {
+                bail!(
+                    "sandbox mount path is used by both a host mount and durable file system: {}",
+                    file_system.mount_path
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_durable_file_systems(file_systems: &[DurableFileSystem]) -> Result<()> {
+    for (index, file_system) in file_systems.iter().enumerate() {
+        if file_system.name.trim().is_empty() {
+            bail!("durable file system name must not be empty");
+        }
+        if file_system.name.contains('/') || file_system.name.contains('\0') {
+            bail!(
+                "durable file system name must not contain path separators or NUL bytes: {}",
+                file_system.name
+            );
+        }
+        if !file_system.mount_path.starts_with('/') {
+            bail!(
+                "durable file system mount path must be absolute: {}",
+                file_system.mount_path
+            );
+        }
+        if file_system.mount_path.trim() == "/" {
+            bail!("durable file system mount path must not be /");
+        }
+        for prior in &file_systems[..index] {
+            if prior.name == file_system.name {
+                bail!("duplicate durable file system name: {}", file_system.name);
+            }
+            if prior.mount_path == file_system.mount_path {
+                bail!(
+                    "duplicate durable file system mount path: {}",
+                    file_system.mount_path
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn durable_file_system_root(configured_root: Option<&Path>) -> Result<PathBuf> {
+    if let Some(value) = std::env::var_os(DURABLE_FILE_SYSTEM_ROOT_ENV) {
+        let path = PathBuf::from(value);
+        if !path.as_os_str().is_empty() {
+            return Ok(path);
+        }
+    }
+    if let Some(root) = configured_root {
+        return Ok(root.to_path_buf());
+    }
+    if let Some(value) = std::env::var_os("XDG_DATA_HOME") {
+        let path = PathBuf::from(value);
+        if !path.as_os_str().is_empty() {
+            return Ok(path.join("exo").join("durable-filesystems"));
+        }
+    }
+    if let Some(value) = std::env::var_os("HOME") {
+        let path = PathBuf::from(value);
+        if !path.as_os_str().is_empty() {
+            return Ok(path
+                .join(".local")
+                .join("share")
+                .join("exo")
+                .join("durable-filesystems"));
+        }
+    }
+    bail!(
+        "could not determine durable file system root: set {DURABLE_FILE_SYSTEM_ROOT_ENV}, XDG_DATA_HOME, or HOME"
+    )
+}
+
+pub(crate) fn stable_fnv1a_hex(input: &str) -> String {
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in input.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{hash:016x}")
 }
 
 async fn touch_warm_sandbox(
@@ -1710,6 +1867,7 @@ mod tests {
             spec: SandboxSpec {
                 image: "docker.io/library/ubuntu:24.04".to_string(),
                 mounts: Vec::new(),
+                durable_file_systems: Vec::new(),
                 network: SandboxNetworkPolicy::Disabled,
                 default_workdir: "/".to_string(),
             },
@@ -1750,6 +1908,7 @@ mod tests {
         let backend = CliContainerSandboxBackend {
             cli: ContainerCliFlavor::AppleContainer,
             container_bin: missing_bin,
+            durable_file_system_root: None,
             system_started: Mutex::new(false),
             network_created: Mutex::new(false),
             warm_sandboxes: Arc::new(Mutex::new(HashMap::new())),

--- a/crates/exoharness/src/sandbox_provider/aws_agentcore.rs
+++ b/crates/exoharness/src/sandbox_provider/aws_agentcore.rs
@@ -26,6 +26,7 @@ pub struct AwsAgentCoreConfig {
     pub qualifier: Option<String>,
     pub endpoint_url: Option<String>,
     pub credentials: Option<AwsAgentCoreCredentials>,
+    pub session_storage_mount_path: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -40,6 +41,7 @@ pub struct AwsAgentCoreSandboxBackend {
     runtime_arn: String,
     invoke_target: AwsAgentCoreInvokeTarget,
     qualifier: Option<String>,
+    session_storage_mount_path: Option<String>,
 }
 
 impl AwsAgentCoreSandboxBackend {
@@ -72,11 +74,17 @@ impl AwsAgentCoreSandboxBackend {
         }
         let service_config = service_config_builder.build();
         let invoke_target = agentcore_invoke_target(&config.runtime_arn)?;
+        let session_storage_mount_path = config
+            .session_storage_mount_path
+            .as_deref()
+            .map(normalize_agentcore_session_storage_mount_path)
+            .transpose()?;
         Ok(Self {
             client: Client::from_conf(service_config),
             runtime_arn: config.runtime_arn,
             invoke_target,
             qualifier: config.qualifier,
+            session_storage_mount_path,
         })
     }
 }
@@ -84,7 +92,7 @@ impl AwsAgentCoreSandboxBackend {
 #[async_trait]
 impl ManagedSandboxBackend for AwsAgentCoreSandboxBackend {
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
-        reject_unsupported_request(&request)?;
+        reject_unsupported_request(&request, self.session_storage_mount_path.as_deref())?;
         let spec_hash = sandbox_spec_hash(&request.spec);
         let runtime_session_id = agentcore_runtime_session_id(&request, &spec_hash);
         Ok(Arc::new(AwsAgentCoreSandboxHandle {
@@ -342,25 +350,73 @@ fn agentcore_invoke_target(runtime_arn: &str) -> Result<AwsAgentCoreInvokeTarget
     }
 }
 
-fn reject_unsupported_request(request: &SandboxRequest) -> Result<()> {
+fn reject_unsupported_request(
+    request: &SandboxRequest,
+    session_storage_mount_path: Option<&str>,
+) -> Result<()> {
     if !request.spec.mounts.is_empty() {
         bail!(
             "AgentCore sandbox backend does not support host bind-mounts; remove conversation mounts or use a local sandbox provider"
         );
     }
     validate_durable_file_systems(&request.spec.durable_file_systems)?;
-    if request
-        .spec
-        .durable_file_systems
-        .iter()
-        .any(|file_system| matches!(file_system.mode, crate::FileSystemMountMode::ReadOnly))
-    {
-        bail!("AgentCore sandbox backend does not support read-only durable file systems");
+    match request.spec.durable_file_systems.as_slice() {
+        [] => {}
+        [file_system] => {
+            if matches!(file_system.mode, crate::FileSystemMountMode::ReadOnly) {
+                bail!("AgentCore sandbox backend does not support read-only durable file systems");
+            }
+            let requested_mount_path =
+                normalize_agentcore_session_storage_mount_path(&file_system.mount_path)?;
+            // AgentCore managed session storage is provisioned on the runtime by
+            // create/update-agent-runtime, not on InvokeAgentRuntime. Exo stores
+            // the mount path it expects here so a durable FS request fails before
+            // we run work against a runtime that was built without matching
+            // filesystemConfigurations.
+            let Some(configured_mount_path) = session_storage_mount_path else {
+                bail!(
+                    "AgentCore sandbox backend was not configured with a managed session storage mount path; configure the runtime with filesystemConfigurations and set session_storage_mount_path"
+                );
+            };
+            if requested_mount_path != configured_mount_path {
+                bail!(
+                    "AgentCore sandbox durable file system mount path {requested_mount_path:?} does not match configured managed session storage mount path {configured_mount_path:?}"
+                );
+            }
+        }
+        _ => {
+            bail!("AgentCore sandbox backend supports at most one durable file system");
+        }
     }
     if matches!(request.spec.network, SandboxNetworkPolicy::Disabled) {
         bail!("AgentCore sandbox backend cannot enforce disabled networking");
     }
     Ok(())
+}
+
+fn normalize_agentcore_session_storage_mount_path(path: &str) -> Result<String> {
+    let trimmed = path.trim();
+    if !(6..=200).contains(&trimmed.len()) {
+        bail!("AgentCore session storage mount path must be between 6 and 200 characters: {path}");
+    }
+    let Some(suffix) = trimmed.strip_prefix("/mnt/") else {
+        bail!("AgentCore session storage mount path must be under /mnt/: {path}");
+    };
+    let suffix = suffix.trim_end_matches('/');
+    if suffix.is_empty() || suffix.contains('/') {
+        bail!(
+            "AgentCore session storage mount path must have exactly one subdirectory under /mnt/: {path}"
+        );
+    }
+    if !suffix
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+    {
+        bail!(
+            "AgentCore session storage mount path may only contain letters, numbers, '.', '_', and '-' after /mnt/: {path}"
+        );
+    }
+    Ok(format!("/mnt/{suffix}"))
 }
 
 fn agentcore_runtime_session_id(request: &SandboxRequest, spec_hash: &str) -> String {
@@ -428,4 +484,71 @@ struct AgentCoreExecResponse {
     cwd: Option<String>,
     #[serde(default)]
     error: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        DurableFileSystem, FileSystemMountMode, SandboxKey, SandboxLifecycleConfig,
+        SandboxNetworkPolicy, SandboxSpec,
+    };
+
+    #[test]
+    fn durable_file_system_requires_configured_session_storage_mount_path() {
+        let request = durable_request("/mnt/workspace", FileSystemMountMode::ReadWrite);
+        let error = reject_unsupported_request(&request, None).expect_err("missing mount path");
+        assert!(
+            error
+                .to_string()
+                .contains("was not configured with a managed session storage mount path")
+        );
+    }
+
+    #[test]
+    fn durable_file_system_must_match_configured_session_storage_mount_path() {
+        let request = durable_request("/mnt/workspace", FileSystemMountMode::ReadWrite);
+        let error =
+            reject_unsupported_request(&request, Some("/mnt/other")).expect_err("mount mismatch");
+        assert!(
+            error
+                .to_string()
+                .contains("does not match configured managed session storage mount path")
+        );
+    }
+
+    #[test]
+    fn durable_file_system_accepts_matching_session_storage_mount_path() {
+        let request = durable_request("/mnt/workspace", FileSystemMountMode::ReadWrite);
+        reject_unsupported_request(&request, Some("/mnt/workspace")).expect("matching mount path");
+    }
+
+    #[test]
+    fn durable_file_system_rejects_non_agentcore_mount_path_shape() {
+        let request = durable_request("/home/exo/workspace", FileSystemMountMode::ReadWrite);
+        let error =
+            reject_unsupported_request(&request, Some("/mnt/workspace")).expect_err("bad path");
+        assert!(error.to_string().contains("must be under /mnt/"));
+    }
+
+    fn durable_request(mount_path: &str, mode: FileSystemMountMode) -> SandboxRequest {
+        SandboxRequest {
+            key: SandboxKey::ConversationSandbox {
+                conversation_id: "conversation".to_string(),
+                sandbox_id: "sandbox".to_string(),
+            },
+            spec: SandboxSpec {
+                image: "agentcore".to_string(),
+                mounts: Vec::new(),
+                durable_file_systems: vec![DurableFileSystem {
+                    name: "workspace".to_string(),
+                    mount_path: mount_path.to_string(),
+                    mode,
+                }],
+                network: SandboxNetworkPolicy::Enabled,
+                default_workdir: "/mnt/workspace".to_string(),
+            },
+            lifecycle: SandboxLifecycleConfig::default(),
+        }
+    }
 }

--- a/crates/exoharness/src/sandbox_provider/aws_agentcore.rs
+++ b/crates/exoharness/src/sandbox_provider/aws_agentcore.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use crate::sandbox::{
     ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand, SandboxCommandOutput,
     SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotPayload, sandbox_spec_hash,
+    validate_durable_file_systems,
 };
 use crate::sandbox_provider::process_bridge;
 
@@ -346,6 +347,15 @@ fn reject_unsupported_request(request: &SandboxRequest) -> Result<()> {
         bail!(
             "AgentCore sandbox backend does not support host bind-mounts; remove conversation mounts or use a local sandbox provider"
         );
+    }
+    validate_durable_file_systems(&request.spec.durable_file_systems)?;
+    if request
+        .spec
+        .durable_file_systems
+        .iter()
+        .any(|file_system| matches!(file_system.mode, crate::FileSystemMountMode::ReadOnly))
+    {
+        bail!("AgentCore sandbox backend does not support read-only durable file systems");
     }
     if matches!(request.spec.network, SandboxNetworkPolicy::Disabled) {
         bail!("AgentCore sandbox backend cannot enforce disabled networking");

--- a/crates/exoharness/src/sandbox_provider/daytona.rs
+++ b/crates/exoharness/src/sandbox_provider/daytona.rs
@@ -238,7 +238,7 @@ impl DaytonaSandboxBackend {
 #[async_trait]
 impl ManagedSandboxBackend for DaytonaSandboxBackend {
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
-        reject_host_mounts(&request)?;
+        reject_unsupported_mounts(&request)?;
         let spec_hash = sandbox_spec_hash(&request.spec);
 
         // Reuse a matching sandbox if one exists (also how we recover across exo
@@ -927,14 +927,17 @@ async fn stop_via_backend(backend: &DaytonaBackendHandle, id: &str) -> Result<()
     Ok(())
 }
 
-fn reject_host_mounts(request: &SandboxRequest) -> Result<()> {
-    if request.spec.mounts.is_empty() {
-        return Ok(());
+fn reject_unsupported_mounts(request: &SandboxRequest) -> Result<()> {
+    if !request.spec.mounts.is_empty() {
+        bail!(
+            "Daytona sandbox backend does not support host bind-mounts; \
+         remove conversation mounts or use a local sandbox provider"
+        );
     }
-    bail!(
-        "Daytona sandbox backend does not support host bind-mounts; \
-     remove conversation mounts or use a local sandbox provider"
-    )
+    if !request.spec.durable_file_systems.is_empty() {
+        bail!("Daytona sandbox backend does not support durable file systems");
+    }
+    Ok(())
 }
 
 fn idle_ttl_to_minutes(ttl: Duration) -> u32 {

--- a/crates/exoharness/src/sandbox_provider/vercel.rs
+++ b/crates/exoharness/src/sandbox_provider/vercel.rs
@@ -151,7 +151,7 @@ impl VercelSandboxBackend {
 #[async_trait]
 impl ManagedSandboxBackend for VercelSandboxBackend {
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
-        reject_host_mounts(&request)?;
+        reject_unsupported_mounts(&request)?;
         let spec_hash = sandbox_spec_hash(&request.spec);
         let sandbox_name = vercel_sandbox_name(&request, &spec_hash);
         let response = match self.get_sandbox_session(&sandbox_name).await? {
@@ -627,14 +627,17 @@ fn stable_fnv1a_hex(input: &str) -> String {
     format!("{hash:016x}")
 }
 
-fn reject_host_mounts(request: &SandboxRequest) -> Result<()> {
-    if request.spec.mounts.is_empty() {
-        return Ok(());
+fn reject_unsupported_mounts(request: &SandboxRequest) -> Result<()> {
+    if !request.spec.mounts.is_empty() {
+        bail!(
+            "Vercel sandbox backend does not support host bind-mounts; \
+         remove conversation mounts or use a local sandbox provider"
+        );
     }
-    bail!(
-        "Vercel sandbox backend does not support host bind-mounts; \
-     remove conversation mounts or use a local sandbox provider"
-    )
+    if !request.spec.durable_file_systems.is_empty() {
+        bail!("Vercel sandbox backend does not support durable file systems");
+    }
+    Ok(())
 }
 
 fn duration_to_millis(duration: Duration) -> u64 {

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -843,6 +843,8 @@ pub enum SandboxProviderConfig {
         qualifier: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         endpoint_url: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        session_storage_mount_path: Option<String>,
         #[serde(default = "crate::sandbox_provider::default_aws_agentcore_image")]
         default_image: String,
     },

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -369,6 +369,8 @@ pub enum EventData {
         image: String,
         default_workdir: String,
         file_system_mounts: Vec<FileSystemMount>,
+        #[serde(default)]
+        durable_file_systems: Vec<DurableFileSystem>,
         enable_networking: bool,
         idle_seconds: u64,
     },
@@ -495,6 +497,13 @@ pub struct FileSystemMount {
     pub internal: Option<bool>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct DurableFileSystem {
+    pub name: String,
+    pub mount_path: String,
+    pub mode: FileSystemMountMode,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CreateSandboxRequest {
     #[serde(default)]
@@ -503,6 +512,7 @@ pub struct CreateSandboxRequest {
     pub image: String,
     pub default_workdir: Option<String>,
     pub file_system_mounts: Option<Vec<FileSystemMount>>,
+    pub durable_file_systems: Option<Vec<DurableFileSystem>>,
     pub enable_networking: Option<bool>,
     pub idle_seconds: Option<u64>,
 }


### PR DESCRIPTION
These are not mapped to host directories, and once mounted, you can assume they'll survive across sandbox restarts for the given sandbox instance.