### PR TITLE
Cleanups for self control (exoharness changes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
  "regex",
  "regex-lite",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
  "serde_urlencoded",
  "smallvec",
  "socket2 0.6.3",
@@ -413,7 +413,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
 ]
 
 [[package]]
@@ -1077,9 +1077,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "big_serde_json"
 version = "0.1.0"
-source = "git+https://github.com/braintrustdata/lingua.git?rev=10f863cf9215c003fcbb4f315b25c011b4bb7569#10f863cf9215c003fcbb4f315b25c011b4bb7569"
+source = "git+https://github.com/braintrustdata/lingua.git?rev=3ab9bcc9b58688be37216e9ab0b3d8362d185cfb#3ab9bcc9b58688be37216e9ab0b3d8362d185cfb"
 dependencies = [
- "serde_json 1.0.145",
+ "braintrust_serde_json",
  "ts-rs",
 ]
 
@@ -1212,7 +1212,7 @@ dependencies = [
  "rustc-hash 2.1.2",
  "ryu-js",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
  "sptr",
  "static_assertions",
  "tap",
@@ -1328,7 +1328,7 @@ dependencies = [
 [[package]]
 name = "braintrust-llm-router"
 version = "0.1.0"
-source = "git+https://github.com/braintrustdata/lingua.git?rev=10f863cf9215c003fcbb4f315b25c011b4bb7569#10f863cf9215c003fcbb4f315b25c011b4bb7569"
+source = "git+https://github.com/braintrustdata/lingua.git?rev=3ab9bcc9b58688be37216e9ab0b3d8362d185cfb#3ab9bcc9b58688be37216e9ab0b3d8362d185cfb"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1358,7 +1358,7 @@ dependencies = [
  "reqwest-middleware",
  "reqwest-retry",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
  "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
@@ -1385,13 +1385,25 @@ dependencies = [
  "regex",
  "reqwest",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
  "serde_repr",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "braintrust_serde_json"
+version = "1.0.145"
+source = "git+https://github.com/braintrustdata/serde-json.git?rev=905b790b50e8922370f3e73ef93d7d5fb7010edc#905b790b50e8922370f3e73ef93d7d5fb7010edc"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1763,7 +1775,7 @@ dependencies = [
  "anyhow",
  "reqwest",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
  "tempfile",
  "tokio",
  "tracing",
@@ -2366,7 +2378,7 @@ dependencies = [
  "lingua",
  "reqwest",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -2388,7 +2400,7 @@ dependencies = [
  "lingua",
  "rustyline",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
  "tabwriter",
  "tempfile",
  "tokio",
@@ -2430,7 +2442,7 @@ dependencies = [
  "object_store",
  "reqwest",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -3564,7 +3576,7 @@ dependencies = [
  "rand 0.8.5",
  "rsa",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
  "sha2 0.10.9",
  "signature",
  "simple_asn1",
@@ -3703,7 +3715,7 @@ dependencies = [
 [[package]]
 name = "lingua"
 version = "0.1.0"
-source = "git+https://github.com/braintrustdata/lingua.git?rev=10f863cf9215c003fcbb4f315b25c011b4bb7569#10f863cf9215c003fcbb4f315b25c011b4bb7569"
+source = "git+https://github.com/braintrustdata/lingua.git?rev=3ab9bcc9b58688be37216e9ab0b3d8362d185cfb#3ab9bcc9b58688be37216e9ab0b3d8362d185cfb"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -3712,10 +3724,11 @@ dependencies = [
  "big_serde_json",
  "bytes",
  "js-sys",
+ "regex",
  "reqwest",
  "serde",
  "serde-wasm-bindgen",
- "serde_json 1.0.149",
+ "serde_json",
  "serde_with",
  "serde_yaml",
  "thiserror 2.0.18",
@@ -4138,7 +4151,7 @@ dependencies = [
  "ring",
  "rustls-pemfile",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
  "serde_urlencoded",
  "thiserror 2.0.18",
  "tokio",
@@ -4900,7 +4913,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-pki-types",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
@@ -5255,7 +5268,7 @@ dependencies = [
  "dyn-clone",
  "ref-cast",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
 ]
 
 [[package]]
@@ -5267,7 +5280,7 @@ dependencies = [
  "dyn-clone",
  "ref-cast",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
 ]
 
 [[package]]
@@ -5391,18 +5404,6 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
-source = "git+https://github.com/ankrgyl/serde-json.git?rev=efa66e3a1d61459ab2d325f92ebe3acbd6ca18b1#efa66e3a1d61459ab2d325f92ebe3acbd6ca18b1"
-dependencies = [
- "itoa",
- "memchr",
- "ryu",
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
@@ -5451,7 +5452,7 @@ dependencies = [
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
- "serde_json 1.0.149",
+ "serde_json",
  "serde_with_macros",
  "time",
 ]
@@ -6305,7 +6306,7 @@ dependencies = [
  "prost",
  "roaring",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
  "thiserror 2.0.18",
  "tracing",
  "turso_core",
@@ -7005,7 +7006,7 @@ dependencies = [
  "once_cell",
  "regex",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
  "tokio",
  "url",
 ]
@@ -7073,7 +7074,7 @@ dependencies = [
  "log",
  "serde",
  "serde_derive",
- "serde_json 1.0.149",
+ "serde_json",
  "wasm-encoder",
  "wasm-metadata",
  "wasmparser",
@@ -7093,7 +7094,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_derive",
- "serde_json 1.0.149",
+ "serde_json",
  "unicode-xid",
  "wasmparser",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2031,6 +2031,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "db-keystore"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2447,6 +2453,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite",
  "tokio-util",
  "tracing",
  "url",
@@ -3076,7 +3083,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -4927,7 +4934,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -5964,6 +5971,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6158,6 +6181,25 @@ dependencies = [
  "quote",
  "syn",
  "termcolor",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
+ "sha1 0.10.6",
+ "thiserror 2.0.18",
+ "utf-8",
 ]
 
 [[package]]
@@ -6455,6 +6497,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6687,6 +6735,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,7 +164,7 @@ dependencies = [
  "regex",
  "regex-lite",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
  "serde_urlencoded",
  "smallvec",
  "socket2 0.6.3",
@@ -413,7 +413,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
 dependencies = [
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
 ]
 
 [[package]]
@@ -1077,9 +1077,9 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 [[package]]
 name = "big_serde_json"
 version = "0.1.0"
-source = "git+https://github.com/braintrustdata/lingua.git?rev=10f863cf9215c003fcbb4f315b25c011b4bb7569#10f863cf9215c003fcbb4f315b25c011b4bb7569"
+source = "git+https://github.com/braintrustdata/lingua.git?rev=3ab9bcc9b58688be37216e9ab0b3d8362d185cfb#3ab9bcc9b58688be37216e9ab0b3d8362d185cfb"
 dependencies = [
- "serde_json 1.0.145",
+ "braintrust_serde_json",
  "ts-rs",
 ]
 
@@ -1212,7 +1212,7 @@ dependencies = [
  "rustc-hash 2.1.2",
  "ryu-js",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
  "sptr",
  "static_assertions",
  "tap",
@@ -1328,7 +1328,7 @@ dependencies = [
 [[package]]
 name = "braintrust-llm-router"
 version = "0.1.0"
-source = "git+https://github.com/braintrustdata/lingua.git?rev=10f863cf9215c003fcbb4f315b25c011b4bb7569#10f863cf9215c003fcbb4f315b25c011b4bb7569"
+source = "git+https://github.com/braintrustdata/lingua.git?rev=3ab9bcc9b58688be37216e9ab0b3d8362d185cfb#3ab9bcc9b58688be37216e9ab0b3d8362d185cfb"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1358,7 +1358,7 @@ dependencies = [
  "reqwest-middleware",
  "reqwest-retry",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
  "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
@@ -1385,13 +1385,25 @@ dependencies = [
  "regex",
  "reqwest",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
  "serde_repr",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "braintrust_serde_json"
+version = "1.0.145"
+source = "git+https://github.com/braintrustdata/serde-json.git?rev=905b790b50e8922370f3e73ef93d7d5fb7010edc#905b790b50e8922370f3e73ef93d7d5fb7010edc"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -1763,7 +1775,7 @@ dependencies = [
  "anyhow",
  "reqwest",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
  "tempfile",
  "tokio",
  "tracing",
@@ -2017,6 +2029,12 @@ dependencies = [
  "parking_lot_core 0.9.12",
  "serde",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "db-keystore"
@@ -2367,7 +2385,7 @@ dependencies = [
  "lingua",
  "reqwest",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
  "tempfile",
  "tokio",
  "tokio-stream",
@@ -2389,7 +2407,7 @@ dependencies = [
  "lingua",
  "rustyline",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
  "tabwriter",
  "tempfile",
  "tokio",
@@ -2431,11 +2449,12 @@ dependencies = [
  "object_store",
  "reqwest",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite",
  "tokio-util",
  "tracing",
  "url",
@@ -3065,7 +3084,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3565,7 +3584,7 @@ dependencies = [
  "rand 0.8.5",
  "rsa",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
  "sha2 0.10.9",
  "signature",
  "simple_asn1",
@@ -3704,7 +3723,7 @@ dependencies = [
 [[package]]
 name = "lingua"
 version = "0.1.0"
-source = "git+https://github.com/braintrustdata/lingua.git?rev=10f863cf9215c003fcbb4f315b25c011b4bb7569#10f863cf9215c003fcbb4f315b25c011b4bb7569"
+source = "git+https://github.com/braintrustdata/lingua.git?rev=3ab9bcc9b58688be37216e9ab0b3d8362d185cfb#3ab9bcc9b58688be37216e9ab0b3d8362d185cfb"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -3713,10 +3732,11 @@ dependencies = [
  "big_serde_json",
  "bytes",
  "js-sys",
+ "regex",
  "reqwest",
  "serde",
  "serde-wasm-bindgen",
- "serde_json 1.0.149",
+ "serde_json",
  "serde_with",
  "serde_yaml",
  "thiserror 2.0.18",
@@ -4139,7 +4159,7 @@ dependencies = [
  "ring",
  "rustls-pemfile",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
  "serde_urlencoded",
  "thiserror 2.0.18",
  "tokio",
@@ -4901,7 +4921,7 @@ dependencies = [
  "rustls-native-certs",
  "rustls-pki-types",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
@@ -4915,7 +4935,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -5256,7 +5276,7 @@ dependencies = [
  "dyn-clone",
  "ref-cast",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
 ]
 
 [[package]]
@@ -5268,7 +5288,7 @@ dependencies = [
  "dyn-clone",
  "ref-cast",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
 ]
 
 [[package]]
@@ -5392,18 +5412,6 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
-source = "git+https://github.com/ankrgyl/serde-json.git?rev=efa66e3a1d61459ab2d325f92ebe3acbd6ca18b1#efa66e3a1d61459ab2d325f92ebe3acbd6ca18b1"
-dependencies = [
- "itoa",
- "memchr",
- "ryu",
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
@@ -5452,7 +5460,7 @@ dependencies = [
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
- "serde_json 1.0.149",
+ "serde_json",
  "serde_with_macros",
  "time",
 ]
@@ -5964,6 +5972,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tungstenite",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6161,6 +6185,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "rustls 0.23.37",
+ "rustls-pki-types",
+ "sha1 0.10.6",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
 name = "turso"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6306,7 +6349,7 @@ dependencies = [
  "prost",
  "roaring",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
  "thiserror 2.0.18",
  "tracing",
  "turso_core",
@@ -6453,6 +6496,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf16_iter"
@@ -6687,6 +6736,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -7006,7 +7064,7 @@ dependencies = [
  "once_cell",
  "regex",
  "serde",
- "serde_json 1.0.149",
+ "serde_json",
  "tokio",
  "url",
 ]
@@ -7074,7 +7132,7 @@ dependencies = [
  "log",
  "serde",
  "serde_derive",
- "serde_json 1.0.149",
+ "serde_json",
  "wasm-encoder",
  "wasm-metadata",
  "wasmparser",
@@ -7094,7 +7152,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_derive",
- "serde_json 1.0.149",
+ "serde_json",
  "unicode-xid",
  "wasmparser",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,8 +66,8 @@ tracing-subscriber = "0.3.20"
 url = "2.5.7"
 uuid = { version = "1.18.1", features = ["serde", "v4", "v7"] }
 
-lingua = { git = "https://github.com/braintrustdata/lingua.git", rev = "10f863cf9215c003fcbb4f315b25c011b4bb7569" }
-braintrust-llm-router = { git = "https://github.com/braintrustdata/lingua.git", package = "braintrust-llm-router", rev = "10f863cf9215c003fcbb4f315b25c011b4bb7569", default-features = false, features = [
+lingua = { git = "https://github.com/braintrustdata/lingua.git", rev = "3ab9bcc9b58688be37216e9ab0b3d8362d185cfb" }
+braintrust-llm-router = { git = "https://github.com/braintrustdata/lingua.git", package = "braintrust-llm-router", rev = "3ab9bcc9b58688be37216e9ab0b3d8362d185cfb", default-features = false, features = [
   "provider-openai",
   "provider-anthropic",
   "provider-google",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -30,7 +30,10 @@ tracing-subscriber.workspace = true
 
 [dev-dependencies]
 bytes.workspace = true
-exoharness = { path = "../exoharness", features = ["basic-backend"] }
+exoharness = { path = "../exoharness", features = [
+  "basic-backend",
+  "contract-tests",
+] }
 futures.workspace = true
 tempfile = "3.23.0"
 wiremock = "0.6"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -611,6 +611,9 @@ struct ProviderConfigureArgs {
     runtime_arn: Option<String>,
     #[arg(long)]
     qualifier: Option<String>,
+    /// AgentCore managed session storage mount path configured on the runtime.
+    #[arg(long = "session-storage-mount-path")]
+    session_storage_mount_path: Option<String>,
     /// Default base image for sandboxes that don't request one.
     #[arg(long)]
     default_image: Option<String>,
@@ -1765,10 +1768,16 @@ async fn main() -> Result<()> {
                     api_url,
                     runtime_arn,
                     qualifier,
+                    session_storage_mount_path,
                     default_image,
                 } = *args;
                 let binding_name =
                     name.unwrap_or_else(|| SandboxProvider::from(provider).as_str().to_string());
+                if !matches!(provider, SandboxProviderArg::AwsAgentCore)
+                    && session_storage_mount_path.is_some()
+                {
+                    bail!("--session-storage-mount-path is only valid for aws-agentcore");
+                }
                 let config = match provider {
                     SandboxProviderArg::Daytona => {
                         let secret =
@@ -1821,6 +1830,7 @@ async fn main() -> Result<()> {
                             region,
                             qualifier,
                             endpoint_url: api_url,
+                            session_storage_mount_path,
                             default_image: default_image
                                 .unwrap_or_else(default_aws_agentcore_image),
                         }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -26,15 +26,16 @@ use executor::{
     AgentHarnessKind, BasicExoHarness, BasicExoHarnessConfig, BasicHarness, BasicToolRuntime,
     Binding, BraintrustProject, BraintrustRuntimeConfig, BraintrustTracingConfig,
     ConversationModelConfig, CreateAgentRequest, CreateConversationRequest, DaytonaBackendSpec,
-    EventKind, EventQuery, EventQueryDirection, ExoHarness, ExoHarnessHttpServeOptions,
-    ExoclawToolRuntime, FileSystemMount, FileSystemMountMode, ForkConversationRequest,
-    HTTP_EXOHARNESS_TRACING_TARGET, Harness, HarnessAgent, HarnessConversation, HttpExoHarness,
-    LocalSandboxExoHarness, PutSecretRequest, RlmHarness, SANDBOX_MAIN_MOUNT_DIR,
-    SandboxBackendChoice, SandboxProvider, SandboxProviderConfig, SandboxScope, Secret,
-    SecretBackendChoice, ToolRequest, ToolRuntime, TypeScriptHarness, TypeScriptHarnessConfig,
-    Uuid7, VercelBackendSpec, default_aws_agentcore_image, default_daytona_image,
-    default_docker_image, default_vercel_image, effective_sandbox_scope, load_agent_config,
-    send_conversation_wakeup, serve_exoharness_http_listener_with_options,
+    E2bBackendSpec, EventKind, EventQuery, EventQueryDirection, ExoHarness,
+    ExoHarnessHttpServeOptions, ExoclawToolRuntime, FileSystemMount, FileSystemMountMode,
+    ForkConversationRequest, HTTP_EXOHARNESS_TRACING_TARGET, Harness, HarnessAgent,
+    HarnessConversation, HttpExoHarness, LocalSandboxExoHarness, PutSecretRequest, RlmHarness,
+    SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, SandboxProvider, SandboxProviderConfig,
+    SandboxScope, Secret, SecretBackendChoice, SpritesBackendSpec, ToolRequest, ToolRuntime,
+    TypeScriptHarness, TypeScriptHarnessConfig, Uuid7, VercelBackendSpec,
+    default_aws_agentcore_image, default_daytona_image, default_docker_image, default_e2b_template,
+    default_vercel_image, effective_sandbox_scope, load_agent_config, send_conversation_wakeup,
+    serve_exoharness_http_listener_with_options,
 };
 use lingua::Message;
 use lingua::universal::{AssistantContent, AssistantContentPart, ToolContentPart, UserContent};
@@ -213,6 +214,10 @@ enum SecretBackendArg {
 #[derive(Debug, Clone, Copy, ValueEnum)]
 enum SandboxProviderArg {
     Daytona,
+    #[value(name = "e2b")]
+    E2b,
+    #[value(name = "sprites")]
+    Sprites,
     Vercel,
     #[value(name = "aws-agentcore")]
     AwsAgentCore,
@@ -227,6 +232,8 @@ impl From<SandboxProviderArg> for SandboxProvider {
     fn from(value: SandboxProviderArg) -> Self {
         match value {
             SandboxProviderArg::Daytona => Self::Daytona,
+            SandboxProviderArg::E2b => Self::E2b,
+            SandboxProviderArg::Sprites => Self::Sprites,
             SandboxProviderArg::Vercel => Self::Vercel,
             SandboxProviderArg::AwsAgentCore => Self::AwsAgentCore,
             SandboxProviderArg::AppleContainer => Self::AppleContainer,
@@ -288,7 +295,9 @@ fn default_sandbox_backends() -> Vec<SandboxBackendChoice> {
     vec![
         default_sandbox_backend(),
         SandboxBackendChoice::LocalProcess,
-        SandboxBackendChoice::Daytona(DaytonaBackendSpec::with_conventional_secrets()),
+        SandboxBackendChoice::Daytona(DaytonaBackendSpec::default()),
+        SandboxBackendChoice::E2b(E2bBackendSpec::default()),
+        SandboxBackendChoice::Sprites(SpritesBackendSpec::default()),
         SandboxBackendChoice::Vercel(VercelBackendSpec::with_conventional_secrets()),
         SandboxBackendChoice::AwsAgentCore,
     ]
@@ -628,12 +637,13 @@ struct ProviderConfigureArgs {
     /// Binding name (default: the provider name).
     #[arg(long)]
     name: Option<String>,
-    /// Secret (by name) holding the provider's API key/token. Required for Daytona and Vercel.
+    /// Secret (by name) holding the provider's API key/token. Required for remote providers.
     #[arg(long)]
     secret: Option<String>,
     /// Region/target. Daytona: us | eu | experimental.
     #[arg(long)]
     region: Option<String>,
+    /// Daytona organization id, or Sprites organization slug.
     #[arg(long)]
     organization_id: Option<String>,
     #[arg(long)]
@@ -644,9 +654,18 @@ struct ProviderConfigureArgs {
     runtime_arn: Option<String>,
     #[arg(long)]
     qualifier: Option<String>,
+    /// AgentCore managed session storage mount path configured on the runtime.
+    #[arg(long = "session-storage-mount-path")]
+    session_storage_mount_path: Option<String>,
     /// Default base image for sandboxes that don't request one.
     #[arg(long)]
     default_image: Option<String>,
+    /// Sprites sprite HTTP URL auth: sprite | public.
+    #[arg(long)]
+    url_auth: Option<String>,
+    /// Extra Sprites labels (repeatable). Exo resume labels are added on create.
+    #[arg(long = "label")]
+    labels: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, Args)]
@@ -1798,10 +1817,18 @@ async fn main() -> Result<()> {
                     api_url,
                     runtime_arn,
                     qualifier,
+                    session_storage_mount_path,
                     default_image,
+                    url_auth,
+                    labels,
                 } = *args;
                 let binding_name =
                     name.unwrap_or_else(|| SandboxProvider::from(provider).as_str().to_string());
+                if !matches!(provider, SandboxProviderArg::AwsAgentCore)
+                    && session_storage_mount_path.is_some()
+                {
+                    bail!("--session-storage-mount-path is only valid for aws-agentcore");
+                }
                 let config = match provider {
                     SandboxProviderArg::Daytona => {
                         let secret =
@@ -1854,6 +1881,7 @@ async fn main() -> Result<()> {
                             region,
                             qualifier,
                             endpoint_url: api_url,
+                            session_storage_mount_path,
                             default_image: default_image
                                 .unwrap_or_else(default_aws_agentcore_image),
                         }
@@ -1861,10 +1889,35 @@ async fn main() -> Result<()> {
                     SandboxProviderArg::Docker => SandboxProviderConfig::Docker {
                         default_image: default_image.unwrap_or_else(default_docker_image),
                     },
-                    other => bail!(
-                        "provider {other:?} has no binding-based config yet \
-                         (E2B and exe.dev are followups)"
-                    ),
+                    SandboxProviderArg::E2b => {
+                        let secret =
+                            secret.ok_or_else(|| anyhow!("--secret is required for e2b"))?;
+                        let secret_id =
+                            find_secret_id(harness.exoharness_handle().as_ref(), &secret)
+                                .await?
+                                .ok_or_else(|| anyhow!("secret not found: {secret}"))?;
+                        SandboxProviderConfig::E2b {
+                            api_key_secret_id: secret_id,
+                            api_url,
+                            default_image: default_image.unwrap_or_else(default_e2b_template),
+                        }
+                    }
+                    SandboxProviderArg::Sprites => {
+                        let secret =
+                            secret.ok_or_else(|| anyhow!("--secret is required for sprites"))?;
+                        let secret_id =
+                            find_secret_id(harness.exoharness_handle().as_ref(), &secret)
+                                .await?
+                                .ok_or_else(|| anyhow!("secret not found: {secret}"))?;
+                        SandboxProviderConfig::Sprites {
+                            token_secret_id: secret_id,
+                            api_url,
+                            url_auth,
+                            organization: organization_id,
+                            labels,
+                        }
+                    }
+                    other => bail!("provider {other:?} has no binding-based config yet"),
                 };
                 let id = harness
                     .exoharness_handle()
@@ -2398,6 +2451,7 @@ async fn find_secret_id(exoharness: &dyn ExoHarness, name: &str) -> Result<Optio
         .list_secrets()
         .await?
         .into_iter()
+        .rev()
         .find(|secret| secret.name == name)
         .map(|secret| secret.id))
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -26,15 +26,16 @@ use executor::{
     AgentHarnessKind, BasicExoHarness, BasicExoHarnessConfig, BasicHarness, BasicToolRuntime,
     Binding, BraintrustProject, BraintrustRuntimeConfig, BraintrustTracingConfig,
     ConversationModelConfig, CreateAgentRequest, CreateConversationRequest, DaytonaBackendSpec,
-    EventKind, EventQuery, EventQueryDirection, ExoHarness, ExoHarnessHttpServeOptions,
-    ExoclawToolRuntime, FileSystemMount, FileSystemMountMode, ForkConversationRequest,
-    HTTP_EXOHARNESS_TRACING_TARGET, Harness, HarnessAgent, HarnessConversation, HttpExoHarness,
-    LocalSandboxExoHarness, PutSecretRequest, RlmHarness, SANDBOX_MAIN_MOUNT_DIR,
-    SandboxBackendChoice, SandboxProvider, SandboxProviderConfig, SandboxScope, Secret,
-    SecretBackendChoice, ToolRequest, ToolRuntime, TypeScriptHarness, TypeScriptHarnessConfig,
-    Uuid7, VercelBackendSpec, default_aws_agentcore_image, default_daytona_image,
-    default_docker_image, default_vercel_image, effective_sandbox_scope, load_agent_config,
-    send_conversation_wakeup, serve_exoharness_http_listener_with_options,
+    E2bBackendSpec, EventKind, EventQuery, EventQueryDirection, ExoHarness,
+    ExoHarnessHttpServeOptions, ExoclawToolRuntime, FileSystemMount, FileSystemMountMode,
+    ForkConversationRequest, HTTP_EXOHARNESS_TRACING_TARGET, Harness, HarnessAgent,
+    HarnessConversation, HttpExoHarness, LocalSandboxExoHarness, PutSecretRequest, RlmHarness,
+    SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, SandboxProvider, SandboxProviderConfig,
+    SandboxScope, Secret, SecretBackendChoice, SpritesBackendSpec, ToolRequest, ToolRuntime,
+    TypeScriptHarness, TypeScriptHarnessConfig, Uuid7, VercelBackendSpec,
+    default_aws_agentcore_image, default_daytona_image, default_docker_image, default_e2b_template,
+    default_vercel_image, effective_sandbox_scope, load_agent_config, send_conversation_wakeup,
+    serve_exoharness_http_listener_with_options,
 };
 use lingua::Message;
 use lingua::universal::{AssistantContent, AssistantContentPart, ToolContentPart, UserContent};
@@ -211,6 +212,10 @@ enum SecretBackendArg {
 #[derive(Debug, Clone, Copy, ValueEnum)]
 enum SandboxProviderArg {
     Daytona,
+    #[value(name = "e2b")]
+    E2b,
+    #[value(name = "sprites")]
+    Sprites,
     Vercel,
     #[value(name = "aws-agentcore")]
     AwsAgentCore,
@@ -225,6 +230,8 @@ impl From<SandboxProviderArg> for SandboxProvider {
     fn from(value: SandboxProviderArg) -> Self {
         match value {
             SandboxProviderArg::Daytona => Self::Daytona,
+            SandboxProviderArg::E2b => Self::E2b,
+            SandboxProviderArg::Sprites => Self::Sprites,
             SandboxProviderArg::Vercel => Self::Vercel,
             SandboxProviderArg::AwsAgentCore => Self::AwsAgentCore,
             SandboxProviderArg::AppleContainer => Self::AppleContainer,
@@ -255,7 +262,9 @@ fn default_sandbox_backends() -> Vec<SandboxBackendChoice> {
     vec![
         default_sandbox_backend(),
         SandboxBackendChoice::LocalProcess,
-        SandboxBackendChoice::Daytona(DaytonaBackendSpec::with_conventional_secrets()),
+        SandboxBackendChoice::Daytona(DaytonaBackendSpec::default()),
+        SandboxBackendChoice::E2b(E2bBackendSpec::default()),
+        SandboxBackendChoice::Sprites(SpritesBackendSpec::default()),
         SandboxBackendChoice::Vercel(VercelBackendSpec::with_conventional_secrets()),
         SandboxBackendChoice::AwsAgentCore,
     ]
@@ -595,12 +604,13 @@ struct ProviderConfigureArgs {
     /// Binding name (default: the provider name).
     #[arg(long)]
     name: Option<String>,
-    /// Secret (by name) holding the provider's API key/token. Required for Daytona and Vercel.
+    /// Secret (by name) holding the provider's API key/token. Required for remote providers.
     #[arg(long)]
     secret: Option<String>,
     /// Region/target. Daytona: us | eu | experimental.
     #[arg(long)]
     region: Option<String>,
+    /// Daytona organization id, or Sprites organization slug.
     #[arg(long)]
     organization_id: Option<String>,
     #[arg(long)]
@@ -617,6 +627,12 @@ struct ProviderConfigureArgs {
     /// Default base image for sandboxes that don't request one.
     #[arg(long)]
     default_image: Option<String>,
+    /// Sprites sprite HTTP URL auth: sprite | public.
+    #[arg(long)]
+    url_auth: Option<String>,
+    /// Extra Sprites labels (repeatable). Exo resume labels are added on create.
+    #[arg(long = "label")]
+    labels: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default, Args)]
@@ -1770,6 +1786,8 @@ async fn main() -> Result<()> {
                     qualifier,
                     session_storage_mount_path,
                     default_image,
+                    url_auth,
+                    labels,
                 } = *args;
                 let binding_name =
                     name.unwrap_or_else(|| SandboxProvider::from(provider).as_str().to_string());
@@ -1838,10 +1856,35 @@ async fn main() -> Result<()> {
                     SandboxProviderArg::Docker => SandboxProviderConfig::Docker {
                         default_image: default_image.unwrap_or_else(default_docker_image),
                     },
-                    other => bail!(
-                        "provider {other:?} has no binding-based config yet \
-                         (E2B and exe.dev are followups)"
-                    ),
+                    SandboxProviderArg::E2b => {
+                        let secret =
+                            secret.ok_or_else(|| anyhow!("--secret is required for e2b"))?;
+                        let secret_id =
+                            find_secret_id(harness.exoharness_handle().as_ref(), &secret)
+                                .await?
+                                .ok_or_else(|| anyhow!("secret not found: {secret}"))?;
+                        SandboxProviderConfig::E2b {
+                            api_key_secret_id: secret_id,
+                            api_url,
+                            default_image: default_image.unwrap_or_else(default_e2b_template),
+                        }
+                    }
+                    SandboxProviderArg::Sprites => {
+                        let secret =
+                            secret.ok_or_else(|| anyhow!("--secret is required for sprites"))?;
+                        let secret_id =
+                            find_secret_id(harness.exoharness_handle().as_ref(), &secret)
+                                .await?
+                                .ok_or_else(|| anyhow!("secret not found: {secret}"))?;
+                        SandboxProviderConfig::Sprites {
+                            token_secret_id: secret_id,
+                            api_url,
+                            url_auth,
+                            organization: organization_id,
+                            labels,
+                        }
+                    }
+                    other => bail!("provider {other:?} has no binding-based config yet"),
                 };
                 let id = harness
                     .exoharness_handle()
@@ -2375,6 +2418,7 @@ async fn find_secret_id(exoharness: &dyn ExoHarness, name: &str) -> Result<Optio
         .list_secrets()
         .await?
         .into_iter()
+        .rev()
         .find(|secret| secret.name == name)
         .map(|secret| secret.id))
 }

--- a/crates/cli/tests/daytona_backend.rs
+++ b/crates/cli/tests/daytona_backend.rs
@@ -32,6 +32,7 @@ fn make_request(conversation_id: &str, sandbox_id: &str) -> SandboxRequest {
         spec: SandboxSpec {
             image: "docker.io/library/ubuntu:24.04".into(),
             mounts: Vec::new(),
+            durable_file_systems: Vec::new(),
             network: SandboxNetworkPolicy::Enabled,
             default_workdir: "/".into(),
         },

--- a/crates/cli/tests/e2b_backend.rs
+++ b/crates/cli/tests/e2b_backend.rs
@@ -1,0 +1,522 @@
+//! Wiremock-driven tests for the E2B sandbox backend.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use bytes::Bytes;
+use exoharness::{
+    E2bConfig, E2bSandboxBackend, ManagedSandboxBackend, SandboxCommand, SandboxKey,
+    SandboxLifecycleConfig, SandboxMount, SandboxMountAccess, SandboxNetworkPolicy, SandboxRequest,
+    SandboxSpec, SnapshotKind, SnapshotPayload,
+};
+use serde_json::{Value, json};
+use wiremock::matchers::{method, path};
+use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate};
+
+fn make_request(conversation_id: &str, sandbox_id: &str) -> SandboxRequest {
+    SandboxRequest {
+        key: SandboxKey::ConversationSandbox {
+            conversation_id: conversation_id.into(),
+            sandbox_id: sandbox_id.into(),
+        },
+        spec: SandboxSpec {
+            image: "base".into(),
+            mounts: Vec::new(),
+            durable_file_systems: Vec::new(),
+            network: SandboxNetworkPolicy::Enabled,
+            default_workdir: "/home/user".into(),
+        },
+        lifecycle: SandboxLifecycleConfig {
+            idle_ttl: Some(Duration::from_secs(300)),
+        },
+    }
+}
+
+fn backend_for_mock(server: &MockServer) -> E2bSandboxBackend {
+    E2bSandboxBackend::new(E2bConfig {
+        api_key: "test-api-key".into(),
+        api_url: server.uri(),
+        template_id: "base".into(),
+        envd_port: 49_983,
+        envd_base_url: Some(server.uri()),
+        secure: false,
+    })
+    .expect("E2bSandboxBackend::new")
+}
+
+fn sandbox_created_json(id: &str) -> Value {
+    json!({
+        "sandboxID": id,
+        "templateID": "base",
+        "envdVersion": "0.1.0",
+    })
+}
+
+async fn mount_empty_sandbox_list(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/v2/sandboxes"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .expect(2)
+        .mount(server)
+        .await;
+}
+
+fn listed_sandbox_json(id: &str, state: &str) -> Value {
+    json!({
+        "sandboxID": id,
+        "templateID": "base",
+        "state": state,
+        "startedAt": "2026-06-01T12:00:00Z",
+        "clientID": "client",
+        "cpuCount": 2,
+        "memoryMB": 512,
+        "diskSizeMB": 1024,
+        "endAt": "2026-06-01T13:00:00Z",
+        "envdVersion": "0.1.0",
+    })
+}
+
+#[tokio::test]
+async fn acquire_posts_to_sandboxes_with_metadata() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    mount_empty_sandbox_list(&server).await;
+    Mock::given(method("POST"))
+        .and(path("/sandboxes"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(sandbox_created_json("sb-fresh")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    backend
+        .acquire(make_request("conv-1", "sandbox-1"))
+        .await
+        .expect("acquire should succeed");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let create = requests
+        .iter()
+        .find(|r| r.method.as_str() == "POST" && r.url.path() == "/sandboxes")
+        .expect("create request");
+    let body: Value = serde_json::from_slice(&create.body).unwrap();
+    assert_eq!(body.get("templateID").and_then(Value::as_str), Some("base"));
+    let metadata = body
+        .get("metadata")
+        .and_then(Value::as_object)
+        .expect("metadata present");
+    assert!(metadata.contains_key("exo.sandbox.key"));
+    assert!(metadata.contains_key("exo.sandbox.spec-hash"));
+}
+
+#[tokio::test]
+async fn acquire_rejects_host_mounts() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    let mut request = make_request("conv-2", "sandbox-2");
+    request.spec.mounts.push(SandboxMount {
+        host_path: PathBuf::from("/tmp/foo"),
+        guest_path: "/workspace".into(),
+        access: SandboxMountAccess::ReadWrite,
+        internal: false,
+    });
+
+    let error = match backend.acquire(request).await {
+        Ok(_) => panic!("acquire should reject host mounts"),
+        Err(error) => error,
+    };
+    let msg = format!("{error:#}").to_lowercase();
+    assert!(
+        msg.contains("mount") || msg.contains("e2b"),
+        "unexpected: {msg}"
+    );
+    assert_eq!(
+        server.received_requests().await.unwrap_or_default().len(),
+        0
+    );
+}
+
+#[tokio::test]
+async fn acquire_reuses_running_sandbox_without_connect() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("GET"))
+        .and(path("/v2/sandboxes"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(json!([listed_sandbox_json("sb-running", "running"),])),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend
+        .acquire(make_request("conv-3", "sandbox-3"))
+        .await
+        .expect("acquire should reuse running sandbox");
+
+    assert_eq!(handle.id(), "e2b:conversation:conv-3:sandbox-3");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert!(
+        !requests.iter().any(|r| r.url.path().contains("/connect")),
+        "running sandbox must not call connect"
+    );
+}
+
+#[tokio::test]
+async fn acquire_connects_paused_sandbox() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("GET"))
+        .and(path("/v2/sandboxes"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(json!([listed_sandbox_json("sb-paused", "paused"),])),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/sandboxes/sb-paused/connect"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(sandbox_created_json("sb-paused")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    backend
+        .acquire(make_request("conv-4", "sandbox-4"))
+        .await
+        .expect("acquire should connect paused sandbox");
+}
+
+#[tokio::test]
+async fn acquire_list_metadata_query_is_not_double_url_encoded() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("GET"))
+        .and(path("/v2/sandboxes"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(json!([listed_sandbox_json("sb-keyed", "running"),])),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    backend
+        .acquire(make_request("conv-colons", "sandbox-colons"))
+        .await
+        .expect("acquire should find sandbox by metadata");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let query = requests[0]
+        .url
+        .query()
+        .expect("list request has query string");
+    assert!(
+        !query.contains("%253A"),
+        "metadata filter must not double-encode ':' in sandbox keys; got {query}"
+    );
+    assert!(
+        query.contains("conversation%3Aconv-colons%3Asandbox-colons")
+            || query.contains("conversation:conv-colons:sandbox-colons"),
+        "expected sandbox key in metadata query; got {query}"
+    );
+    assert!(
+        query.contains("state=running%2Cpaused") || query.contains("state=running,paused"),
+        "expected comma-separated state filter; got {query}"
+    );
+}
+
+#[tokio::test]
+async fn acquire_creates_when_metadata_list_is_empty() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("GET"))
+        .and(path("/v2/sandboxes"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!([])))
+        .expect(2)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/sandboxes"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(sandbox_created_json("sb-fresh")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    backend
+        .acquire(make_request("conv-5", "sandbox-5"))
+        .await
+        .expect("acquire should create when no metadata match");
+}
+
+#[tokio::test]
+async fn stop_calls_pause_not_delete() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    mount_empty_sandbox_list(&server).await;
+    Mock::given(method("POST"))
+        .and(path("/sandboxes"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(sandbox_created_json("sb-stop")))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/sandboxes/sb-stop/pause"))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend
+        .acquire(make_request("conv-6", "sandbox-6"))
+        .await
+        .unwrap();
+    handle.stop().await.expect("stop should pause");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert!(
+        !requests
+            .iter()
+            .any(|r| r.method.to_string().to_uppercase() == "DELETE")
+    );
+}
+
+#[tokio::test]
+async fn snapshot_returns_e2b_snapshot_payload() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    mount_empty_sandbox_list(&server).await;
+    Mock::given(method("POST"))
+        .and(path("/sandboxes"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(sandbox_created_json("sb-snap")))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/sandboxes/sb-snap/snapshots"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "snapshotID": "team/exo-snap-test:default",
+            "names": ["team/exo-snap-test:default"],
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend
+        .acquire(make_request("conv-7", "sandbox-7"))
+        .await
+        .unwrap();
+    let payload = handle.snapshot().await.expect("snapshot ok");
+
+    assert!(matches!(payload.kind, SnapshotKind::E2bSnapshot));
+    let manifest: Value = serde_json::from_slice(&payload.bytes).unwrap();
+    assert_eq!(
+        manifest.get("snapshot_id").and_then(Value::as_str),
+        Some("team/exo-snap-test:default")
+    );
+}
+
+#[tokio::test]
+async fn acquire_from_snapshot_uses_snapshot_template_id() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    Mock::given(method("POST"))
+        .and(path("/sandboxes"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(sandbox_created_json("sb-restored")))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let manifest = json!({
+        "snapshot_id": "team/exo-snap-canonical:default",
+        "base_template": "base",
+    });
+    let payload = SnapshotPayload {
+        kind: SnapshotKind::E2bSnapshot,
+        bytes: Bytes::from(serde_json::to_vec(&manifest).unwrap()),
+    };
+
+    backend
+        .acquire_from_snapshot(make_request("conv-8", "sandbox-8"), payload)
+        .await
+        .expect("restore ok");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let create = requests
+        .iter()
+        .find(|r| r.url.path() == "/sandboxes" && r.method.as_str() == "POST")
+        .expect("create called");
+    let body: Value = serde_json::from_slice(&create.body).unwrap();
+    assert_eq!(
+        body.get("templateID").and_then(Value::as_str),
+        Some("team/exo-snap-canonical:default")
+    );
+}
+
+#[tokio::test]
+async fn acquire_from_snapshot_rejects_wrong_kind() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    let payload = SnapshotPayload {
+        kind: SnapshotKind::DockerImageTar,
+        bytes: Bytes::from_static(b"\x00"),
+    };
+    let error = match backend
+        .acquire_from_snapshot(make_request("conv-9", "sandbox-9"), payload)
+        .await
+    {
+        Ok(_) => panic!("expected kind mismatch error"),
+        Err(error) => error,
+    };
+    let msg = format!("{error:#}").to_lowercase();
+    assert!(msg.contains("e2b") || msg.contains("kind"));
+}
+
+#[tokio::test]
+async fn exec_uses_envd_process_start() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    mount_empty_sandbox_list(&server).await;
+    Mock::given(method("POST"))
+        .and(path("/sandboxes"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(sandbox_created_json("sb-exec")))
+        .mount(&server)
+        .await;
+
+    let connect_stream = connect_enveloped_stream(&[
+        (0, json!({"event": {"data": {"stdout": "hello from mock"}}})),
+        (2, json!({"event": {"end": {"status": "exit status 0"}}})),
+    ]);
+
+    Mock::given(method("POST"))
+        .and(path("/process.Process/Start"))
+        .and(exec_start_request_with_stdin(false))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_raw(connect_stream, "application/connect+json"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend
+        .acquire(make_request("conv-10", "sandbox-10"))
+        .await
+        .unwrap();
+    let output = handle
+        .exec(&exoharness::SandboxCommand {
+            argv: vec!["/bin/echo".into(), "hello".into()],
+            env: HashMap::new(),
+            display_argv: None,
+            cwd: None,
+            timeout: None,
+        })
+        .await
+        .expect("exec ok");
+
+    assert_eq!(output.exit_code, Some(0));
+    assert_eq!(output.stdout, "hello from mock");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert!(
+        requests
+            .iter()
+            .any(|r| r.url.path() == "/process.Process/Start"),
+        "exec must hit envd process start"
+    );
+}
+
+#[tokio::test]
+async fn start_process_streams_envd_process_stdout() {
+    use futures::io::AsyncReadExt;
+
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    mount_empty_sandbox_list(&server).await;
+    Mock::given(method("POST"))
+        .and(path("/sandboxes"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(sandbox_created_json("sb-stream")))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/process.Process/Start"))
+        .and(exec_start_request_with_stdin(true))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            connect_enveloped_stream(&[
+                (0, json!({"event": {"start": {"pid": 42}}})),
+                (0, json!({"event": {"data": {"stdout": "streamed-line\n"}}})),
+                (0, json!({"event": {"end": {"status": "exit status 0"}}})),
+            ]),
+            "application/connect+json",
+        ))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend
+        .acquire(make_request("conv-stream", "sandbox-stream"))
+        .await
+        .unwrap();
+    let mut process = handle
+        .start_process(&SandboxCommand {
+            argv: vec!["/bin/echo".into(), "ignored".into()],
+            env: HashMap::new(),
+            display_argv: None,
+            cwd: None,
+            timeout: None,
+        })
+        .await
+        .expect("start_process should stream envd output");
+
+    let mut stdout = String::new();
+    process
+        .stdout
+        .read_to_string(&mut stdout)
+        .await
+        .expect("read streamed stdout");
+    let exit_code = process.wait.await.expect("wait for process exit");
+
+    assert_eq!(stdout, "streamed-line\n");
+    assert_eq!(exit_code, 0);
+}
+
+fn exec_start_request_with_stdin(enabled: bool) -> impl Match {
+    struct HasStdin {
+        enabled: bool,
+    }
+    impl Match for HasStdin {
+        fn matches(&self, request: &Request) -> bool {
+            let body = String::from_utf8_lossy(&request.body);
+            if self.enabled {
+                body.contains("\"stdin\":true")
+            } else {
+                body.contains("\"stdin\":false")
+            }
+        }
+    }
+    HasStdin { enabled }
+}
+
+/// Build a Connect server-stream body (5-byte framed JSON messages).
+fn connect_enveloped_stream(messages: &[(u8, Value)]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for (flags, value) in messages {
+        let payload = serde_json::to_vec(value).expect("json");
+        let len = payload.len() as u32;
+        out.push(*flags);
+        out.extend_from_slice(&len.to_be_bytes());
+        out.extend_from_slice(&payload);
+    }
+    out
+}

--- a/crates/cli/tests/sandbox_start_process_live.rs
+++ b/crates/cli/tests/sandbox_start_process_live.rs
@@ -1,0 +1,221 @@
+//! Live `start_process` contract tests for native streaming backends.
+//!
+//! E2B:
+//! `E2B_API_KEY=... E2B_SECURE=0 E2B_TEMPLATE_ID=base cargo test -p exo --test sandbox_start_process_live e2b_ -- --ignored --nocapture`
+//!
+//! Sprites (set `SPRITES_ORGANIZATION` when your token spans multiple orgs):
+//! `SPRITES_TOKEN=... cargo test -p exo --test sandbox_start_process_live sprites_ -- --ignored --nocapture`
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use exoharness::{
+    E2bConfig, E2bSandboxBackend, ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand,
+    SandboxKey, SandboxLifecycleConfig, SandboxNetworkPolicy, SandboxRequest, SandboxSpec,
+    SpritesConfig, SpritesSandboxBackend,
+};
+use futures::io::AsyncReadExt;
+use tokio::time::timeout;
+
+fn e2b_template_id() -> String {
+    std::env::var("E2B_TEMPLATE_ID").unwrap_or_else(|_| "base".into())
+}
+
+fn make_e2b_request(conversation_id: &str, sandbox_id: &str) -> SandboxRequest {
+    SandboxRequest {
+        key: SandboxKey::ConversationSandbox {
+            conversation_id: conversation_id.into(),
+            sandbox_id: sandbox_id.into(),
+        },
+        spec: SandboxSpec {
+            image: e2b_template_id(),
+            mounts: Vec::new(),
+            durable_file_systems: Vec::new(),
+            network: SandboxNetworkPolicy::Enabled,
+            default_workdir: "/home/user".into(),
+        },
+        lifecycle: SandboxLifecycleConfig {
+            idle_ttl: Some(Duration::from_secs(300)),
+        },
+    }
+}
+
+fn sprites_config_from_env() -> SpritesConfig {
+    SpritesConfig {
+        token: std::env::var("SPRITES_TOKEN").expect("SPRITES_TOKEN must be set"),
+        api_url: std::env::var("SPRITES_API_URL")
+            .unwrap_or_else(|_| exoharness::DEFAULT_SPRITES_API_URL.into()),
+        url_auth: std::env::var("SPRITES_URL_AUTH").ok(),
+        organization: std::env::var("SPRITES_ORGANIZATION").ok(),
+        extra_labels: Vec::new(),
+    }
+}
+
+fn make_sprites_request(conversation_id: &str, sandbox_id: &str) -> SandboxRequest {
+    SandboxRequest {
+        key: SandboxKey::ConversationSandbox {
+            conversation_id: conversation_id.into(),
+            sandbox_id: sandbox_id.into(),
+        },
+        spec: SandboxSpec {
+            image: "default".into(),
+            mounts: Vec::new(),
+            durable_file_systems: Vec::new(),
+            network: SandboxNetworkPolicy::Enabled,
+            default_workdir: "/home/sprite".into(),
+        },
+        lifecycle: SandboxLifecycleConfig {
+            idle_ttl: Some(Duration::from_secs(300)),
+        },
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires E2B_API_KEY"]
+async fn e2b_start_process_streams_incrementally() {
+    let api_key = std::env::var("E2B_API_KEY").expect("E2B_API_KEY must be set");
+    let template_id = e2b_template_id();
+    let backend = E2bSandboxBackend::new(E2bConfig {
+        api_key,
+        api_url: exoharness::DEFAULT_E2B_API_URL.into(),
+        template_id: template_id.clone(),
+        envd_port: exoharness::DEFAULT_E2B_ENVD_PORT,
+        envd_base_url: None,
+        secure: std::env::var("E2B_SECURE")
+            .ok()
+            .is_some_and(|value| value != "0"),
+    })
+    .expect("E2bSandboxBackend::new");
+
+    let handle = backend
+        .acquire(make_e2b_request("live-e2b-stream", "sandbox-live-stream"))
+        .await
+        .expect("acquire E2B sandbox");
+    assert_streaming_script(handle, "E2B", "/home/user").await;
+}
+
+#[tokio::test]
+#[ignore = "requires SPRITES_TOKEN"]
+async fn sprites_start_process_streams_incrementally() {
+    let backend =
+        SpritesSandboxBackend::new(sprites_config_from_env()).expect("SpritesSandboxBackend::new");
+
+    let handle = backend
+        .acquire(make_sprites_request(
+            "live-sprites-stream",
+            "sandbox-live-stream",
+        ))
+        .await
+        .expect("acquire Sprites sprite");
+    assert_streaming_script(handle, "Sprites", "/home/sprite").await;
+}
+
+#[tokio::test]
+#[ignore = "requires E2B_API_KEY"]
+async fn e2b_start_process_contract() {
+    let api_key = std::env::var("E2B_API_KEY").expect("E2B_API_KEY must be set");
+    let template_id = e2b_template_id();
+    let backend = E2bSandboxBackend::new(E2bConfig {
+        api_key,
+        api_url: exoharness::DEFAULT_E2B_API_URL.into(),
+        template_id: template_id.clone(),
+        envd_port: exoharness::DEFAULT_E2B_ENVD_PORT,
+        envd_base_url: None,
+        secure: std::env::var("E2B_SECURE")
+            .ok()
+            .is_some_and(|value| value != "0"),
+    })
+    .expect("E2bSandboxBackend::new");
+
+    let handle = backend
+        .acquire(make_e2b_request(
+            "live-e2b-contract",
+            "sandbox-live-contract",
+        ))
+        .await
+        .expect("acquire E2B sandbox");
+    exoharness::contract_tests::sandbox_handle_start_process_supports_interactive_stdio_and_env(
+        handle,
+    )
+    .await
+    .expect("E2B start_process contract");
+}
+
+#[tokio::test]
+#[ignore = "requires SPRITES_TOKEN"]
+async fn sprites_start_process_contract() {
+    let backend =
+        SpritesSandboxBackend::new(sprites_config_from_env()).expect("SpritesSandboxBackend::new");
+
+    let handle = backend
+        .acquire(make_sprites_request(
+            "live-sprites-contract",
+            "sandbox-live-contract",
+        ))
+        .await
+        .expect("acquire Sprites sprite");
+    exoharness::contract_tests::sandbox_handle_start_process_supports_interactive_stdio_and_env(
+        handle,
+    )
+    .await
+    .expect("Sprites start_process contract");
+}
+
+async fn assert_streaming_script(handle: Arc<dyn ManagedSandboxHandle>, provider: &str, cwd: &str) {
+    let mut process = handle
+        .start_process(&SandboxCommand {
+            argv: vec![
+                "/bin/sh".to_string(),
+                "-c".to_string(),
+                "printf 'first\\n'; sleep 1; printf 'second\\n'".to_string(),
+            ],
+            env: HashMap::new(),
+            display_argv: None,
+            cwd: Some(cwd.into()),
+            timeout: Some(Duration::from_secs(30)),
+        })
+        .await
+        .expect("start_process");
+
+    let mut first = [0u8; 6];
+    timeout(
+        Duration::from_secs(10),
+        process.stdout.read_exact(&mut first),
+    )
+    .await
+    .expect("first chunk should arrive quickly")
+    .expect("read first chunk");
+    assert_eq!(
+        std::str::from_utf8(&first).expect("utf8"),
+        "first\n",
+        "{provider} should stream the first line before the process exits"
+    );
+
+    let started = Instant::now();
+    let mut second = [0u8; 7];
+    timeout(
+        Duration::from_secs(10),
+        process.stdout.read_exact(&mut second),
+    )
+    .await
+    .expect("second chunk should arrive after sleep")
+    .expect("read second chunk");
+    assert!(
+        started.elapsed() >= Duration::from_millis(500),
+        "{provider} second line arrived too quickly; output may have been buffered"
+    );
+    assert_eq!(
+        std::str::from_utf8(&second).expect("utf8"),
+        "second\n",
+        "{provider} should stream the second line"
+    );
+
+    let exit_code = timeout(Duration::from_secs(30), process.wait)
+        .await
+        .expect("process should exit")
+        .expect("wait");
+    assert_eq!(exit_code, 0, "{provider} process should exit successfully");
+
+    println!("{provider} streaming start_process ok");
+}

--- a/crates/cli/tests/snapshot_round_trip.rs
+++ b/crates/cli/tests/snapshot_round_trip.rs
@@ -75,6 +75,7 @@ async fn filesystem_snapshot_and_rewind_round_trip() {
             image: SANDBOX_IMAGE.into(),
             default_workdir: Some("/".into()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(false),
             idle_seconds: Some(60),
         })

--- a/crates/cli/tests/sprites_backend.rs
+++ b/crates/cli/tests/sprites_backend.rs
@@ -1,0 +1,460 @@
+//! Wiremock-driven tests for the Sprites sandbox backend.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use bytes::Bytes;
+use exoharness::{
+    ManagedSandboxBackend, SandboxKey, SandboxLifecycleConfig, SandboxMount, SandboxMountAccess,
+    SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotKind, SnapshotPayload,
+    SpritesConfig, SpritesSandboxBackend,
+};
+use serde_json::{Value, json};
+use wiremock::matchers::{method, path, path_regex};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn make_request(conversation_id: &str, sandbox_id: &str) -> SandboxRequest {
+    SandboxRequest {
+        key: SandboxKey::ConversationSandbox {
+            conversation_id: conversation_id.into(),
+            sandbox_id: sandbox_id.into(),
+        },
+        spec: SandboxSpec {
+            image: "default".into(),
+            mounts: Vec::new(),
+            durable_file_systems: Vec::new(),
+            network: SandboxNetworkPolicy::Enabled,
+            default_workdir: "/home/sprite".into(),
+        },
+        lifecycle: SandboxLifecycleConfig {
+            idle_ttl: Some(Duration::from_secs(300)),
+        },
+    }
+}
+
+fn sandbox_spec_hash(spec: &SandboxSpec) -> String {
+    let mut hasher = DefaultHasher::new();
+    spec.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+fn expected_sprite_name(request: &SandboxRequest) -> String {
+    let mut hasher = DefaultHasher::new();
+    request.key.hash(&mut hasher);
+    sandbox_spec_hash(&request.spec).hash(&mut hasher);
+    format!("exo-{:016x}", hasher.finish())
+}
+
+fn backend_for_mock(server: &MockServer) -> SpritesSandboxBackend {
+    backend_with_config(
+        server,
+        SpritesConfig {
+            token: "test-token".into(),
+            api_url: server.uri(),
+            url_auth: None,
+            organization: None,
+            extra_labels: Vec::new(),
+        },
+    )
+}
+
+fn backend_with_config(_server: &MockServer, config: SpritesConfig) -> SpritesSandboxBackend {
+    SpritesSandboxBackend::new(config).expect("SpritesSandboxBackend::new")
+}
+
+fn sprite_info_json(name: &str) -> Value {
+    json!({
+        "id": "sprite-test-id",
+        "name": name,
+        "status": "cold",
+        "url": "https://example.sprites.app",
+        "organization": "test-org",
+        "created_at": "2026-06-01T12:00:00Z",
+        "updated_at": "2026-06-01T12:00:00Z",
+    })
+}
+
+#[tokio::test]
+async fn acquire_creates_sprite_when_missing() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-1", "sandbox-1");
+    let name = expected_sprite_name(&request);
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/sprites/{name}")))
+        .respond_with(ResponseTemplate::new(404))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/sprites"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(sprite_info_json(&name)))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend.acquire(request).await.expect("acquire");
+    assert_eq!(handle.id(), "sprites:conversation:conv-1:sandbox-1");
+}
+
+#[tokio::test]
+async fn acquire_create_includes_exo_metadata_labels() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-labels", "sandbox-labels");
+    let name = expected_sprite_name(&request);
+    let spec_hash = sandbox_spec_hash(&request.spec);
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/sprites/{name}")))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/sprites"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(sprite_info_json(&name)))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    backend.acquire(request).await.expect("acquire");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let create = requests
+        .iter()
+        .find(|r| r.method.as_str() == "POST")
+        .expect("create request");
+    let body: Value = serde_json::from_slice(&create.body).unwrap();
+    let labels = body
+        .get("labels")
+        .and_then(Value::as_array)
+        .expect("labels array");
+    assert!(labels.iter().any(|label| {
+        label.as_str() == Some("exo.sandbox.key=conversation:conv-labels:sandbox-labels")
+    }));
+    assert!(
+        labels
+            .iter()
+            .any(|label| label.as_str() == Some(&format!("exo.sandbox.spec-hash={spec_hash}")))
+    );
+}
+
+#[tokio::test]
+async fn acquire_create_honors_binding_url_auth_and_organization() {
+    let server = MockServer::start().await;
+    let backend = backend_with_config(
+        &server,
+        SpritesConfig {
+            token: "test-token".into(),
+            api_url: server.uri(),
+            url_auth: Some("public".into()),
+            organization: Some("my-org".into()),
+            extra_labels: vec!["prod".into()],
+        },
+    );
+    let request = make_request("conv-bind", "sandbox-bind");
+    let name = expected_sprite_name(&request);
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/sprites/{name}")))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/sprites"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(sprite_info_json(&name)))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    backend.acquire(request).await.expect("acquire");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let create = requests
+        .iter()
+        .find(|r| r.method.as_str() == "POST")
+        .expect("create request");
+    let body: Value = serde_json::from_slice(&create.body).unwrap();
+    assert_eq!(
+        body.pointer("/url_settings/auth").and_then(Value::as_str),
+        Some("public")
+    );
+    assert_eq!(
+        body.get("organization").and_then(Value::as_str),
+        Some("my-org")
+    );
+    let labels = body
+        .get("labels")
+        .and_then(Value::as_array)
+        .expect("labels");
+    assert!(labels.iter().any(|label| label.as_str() == Some("prod")));
+}
+
+#[tokio::test]
+async fn acquire_rejects_host_mounts() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    let mut request = make_request("conv-2", "sandbox-2");
+    request.spec.mounts.push(SandboxMount {
+        host_path: PathBuf::from("/tmp/foo"),
+        guest_path: "/workspace".into(),
+        access: SandboxMountAccess::ReadWrite,
+        internal: false,
+    });
+
+    let error = match backend.acquire(request).await {
+        Ok(_) => panic!("acquire should reject host mounts"),
+        Err(error) => error,
+    };
+    let msg = format!("{error:#}").to_lowercase();
+    assert!(
+        msg.contains("mount") || msg.contains("sprites"),
+        "unexpected: {msg}"
+    );
+    assert_eq!(
+        server.received_requests().await.unwrap_or_default().len(),
+        0
+    );
+}
+
+#[tokio::test]
+async fn acquire_reuses_existing_sprite_without_create() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-3", "sandbox-3");
+    let name = expected_sprite_name(&request);
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/sprites/{name}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sprite_info_json(&name)))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend
+        .acquire(request)
+        .await
+        .expect("acquire should reuse existing sprite");
+    assert_eq!(handle.id(), "sprites:conversation:conv-3:sandbox-3");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert!(
+        !requests.iter().any(|r| r.method.as_str() == "POST"),
+        "acquire must not create sprites when one already exists"
+    );
+}
+
+#[tokio::test]
+async fn stop_does_not_delete_sprite() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-5", "sandbox-5");
+    let name = expected_sprite_name(&request);
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/sprites/{name}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sprite_info_json(&name)))
+        .mount(&server)
+        .await;
+
+    let handle = backend.acquire(request).await.unwrap();
+    handle.stop().await.expect("stop is a no-op");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    assert!(
+        !requests.iter().any(|r| r.method.as_str() == "DELETE"),
+        "stop must not delete the sprite"
+    );
+}
+
+#[tokio::test]
+async fn exec_accepts_plain_text_http_response() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-plain", "sandbox-plain");
+    let name = expected_sprite_name(&request);
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/sprites/{name}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sprite_info_json(&name)))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path_regex(r"/v1/sprites/.+/exec$"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("4\n"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend.acquire(request).await.unwrap();
+    let output = handle
+        .exec(&exoharness::SandboxCommand {
+            argv: vec!["python3".into(), "-c".into(), "print(2+2)".into()],
+            env: Default::default(),
+            display_argv: None,
+            cwd: None,
+            timeout: None,
+        })
+        .await
+        .expect("plain text exec body should parse");
+
+    assert_eq!(output.stdout, "4\n");
+    assert!(output.ok);
+}
+
+#[tokio::test]
+async fn exec_uses_http_post_with_cmd_query_params() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-6", "sandbox-6");
+    let name = expected_sprite_name(&request);
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/sprites/{name}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sprite_info_json(&name)))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path_regex(r"/v1/sprites/.+/exec$"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "exitCode": 0,
+            "stdout": "hello\n",
+            "stderr": "",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend.acquire(request).await.unwrap();
+    let output = handle
+        .exec(&exoharness::SandboxCommand {
+            argv: vec!["echo".into(), "hello".into()],
+            env: Default::default(),
+            display_argv: None,
+            cwd: None,
+            timeout: None,
+        })
+        .await
+        .expect("exec");
+
+    assert!(output.ok);
+    assert_eq!(output.stdout, "hello\n");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let exec_req = requests
+        .iter()
+        .find(|r| r.url.path().ends_with("/exec"))
+        .expect("exec request");
+    let query = exec_req.url.query().expect("query string");
+    assert!(query.contains("cmd=echo"));
+    assert!(query.contains("cmd=hello"));
+    assert!(query.contains("stdin=false"));
+}
+
+#[tokio::test]
+async fn snapshot_returns_sprites_snapshot_payload() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-7", "sandbox-7");
+    let name = expected_sprite_name(&request);
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/sprites/{name}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sprite_info_json(&name)))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(format!("/v1/sprites/{name}/checkpoint")))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            concat!(
+                r#"{"type":"info","data":"  ID: v3","time":"2026-06-01T12:00:00Z"}"#,
+                "\n",
+                r#"{"type":"complete","data":"Checkpoint v3 created","time":"2026-06-01T12:00:01Z"}"#,
+                "\n",
+            ),
+            "application/x-ndjson",
+        ))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend.acquire(request).await.unwrap();
+    let payload = handle.snapshot().await.expect("snapshot");
+
+    assert!(matches!(payload.kind, SnapshotKind::SpritesSnapshot));
+    let manifest: Value = serde_json::from_slice(&payload.bytes).unwrap();
+    assert_eq!(
+        manifest.get("checkpoint_id").and_then(Value::as_str),
+        Some("v3")
+    );
+    assert_eq!(
+        manifest.get("sprite_name").and_then(Value::as_str),
+        Some(name.as_str())
+    );
+}
+
+#[tokio::test]
+async fn acquire_from_snapshot_restores_checkpoint() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-8", "sandbox-8");
+    let name = expected_sprite_name(&request);
+
+    Mock::given(method("GET"))
+        .and(path(format!("/v1/sprites/{name}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sprite_info_json(&name)))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path(format!("/v1/sprites/{name}/checkpoints/v2/restore")))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            r#"{"type":"complete","data":"Restore complete","time":"2026-06-01T12:00:00Z"}"#,
+            "application/x-ndjson",
+        ))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let manifest = json!({
+        "checkpoint_id": "v2",
+        "sprite_name": name,
+    });
+    let payload = SnapshotPayload {
+        kind: SnapshotKind::SpritesSnapshot,
+        bytes: Bytes::from(serde_json::to_vec(&manifest).unwrap()),
+    };
+
+    backend
+        .acquire_from_snapshot(request, payload)
+        .await
+        .expect("restore");
+}
+
+#[tokio::test]
+async fn acquire_from_snapshot_rejects_wrong_kind() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    let payload = SnapshotPayload {
+        kind: SnapshotKind::DockerImageTar,
+        bytes: Bytes::from_static(b"not-a-tar"),
+    };
+
+    let error = match backend
+        .acquire_from_snapshot(make_request("conv-9", "sandbox-9"), payload)
+        .await
+    {
+        Ok(_) => panic!("wrong snapshot kind should fail"),
+        Err(error) => error,
+    };
+    let msg = format!("{error:#}").to_lowercase();
+    assert!(
+        msg.contains("sprites") || msg.contains("kind"),
+        "unexpected: {msg}"
+    );
+}

--- a/crates/cli/tests/vercel_backend.rs
+++ b/crates/cli/tests/vercel_backend.rs
@@ -22,6 +22,7 @@ fn make_request(conversation_id: &str, sandbox_id: &str) -> SandboxRequest {
         spec: SandboxSpec {
             image: "node24".into(),
             mounts: Vec::new(),
+            durable_file_systems: Vec::new(),
             network: SandboxNetworkPolicy::Enabled,
             default_workdir: "/vercel/sandbox".into(),
         },

--- a/crates/executor/src/adapter/runtime.rs
+++ b/crates/executor/src/adapter/runtime.rs
@@ -394,11 +394,9 @@ pub async fn send_adapter_message_with_handles(
         );
     }
     // Note: we intentionally do not write a conversation artifact here.
-    // This tool is invoked from inside an active agent turn, and writing to
-    // the conversation outside the turn handle advances the conversation
-    // head, which makes the active turn stale and crashes the adapter
-    // worker. The outbound message is durably queued in the AdapterStore
-    // outbox, and the event below records it for audit.
+    // The outbound message is durably queued in the AdapterStore outbox, and
+    // the event below records it for audit without adding adapter bookkeeping
+    // to the agent-visible conversation history.
     store
         .record_event(
             adapter.id.clone(),
@@ -759,11 +757,9 @@ async fn handle_worker_message(
         return Ok(());
     }
     // Note: we intentionally do not write a conversation artifact here.
-    // The wakeup turn below begins immediately, and any artifact writes
-    // through the conversation handle (rather than the active turn) advance
-    // the conversation head and could race with concurrent turns. The full
-    // inbound text is delivered to the agent via the wakeup prompt and the
-    // event is recorded in the AdapterStore for audit.
+    // The full inbound text is delivered to the agent via the wakeup prompt,
+    // and the event is recorded in the AdapterStore for audit without adding
+    // adapter bookkeeping to the agent-visible conversation history.
     store
         .record_event(
             adapter.id.clone(),
@@ -798,6 +794,7 @@ async fn handle_worker_message(
             text: prompt,
             encrypted_content: None,
             provider_options: None,
+            cache_control: None,
         })];
         parts.extend(image_parts);
         UserContent::Array(parts)
@@ -946,9 +943,8 @@ async fn record_worker_lifecycle(
     event_type: &str,
     _payload: serde_json::Value,
 ) -> Result<()> {
-    // Note: lifecycle events are recorded only in the AdapterStore. Writing
-    // them to the conversation as artifacts can advance the head outside of
-    // any active turn and corrupt the agent's turn state.
+    // Note: lifecycle events are recorded only in the AdapterStore so adapter
+    // bookkeeping does not pollute the agent-visible conversation history.
     store
         .record_event(
             adapter.id.clone(),

--- a/crates/executor/src/adapter/runtime.rs
+++ b/crates/executor/src/adapter/runtime.rs
@@ -111,11 +111,9 @@ pub async fn send_adapter_message_with_handles(
         );
     }
     // Note: we intentionally do not write a conversation artifact here.
-    // This tool is invoked from inside an active agent turn, and writing to
-    // the conversation outside the turn handle advances the conversation
-    // head, which makes the active turn stale and crashes the adapter
-    // worker. The outbound message is durably queued in the AdapterStore
-    // outbox, and the event below records it for audit.
+    // The outbound message is durably queued in the AdapterStore outbox, and
+    // the event below records it for audit without adding adapter bookkeeping
+    // to the agent-visible conversation history.
     store
         .record_event(
             adapter.id.clone(),
@@ -349,11 +347,9 @@ async fn handle_worker_message(
         return Ok(());
     }
     // Note: we intentionally do not write a conversation artifact here.
-    // The wakeup turn below begins immediately, and any artifact writes
-    // through the conversation handle (rather than the active turn) advance
-    // the conversation head and could race with concurrent turns. The full
-    // inbound text is delivered to the agent via the wakeup prompt and the
-    // event is recorded in the AdapterStore for audit.
+    // The full inbound text is delivered to the agent via the wakeup prompt,
+    // and the event is recorded in the AdapterStore for audit without adding
+    // adapter bookkeeping to the agent-visible conversation history.
     store
         .record_event(
             adapter.id.clone(),
@@ -393,9 +389,8 @@ async fn record_worker_lifecycle(
     event_type: &str,
     _payload: serde_json::Value,
 ) -> Result<()> {
-    // Note: lifecycle events are recorded only in the AdapterStore. Writing
-    // them to the conversation as artifacts can advance the head outside of
-    // any active turn and corrupt the agent's turn state.
+    // Note: lifecycle events are recorded only in the AdapterStore so adapter
+    // bookkeeping does not pollute the agent-visible conversation history.
     store
         .record_event(
             adapter.id.clone(),

--- a/crates/executor/src/adapter/tools.rs
+++ b/crates/executor/src/adapter/tools.rs
@@ -773,13 +773,8 @@ async fn read_sandbox_file(
 ) -> Result<Vec<u8>> {
     match effective_sandbox_scope(agent_config, config) {
         SandboxScope::Agent => {
-            let sandbox = ensure_agent_sandbox(agent, conversation, agent_config, config).await?;
-            read_sandbox_file_bytes(
-                sandbox.conversation.as_ref(),
-                sandbox.sandbox_id,
-                sandbox_path,
-            )
-            .await
+            let sandbox = ensure_agent_sandbox(agent, agent_config, config).await?;
+            read_agent_sandbox_file_bytes(agent, sandbox.sandbox_id, sandbox_path).await
         }
         SandboxScope::Conversation => {
             let sandbox_id =
@@ -847,6 +842,41 @@ async fn read_sandbox_file_bytes(
     sandbox_path: &str,
 ) -> Result<Vec<u8>> {
     let process = conversation
+        .run_in_sandbox(RunInSandboxRequest {
+            id: sandbox_id,
+            command: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "cat -- \"$1\"".to_string(),
+                "exo-read-attachment".to_string(),
+                sandbox_path.to_string(),
+            ],
+            env: Default::default(),
+        })
+        .await?;
+    let output = read_process_limited(process, MAX_ATTACHMENT_BYTES).await?;
+    if output.exit_code != 0 {
+        bail!(
+            "failed to read sandbox attachment {}: {}",
+            sandbox_path,
+            output.stderr.trim()
+        );
+    }
+    if output.truncated {
+        bail!(
+            "sandbox attachment is too large: exceeds {} bytes",
+            MAX_ATTACHMENT_BYTES
+        );
+    }
+    Ok(output.stdout)
+}
+
+async fn read_agent_sandbox_file_bytes(
+    agent: &dyn AgentHandle,
+    sandbox_id: String,
+    sandbox_path: &str,
+) -> Result<Vec<u8>> {
+    let process = agent
         .run_in_sandbox(RunInSandboxRequest {
             id: sandbox_id,
             command: vec![

--- a/crates/executor/src/agent_sandbox.rs
+++ b/crates/executor/src/agent_sandbox.rs
@@ -7,7 +7,9 @@ use serde::{Deserialize, Serialize};
 use crate::conversation_sandbox::{ConversationSandboxSpec, conversation_sandbox_spec};
 use crate::{AgentConfig, ConversationConfig};
 
-const AGENT_SANDBOX_ARTIFACT_PATH: &str = "config/agent-sandbox.json";
+// v1 was a conversation-owned handle with `conversationId`/`sandboxId`. The
+// agent-owned record has a different shape, so keep it on a distinct path.
+const AGENT_SANDBOX_ARTIFACT_PATH: &str = "config/agent-sandbox-v2.json";
 const AGENT_SANDBOX_NAME_PREFIX: &str = "agent-sandbox";
 
 #[derive(Clone)]

--- a/crates/executor/src/agent_sandbox.rs
+++ b/crates/executor/src/agent_sandbox.rs
@@ -1,6 +1,6 @@
 use exoharness::{
-    AgentHandle, Artifact, ArtifactVersion, ConversationHandle, CreateSandboxRequest,
-    ReadArtifactRequest, Result, SandboxProvider, Uuid7, WriteArtifactRequest,
+    AgentHandle, Artifact, ArtifactVersion, CreateSandboxRequest, ReadArtifactRequest, Result,
+    SandboxProvider, Uuid7, WriteArtifactRequest,
 };
 use serde::{Deserialize, Serialize};
 
@@ -12,14 +12,12 @@ const AGENT_SANDBOX_NAME_PREFIX: &str = "agent-sandbox";
 
 #[derive(Clone)]
 pub(crate) struct AgentSandboxHandle {
-    pub(crate) conversation: std::sync::Arc<dyn ConversationHandle>,
     pub(crate) sandbox_id: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct AgentSandboxRecord {
-    conversation_id: String,
     sandbox_name: String,
     provider: SandboxProvider,
     image: String,
@@ -42,7 +40,6 @@ impl AgentSandboxRecord {
 
 pub(crate) async fn ensure_agent_sandbox(
     agent: &dyn AgentHandle,
-    current_conversation: &dyn ConversationHandle,
     agent_config: &AgentConfig,
     conversation_config: &ConversationConfig,
 ) -> Result<AgentSandboxHandle> {
@@ -52,7 +49,7 @@ pub(crate) async fn ensure_agent_sandbox(
     }
 
     let sandbox_name = new_agent_sandbox_name();
-    let sandbox_id = current_conversation
+    let sandbox_id = agent
         .create_sandbox(CreateSandboxRequest {
             name: Some(sandbox_name.clone()),
             provider: spec.provider,
@@ -66,7 +63,6 @@ pub(crate) async fn ensure_agent_sandbox(
     store_agent_sandbox_record(
         agent,
         &AgentSandboxRecord {
-            conversation_id: current_conversation.record().id.to_string(),
             sandbox_name,
             provider: spec.provider,
             image: spec.image,
@@ -78,19 +74,7 @@ pub(crate) async fn ensure_agent_sandbox(
     )
     .await?;
 
-    let Some(owner) = agent
-        .get_conversation(&current_conversation.record().id)
-        .await?
-    else {
-        anyhow::bail!(
-            "agent sandbox owner conversation disappeared: {}",
-            current_conversation.record().id
-        );
-    };
-    Ok(AgentSandboxHandle {
-        conversation: owner,
-        sandbox_id,
-    })
+    Ok(AgentSandboxHandle { sandbox_id })
 }
 
 pub(crate) async fn current_agent_sandbox(
@@ -103,13 +87,7 @@ pub(crate) async fn current_agent_sandbox(
     if !record.matches_spec(spec) {
         return Ok(None);
     }
-    let Ok(conversation_id) = record.conversation_id.parse::<Uuid7>() else {
-        return Ok(None);
-    };
-    let Some(owner) = agent.get_conversation(&conversation_id).await? else {
-        return Ok(None);
-    };
-    let sandbox_id = owner
+    let sandbox_id = agent
         .create_sandbox(CreateSandboxRequest {
             name: Some(record.sandbox_name),
             provider: spec.provider,
@@ -120,10 +98,7 @@ pub(crate) async fn current_agent_sandbox(
             idle_seconds: Some(spec.idle_seconds),
         })
         .await?;
-    Ok(Some(AgentSandboxHandle {
-        conversation: owner,
-        sandbox_id,
-    }))
+    Ok(Some(AgentSandboxHandle { sandbox_id }))
 }
 
 async fn load_agent_sandbox_record(agent: &dyn AgentHandle) -> Result<Option<AgentSandboxRecord>> {

--- a/crates/executor/src/agent_sandbox.rs
+++ b/crates/executor/src/agent_sandbox.rs
@@ -25,6 +25,8 @@ struct AgentSandboxRecord {
     image: String,
     default_workdir: String,
     file_system_mounts: Vec<exoharness::FileSystemMount>,
+    #[serde(default)]
+    durable_file_systems: Vec<exoharness::DurableFileSystem>,
     enable_networking: bool,
     idle_seconds: u64,
 }
@@ -35,6 +37,7 @@ impl AgentSandboxRecord {
             && self.image == spec.image
             && self.default_workdir == spec.default_workdir
             && self.file_system_mounts == spec.file_system_mounts
+            && self.durable_file_systems == spec.durable_file_systems
             && self.enable_networking == spec.enable_networking
             && self.idle_seconds == spec.idle_seconds
     }
@@ -58,6 +61,7 @@ pub(crate) async fn ensure_agent_sandbox(
             image: spec.image.clone(),
             default_workdir: Some(spec.default_workdir.clone()),
             file_system_mounts: Some(spec.file_system_mounts.clone()),
+            durable_file_systems: Some(spec.durable_file_systems.clone()),
             enable_networking: Some(spec.enable_networking),
             idle_seconds: Some(spec.idle_seconds),
         })
@@ -70,6 +74,7 @@ pub(crate) async fn ensure_agent_sandbox(
             image: spec.image,
             default_workdir: spec.default_workdir,
             file_system_mounts: spec.file_system_mounts,
+            durable_file_systems: spec.durable_file_systems,
             enable_networking: spec.enable_networking,
             idle_seconds: spec.idle_seconds,
         },
@@ -96,6 +101,7 @@ pub(crate) async fn current_agent_sandbox(
             image: spec.image.clone(),
             default_workdir: Some(spec.default_workdir.clone()),
             file_system_mounts: Some(spec.file_system_mounts.clone()),
+            durable_file_systems: Some(spec.durable_file_systems.clone()),
             enable_networking: Some(spec.enable_networking),
             idle_seconds: Some(spec.idle_seconds),
         })

--- a/crates/executor/src/agent_sandbox.rs
+++ b/crates/executor/src/agent_sandbox.rs
@@ -26,6 +26,8 @@ struct AgentSandboxRecord {
     image: String,
     default_workdir: String,
     file_system_mounts: Vec<exoharness::FileSystemMount>,
+    #[serde(default)]
+    durable_file_systems: Vec<exoharness::DurableFileSystem>,
     enable_networking: bool,
     idle_seconds: u64,
 }
@@ -36,6 +38,7 @@ impl AgentSandboxRecord {
             && self.image == spec.image
             && self.default_workdir == spec.default_workdir
             && self.file_system_mounts == spec.file_system_mounts
+            && self.durable_file_systems == spec.durable_file_systems
             && self.enable_networking == spec.enable_networking
             && self.idle_seconds == spec.idle_seconds
     }
@@ -70,6 +73,7 @@ pub(crate) async fn ensure_agent_sandbox(
             image: spec.image.clone(),
             default_workdir: Some(spec.default_workdir.clone()),
             file_system_mounts: Some(spec.file_system_mounts.clone()),
+            durable_file_systems: Some(spec.durable_file_systems.clone()),
             enable_networking: Some(spec.enable_networking),
             idle_seconds: Some(spec.idle_seconds),
         })
@@ -83,6 +87,7 @@ pub(crate) async fn ensure_agent_sandbox(
             image: spec.image,
             default_workdir: spec.default_workdir,
             file_system_mounts: spec.file_system_mounts,
+            durable_file_systems: spec.durable_file_systems,
             enable_networking: spec.enable_networking,
             idle_seconds: spec.idle_seconds,
         },

--- a/crates/executor/src/basic_tests.rs
+++ b/crates/executor/src/basic_tests.rs
@@ -10,10 +10,10 @@ use exoharness::{
     ConversationId, ConversationRecord, CreateSandboxRequest, Event, EventData, EventQuery,
     EventQueryDirection, EventStream, ExoHarness, ForkConversationRequest, GetEventsResult,
     NewAgentRequest, NewConversationRequest, PutSecretRequest, ReadArtifactRequest, Result,
-    RunInSandboxRequest, SandboxId, SandboxProcess, SandboxProcessEventQuery, SandboxProcessParts,
-    SandboxProcessRecord, SandboxProcessStatus, Secret, SecretMetadata, SecretType, SessionId,
-    SnapshotId, StartSandboxProcessRequest, StartSandboxRequest, ToolRequest, ToolResult,
-    TurnHandle, TurnId, TurnRecord, Uuid7, WriteArtifactRequest,
+    RunInSandboxRequest, SandboxHandle, SandboxId, SandboxProcess, SandboxProcessEventQuery,
+    SandboxProcessParts, SandboxProcessRecord, SandboxProcessStatus, Secret, SecretMetadata,
+    SecretType, SessionId, SnapshotId, StartSandboxProcessRequest, StartSandboxRequest,
+    ToolRequest, ToolResult, TurnHandle, TurnId, TurnRecord, Uuid7, WriteArtifactRequest,
 };
 use futures::FutureExt;
 use futures::io::Cursor;
@@ -784,6 +784,74 @@ impl AgentHandle for FakeAgentHandle {
     }
 }
 
+#[async_trait]
+impl SandboxHandle for FakeAgentHandle {
+    async fn create_sandbox(&self, _request: CreateSandboxRequest) -> Result<SandboxId> {
+        Ok("agent-sandbox".to_string())
+    }
+
+    async fn snapshot_sandbox(&self, _id: SandboxId) -> Result<SnapshotId> {
+        Ok(Uuid7::now())
+    }
+
+    async fn start_sandbox(&self, _request: StartSandboxRequest) -> Result<()> {
+        Ok(())
+    }
+
+    async fn stop_sandbox(&self, _id: SandboxId) -> Result<()> {
+        Ok(())
+    }
+
+    async fn start_sandbox_process(
+        &self,
+        _request: StartSandboxProcessRequest,
+    ) -> Result<SandboxProcessRecord> {
+        Err(anyhow!("not implemented"))
+    }
+
+    async fn write_sandbox_process_input(
+        &self,
+        _request: exoharness::WriteSandboxProcessInputRequest,
+    ) -> Result<()> {
+        Err(anyhow!("not implemented"))
+    }
+
+    async fn close_sandbox_process_input(
+        &self,
+        _request: exoharness::CloseSandboxProcessInputRequest,
+    ) -> Result<()> {
+        Err(anyhow!("not implemented"))
+    }
+
+    async fn get_sandbox_process_events(
+        &self,
+        _query: SandboxProcessEventQuery,
+    ) -> Result<exoharness::GetSandboxProcessEventsResult> {
+        Err(anyhow!("not implemented"))
+    }
+
+    async fn wait_sandbox_process(
+        &self,
+        _request: exoharness::WaitSandboxProcessRequest,
+    ) -> Result<SandboxProcessStatus> {
+        Err(anyhow!("not implemented"))
+    }
+
+    async fn cancel_sandbox_process(
+        &self,
+        _request: exoharness::CancelSandboxProcessRequest,
+    ) -> Result<SandboxProcessStatus> {
+        Err(anyhow!("not implemented"))
+    }
+
+    async fn run_in_sandbox(
+        &self,
+        _request: RunInSandboxRequest,
+    ) -> Result<Box<dyn SandboxProcess>> {
+        Ok(Box::new(FakeSandboxProcess))
+    }
+}
+
 struct FakeConversationHandle {
     state: Arc<Mutex<FakeState>>,
     record: ConversationRecord,
@@ -962,6 +1030,35 @@ impl ConversationHandle for FakeConversationHandle {
         Ok(Vec::new())
     }
 
+    async fn list_bindings(&self) -> Result<Vec<BindingRecord>> {
+        Ok(vec![test_model_binding_record()])
+    }
+
+    async fn put_binding(&self, _binding: Binding) -> Result<exoharness::BindingId> {
+        Err(anyhow!("not implemented"))
+    }
+
+    async fn get_binding(&self, _id: &exoharness::BindingId) -> Result<Option<Binding>> {
+        Ok(Some(test_model_binding()))
+    }
+
+    async fn list_secrets(&self) -> Result<Vec<SecretMetadata>> {
+        Ok(vec![test_secret_metadata()])
+    }
+
+    async fn put_secret(&self, _secret: PutSecretRequest) -> Result<exoharness::SecretId> {
+        Err(anyhow!("not implemented"))
+    }
+
+    async fn get_secret(&self, _id: &exoharness::SecretId) -> Result<Option<Secret>> {
+        Ok(Some(Secret::Key {
+            value: "test-key".to_string(),
+        }))
+    }
+}
+
+#[async_trait]
+impl SandboxHandle for FakeConversationHandle {
     async fn create_sandbox(&self, _request: CreateSandboxRequest) -> Result<SandboxId> {
         Err(anyhow!("not implemented"))
     }
@@ -1025,32 +1122,6 @@ impl ConversationHandle for FakeConversationHandle {
         _request: RunInSandboxRequest,
     ) -> Result<Box<dyn SandboxProcess>> {
         Ok(Box::new(FakeSandboxProcess))
-    }
-
-    async fn list_bindings(&self) -> Result<Vec<BindingRecord>> {
-        Ok(vec![test_model_binding_record()])
-    }
-
-    async fn put_binding(&self, _binding: Binding) -> Result<exoharness::BindingId> {
-        Err(anyhow!("not implemented"))
-    }
-
-    async fn get_binding(&self, _id: &exoharness::BindingId) -> Result<Option<Binding>> {
-        Ok(Some(test_model_binding()))
-    }
-
-    async fn list_secrets(&self) -> Result<Vec<SecretMetadata>> {
-        Ok(vec![test_secret_metadata()])
-    }
-
-    async fn put_secret(&self, _secret: PutSecretRequest) -> Result<exoharness::SecretId> {
-        Err(anyhow!("not implemented"))
-    }
-
-    async fn get_secret(&self, _id: &exoharness::SecretId) -> Result<Option<Secret>> {
-        Ok(Some(Secret::Key {
-            value: "test-key".to_string(),
-        }))
     }
 }
 

--- a/crates/executor/src/basic_tests.rs
+++ b/crates/executor/src/basic_tests.rs
@@ -987,10 +987,6 @@ impl ConversationHandle for FakeConversationHandle {
 
     async fn add_events(&self, request: AddEventsRequest) -> Result<AddEventsResult> {
         let mut state = self.state.lock().expect("state poisoned");
-        if request.expected_head != state.conversation.record.latest_event_id {
-            return Err(anyhow!("head mismatch"));
-        }
-
         let mut event_ids = Vec::new();
         let mut latest_event_id = state.conversation.record.latest_event_id;
 
@@ -1156,10 +1152,6 @@ impl TurnHandle for FakeTurnHandle {
     }
 
     async fn add_events(&self, data: Vec<EventData>) -> Result<AddEventsResult> {
-        let expected_head = *self
-            .latest_event_id
-            .lock()
-            .expect("turn latest event id poisoned");
         let add_result = FakeConversationHandle {
             state: Arc::clone(&self.state),
             record: {
@@ -1170,7 +1162,6 @@ impl TurnHandle for FakeTurnHandle {
         .add_events(AddEventsRequest {
             session_id: Some(self.record.session_id),
             turn_id: Some(self.record.id),
-            expected_head,
             data,
         })
         .await?;

--- a/crates/executor/src/basic_tests.rs
+++ b/crates/executor/src/basic_tests.rs
@@ -12,8 +12,9 @@ use exoharness::{
     NewAgentRequest, NewConversationRequest, PutSecretRequest, ReadArtifactRequest, Result,
     RunInSandboxRequest, SandboxHandle, SandboxId, SandboxProcess, SandboxProcessEventQuery,
     SandboxProcessParts, SandboxProcessRecord, SandboxProcessStatus, Secret, SecretMetadata,
-    SecretType, SessionId, SnapshotId, StartSandboxProcessRequest, StartSandboxRequest,
-    ToolRequest, ToolResult, TurnHandle, TurnId, TurnRecord, Uuid7, WriteArtifactRequest,
+    SecretType, SessionId, SnapshotHandle, SnapshotId, StartSandboxProcessRequest,
+    StartSandboxRequest, ToolRequest, ToolResult, TurnHandle, TurnId, TurnRecord, Uuid7,
+    WriteArtifactRequest,
 };
 use futures::FutureExt;
 use futures::io::Cursor;
@@ -785,17 +786,20 @@ impl AgentHandle for FakeAgentHandle {
 }
 
 #[async_trait]
-impl SandboxHandle for FakeAgentHandle {
-    async fn create_sandbox(&self, _request: CreateSandboxRequest) -> Result<SandboxId> {
-        Ok("agent-sandbox".to_string())
-    }
-
+impl SnapshotHandle for FakeAgentHandle {
     async fn snapshot_sandbox(&self, _id: SandboxId) -> Result<SnapshotId> {
         Ok(Uuid7::now())
     }
 
     async fn start_sandbox(&self, _request: StartSandboxRequest) -> Result<()> {
         Ok(())
+    }
+}
+
+#[async_trait]
+impl SandboxHandle for FakeAgentHandle {
+    async fn create_sandbox(&self, _request: CreateSandboxRequest) -> Result<SandboxId> {
+        Ok("agent-sandbox".to_string())
     }
 
     async fn stop_sandbox(&self, _id: SandboxId) -> Result<()> {
@@ -1058,16 +1062,19 @@ impl ConversationHandle for FakeConversationHandle {
 }
 
 #[async_trait]
-impl SandboxHandle for FakeConversationHandle {
-    async fn create_sandbox(&self, _request: CreateSandboxRequest) -> Result<SandboxId> {
-        Err(anyhow!("not implemented"))
-    }
-
+impl SnapshotHandle for FakeConversationHandle {
     async fn snapshot_sandbox(&self, _id: SandboxId) -> Result<SnapshotId> {
         Err(anyhow!("not implemented"))
     }
 
     async fn start_sandbox(&self, _request: StartSandboxRequest) -> Result<()> {
+        Err(anyhow!("not implemented"))
+    }
+}
+
+#[async_trait]
+impl SandboxHandle for FakeConversationHandle {
+    async fn create_sandbox(&self, _request: CreateSandboxRequest) -> Result<SandboxId> {
         Err(anyhow!("not implemented"))
     }
 
@@ -1132,6 +1139,17 @@ struct FakeTurnHandle {
 }
 
 #[async_trait]
+impl SnapshotHandle for FakeTurnHandle {
+    async fn snapshot_sandbox(&self, _id: SandboxId) -> Result<SnapshotId> {
+        Err(anyhow!("not implemented"))
+    }
+
+    async fn start_sandbox(&self, _request: StartSandboxRequest) -> Result<()> {
+        Err(anyhow!("not implemented"))
+    }
+}
+
+#[async_trait]
 impl TurnHandle for FakeTurnHandle {
     fn record(&self) -> &TurnRecord {
         &self.record
@@ -1165,14 +1183,6 @@ impl TurnHandle for FakeTurnHandle {
     }
 
     async fn write_artifact(&self, _request: WriteArtifactRequest) -> Result<ArtifactVersion> {
-        Err(anyhow!("not implemented"))
-    }
-
-    async fn snapshot_sandbox(&self, _id: SandboxId) -> Result<SnapshotId> {
-        Err(anyhow!("not implemented"))
-    }
-
-    async fn start_sandbox(&self, _request: StartSandboxRequest) -> Result<()> {
         Err(anyhow!("not implemented"))
     }
 

--- a/crates/executor/src/basic_tests.rs
+++ b/crates/executor/src/basic_tests.rs
@@ -1097,6 +1097,14 @@ impl TurnHandle for FakeTurnHandle {
         Err(anyhow!("not implemented"))
     }
 
+    async fn snapshot_sandbox(&self, _id: SandboxId) -> Result<SnapshotId> {
+        Err(anyhow!("not implemented"))
+    }
+
+    async fn start_sandbox(&self, _request: StartSandboxRequest) -> Result<()> {
+        Err(anyhow!("not implemented"))
+    }
+
     async fn finish(&self) -> Result<exoharness::EventId> {
         let event_id = append_event(
             &self.state,

--- a/crates/executor/src/basic_tests.rs
+++ b/crates/executor/src/basic_tests.rs
@@ -913,10 +913,6 @@ impl ConversationHandle for FakeConversationHandle {
 
     async fn add_events(&self, request: AddEventsRequest) -> Result<AddEventsResult> {
         let mut state = self.state.lock().expect("state poisoned");
-        if request.expected_head != state.conversation.record.latest_event_id {
-            return Err(anyhow!("head mismatch"));
-        }
-
         let mut event_ids = Vec::new();
         let mut latest_event_id = state.conversation.record.latest_event_id;
 
@@ -1065,10 +1061,6 @@ impl TurnHandle for FakeTurnHandle {
     }
 
     async fn add_events(&self, data: Vec<EventData>) -> Result<AddEventsResult> {
-        let expected_head = *self
-            .latest_event_id
-            .lock()
-            .expect("turn latest event id poisoned");
         let add_result = FakeConversationHandle {
             state: Arc::clone(&self.state),
             record: {
@@ -1079,7 +1071,6 @@ impl TurnHandle for FakeTurnHandle {
         .add_events(AddEventsRequest {
             session_id: Some(self.record.session_id),
             turn_id: Some(self.record.id),
-            expected_head,
             data,
         })
         .await?;

--- a/crates/executor/src/braintrust_tests.rs
+++ b/crates/executor/src/braintrust_tests.rs
@@ -12,6 +12,7 @@ fn llm_metrics_use_braintrust_metric_names() {
         prompt_cached_tokens: Some(3),
         prompt_cache_creation_tokens: Some(2),
         completion_reasoning_tokens: Some(5),
+        ..Default::default()
     };
 
     let metrics = llm_metrics(Some(&usage), Some(Duration::from_millis(250)));

--- a/crates/executor/src/conversation_events.rs
+++ b/crates/executor/src/conversation_events.rs
@@ -58,7 +58,6 @@ pub async fn record_host_event(
         .add_events(AddEventsRequest {
             session_id: None,
             turn_id: None,
-            expected_head: None,
             data: vec![EventData::Custom {
                 event_type: event_type.to_string(),
                 payload,

--- a/crates/executor/src/conversation_sandbox.rs
+++ b/crates/executor/src/conversation_sandbox.rs
@@ -15,6 +15,7 @@ pub(crate) struct ConversationSandboxInfo {
     pub(crate) image: String,
     pub(crate) default_workdir: String,
     pub(crate) file_system_mounts: Vec<FileSystemMount>,
+    pub(crate) durable_file_systems: Vec<exoharness::DurableFileSystem>,
     pub(crate) enable_networking: bool,
     pub(crate) idle_seconds: u64,
 }
@@ -25,6 +26,7 @@ impl ConversationSandboxInfo {
             && self.image == spec.image
             && self.default_workdir == spec.default_workdir
             && self.file_system_mounts == spec.file_system_mounts
+            && self.durable_file_systems == spec.durable_file_systems
             && self.enable_networking == spec.enable_networking
             && self.idle_seconds == spec.idle_seconds
     }
@@ -36,6 +38,7 @@ pub(crate) struct ConversationSandboxSpec {
     pub(crate) image: String,
     pub(crate) default_workdir: String,
     pub(crate) file_system_mounts: Vec<FileSystemMount>,
+    pub(crate) durable_file_systems: Vec<exoharness::DurableFileSystem>,
     pub(crate) enable_networking: bool,
     pub(crate) idle_seconds: u64,
 }
@@ -71,6 +74,7 @@ pub(crate) async fn create_conversation_sandbox(
             image: spec.image,
             default_workdir: Some(spec.default_workdir),
             file_system_mounts: Some(spec.file_system_mounts),
+            durable_file_systems: Some(spec.durable_file_systems),
             enable_networking: Some(spec.enable_networking),
             idle_seconds: Some(spec.idle_seconds),
         })
@@ -100,6 +104,7 @@ pub(crate) async fn conversation_sandboxes(
             image,
             default_workdir,
             file_system_mounts,
+            durable_file_systems,
             enable_networking,
             idle_seconds,
             ..
@@ -111,6 +116,7 @@ pub(crate) async fn conversation_sandboxes(
                 image,
                 default_workdir,
                 file_system_mounts,
+                durable_file_systems,
                 enable_networking,
                 idle_seconds,
             });
@@ -134,8 +140,15 @@ pub(crate) fn conversation_sandbox_spec(
             .mounts
             .first()
             .map(|mount| mount.mount_path.clone())
+            .or_else(|| {
+                config
+                    .durable_file_systems
+                    .first()
+                    .map(|file_system| file_system.mount_path.clone())
+            })
             .unwrap_or_else(|| "/".to_string()),
         file_system_mounts: normalize_mounts(&config.mounts),
+        durable_file_systems: config.durable_file_systems.clone(),
         enable_networking: agent_config.enable_networking,
         idle_seconds: 300,
     }

--- a/crates/executor/src/executor_types.rs
+++ b/crates/executor/src/executor_types.rs
@@ -5,8 +5,9 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use exoharness::{
-    AgentHandle, ConversationHandle, EventId, FileSystemMount, ResponseId, Result, SandboxProvider,
-    SessionId, ToolArguments, ToolCallId, ToolRequest, ToolResult, TurnHandle, TurnId,
+    AgentHandle, ConversationHandle, DurableFileSystem, EventId, FileSystemMount, ResponseId,
+    Result, SandboxProvider, SessionId, ToolArguments, ToolCallId, ToolRequest, ToolResult,
+    TurnHandle, TurnId,
 };
 use lingua::{Message, UniversalStreamChunk, UniversalUsage};
 use serde::{Deserialize, Serialize};
@@ -68,6 +69,8 @@ pub struct ConversationConfig {
     #[serde(default)]
     pub mounts: Vec<FileSystemMount>,
     #[serde(default)]
+    pub durable_file_systems: Vec<DurableFileSystem>,
+    #[serde(default)]
     pub sandbox_scope: Option<SandboxScope>,
 }
 
@@ -104,6 +107,7 @@ impl Default for ConversationConfig {
             sandbox_provider: None,
             shell_program: Some("/bin/bash".to_string()),
             mounts: Vec::new(),
+            durable_file_systems: Vec::new(),
             sandbox_scope: None,
         }
     }

--- a/crates/executor/src/executor_types.rs
+++ b/crates/executor/src/executor_types.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use exoharness::{
-    AgentHandle, ConversationHandle, EventId, FileSystemMount, ResponseId, Result, SandboxProvider,
-    SessionId, ToolArguments, ToolCallId, ToolRequest, ToolResult, TurnId,
+    AgentHandle, ConversationHandle, DurableFileSystem, EventId, FileSystemMount, ResponseId,
+    Result, SandboxProvider, SessionId, ToolArguments, ToolCallId, ToolRequest, ToolResult, TurnId,
 };
 use lingua::{Message, UniversalStreamChunk, UniversalUsage};
 use serde::{Deserialize, Serialize};
@@ -68,6 +68,8 @@ pub struct ConversationConfig {
     #[serde(default)]
     pub mounts: Vec<FileSystemMount>,
     #[serde(default)]
+    pub durable_file_systems: Vec<DurableFileSystem>,
+    #[serde(default)]
     pub sandbox_scope: Option<SandboxScope>,
 }
 
@@ -104,6 +106,7 @@ impl Default for ConversationConfig {
             sandbox_provider: None,
             shell_program: Some("/bin/bash".to_string()),
             mounts: Vec::new(),
+            durable_file_systems: Vec::new(),
             sandbox_scope: None,
         }
     }

--- a/crates/executor/src/harness_basic_tests.rs
+++ b/crates/executor/src/harness_basic_tests.rs
@@ -211,6 +211,7 @@ async fn usage_record_is_persisted_with_computed_cost() {
                 prompt_cached_tokens: None,
                 prompt_cache_creation_tokens: None,
                 completion_reasoning_tokens: None,
+                ..Default::default()
             }),
             model: Some("claude-sonnet-4-6".to_string()),
             ttft: None,
@@ -355,6 +356,7 @@ async fn usage_record_with_anthropic_cache_hits() {
                 prompt_cached_tokens: Some(10_000),
                 prompt_cache_creation_tokens: Some(2_000),
                 completion_reasoning_tokens: None,
+                ..Default::default()
             }),
             model: Some("claude-sonnet-4-6".to_string()),
             ttft: None,
@@ -474,6 +476,7 @@ async fn usage_record_with_openai_inclusive_accounting() {
                 prompt_cached_tokens: Some(500),
                 prompt_cache_creation_tokens: None,
                 completion_reasoning_tokens: None,
+                ..Default::default()
             }),
             model: Some("gpt-4o-mini".to_string()),
             ttft: None,

--- a/crates/executor/src/harness_facade.rs
+++ b/crates/executor/src/harness_facade.rs
@@ -247,6 +247,7 @@ where
                 .shell_program
                 .or(default_conversation_config.shell_program),
             mounts: default_conversation_config.mounts,
+            durable_file_systems: default_conversation_config.durable_file_systems,
             sandbox_scope: default_conversation_config.sandbox_scope,
         };
         self.runtime

--- a/crates/executor/src/harness_helpers.rs
+++ b/crates/executor/src/harness_helpers.rs
@@ -178,7 +178,6 @@ pub(crate) async fn put_conversation_model_override(
         .add_events(AddEventsRequest {
             session_id: None,
             turn_id: None,
-            expected_head: None,
             data: vec![EventData::Custom {
                 event_type: CONVERSATION_MODEL_CONFIG_EVENT_TYPE.to_string(),
                 payload,

--- a/crates/executor/src/harness_runtime.rs
+++ b/crates/executor/src/harness_runtime.rs
@@ -44,9 +44,8 @@ impl ModelClient for RouterModelClient {
         let router = build_router(&request, format, &config)?;
         let universal_request = build_universal_request(&request, false)?;
         let payload = serialize_request(format, &universal_request)?;
-        let (prepared, _router_metadata) = router
-            .create_request(payload, &request.model, format)
-            .await?;
+        let route = resolve_provider_route(&router, &request.model, format)?;
+        let (prepared, _router_metadata) = router.create_request(payload, format, &route).await?;
         let body = router.complete(prepared, &ClientHeaders::new()).await?;
         let response = lingua::response_to_universal(body)?;
         normalize_model_response(response)
@@ -58,11 +57,12 @@ impl ModelClient for RouterModelClient {
         let router = build_router(&request, format, &config)?;
         let universal_request = build_universal_request(&request, true)?;
         let payload = serialize_request(format, &universal_request)?;
+        let route = resolve_provider_route(&router, &request.model, format)?;
         let (prepared, _router_metadata) = router
-            .create_stream_request(payload, &request.model, format)
+            .create_stream_request(payload, format, &route)
             .await?;
         let raw_stream = router
-            .complete_stream(prepared, &ClientHeaders::new())
+            .complete_stream(prepared, &ClientHeaders::new(), None)
             .await?;
         Ok(Box::new(RouterModelResponseStream {
             stream: map_universal_stream(raw_stream, format),
@@ -193,6 +193,18 @@ fn build_router(
         )
         .build()
         .map_err(Into::into)
+}
+
+fn resolve_provider_route(
+    router: &Router,
+    model: &str,
+    format: ProviderFormat,
+) -> Result<braintrust_llm_router::ProviderRoute> {
+    router
+        .resolve_provider_routes(model, format, &[])?
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("no provider route resolved for model {model}"))
 }
 
 fn build_universal_request(request: &ModelRequest, stream: bool) -> Result<UniversalRequest> {
@@ -526,6 +538,7 @@ impl UniversalResponseAccumulator {
                 text: self.text.clone(),
                 encrypted_content: None,
                 provider_options: None,
+                cache_control: None,
             }));
         }
 

--- a/crates/executor/src/harness_tool.rs
+++ b/crates/executor/src/harness_tool.rs
@@ -410,8 +410,15 @@ pub(crate) async fn ensure_shell_sandbox(
         .mounts
         .first()
         .map(|mount| mount.mount_path.clone())
+        .or_else(|| {
+            config
+                .durable_file_systems
+                .first()
+                .map(|file_system| file_system.mount_path.clone())
+        })
         .unwrap_or_else(|| "/".to_string());
     let desired_mounts = normalize_mounts(&config.mounts);
+    let desired_durable_file_systems = config.durable_file_systems.clone();
     let desired_provider = config.effective_sandbox_provider(agent_config);
     // Empty means "unspecified"; the harness fills the provider's default.
     let requested_image = config.effective_sandbox_image(agent_config);
@@ -425,6 +432,7 @@ pub(crate) async fn ensure_shell_sandbox(
         let config_matches = image_matches
             && sandbox.default_workdir == desired_default_workdir
             && sandbox.file_system_mounts == desired_mounts
+            && sandbox.durable_file_systems == desired_durable_file_systems
             && sandbox.enable_networking == desired_enable_networking
             && sandbox.idle_seconds == 300;
 
@@ -453,6 +461,7 @@ pub(crate) async fn ensure_shell_sandbox(
             image: desired_image,
             default_workdir: Some(desired_default_workdir),
             file_system_mounts: Some(desired_mounts),
+            durable_file_systems: Some(desired_durable_file_systems),
             enable_networking: Some(desired_enable_networking),
             idle_seconds: Some(300),
         })
@@ -480,6 +489,7 @@ struct ShellSandboxInfo {
     image: String,
     default_workdir: String,
     file_system_mounts: Vec<FileSystemMount>,
+    durable_file_systems: Vec<exoharness::DurableFileSystem>,
     enable_networking: bool,
     idle_seconds: u64,
 }
@@ -510,6 +520,7 @@ async fn latest_shell_sandbox(
             image,
             default_workdir,
             file_system_mounts,
+            durable_file_systems,
             enable_networking,
             idle_seconds,
             ..
@@ -522,6 +533,7 @@ async fn latest_shell_sandbox(
                 image,
                 default_workdir,
                 file_system_mounts,
+                durable_file_systems,
                 enable_networking,
                 idle_seconds,
             }))

--- a/crates/executor/src/harness_tool.rs
+++ b/crates/executor/src/harness_tool.rs
@@ -519,9 +519,7 @@ async fn execute_snapshot_sandbox_tool(
         SandboxControlScope::Agent => {
             let handle = ensure_agent_sandbox(agent, conversation, agent_config, config).await?;
             let owner_conversation_id = handle.conversation.record().id;
-            let snapshot_id = turn
-                .snapshot_sandbox(owner_conversation_id, handle.sandbox_id.clone())
-                .await?;
+            let snapshot_id = turn.snapshot_sandbox(handle.sandbox_id.clone()).await?;
             record_sandbox_snapshot(
                 agent,
                 scope,
@@ -541,9 +539,7 @@ async fn execute_snapshot_sandbox_tool(
         SandboxControlScope::Conversation => {
             let sandbox_id =
                 ensure_conversation_sandbox(conversation, agent_config, config).await?;
-            let snapshot_id = turn
-                .snapshot_sandbox(conversation.record().id, sandbox_id.clone())
-                .await?;
+            let snapshot_id = turn.snapshot_sandbox(sandbox_id.clone()).await?;
             record_sandbox_snapshot(
                 agent,
                 scope,
@@ -580,14 +576,11 @@ async fn execute_rewind_sandbox_tool(
         SandboxControlScope::Agent => {
             let handle = ensure_agent_sandbox(agent, conversation, agent_config, config).await?;
             let owner_conversation_id = handle.conversation.record().id;
-            turn.start_sandbox(
-                owner_conversation_id,
-                StartSandboxRequest {
-                    id: handle.sandbox_id.clone(),
-                    snapshot_id,
-                    idle_seconds: Some(spec.idle_seconds),
-                },
-            )
+            turn.start_sandbox(StartSandboxRequest {
+                id: handle.sandbox_id.clone(),
+                snapshot_id,
+                idle_seconds: Some(spec.idle_seconds),
+            })
             .await?;
             record_current_sandbox_snapshot(
                 agent,
@@ -609,14 +602,11 @@ async fn execute_rewind_sandbox_tool(
         SandboxControlScope::Conversation => {
             let sandbox_id =
                 ensure_conversation_sandbox(conversation, agent_config, config).await?;
-            turn.start_sandbox(
-                conversation.record().id,
-                StartSandboxRequest {
-                    id: sandbox_id.clone(),
-                    snapshot_id,
-                    idle_seconds: Some(spec.idle_seconds),
-                },
-            )
+            turn.start_sandbox(StartSandboxRequest {
+                id: sandbox_id.clone(),
+                snapshot_id,
+                idle_seconds: Some(spec.idle_seconds),
+            })
             .await?;
             record_current_sandbox_snapshot(
                 agent,

--- a/crates/executor/src/harness_tool.rs
+++ b/crates/executor/src/harness_tool.rs
@@ -889,8 +889,15 @@ pub(crate) async fn ensure_shell_sandbox(
         .mounts
         .first()
         .map(|mount| mount.mount_path.clone())
+        .or_else(|| {
+            config
+                .durable_file_systems
+                .first()
+                .map(|file_system| file_system.mount_path.clone())
+        })
         .unwrap_or_else(|| "/".to_string());
     let desired_mounts = normalize_mounts(&config.mounts);
+    let desired_durable_file_systems = config.durable_file_systems.clone();
     let desired_provider = config.effective_sandbox_provider(agent_config);
     // Empty means "unspecified"; the harness fills the provider's default.
     let requested_image = config.effective_sandbox_image(agent_config);
@@ -904,6 +911,7 @@ pub(crate) async fn ensure_shell_sandbox(
         let config_matches = image_matches
             && sandbox.default_workdir == desired_default_workdir
             && sandbox.file_system_mounts == desired_mounts
+            && sandbox.durable_file_systems == desired_durable_file_systems
             && sandbox.enable_networking == desired_enable_networking
             && sandbox.idle_seconds == 300;
 
@@ -932,6 +940,7 @@ pub(crate) async fn ensure_shell_sandbox(
             image: desired_image,
             default_workdir: Some(desired_default_workdir),
             file_system_mounts: Some(desired_mounts),
+            durable_file_systems: Some(desired_durable_file_systems),
             enable_networking: Some(desired_enable_networking),
             idle_seconds: Some(300),
         })
@@ -959,6 +968,7 @@ struct ShellSandboxInfo {
     image: String,
     default_workdir: String,
     file_system_mounts: Vec<FileSystemMount>,
+    durable_file_systems: Vec<exoharness::DurableFileSystem>,
     enable_networking: bool,
     idle_seconds: u64,
 }
@@ -989,6 +999,7 @@ async fn latest_shell_sandbox(
             image,
             default_workdir,
             file_system_mounts,
+            durable_file_systems,
             enable_networking,
             idle_seconds,
             ..
@@ -1001,6 +1012,7 @@ async fn latest_shell_sandbox(
                 image,
                 default_workdir,
                 file_system_mounts,
+                durable_file_systems,
                 enable_networking,
                 idle_seconds,
             }))

--- a/crates/executor/src/harness_tool.rs
+++ b/crates/executor/src/harness_tool.rs
@@ -95,7 +95,7 @@ impl ToolRuntime for ExoclawToolRuntime {
     ) -> Result<()> {
         match effective_sandbox_scope(agent_config, config) {
             SandboxScope::Agent => {
-                ensure_agent_sandbox(agent, conversation, agent_config, config).await?;
+                ensure_agent_sandbox(agent, agent_config, config).await?;
             }
             SandboxScope::Conversation => {
                 ensure_conversation_sandbox(conversation, agent_config, config).await?;
@@ -305,7 +305,7 @@ struct RewindSandboxArguments {
 struct SandboxSnapshotInfo {
     snapshot_id: String,
     sandbox_id: String,
-    owner_conversation_id: String,
+    owner_conversation_id: Option<String>,
     scope: SandboxControlScope,
     created_at_ms: u64,
 }
@@ -476,13 +476,7 @@ async fn execute_list_sandbox_snapshots_tool(
             let Some(handle) = current_agent_sandbox(agent, &spec).await? else {
                 return Ok(empty_sandbox_snapshot_result(scope));
             };
-            sandbox_snapshot_result(
-                agent,
-                scope,
-                Some(handle.conversation.record().id.to_string()),
-                handle.sandbox_id,
-            )
-            .await
+            sandbox_snapshot_result(agent, scope, None, handle.sandbox_id).await
         }
         SandboxControlScope::Conversation => {
             let spec = conversation_sandbox_spec(agent_config, config);
@@ -517,13 +511,17 @@ async fn execute_snapshot_sandbox_tool(
     let scope = SandboxControlScope::or_default(args.scope);
     match scope {
         SandboxControlScope::Agent => {
-            let handle = ensure_agent_sandbox(agent, conversation, agent_config, config).await?;
-            let owner_conversation_id = handle.conversation.record().id;
-            let snapshot_id = turn.snapshot_sandbox(handle.sandbox_id.clone()).await?;
+            let handle = ensure_agent_sandbox(agent, agent_config, config).await?;
+            let snapshot_id = agent.snapshot_sandbox(handle.sandbox_id.clone()).await?;
+            turn.add_events(vec![EventData::SandboxSnapshotted {
+                sandbox_id: handle.sandbox_id.clone(),
+                snapshot_id,
+            }])
+            .await?;
             record_sandbox_snapshot(
                 agent,
                 scope,
-                owner_conversation_id.to_string(),
+                String::new(),
                 handle.sandbox_id.clone(),
                 snapshot_id.to_string(),
             )
@@ -532,7 +530,7 @@ async fn execute_snapshot_sandbox_tool(
                 "ok": true,
                 "scope": scope.as_str(),
                 "sandboxId": handle.sandbox_id,
-                "ownerConversationId": owner_conversation_id.to_string(),
+                "ownerConversationId": null,
                 "snapshotId": snapshot_id.to_string(),
             }))
         }
@@ -574,18 +572,23 @@ async fn execute_rewind_sandbox_tool(
     let spec = conversation_sandbox_spec(agent_config, config);
     match scope {
         SandboxControlScope::Agent => {
-            let handle = ensure_agent_sandbox(agent, conversation, agent_config, config).await?;
-            let owner_conversation_id = handle.conversation.record().id;
-            turn.start_sandbox(StartSandboxRequest {
-                id: handle.sandbox_id.clone(),
-                snapshot_id,
-                idle_seconds: Some(spec.idle_seconds),
-            })
+            let handle = ensure_agent_sandbox(agent, agent_config, config).await?;
+            agent
+                .start_sandbox(StartSandboxRequest {
+                    id: handle.sandbox_id.clone(),
+                    snapshot_id,
+                    idle_seconds: Some(spec.idle_seconds),
+                })
+                .await?;
+            turn.add_events(vec![EventData::SandboxStarted {
+                sandbox_id: handle.sandbox_id.clone(),
+                snapshot_id: Some(snapshot_id),
+            }])
             .await?;
             record_current_sandbox_snapshot(
                 agent,
                 scope,
-                owner_conversation_id.to_string(),
+                String::new(),
                 handle.sandbox_id.clone(),
                 args.snapshot_id.clone(),
             )
@@ -594,7 +597,7 @@ async fn execute_rewind_sandbox_tool(
                 "ok": true,
                 "scope": scope.as_str(),
                 "sandboxId": handle.sandbox_id,
-                "ownerConversationId": owner_conversation_id.to_string(),
+                "ownerConversationId": null,
                 "snapshotId": args.snapshot_id,
                 "rewound": true,
             }))
@@ -635,6 +638,10 @@ async fn sandbox_snapshot_result(
     sandbox_id: String,
 ) -> Result<ToolResult> {
     let owner_conversation_id = owner_conversation_id.unwrap_or_default();
+    let owner_conversation_id_result = match scope {
+        SandboxControlScope::Agent => None,
+        SandboxControlScope::Conversation => Some(owner_conversation_id.clone()),
+    };
     let registry = load_sandbox_snapshot_registry(agent).await?;
     let snapshots = registry
         .snapshots
@@ -647,7 +654,7 @@ async fn sandbox_snapshot_result(
         .map(|snapshot| SandboxSnapshotInfo {
             snapshot_id: snapshot.snapshot_id.clone(),
             sandbox_id: snapshot.sandbox_id.clone(),
-            owner_conversation_id: snapshot.owner_conversation_id.clone(),
+            owner_conversation_id: owner_conversation_id_result.clone(),
             scope: snapshot.scope,
             created_at_ms: snapshot.created_at_ms,
         })
@@ -666,7 +673,7 @@ async fn sandbox_snapshot_result(
         "ok": true,
         "scope": scope.as_str(),
         "sandboxId": sandbox_id,
-        "ownerConversationId": owner_conversation_id,
+        "ownerConversationId": owner_conversation_id_result,
         "currentSnapshotId": current_snapshot_id,
         "snapshots": snapshots,
     }))
@@ -862,9 +869,8 @@ async fn execute_exoclaw_shell_tool(
         .shell_program
         .clone()
         .ok_or_else(|| anyhow::anyhow!("shell tool is not enabled for this conversation"))?;
-    let agent_sandbox = ensure_agent_sandbox(agent, conversation, agent_config, config).await?;
-    let process = agent_sandbox
-        .conversation
+    let agent_sandbox = ensure_agent_sandbox(agent, agent_config, config).await?;
+    let process = agent
         .run_in_sandbox(RunInSandboxRequest {
             id: agent_sandbox.sandbox_id,
             command: vec![program, "-lc".to_string(), args.command],

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -49,14 +49,15 @@ pub use executor_types::{
 };
 pub use exoharness::{
     AgentHandle, BasicExoHarness, BasicExoHarnessConfig, Binding, BindingRecord,
-    ConversationHandle, DEFAULT_SANDBOX_IMAGE, DaytonaBackendSpec, EventData, EventId, EventKind,
-    EventQuery, EventQueryDirection, ExoHarness, ExoHarnessHttpServeOptions, FileSystemMount,
-    FileSystemMountMode, ForkConversationRequest, HTTP_EXOHARNESS_TRACING_TARGET, HttpExoHarness,
-    PutSecretRequest, SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, SandboxId, SandboxProvider,
-    SandboxProviderConfig, Secret, SecretBackendChoice, SecretMetadata, SessionId, SnapshotId,
-    StartSandboxRequest, ToolRequest, Uuid7, VercelBackendSpec, default_aws_agentcore_image,
-    default_daytona_image, default_docker_image, default_vercel_image,
-    serve_exoharness_http_listener, serve_exoharness_http_listener_with_options,
+    ConversationHandle, DEFAULT_SANDBOX_IMAGE, DaytonaBackendSpec, E2bBackendSpec, EventData,
+    EventId, EventKind, EventQuery, EventQueryDirection, ExoHarness, ExoHarnessHttpServeOptions,
+    FileSystemMount, FileSystemMountMode, ForkConversationRequest, HTTP_EXOHARNESS_TRACING_TARGET,
+    HttpExoHarness, PutSecretRequest, SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, SandboxId,
+    SandboxProvider, SandboxProviderConfig, Secret, SecretBackendChoice, SecretMetadata, SessionId,
+    SnapshotId, SpritesBackendSpec, StartSandboxRequest, ToolRequest, Uuid7, VercelBackendSpec,
+    default_aws_agentcore_image, default_daytona_image, default_docker_image, default_e2b_template,
+    default_vercel_image, serve_exoharness_http_listener,
+    serve_exoharness_http_listener_with_options,
 };
 pub use harness_basic::BasicHarness;
 pub use harness_config::load_agent_config;

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -50,14 +50,15 @@ pub use executor_types::{
 };
 pub use exoharness::{
     AgentHandle, BasicExoHarness, BasicExoHarnessConfig, Binding, BindingRecord,
-    ConversationHandle, DEFAULT_SANDBOX_IMAGE, DaytonaBackendSpec, EventData, EventId, EventKind,
-    EventQuery, EventQueryDirection, ExoHarness, ExoHarnessHttpServeOptions, FileSystemMount,
-    FileSystemMountMode, ForkConversationRequest, HTTP_EXOHARNESS_TRACING_TARGET, HttpExoHarness,
-    PutSecretRequest, SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, SandboxId, SandboxProvider,
-    SandboxProviderConfig, Secret, SecretBackendChoice, SecretMetadata, SessionId, SnapshotId,
-    StartSandboxRequest, ToolRequest, Uuid7, VercelBackendSpec, default_aws_agentcore_image,
-    default_daytona_image, default_docker_image, default_vercel_image,
-    serve_exoharness_http_listener, serve_exoharness_http_listener_with_options,
+    ConversationHandle, DEFAULT_SANDBOX_IMAGE, DaytonaBackendSpec, E2bBackendSpec, EventData,
+    EventId, EventKind, EventQuery, EventQueryDirection, ExoHarness, ExoHarnessHttpServeOptions,
+    FileSystemMount, FileSystemMountMode, ForkConversationRequest, HTTP_EXOHARNESS_TRACING_TARGET,
+    HttpExoHarness, PutSecretRequest, SANDBOX_MAIN_MOUNT_DIR, SandboxBackendChoice, SandboxId,
+    SandboxProvider, SandboxProviderConfig, Secret, SecretBackendChoice, SecretMetadata, SessionId,
+    SnapshotId, SpritesBackendSpec, StartSandboxRequest, ToolRequest, Uuid7, VercelBackendSpec,
+    default_aws_agentcore_image, default_daytona_image, default_docker_image, default_e2b_template,
+    default_vercel_image, serve_exoharness_http_listener,
+    serve_exoharness_http_listener_with_options,
 };
 pub use harness_basic::BasicHarness;
 pub use harness_config::load_agent_config;

--- a/crates/executor/src/local_sandbox.rs
+++ b/crates/executor/src/local_sandbox.rs
@@ -640,7 +640,6 @@ impl LocalSandboxConversation {
             .add_events(AddEventsRequest {
                 session_id: None,
                 turn_id: None,
-                expected_head: None,
                 data: vec![EventData::Custom {
                     event_type: LOCAL_SANDBOX_MAP_EVENT.to_string(),
                     payload: serde_json::to_value(LocalSandboxMapEvent {
@@ -658,7 +657,6 @@ impl LocalSandboxConversation {
             .add_events(AddEventsRequest {
                 session_id: None,
                 turn_id: None,
-                expected_head: None,
                 data,
             })
             .await?;
@@ -818,6 +816,7 @@ impl SandboxHandle for LocalSandboxConversation {
                 image: request.image,
                 default_workdir: request.default_workdir.unwrap_or_default(),
                 file_system_mounts: request.file_system_mounts.unwrap_or_default(),
+                durable_file_systems: request.durable_file_systems.unwrap_or_default(),
                 enable_networking: request.enable_networking.unwrap_or(true),
                 idle_seconds: request.idle_seconds.unwrap_or(60),
             },
@@ -1037,6 +1036,7 @@ mod tests {
                 image: "local-image".to_string(),
                 default_workdir: Some("/workspace".to_string()),
                 file_system_mounts: Some(Vec::new()),
+                durable_file_systems: None,
                 enable_networking: Some(false),
                 idle_seconds: Some(120),
             })

--- a/crates/executor/src/local_sandbox.rs
+++ b/crates/executor/src/local_sandbox.rs
@@ -11,8 +11,8 @@ use exoharness::{
     ListConversationsResult, NewAgentRequest, NewConversationRequest, PutSecretRequest,
     ReadArtifactRequest, Result, RunInSandboxRequest, SandboxHandle, SandboxId, SandboxProcess,
     SandboxProcessEventQuery, SandboxProcessRecord, SandboxProcessStatus, Secret, SecretId,
-    SecretMetadata, SnapshotId, StartSandboxProcessRequest, StartSandboxRequest, TurnHandle,
-    TurnRecord, Uuid7, WaitSandboxProcessRequest, WriteArtifactRequest,
+    SecretMetadata, SnapshotHandle, SnapshotId, StartSandboxProcessRequest, StartSandboxRequest,
+    TurnHandle, TurnRecord, Uuid7, WaitSandboxProcessRequest, WriteArtifactRequest,
     WriteSandboxProcessInputRequest,
 };
 use serde::{Deserialize, Serialize};
@@ -277,18 +277,7 @@ impl AgentHandle for LocalSandboxAgent {
 }
 
 #[async_trait]
-impl SandboxHandle for LocalSandboxAgent {
-    async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
-        if !self.wants_local_sandbox(&request) {
-            return self.remote.create_sandbox(request).await;
-        }
-
-        let local_id = self.local_agent().await?.create_sandbox(request).await?;
-        let remote_id = local_id.clone();
-        self.map_local_sandbox(remote_id.clone(), local_id).await;
-        Ok(remote_id)
-    }
-
+impl SnapshotHandle for LocalSandboxAgent {
     async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
         let Some(local_id) = self.local_sandbox_id(&id).await? else {
             return self.remote.snapshot_sandbox(id).await;
@@ -308,6 +297,20 @@ impl SandboxHandle for LocalSandboxAgent {
                 idle_seconds: request.idle_seconds,
             })
             .await
+    }
+}
+
+#[async_trait]
+impl SandboxHandle for LocalSandboxAgent {
+    async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
+        if !self.wants_local_sandbox(&request) {
+            return self.remote.create_sandbox(request).await;
+        }
+
+        let local_id = self.local_agent().await?.create_sandbox(request).await?;
+        let remote_id = local_id.clone();
+        self.map_local_sandbox(remote_id.clone(), local_id).await;
+        Ok(remote_id)
     }
 
     async fn stop_sandbox(&self, id: SandboxId) -> Result<()> {
@@ -755,39 +758,7 @@ impl ConversationHandle for LocalSandboxConversation {
 }
 
 #[async_trait]
-impl SandboxHandle for LocalSandboxConversation {
-    async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
-        if !self.wants_local_sandbox(&request) {
-            return self.remote.create_sandbox(request).await;
-        }
-
-        let remote_id = format!("sandbox-{}", Uuid7::now());
-        let local_id = self
-            .local_conversation()
-            .await?
-            .create_sandbox(request.clone())
-            .await?;
-        self.map_local_sandbox(remote_id.clone(), local_id).await?;
-        self.append_remote_sandbox_events(vec![
-            EventData::SandboxCreated {
-                sandbox_id: remote_id.clone(),
-                name: request.name,
-                provider: request.provider,
-                image: request.image,
-                default_workdir: request.default_workdir.unwrap_or_default(),
-                file_system_mounts: request.file_system_mounts.unwrap_or_default(),
-                enable_networking: request.enable_networking.unwrap_or(true),
-                idle_seconds: request.idle_seconds.unwrap_or(60),
-            },
-            EventData::SandboxStarted {
-                sandbox_id: remote_id.clone(),
-                snapshot_id: None,
-            },
-        ])
-        .await?;
-        Ok(remote_id)
-    }
-
+impl SnapshotHandle for LocalSandboxConversation {
     async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
         let Some(local_id) = self.local_sandbox_id(&id).await? else {
             return self.remote.snapshot_sandbox(id).await;
@@ -822,6 +793,41 @@ impl SandboxHandle for LocalSandboxConversation {
             snapshot_id: Some(request.snapshot_id),
         }])
         .await
+    }
+}
+
+#[async_trait]
+impl SandboxHandle for LocalSandboxConversation {
+    async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
+        if !self.wants_local_sandbox(&request) {
+            return self.remote.create_sandbox(request).await;
+        }
+
+        let remote_id = format!("sandbox-{}", Uuid7::now());
+        let local_id = self
+            .local_conversation()
+            .await?
+            .create_sandbox(request.clone())
+            .await?;
+        self.map_local_sandbox(remote_id.clone(), local_id).await?;
+        self.append_remote_sandbox_events(vec![
+            EventData::SandboxCreated {
+                sandbox_id: remote_id.clone(),
+                name: request.name,
+                provider: request.provider,
+                image: request.image,
+                default_workdir: request.default_workdir.unwrap_or_default(),
+                file_system_mounts: request.file_system_mounts.unwrap_or_default(),
+                enable_networking: request.enable_networking.unwrap_or(true),
+                idle_seconds: request.idle_seconds.unwrap_or(60),
+            },
+            EventData::SandboxStarted {
+                sandbox_id: remote_id.clone(),
+                snapshot_id: None,
+            },
+        ])
+        .await?;
+        Ok(remote_id)
     }
 
     async fn stop_sandbox(&self, id: SandboxId) -> Result<()> {
@@ -916,19 +922,7 @@ struct LocalSandboxTurnHandle {
 }
 
 #[async_trait]
-impl TurnHandle for LocalSandboxTurnHandle {
-    fn record(&self) -> &TurnRecord {
-        self.remote.record()
-    }
-
-    async fn add_events(&self, data: Vec<EventData>) -> Result<AddEventsResult> {
-        self.remote.add_events(data).await
-    }
-
-    async fn write_artifact(&self, request: WriteArtifactRequest) -> Result<ArtifactVersion> {
-        self.remote.write_artifact(request).await
-    }
-
+impl SnapshotHandle for LocalSandboxTurnHandle {
     async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
         let Some(local_id) = local_sandbox_id_for(&self.state, self.conversation_id, &id).await?
         else {
@@ -976,6 +970,21 @@ impl TurnHandle for LocalSandboxTurnHandle {
             }])
             .await?;
         Ok(())
+    }
+}
+
+#[async_trait]
+impl TurnHandle for LocalSandboxTurnHandle {
+    fn record(&self) -> &TurnRecord {
+        self.remote.record()
+    }
+
+    async fn add_events(&self, data: Vec<EventData>) -> Result<AddEventsResult> {
+        self.remote.add_events(data).await
+    }
+
+    async fn write_artifact(&self, request: WriteArtifactRequest) -> Result<ArtifactVersion> {
+        self.remote.write_artifact(request).await
     }
 
     async fn finish(&self) -> Result<EventId> {

--- a/crates/executor/src/local_sandbox.rs
+++ b/crates/executor/src/local_sandbox.rs
@@ -9,7 +9,7 @@ use exoharness::{
     ConversationHandle, ConversationId, CreateSandboxRequest, Event, EventData, EventId, EventKind,
     EventStream, ExoHarness, ForkConversationRequest, GetEventsResult, ListConversationsRequest,
     ListConversationsResult, NewAgentRequest, NewConversationRequest, PutSecretRequest,
-    ReadArtifactRequest, Result, RunInSandboxRequest, SandboxId, SandboxProcess,
+    ReadArtifactRequest, Result, RunInSandboxRequest, SandboxHandle, SandboxId, SandboxProcess,
     SandboxProcessEventQuery, SandboxProcessRecord, SandboxProcessStatus, Secret, SecretId,
     SecretMetadata, SnapshotId, StartSandboxProcessRequest, StartSandboxRequest, TurnHandle,
     TurnRecord, Uuid7, WaitSandboxProcessRequest, WriteArtifactRequest,
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 
 const LOCAL_SANDBOX_AGENT_SLUG: &str = "__exo_local_sandbox";
+const LOCAL_AGENT_SANDBOX_SLUG_PREFIX: &str = "__exo_local_agent_sandbox";
 const LOCAL_SANDBOX_MAP_EVENT: &str = "local_sandbox_mapped";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -34,6 +35,7 @@ pub struct LocalSandboxExoHarness {
 struct LocalSandboxState {
     remote: Arc<dyn ExoHarness>,
     local: Arc<dyn ExoHarness>,
+    agents: Mutex<HashMap<AgentId, Arc<dyn AgentHandle>>>,
     conversations: Mutex<HashMap<ConversationId, Arc<dyn ConversationHandle>>>,
     conversation_init: Mutex<()>,
     sandboxes: Mutex<HashMap<SandboxId, SandboxId>>,
@@ -54,6 +56,7 @@ impl LocalSandboxExoHarness {
             state: Arc::new(LocalSandboxState {
                 remote,
                 local,
+                agents: Mutex::new(HashMap::new()),
                 conversations: Mutex::new(HashMap::new()),
                 conversation_init: Mutex::new(()),
                 sandboxes: Mutex::new(HashMap::new()),
@@ -126,6 +129,70 @@ struct LocalSandboxAgent {
 
 fn wrap_agent(state: Arc<LocalSandboxState>, remote: Arc<dyn AgentHandle>) -> Arc<dyn AgentHandle> {
     Arc::new(LocalSandboxAgent { state, remote })
+}
+
+async fn local_agent_for(
+    state: &Arc<LocalSandboxState>,
+    remote_agent_id: AgentId,
+    remote_slug: &str,
+) -> Result<Arc<dyn AgentHandle>> {
+    {
+        let agents = state.agents.lock().await;
+        if let Some(agent) = agents.get(&remote_agent_id) {
+            return Ok(Arc::clone(agent));
+        }
+    }
+
+    let slug = format!("{LOCAL_AGENT_SANDBOX_SLUG_PREFIX}-{remote_agent_id}");
+    let local_agent = match state
+        .local
+        .list_agents()
+        .await?
+        .into_iter()
+        .find(|agent| agent.record().slug == slug)
+    {
+        Some(agent) => agent,
+        None => {
+            state
+                .local
+                .new_agent(NewAgentRequest {
+                    slug,
+                    name: format!("Local agent sandbox for {remote_slug}"),
+                })
+                .await?
+        }
+    };
+
+    let mut agents = state.agents.lock().await;
+    agents.insert(remote_agent_id, Arc::clone(&local_agent));
+    Ok(local_agent)
+}
+
+impl LocalSandboxAgent {
+    async fn local_agent(&self) -> Result<Arc<dyn AgentHandle>> {
+        local_agent_for(
+            &self.state,
+            self.remote.record().id,
+            self.remote.record().slug.as_str(),
+        )
+        .await
+    }
+
+    fn wants_local_sandbox(&self, request: &CreateSandboxRequest) -> bool {
+        self.state.force_local || request.provider.is_local()
+    }
+
+    async fn local_sandbox_id(&self, sandbox_id: &SandboxId) -> Result<Option<SandboxId>> {
+        Ok(self.state.sandboxes.lock().await.get(sandbox_id).cloned())
+    }
+
+    async fn map_local_sandbox(&self, remote_id: SandboxId, local_id: SandboxId) {
+        self.state
+            .sandboxes
+            .lock()
+            .await
+            .insert(remote_id, local_id);
+    }
 }
 
 #[async_trait]
@@ -206,6 +273,118 @@ impl AgentHandle for LocalSandboxAgent {
 
     async fn list_artifacts(&self) -> Result<Vec<ArtifactVersion>> {
         self.remote.list_artifacts().await
+    }
+}
+
+#[async_trait]
+impl SandboxHandle for LocalSandboxAgent {
+    async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
+        if !self.wants_local_sandbox(&request) {
+            return self.remote.create_sandbox(request).await;
+        }
+
+        let local_id = self.local_agent().await?.create_sandbox(request).await?;
+        let remote_id = local_id.clone();
+        self.map_local_sandbox(remote_id.clone(), local_id).await;
+        Ok(remote_id)
+    }
+
+    async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
+        let Some(local_id) = self.local_sandbox_id(&id).await? else {
+            return self.remote.snapshot_sandbox(id).await;
+        };
+        self.local_agent().await?.snapshot_sandbox(local_id).await
+    }
+
+    async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
+        let Some(local_id) = self.local_sandbox_id(&request.id).await? else {
+            return self.remote.start_sandbox(request).await;
+        };
+        self.local_agent()
+            .await?
+            .start_sandbox(StartSandboxRequest {
+                id: local_id,
+                snapshot_id: request.snapshot_id,
+                idle_seconds: request.idle_seconds,
+            })
+            .await
+    }
+
+    async fn stop_sandbox(&self, id: SandboxId) -> Result<()> {
+        let Some(local_id) = self.local_sandbox_id(&id).await? else {
+            return self.remote.stop_sandbox(id).await;
+        };
+        self.local_agent().await?.stop_sandbox(local_id).await
+    }
+
+    async fn start_sandbox_process(
+        &self,
+        request: StartSandboxProcessRequest,
+    ) -> Result<SandboxProcessRecord> {
+        let Some(local_id) = self.local_sandbox_id(&request.sandbox_id).await? else {
+            return self.remote.start_sandbox_process(request).await;
+        };
+        start_mapped_sandbox_process(self.local_agent().await?, local_id, request).await
+    }
+
+    async fn write_sandbox_process_input(
+        &self,
+        request: WriteSandboxProcessInputRequest,
+    ) -> Result<()> {
+        let Some(local_id) = self.local_sandbox_id(&request.sandbox_id).await? else {
+            return self.remote.write_sandbox_process_input(request).await;
+        };
+        write_mapped_sandbox_process_input(self.local_agent().await?, local_id, request).await
+    }
+
+    async fn close_sandbox_process_input(
+        &self,
+        request: CloseSandboxProcessInputRequest,
+    ) -> Result<()> {
+        let Some(local_id) = self.local_sandbox_id(&request.sandbox_id).await? else {
+            return self.remote.close_sandbox_process_input(request).await;
+        };
+        close_mapped_sandbox_process_input(self.local_agent().await?, local_id, request).await
+    }
+
+    async fn get_sandbox_process_events(
+        &self,
+        query: SandboxProcessEventQuery,
+    ) -> Result<exoharness::GetSandboxProcessEventsResult> {
+        let Some(local_id) = self.local_sandbox_id(&query.sandbox_id).await? else {
+            return self.remote.get_sandbox_process_events(query).await;
+        };
+        get_mapped_sandbox_process_events(self.local_agent().await?, local_id, query).await
+    }
+
+    async fn wait_sandbox_process(
+        &self,
+        request: WaitSandboxProcessRequest,
+    ) -> Result<SandboxProcessStatus> {
+        let Some(local_id) = self.local_sandbox_id(&request.sandbox_id).await? else {
+            return self.remote.wait_sandbox_process(request).await;
+        };
+        wait_mapped_sandbox_process(self.local_agent().await?, local_id, request).await
+    }
+
+    async fn cancel_sandbox_process(
+        &self,
+        request: CancelSandboxProcessRequest,
+    ) -> Result<SandboxProcessStatus> {
+        let Some(local_id) = self.local_sandbox_id(&request.sandbox_id).await? else {
+            return self.remote.cancel_sandbox_process(request).await;
+        };
+        cancel_mapped_sandbox_process(self.local_agent().await?, local_id, request).await
+    }
+
+    async fn run_in_sandbox(
+        &self,
+        request: RunInSandboxRequest,
+    ) -> Result<Box<dyn SandboxProcess>> {
+        let Some(local_id) = self.local_sandbox_id(&request.id).await? else {
+            return self.remote.run_in_sandbox(request).await;
+        };
+        run_in_mapped_sandbox(self.local_agent().await?, local_id, request).await
     }
 }
 
@@ -335,6 +514,100 @@ async fn local_sandbox_id_for(
     Ok(None)
 }
 
+async fn start_mapped_sandbox_process(
+    local: Arc<dyn SandboxHandle>,
+    local_id: SandboxId,
+    request: StartSandboxProcessRequest,
+) -> Result<SandboxProcessRecord> {
+    let remote_id = request.sandbox_id.clone();
+    let mut process = local
+        .start_sandbox_process(StartSandboxProcessRequest {
+            sandbox_id: local_id,
+            ..request
+        })
+        .await?;
+    process.sandbox_id = remote_id;
+    Ok(process)
+}
+
+async fn write_mapped_sandbox_process_input(
+    local: Arc<dyn SandboxHandle>,
+    local_id: SandboxId,
+    request: WriteSandboxProcessInputRequest,
+) -> Result<()> {
+    local
+        .write_sandbox_process_input(WriteSandboxProcessInputRequest {
+            sandbox_id: local_id,
+            ..request
+        })
+        .await
+}
+
+async fn close_mapped_sandbox_process_input(
+    local: Arc<dyn SandboxHandle>,
+    local_id: SandboxId,
+    request: CloseSandboxProcessInputRequest,
+) -> Result<()> {
+    local
+        .close_sandbox_process_input(CloseSandboxProcessInputRequest {
+            sandbox_id: local_id,
+            ..request
+        })
+        .await
+}
+
+async fn get_mapped_sandbox_process_events(
+    local: Arc<dyn SandboxHandle>,
+    local_id: SandboxId,
+    query: SandboxProcessEventQuery,
+) -> Result<exoharness::GetSandboxProcessEventsResult> {
+    local
+        .get_sandbox_process_events(SandboxProcessEventQuery {
+            sandbox_id: local_id,
+            ..query
+        })
+        .await
+}
+
+async fn wait_mapped_sandbox_process(
+    local: Arc<dyn SandboxHandle>,
+    local_id: SandboxId,
+    request: WaitSandboxProcessRequest,
+) -> Result<SandboxProcessStatus> {
+    local
+        .wait_sandbox_process(WaitSandboxProcessRequest {
+            sandbox_id: local_id,
+            ..request
+        })
+        .await
+}
+
+async fn cancel_mapped_sandbox_process(
+    local: Arc<dyn SandboxHandle>,
+    local_id: SandboxId,
+    request: CancelSandboxProcessRequest,
+) -> Result<SandboxProcessStatus> {
+    local
+        .cancel_sandbox_process(CancelSandboxProcessRequest {
+            sandbox_id: local_id,
+            ..request
+        })
+        .await
+}
+
+async fn run_in_mapped_sandbox(
+    local: Arc<dyn SandboxHandle>,
+    local_id: SandboxId,
+    request: RunInSandboxRequest,
+) -> Result<Box<dyn SandboxProcess>> {
+    local
+        .run_in_sandbox(RunInSandboxRequest {
+            id: local_id,
+            ..request
+        })
+        .await
+}
+
 impl LocalSandboxConversation {
     async fn local_conversation(&self) -> Result<Arc<dyn ConversationHandle>> {
         local_conversation_for(
@@ -456,6 +729,33 @@ impl ConversationHandle for LocalSandboxConversation {
         self.remote.list_artifacts().await
     }
 
+    async fn list_bindings(&self) -> Result<Vec<BindingRecord>> {
+        self.remote.list_bindings().await
+    }
+
+    async fn put_binding(&self, binding: Binding) -> Result<BindingId> {
+        self.remote.put_binding(binding).await
+    }
+
+    async fn get_binding(&self, id: &BindingId) -> Result<Option<Binding>> {
+        self.remote.get_binding(id).await
+    }
+
+    async fn list_secrets(&self) -> Result<Vec<SecretMetadata>> {
+        self.remote.list_secrets().await
+    }
+
+    async fn put_secret(&self, request: PutSecretRequest) -> Result<SecretId> {
+        self.remote.put_secret(request).await
+    }
+
+    async fn get_secret(&self, id: &SecretId) -> Result<Option<Secret>> {
+        self.remote.get_secret(id).await
+    }
+}
+
+#[async_trait]
+impl SandboxHandle for LocalSandboxConversation {
     async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
         if !self.wants_local_sandbox(&request) {
             return self.remote.create_sandbox(request).await;
@@ -543,17 +843,7 @@ impl ConversationHandle for LocalSandboxConversation {
         let Some(local_id) = self.local_sandbox_id(&request.sandbox_id).await? else {
             return self.remote.start_sandbox_process(request).await;
         };
-        let remote_id = request.sandbox_id.clone();
-        let mut process = self
-            .local_conversation()
-            .await?
-            .start_sandbox_process(StartSandboxProcessRequest {
-                sandbox_id: local_id,
-                ..request
-            })
-            .await?;
-        process.sandbox_id = remote_id;
-        Ok(process)
+        start_mapped_sandbox_process(self.local_conversation().await?, local_id, request).await
     }
 
     async fn write_sandbox_process_input(
@@ -563,12 +853,7 @@ impl ConversationHandle for LocalSandboxConversation {
         let Some(local_id) = self.local_sandbox_id(&request.sandbox_id).await? else {
             return self.remote.write_sandbox_process_input(request).await;
         };
-        self.local_conversation()
-            .await?
-            .write_sandbox_process_input(WriteSandboxProcessInputRequest {
-                sandbox_id: local_id,
-                ..request
-            })
+        write_mapped_sandbox_process_input(self.local_conversation().await?, local_id, request)
             .await
     }
 
@@ -579,12 +864,7 @@ impl ConversationHandle for LocalSandboxConversation {
         let Some(local_id) = self.local_sandbox_id(&request.sandbox_id).await? else {
             return self.remote.close_sandbox_process_input(request).await;
         };
-        self.local_conversation()
-            .await?
-            .close_sandbox_process_input(CloseSandboxProcessInputRequest {
-                sandbox_id: local_id,
-                ..request
-            })
+        close_mapped_sandbox_process_input(self.local_conversation().await?, local_id, request)
             .await
     }
 
@@ -595,13 +875,7 @@ impl ConversationHandle for LocalSandboxConversation {
         let Some(local_id) = self.local_sandbox_id(&query.sandbox_id).await? else {
             return self.remote.get_sandbox_process_events(query).await;
         };
-        self.local_conversation()
-            .await?
-            .get_sandbox_process_events(SandboxProcessEventQuery {
-                sandbox_id: local_id,
-                ..query
-            })
-            .await
+        get_mapped_sandbox_process_events(self.local_conversation().await?, local_id, query).await
     }
 
     async fn wait_sandbox_process(
@@ -611,13 +885,7 @@ impl ConversationHandle for LocalSandboxConversation {
         let Some(local_id) = self.local_sandbox_id(&request.sandbox_id).await? else {
             return self.remote.wait_sandbox_process(request).await;
         };
-        self.local_conversation()
-            .await?
-            .wait_sandbox_process(WaitSandboxProcessRequest {
-                sandbox_id: local_id,
-                ..request
-            })
-            .await
+        wait_mapped_sandbox_process(self.local_conversation().await?, local_id, request).await
     }
 
     async fn cancel_sandbox_process(
@@ -627,13 +895,7 @@ impl ConversationHandle for LocalSandboxConversation {
         let Some(local_id) = self.local_sandbox_id(&request.sandbox_id).await? else {
             return self.remote.cancel_sandbox_process(request).await;
         };
-        self.local_conversation()
-            .await?
-            .cancel_sandbox_process(CancelSandboxProcessRequest {
-                sandbox_id: local_id,
-                ..request
-            })
-            .await
+        cancel_mapped_sandbox_process(self.local_conversation().await?, local_id, request).await
     }
 
     async fn run_in_sandbox(
@@ -643,37 +905,7 @@ impl ConversationHandle for LocalSandboxConversation {
         let Some(local_id) = self.local_sandbox_id(&request.id).await? else {
             return self.remote.run_in_sandbox(request).await;
         };
-        self.local_conversation()
-            .await?
-            .run_in_sandbox(RunInSandboxRequest {
-                id: local_id,
-                ..request
-            })
-            .await
-    }
-
-    async fn list_bindings(&self) -> Result<Vec<BindingRecord>> {
-        self.remote.list_bindings().await
-    }
-
-    async fn put_binding(&self, binding: Binding) -> Result<BindingId> {
-        self.remote.put_binding(binding).await
-    }
-
-    async fn get_binding(&self, id: &BindingId) -> Result<Option<Binding>> {
-        self.remote.get_binding(id).await
-    }
-
-    async fn list_secrets(&self) -> Result<Vec<SecretMetadata>> {
-        self.remote.list_secrets().await
-    }
-
-    async fn put_secret(&self, request: PutSecretRequest) -> Result<SecretId> {
-        self.remote.put_secret(request).await
-    }
-
-    async fn get_secret(&self, id: &SecretId) -> Result<Option<Secret>> {
-        self.remote.get_secret(id).await
+        run_in_mapped_sandbox(self.local_conversation().await?, local_id, request).await
     }
 }
 

--- a/crates/executor/src/local_sandbox.rs
+++ b/crates/executor/src/local_sandbox.rs
@@ -339,7 +339,6 @@ impl LocalSandboxConversation {
             .add_events(AddEventsRequest {
                 session_id: None,
                 turn_id: None,
-                expected_head: None,
                 data: vec![EventData::Custom {
                     event_type: LOCAL_SANDBOX_MAP_EVENT.to_string(),
                     payload: serde_json::to_value(LocalSandboxMapEvent {
@@ -357,7 +356,6 @@ impl LocalSandboxConversation {
             .add_events(AddEventsRequest {
                 session_id: None,
                 turn_id: None,
-                expected_head: None,
                 data,
             })
             .await?;

--- a/crates/executor/src/local_sandbox.rs
+++ b/crates/executor/src/local_sandbox.rs
@@ -410,6 +410,7 @@ impl ConversationHandle for LocalSandboxConversation {
     ) -> Result<Arc<dyn TurnHandle>> {
         Ok(Arc::new(LocalSandboxTurnHandle {
             state: Arc::clone(&self.state),
+            conversation_id: self.remote.record().id,
             remote: self.remote.begin_turn(request).await?,
         }))
     }
@@ -417,6 +418,7 @@ impl ConversationHandle for LocalSandboxConversation {
     async fn turn_handle(&self, record: TurnRecord) -> Result<Arc<dyn TurnHandle>> {
         Ok(Arc::new(LocalSandboxTurnHandle {
             state: Arc::clone(&self.state),
+            conversation_id: self.remote.record().id,
             remote: self.remote.turn_handle(record).await?,
         }))
     }
@@ -677,6 +679,7 @@ impl ConversationHandle for LocalSandboxConversation {
 
 struct LocalSandboxTurnHandle {
     state: Arc<LocalSandboxState>,
+    conversation_id: ConversationId,
     remote: Arc<dyn TurnHandle>,
 }
 
@@ -694,19 +697,19 @@ impl TurnHandle for LocalSandboxTurnHandle {
         self.remote.write_artifact(request).await
     }
 
-    async fn snapshot_sandbox(
-        &self,
-        conversation_id: ConversationId,
-        id: SandboxId,
-    ) -> Result<SnapshotId> {
-        let Some(local_id) = local_sandbox_id_for(&self.state, conversation_id, &id).await? else {
-            return self.remote.snapshot_sandbox(conversation_id, id).await;
+    async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
+        let Some(local_id) = local_sandbox_id_for(&self.state, self.conversation_id, &id).await?
+        else {
+            return self.remote.snapshot_sandbox(id).await;
         };
-        let snapshot_id =
-            local_conversation_for(&self.state, conversation_id, &conversation_id.to_string())
-                .await?
-                .snapshot_sandbox(local_id)
-                .await?;
+        let snapshot_id = local_conversation_for(
+            &self.state,
+            self.conversation_id,
+            &self.conversation_id.to_string(),
+        )
+        .await?
+        .snapshot_sandbox(local_id)
+        .await?;
         self.remote
             .add_events(vec![EventData::SandboxSnapshotted {
                 sandbox_id: id,
@@ -716,24 +719,24 @@ impl TurnHandle for LocalSandboxTurnHandle {
         Ok(snapshot_id)
     }
 
-    async fn start_sandbox(
-        &self,
-        conversation_id: ConversationId,
-        request: StartSandboxRequest,
-    ) -> Result<()> {
+    async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
         let Some(local_id) =
-            local_sandbox_id_for(&self.state, conversation_id, &request.id).await?
+            local_sandbox_id_for(&self.state, self.conversation_id, &request.id).await?
         else {
-            return self.remote.start_sandbox(conversation_id, request).await;
+            return self.remote.start_sandbox(request).await;
         };
-        local_conversation_for(&self.state, conversation_id, &conversation_id.to_string())
-            .await?
-            .start_sandbox(StartSandboxRequest {
-                id: local_id,
-                snapshot_id: request.snapshot_id,
-                idle_seconds: request.idle_seconds,
-            })
-            .await?;
+        local_conversation_for(
+            &self.state,
+            self.conversation_id,
+            &self.conversation_id.to_string(),
+        )
+        .await?
+        .start_sandbox(StartSandboxRequest {
+            id: local_id,
+            snapshot_id: request.snapshot_id,
+            idle_seconds: request.idle_seconds,
+        })
+        .await?;
         self.remote
             .add_events(vec![EventData::SandboxStarted {
                 sandbox_id: request.id,

--- a/crates/executor/src/local_sandbox.rs
+++ b/crates/executor/src/local_sandbox.rs
@@ -443,6 +443,7 @@ impl ConversationHandle for LocalSandboxConversation {
                 image: request.image,
                 default_workdir: request.default_workdir.unwrap_or_default(),
                 file_system_mounts: request.file_system_mounts.unwrap_or_default(),
+                durable_file_systems: request.durable_file_systems.unwrap_or_default(),
                 enable_networking: request.enable_networking.unwrap_or(true),
                 idle_seconds: request.idle_seconds.unwrap_or(60),
             },
@@ -690,6 +691,7 @@ mod tests {
                 image: "local-image".to_string(),
                 default_workdir: Some("/workspace".to_string()),
                 file_system_mounts: Some(Vec::new()),
+                durable_file_systems: None,
                 enable_networking: Some(false),
                 idle_seconds: Some(120),
             })

--- a/crates/executor/src/scheduler_runtime.rs
+++ b/crates/executor/src/scheduler_runtime.rs
@@ -5,7 +5,7 @@ use exoharness::{RunInSandboxRequest, SandboxProcess, WriteArtifactRequest};
 use futures::io::{AsyncRead, AsyncReadExt};
 use serde::Serialize;
 
-use crate::agent_sandbox::{AgentSandboxHandle, ensure_agent_sandbox};
+use crate::agent_sandbox::ensure_agent_sandbox;
 use crate::conversation_sandbox::{create_conversation_sandbox, ensure_conversation_sandbox};
 use crate::conversation_wakeup::send_conversation_wakeup;
 use crate::scheduler_store::SchedulerStore;
@@ -155,9 +155,10 @@ async fn run_task_inner(
     let agent_config = agent.config().await?;
     let conversation_config = conversation.config().await?;
     let conversation_handle = conversation.exoharness_handle();
+    let agent_handle = agent.exoharness_handle();
     let sandbox = resolve_task_sandbox(
         task,
-        agent.exoharness_handle().as_ref(),
+        agent_handle.as_ref(),
         std::sync::Arc::clone(&conversation_handle),
         &agent_config,
         &conversation_config,
@@ -165,21 +166,18 @@ async fn run_task_inner(
     .await?;
     let command_result: Result<CommandOutput> = async {
         let process = sandbox
-            .conversation
-            .run_in_sandbox(RunInSandboxRequest {
-                id: sandbox.sandbox_id.clone(),
-                command: task
-                    .setup_command
+            .run_in_sandbox(
+                agent_handle.as_ref(),
+                task.setup_command
                     .clone()
                     .unwrap_or_else(|| task.command.clone()),
-                env: Default::default(),
-            })
+            )
             .await?;
         let setup_output =
             read_process_output(process, task.max_output_bytes, DEFAULT_COMMAND_TIMEOUT_MS).await?;
         if task.setup_command.is_none() {
             return Ok(CommandOutput {
-                sandbox_id: sandbox.sandbox_id.clone(),
+                sandbox_id: sandbox.sandbox_id().to_string(),
                 setup: None,
                 main: setup_output,
                 error: None,
@@ -187,24 +185,19 @@ async fn run_task_inner(
         }
         if setup_output.exit_code != Some(0) {
             return Ok(CommandOutput {
-                sandbox_id: sandbox.sandbox_id.clone(),
+                sandbox_id: sandbox.sandbox_id().to_string(),
                 setup: Some(setup_output),
                 main: ProcessOutput::empty(),
                 error: Some("setup command exited non-zero".to_string()),
             });
         }
         let process = sandbox
-            .conversation
-            .run_in_sandbox(RunInSandboxRequest {
-                id: sandbox.sandbox_id.clone(),
-                command: task.command.clone(),
-                env: Default::default(),
-            })
+            .run_in_sandbox(agent_handle.as_ref(), task.command.clone())
             .await?;
         let main_output =
             read_process_output(process, task.max_output_bytes, DEFAULT_COMMAND_TIMEOUT_MS).await?;
         Ok(CommandOutput {
-            sandbox_id: sandbox.sandbox_id.clone(),
+            sandbox_id: sandbox.sandbox_id().to_string(),
             setup: Some(setup_output),
             main: main_output,
             error: None,
@@ -294,18 +287,15 @@ async fn resolve_task_sandbox(
     conversation: std::sync::Arc<dyn exoharness::ConversationHandle>,
     agent_config: &crate::AgentConfig,
     conversation_config: &crate::ConversationConfig,
-) -> Result<AgentSandboxHandle> {
+) -> Result<ResolvedTaskSandbox> {
     match task.sandbox_mode {
         ScheduledTaskSandboxMode::Agent => {
-            ensure_agent_sandbox(
-                agent,
-                conversation.as_ref(),
-                agent_config,
-                conversation_config,
-            )
-            .await
+            let sandbox = ensure_agent_sandbox(agent, agent_config, conversation_config).await?;
+            Ok(ResolvedTaskSandbox::Agent {
+                sandbox_id: sandbox.sandbox_id,
+            })
         }
-        ScheduledTaskSandboxMode::Conversation => Ok(AgentSandboxHandle {
+        ScheduledTaskSandboxMode::Conversation => Ok(ResolvedTaskSandbox::Conversation {
             sandbox_id: ensure_conversation_sandbox(
                 conversation.as_ref(),
                 agent_config,
@@ -316,7 +306,7 @@ async fn resolve_task_sandbox(
         }),
         ScheduledTaskSandboxMode::TaskFresh => {
             if let Some(sandbox_id) = &task.task_sandbox_id {
-                return Ok(AgentSandboxHandle {
+                return Ok(ResolvedTaskSandbox::Conversation {
                     conversation,
                     sandbox_id: sandbox_id.clone(),
                 });
@@ -328,10 +318,58 @@ async fn resolve_task_sandbox(
             )
             .await?;
             task.task_sandbox_id = Some(sandbox_id.clone());
-            Ok(AgentSandboxHandle {
+            Ok(ResolvedTaskSandbox::Conversation {
                 conversation,
                 sandbox_id,
             })
+        }
+    }
+}
+
+enum ResolvedTaskSandbox {
+    Agent {
+        sandbox_id: String,
+    },
+    Conversation {
+        conversation: std::sync::Arc<dyn exoharness::ConversationHandle>,
+        sandbox_id: String,
+    },
+}
+
+impl ResolvedTaskSandbox {
+    fn sandbox_id(&self) -> &str {
+        match self {
+            Self::Agent { sandbox_id } | Self::Conversation { sandbox_id, .. } => sandbox_id,
+        }
+    }
+
+    async fn run_in_sandbox(
+        &self,
+        agent: &dyn exoharness::AgentHandle,
+        command: Vec<String>,
+    ) -> Result<Box<dyn SandboxProcess>> {
+        match self {
+            Self::Agent { sandbox_id } => {
+                agent
+                    .run_in_sandbox(RunInSandboxRequest {
+                        id: sandbox_id.clone(),
+                        command,
+                        env: Default::default(),
+                    })
+                    .await
+            }
+            Self::Conversation {
+                conversation,
+                sandbox_id,
+            } => {
+                conversation
+                    .run_in_sandbox(RunInSandboxRequest {
+                        id: sandbox_id.clone(),
+                        command,
+                        env: Default::default(),
+                    })
+                    .await
+            }
         }
     }
 }

--- a/crates/executor/src/typescript.rs
+++ b/crates/executor/src/typescript.rs
@@ -411,13 +411,13 @@ impl TypeScriptRunnerProcess {
                                 Ok(response) => HostToGuestMessage::ExoResponse {
                                     id,
                                     ok: true,
-                                    response: Some(response),
+                                    response: Box::new(Some(response)),
                                     error: None,
                                 },
                                 Err(error) => HostToGuestMessage::ExoResponse {
                                     id,
                                     ok: false,
-                                    response: None,
+                                    response: Box::new(None),
                                     error: Some(format_error_chain(
                                         &error,
                                         format_args!(
@@ -590,7 +590,6 @@ impl TypeScriptRunnerProcess {
                         .add_events(AddEventsRequest {
                             session_id: None,
                             turn_id: None,
-                            expected_head: None,
                             data: vec![EventData::Custom {
                                 event_type: TYPESCRIPT_SANDBOX_PROCESS_REUSE_EVENT.to_string(),
                                 payload: serde_json::to_value(
@@ -898,7 +897,7 @@ enum HostToGuestMessage {
     ExoResponse {
         id: u64,
         ok: bool,
-        response: Option<ExoResponse>,
+        response: Box<Option<ExoResponse>>,
         error: Option<String>,
     },
     RuntimeEvent {

--- a/crates/executor/src/typescript.rs
+++ b/crates/executor/src/typescript.rs
@@ -585,7 +585,6 @@ impl TypeScriptRunnerProcess {
                         .add_events(AddEventsRequest {
                             session_id: None,
                             turn_id: None,
-                            expected_head: None,
                             data: vec![EventData::Custom {
                                 event_type: TYPESCRIPT_SANDBOX_PROCESS_REUSE_EVENT.to_string(),
                                 payload: serde_json::to_value(

--- a/crates/executor/src/typescript.rs
+++ b/crates/executor/src/typescript.rs
@@ -408,13 +408,13 @@ impl TypeScriptRunnerProcess {
                                 Ok(response) => HostToGuestMessage::ExoResponse {
                                     id,
                                     ok: true,
-                                    response: Some(response),
+                                    response: Box::new(Some(response)),
                                     error: None,
                                 },
                                 Err(error) => HostToGuestMessage::ExoResponse {
                                     id,
                                     ok: false,
-                                    response: None,
+                                    response: Box::new(None),
                                     error: Some(format_error_chain(
                                         &error,
                                         format_args!(
@@ -890,7 +890,7 @@ enum HostToGuestMessage {
     ExoResponse {
         id: u64,
         ok: bool,
-        response: Option<ExoResponse>,
+        response: Box<Option<ExoResponse>>,
         error: Option<String>,
     },
     RuntimeEvent {

--- a/crates/exoharness/Cargo.toml
+++ b/crates/exoharness/Cargo.toml
@@ -15,6 +15,7 @@ basic-backend = [
   "dep:reqwest",
   "dep:tokio",
   "dep:tokio-stream",
+  "dep:tokio-tungstenite",
   "dep:tokio-util",
   "dep:tracing",
   "dep:url",
@@ -51,12 +52,17 @@ thiserror.workspace = true
 tokio = { version = "1.52.1", default-features = false, features = [
   "fs",
   "io-util",
+  "net",
   "process",
   "rt",
   "sync",
   "time",
 ], optional = true }
 tokio-stream = { workspace = true, optional = true }
+tokio-tungstenite = { version = "0.26.2", default-features = false, features = [
+  "connect",
+  "rustls-tls-webpki-roots",
+], optional = true }
 tokio-util = { workspace = true, optional = true, features = ["compat"] }
 tracing = { workspace = true, optional = true }
 url = { workspace = true, optional = true }

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -34,17 +34,17 @@ use crate::{
     AddEventsRequest, AddEventsResult, AgentHandle, AgentId, AgentRecord, Artifact,
     ArtifactVersion, BeginTurnRequest, Binding, BindingId, BindingRecord, BindingType,
     BoxAsyncRead, BoxAsyncWrite, CancelSandboxProcessRequest, CloseSandboxProcessInputRequest,
-    ConversationHandle, ConversationId, ConversationRecord, CreateSandboxRequest, Event, EventData,
-    EventId, EventKind, EventQuery, EventQueryDirection, EventStream, ExoHarness, FileSystemMount,
-    ForkConversationRequest, GetEventsResult, GetSandboxProcessEventsResult,
-    ListConversationsRequest, ListConversationsResult, NewAgentRequest, NewConversationRequest,
-    PutSecretRequest, ReadArtifactRequest, Result, RunInSandboxRequest, SandboxId, SandboxProcess,
-    SandboxProcessEvent, SandboxProcessEventQuery, SandboxProcessId, SandboxProcessMode,
-    SandboxProcessParts, SandboxProcessRecord, SandboxProcessStatus, SandboxProcessStdin,
-    SandboxProvider, SandboxProviderConfig, Secret, SecretId, SecretMetadata, SecretType,
-    SessionId, SnapshotId, StartSandboxProcessRequest, StartSandboxRequest, TurnHandle, TurnId,
-    TurnRecord, Uuid7, WaitSandboxProcessRequest, WriteArtifactRequest,
-    WriteSandboxProcessInputRequest,
+    ConversationHandle, ConversationId, ConversationRecord, CreateSandboxRequest,
+    DurableFileSystem, Event, EventData, EventId, EventKind, EventQuery, EventQueryDirection,
+    EventStream, ExoHarness, FileSystemMount, ForkConversationRequest, GetEventsResult,
+    GetSandboxProcessEventsResult, ListConversationsRequest, ListConversationsResult,
+    NewAgentRequest, NewConversationRequest, PutSecretRequest, ReadArtifactRequest, Result,
+    RunInSandboxRequest, SandboxId, SandboxProcess, SandboxProcessEvent, SandboxProcessEventQuery,
+    SandboxProcessId, SandboxProcessMode, SandboxProcessParts, SandboxProcessRecord,
+    SandboxProcessStatus, SandboxProcessStdin, SandboxProvider, SandboxProviderConfig, Secret,
+    SecretId, SecretMetadata, SecretType, SessionId, SnapshotId, StartSandboxProcessRequest,
+    StartSandboxRequest, TurnHandle, TurnId, TurnRecord, Uuid7, WaitSandboxProcessRequest,
+    WriteArtifactRequest, WriteSandboxProcessInputRequest,
 };
 
 #[derive(Debug, Clone)]
@@ -148,6 +148,7 @@ pub struct BasicExoHarness {
 }
 
 struct BasicExoHarnessInner {
+    root: PathBuf,
     storage: BasicObjectStore,
     write_lock: AsyncMutex<()>,
     subscribers: Mutex<HashMap<ConversationId, Vec<mpsc::UnboundedSender<Result<Event>>>>>,
@@ -187,10 +188,14 @@ impl BasicExoHarnessInner {
         choice: &SandboxBackendChoice,
     ) -> Result<Arc<dyn ManagedSandboxBackend>> {
         let backend: Arc<dyn ManagedSandboxBackend> = match choice {
-            SandboxBackendChoice::AppleContainer => {
-                Arc::new(CliContainerSandboxBackend::apple_container())
-            }
-            SandboxBackendChoice::Docker => Arc::new(CliContainerSandboxBackend::docker()),
+            SandboxBackendChoice::AppleContainer => Arc::new(
+                CliContainerSandboxBackend::apple_container()
+                    .with_durable_file_system_root(self.root.join("durable-filesystems")),
+            ),
+            SandboxBackendChoice::Docker => Arc::new(
+                CliContainerSandboxBackend::docker()
+                    .with_durable_file_system_root(self.root.join("durable-filesystems")),
+            ),
             SandboxBackendChoice::LocalProcess => Arc::new(LocalProcessSandboxBackend::new()),
             SandboxBackendChoice::Daytona(spec) => {
                 // Prefer a root `Binding::Sandbox` for Daytona; fall back to the
@@ -421,32 +426,44 @@ impl BasicExoHarnessInner {
     #[cfg(feature = "aws-agentcore")]
     async fn aws_agentcore_config_from_binding(&self) -> Result<Option<crate::AwsAgentCoreConfig>> {
         let bindings = list_binding_records(&self.storage, Path::new("bindings")).await?;
-        let Some((runtime_arn, region, qualifier, endpoint_url)) = bindings
-            .into_iter()
-            .rev()
-            .find_map(|record| match record.binding {
-                Binding::Sandbox {
-                    config:
-                        SandboxProviderConfig::AwsAgentCore {
-                            runtime_arn,
-                            region,
-                            qualifier,
-                            endpoint_url,
-                            ..
-                        },
-                    ..
-                } => Some((runtime_arn, region, qualifier, endpoint_url)),
-                _ => None,
-            })
+        let Some((runtime_arn, region, qualifier, endpoint_url, session_storage_mount_path)) =
+            bindings
+                .into_iter()
+                .rev()
+                .find_map(|record| match record.binding {
+                    Binding::Sandbox {
+                        config:
+                            SandboxProviderConfig::AwsAgentCore {
+                                runtime_arn,
+                                region,
+                                qualifier,
+                                endpoint_url,
+                                session_storage_mount_path,
+                                ..
+                            },
+                        ..
+                    } => Some((
+                        runtime_arn,
+                        region,
+                        qualifier,
+                        endpoint_url,
+                        session_storage_mount_path,
+                    )),
+                    _ => None,
+                })
         else {
             return Ok(None);
         };
+        let session_storage_mount_path = session_storage_mount_path
+            .or_else(|| nonempty_env("AWS_AGENTCORE_SESSION_STORAGE_MOUNT_PATH"))
+            .or_else(|| nonempty_env("AGENTCORE_SESSION_STORAGE_MOUNT_PATH"));
         Ok(Some(crate::AwsAgentCoreConfig {
             runtime_arn,
             region,
             qualifier,
             endpoint_url,
             credentials: aws_agentcore_credentials_from_env(),
+            session_storage_mount_path,
         }))
     }
 
@@ -481,6 +498,14 @@ fn aws_agentcore_credentials_from_env() -> Option<crate::AwsAgentCoreCredentials
         secret_access_key,
         session_token,
     })
+}
+
+#[cfg(feature = "aws-agentcore")]
+fn nonempty_env(name: &str) -> Option<String> {
+    std::env::var(name)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
 }
 
 impl BasicExoHarness {
@@ -537,6 +562,7 @@ impl BasicExoHarness {
             build_secret_cipher(secret_backend, root.to_string_lossy().to_string())?;
         Ok(Self {
             inner: Arc::new(BasicExoHarnessInner {
+                root,
                 storage,
                 write_lock: AsyncMutex::new(()),
                 subscribers: Mutex::new(HashMap::new()),
@@ -1121,6 +1147,7 @@ impl BasicConversationHandle {
             image,
             default_workdir: request.default_workdir,
             file_system_mounts: request.file_system_mounts.unwrap_or_default(),
+            durable_file_systems: request.durable_file_systems.unwrap_or_default(),
             enable_networking: request.enable_networking.unwrap_or(true),
             idle_seconds: request.idle_seconds.unwrap_or(60),
         })
@@ -1153,6 +1180,7 @@ impl BasicConversationHandle {
                 image,
                 default_workdir,
                 file_system_mounts,
+                durable_file_systems,
                 enable_networking,
                 idle_seconds,
                 ..
@@ -1171,6 +1199,7 @@ impl BasicConversationHandle {
                 || image != request.image
                 || default_workdir != request.default_workdir.clone().unwrap_or_default()
                 || file_system_mounts != request.file_system_mounts
+                || durable_file_systems != request.durable_file_systems
                 || enable_networking != request.enable_networking
                 || idle_seconds != request.idle_seconds
             {
@@ -1249,6 +1278,7 @@ impl BasicConversationHandle {
                     image: sandbox.image,
                     default_workdir: sandbox.default_workdir.unwrap_or_default(),
                     file_system_mounts: sandbox.file_system_mounts,
+                    durable_file_systems: sandbox.durable_file_systems,
                     enable_networking: sandbox.enable_networking,
                     idle_seconds: sandbox.idle_seconds,
                 },
@@ -2455,6 +2485,7 @@ struct StoredSandbox {
     image: String,
     default_workdir: Option<String>,
     file_system_mounts: Vec<FileSystemMount>,
+    durable_file_systems: Vec<DurableFileSystem>,
     enable_networking: bool,
     idle_seconds: u64,
     running: bool,
@@ -2468,6 +2499,7 @@ struct PreparedSandboxRequest {
     image: String,
     default_workdir: Option<String>,
     file_system_mounts: Vec<FileSystemMount>,
+    durable_file_systems: Vec<DurableFileSystem>,
     enable_networking: bool,
     idle_seconds: u64,
 }
@@ -2481,6 +2513,7 @@ impl PreparedSandboxRequest {
             image: self.image.clone(),
             default_workdir: self.default_workdir.clone(),
             file_system_mounts: self.file_system_mounts.clone(),
+            durable_file_systems: self.durable_file_systems.clone(),
             enable_networking: self.enable_networking,
             idle_seconds: self.idle_seconds,
             running: true,
@@ -2814,6 +2847,7 @@ fn sandbox_request(
             } else {
                 SandboxNetworkPolicy::Disabled
             },
+            durable_file_systems: sandbox.durable_file_systems.clone(),
             default_workdir: sandbox
                 .default_workdir
                 .clone()

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -64,6 +64,8 @@ pub enum SandboxBackendChoice {
     Docker,
     LocalProcess,
     Daytona(DaytonaBackendSpec),
+    E2b(E2bBackendSpec),
+    Sprites(SpritesBackendSpec),
     Vercel(VercelBackendSpec),
     AwsAgentCore,
 }
@@ -75,6 +77,8 @@ impl SandboxBackendChoice {
             Self::Docker => SandboxProvider::Docker,
             Self::LocalProcess => SandboxProvider::LocalProcess,
             Self::Daytona(_) => SandboxProvider::Daytona,
+            Self::E2b(_) => SandboxProvider::E2b,
+            Self::Sprites(_) => SandboxProvider::Sprites,
             Self::Vercel(_) => SandboxProvider::Vercel,
             Self::AwsAgentCore => SandboxProvider::AwsAgentCore,
         }
@@ -93,16 +97,58 @@ pub struct DaytonaBackendSpec {
     pub target_secret: Option<String>,
 }
 
-impl DaytonaBackendSpec {
+impl Default for DaytonaBackendSpec {
     /// Official endpoints; credentials read from the conventional `DAYTONA_*`
     /// secret names.
-    pub fn with_conventional_secrets() -> Self {
+    fn default() -> Self {
         Self {
             api_url: crate::DEFAULT_DAYTONA_API_URL.to_string(),
             toolbox_url: crate::DEFAULT_DAYTONA_TOOLBOX_URL.to_string(),
             api_key_secret: "DAYTONA_API_KEY".to_string(),
             organization_id_secret: Some("DAYTONA_ORGANIZATION_ID".to_string()),
             target_secret: Some("DAYTONA_TARGET".to_string()),
+        }
+    }
+}
+
+/// E2B connection config plus secret-store names for credentials, resolved
+/// lazily on first use.
+#[derive(Debug, Clone)]
+pub struct E2bBackendSpec {
+    pub api_url: String,
+    pub api_key_secret: String,
+    pub template_id: String,
+}
+
+impl Default for E2bBackendSpec {
+    fn default() -> Self {
+        Self {
+            api_url: crate::DEFAULT_E2B_API_URL.to_string(),
+            api_key_secret: "E2B_API_KEY".to_string(),
+            template_id: crate::default_e2b_template(),
+        }
+    }
+}
+
+/// Sprites connection config plus secret-store name for the bearer token,
+/// resolved lazily on first use.
+#[derive(Debug, Clone)]
+pub struct SpritesBackendSpec {
+    pub api_url: String,
+    pub token_secret: String,
+    pub url_auth: Option<String>,
+    pub organization: Option<String>,
+    pub labels: Vec<String>,
+}
+
+impl Default for SpritesBackendSpec {
+    fn default() -> Self {
+        Self {
+            api_url: crate::DEFAULT_SPRITES_API_URL.to_string(),
+            token_secret: "SPRITES_TOKEN".to_string(),
+            url_auth: None,
+            organization: None,
+            labels: Vec::new(),
         }
     }
 }
@@ -204,6 +250,20 @@ impl BasicExoHarnessInner {
                     None => self.daytona_config_from_spec(spec).await?,
                 };
                 Arc::new(crate::DaytonaSandboxBackend::new(config)?)
+            }
+            SandboxBackendChoice::E2b(spec) => {
+                let config = match self.e2b_config_from_binding().await? {
+                    Some(config) => config,
+                    None => self.e2b_config_from_spec(spec).await?,
+                };
+                Arc::new(crate::E2bSandboxBackend::new(config)?)
+            }
+            SandboxBackendChoice::Sprites(spec) => {
+                let config = match self.sprites_config_from_binding().await? {
+                    Some(config) => config,
+                    None => self.sprites_config_from_spec(spec).await?,
+                };
+                Arc::new(crate::SpritesSandboxBackend::new(config)?)
             }
             SandboxBackendChoice::Vercel(spec) => {
                 let config = match self.vercel_config_from_binding().await? {
@@ -383,6 +443,124 @@ impl BasicExoHarnessInner {
         }))
     }
 
+    async fn e2b_config_from_spec(&self, spec: &E2bBackendSpec) -> Result<crate::E2bConfig> {
+        let api_key = self
+            .secret_key(&spec.api_key_secret)
+            .await?
+            .ok_or_else(|| {
+                anyhow!(
+                    "e2b sandbox requested but secret {:?} is not set",
+                    spec.api_key_secret
+                )
+            })?;
+        Ok(crate::E2bConfig {
+            api_key,
+            api_url: spec.api_url.clone(),
+            template_id: spec.template_id.clone(),
+            envd_port: crate::DEFAULT_E2B_ENVD_PORT,
+            envd_base_url: None,
+            secure: false,
+        })
+    }
+
+    async fn e2b_config_from_binding(&self) -> Result<Option<crate::E2bConfig>> {
+        let bindings = list_binding_records(&self.storage, Path::new("bindings")).await?;
+        let Some((api_key_secret_id, api_url, default_image)) = bindings
+            .into_iter()
+            .rev()
+            .find_map(|record| match record.binding {
+                Binding::Sandbox {
+                    config:
+                        SandboxProviderConfig::E2b {
+                            api_key_secret_id,
+                            api_url,
+                            default_image,
+                        },
+                    ..
+                } => Some((api_key_secret_id, api_url, default_image)),
+                _ => None,
+            })
+        else {
+            return Ok(None);
+        };
+        let api_key = self
+            .secret_key_by_id(api_key_secret_id)
+            .await?
+            .ok_or_else(|| {
+                anyhow!(
+                    "e2b sandbox binding references secret id {api_key_secret_id}, \
+                 which is not set"
+                )
+            })?;
+        Ok(Some(crate::E2bConfig {
+            api_key,
+            api_url: api_url.unwrap_or_else(|| crate::DEFAULT_E2B_API_URL.to_string()),
+            template_id: default_image,
+            envd_port: crate::DEFAULT_E2B_ENVD_PORT,
+            envd_base_url: None,
+            secure: false,
+        }))
+    }
+
+    async fn sprites_config_from_spec(
+        &self,
+        spec: &SpritesBackendSpec,
+    ) -> Result<crate::SpritesConfig> {
+        let token = self.secret_key(&spec.token_secret).await?.ok_or_else(|| {
+            anyhow!(
+                "sprites sandbox requested but secret {:?} is not set",
+                spec.token_secret
+            )
+        })?;
+        Ok(crate::SpritesConfig {
+            token,
+            api_url: spec.api_url.clone(),
+            url_auth: spec.url_auth.clone(),
+            organization: spec.organization.clone(),
+            extra_labels: spec.labels.clone(),
+        })
+    }
+
+    async fn sprites_config_from_binding(&self) -> Result<Option<crate::SpritesConfig>> {
+        let bindings = list_binding_records(&self.storage, Path::new("bindings")).await?;
+        let Some((token_secret_id, api_url, url_auth, organization, labels)) = bindings
+            .into_iter()
+            .rev()
+            .find_map(|record| match record.binding {
+                Binding::Sandbox {
+                    config:
+                        SandboxProviderConfig::Sprites {
+                            token_secret_id,
+                            api_url,
+                            url_auth,
+                            organization,
+                            labels,
+                        },
+                    ..
+                } => Some((token_secret_id, api_url, url_auth, organization, labels)),
+                _ => None,
+            })
+        else {
+            return Ok(None);
+        };
+        let token = self
+            .secret_key_by_id(token_secret_id)
+            .await?
+            .ok_or_else(|| {
+                anyhow!(
+                    "sprites sandbox binding references secret id {token_secret_id}, \
+                 which is not set"
+                )
+            })?;
+        Ok(Some(crate::SpritesConfig {
+            token,
+            api_url: api_url.unwrap_or_else(|| crate::DEFAULT_SPRITES_API_URL.to_string()),
+            url_auth,
+            organization,
+            extra_labels: labels,
+        }))
+    }
+
     async fn vercel_config_from_binding(&self) -> Result<Option<crate::VercelConfig>> {
         let bindings = list_binding_records(&self.storage, Path::new("bindings")).await?;
         let Some((api_token_secret_id, team_id, project_id, api_url)) = bindings
@@ -475,7 +653,10 @@ impl BasicExoHarnessInner {
             let Binding::Sandbox { config, .. } = record.binding else {
                 return None;
             };
-            (config.provider() == provider).then(|| config.default_image().to_string())
+            (config.provider() == provider)
+                .then(|| config.default_image())
+                .flatten()
+                .map(str::to_string)
         }))
     }
 }

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -42,9 +42,9 @@ use crate::{
     SandboxProcess, SandboxProcessEvent, SandboxProcessEventQuery, SandboxProcessId,
     SandboxProcessMode, SandboxProcessParts, SandboxProcessRecord, SandboxProcessStatus,
     SandboxProcessStdin, SandboxProvider, SandboxProviderConfig, Secret, SecretId, SecretMetadata,
-    SecretType, SessionId, SnapshotId, StartSandboxProcessRequest, StartSandboxRequest, TurnHandle,
-    TurnId, TurnRecord, Uuid7, WaitSandboxProcessRequest, WriteArtifactRequest,
-    WriteSandboxProcessInputRequest,
+    SecretType, SessionId, SnapshotHandle, SnapshotId, StartSandboxProcessRequest,
+    StartSandboxRequest, TurnHandle, TurnId, TurnRecord, Uuid7, WaitSandboxProcessRequest,
+    WriteArtifactRequest, WriteSandboxProcessInputRequest,
 };
 
 #[derive(Debug, Clone)]
@@ -973,6 +973,26 @@ impl AgentHandle for BasicAgentHandle {
 }
 
 #[async_trait]
+impl SnapshotHandle for BasicAgentHandle {
+    async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
+        let (snapshot_id, _event) =
+            snapshot_sandbox_side_effect(&self.harness, &self.agent_dir(), id).await?;
+        Ok(snapshot_id)
+    }
+
+    async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
+        start_sandbox_side_effect(
+            &self.harness,
+            &self.agent_dir(),
+            SandboxOwner::Agent(self.record.id),
+            request,
+        )
+        .await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
 impl SandboxHandle for BasicAgentHandle {
     async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
         if request.name.is_none() {
@@ -997,23 +1017,6 @@ impl SandboxHandle for BasicAgentHandle {
             return Ok(sandbox_id);
         }
         self.create_new_sandbox_locked(prepared).await
-    }
-
-    async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
-        let (snapshot_id, _event) =
-            snapshot_sandbox_side_effect(&self.harness, &self.agent_dir(), id).await?;
-        Ok(snapshot_id)
-    }
-
-    async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
-        start_sandbox_side_effect(
-            &self.harness,
-            &self.agent_dir(),
-            SandboxOwner::Agent(self.record.id),
-            request,
-        )
-        .await?;
-        Ok(())
     }
 
     async fn stop_sandbox(&self, id: SandboxId) -> Result<()> {
@@ -1978,20 +1981,7 @@ impl ConversationHandle for BasicConversationHandle {
 }
 
 #[async_trait]
-impl SandboxHandle for BasicConversationHandle {
-    async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
-        if request.name.is_none() {
-            return self.create_new_sandbox(request).await;
-        }
-        let prepared = self.prepare_sandbox_request(request).await?;
-        let _guard = self.harness.inner.write_lock.lock().await;
-        if let Some((sandbox_id, sandbox)) = self.find_matching_sandbox(&prepared).await? {
-            self.active_sandbox_handle(&sandbox_id, &sandbox).await?;
-            return Ok(sandbox_id);
-        }
-        self.create_new_sandbox_locked(prepared).await
-    }
-
+impl SnapshotHandle for BasicConversationHandle {
     async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
         let (snapshot_id, event) =
             snapshot_sandbox_side_effect(&self.harness, &self.conversation_dir(), id).await?;
@@ -2011,6 +2001,22 @@ impl SandboxHandle for BasicConversationHandle {
         self.append_events_internal(None, None, None, vec![event])
             .await?;
         Ok(())
+    }
+}
+
+#[async_trait]
+impl SandboxHandle for BasicConversationHandle {
+    async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
+        if request.name.is_none() {
+            return self.create_new_sandbox(request).await;
+        }
+        let prepared = self.prepare_sandbox_request(request).await?;
+        let _guard = self.harness.inner.write_lock.lock().await;
+        if let Some((sandbox_id, sandbox)) = self.find_matching_sandbox(&prepared).await? {
+            self.active_sandbox_handle(&sandbox_id, &sandbox).await?;
+            return Ok(sandbox_id);
+        }
+        self.create_new_sandbox_locked(prepared).await
     }
 
     async fn stop_sandbox(&self, id: SandboxId) -> Result<()> {
@@ -2565,6 +2571,28 @@ struct BasicTurnState {
 }
 
 #[async_trait]
+impl SnapshotHandle for BasicTurnHandle {
+    async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
+        let (snapshot_id, event) =
+            snapshot_sandbox_side_effect(&self.harness, &self.conversation_dir, id).await?;
+        self.add_events(vec![event]).await?;
+        Ok(snapshot_id)
+    }
+
+    async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
+        let event = start_sandbox_side_effect(
+            &self.harness,
+            &self.conversation_dir,
+            SandboxOwner::Conversation(self.conversation_id),
+            request,
+        )
+        .await?;
+        self.add_events(vec![event]).await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
 impl TurnHandle for BasicTurnHandle {
     fn record(&self) -> &TurnRecord {
         &self.record
@@ -2652,25 +2680,6 @@ impl TurnHandle for BasicTurnHandle {
             .expect("turn state poisoned")
             .latest_event_id = Some(add_result.latest_event_id);
         Ok(artifact_version)
-    }
-
-    async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
-        let (snapshot_id, event) =
-            snapshot_sandbox_side_effect(&self.harness, &self.conversation_dir, id).await?;
-        self.add_events(vec![event]).await?;
-        Ok(snapshot_id)
-    }
-
-    async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
-        let event = start_sandbox_side_effect(
-            &self.harness,
-            &self.conversation_dir,
-            SandboxOwner::Conversation(self.conversation_id),
-            request,
-        )
-        .await?;
-        self.add_events(vec![event]).await?;
-        Ok(())
     }
 
     async fn finish(&self) -> Result<EventId> {

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -1336,7 +1336,6 @@ impl ConversationHandle for BasicConversationHandle {
 
         Ok(Arc::new(BasicTurnHandle {
             harness: self.harness.clone(),
-            agent_id: self.agent_id,
             conversation_dir,
             conversation_id: self.record.id,
             record: turn_record,
@@ -1368,7 +1367,6 @@ impl ConversationHandle for BasicConversationHandle {
         }
         Ok(Arc::new(BasicTurnHandle {
             harness: self.harness.clone(),
-            agent_id: self.agent_id,
             conversation_dir: self.conversation_dir(),
             conversation_id: self.record.id,
             record,
@@ -2289,7 +2287,6 @@ async fn load_stored_sandbox(
 
 struct BasicTurnHandle {
     harness: BasicExoHarness,
-    agent_id: AgentId,
     conversation_dir: PathBuf,
     conversation_id: ConversationId,
     record: TurnRecord,
@@ -2299,19 +2296,6 @@ struct BasicTurnHandle {
 struct BasicTurnState {
     latest_event_id: Option<EventId>,
     finished: bool,
-}
-
-impl BasicTurnHandle {
-    fn owner_conversation_dir(&self, conversation_id: ConversationId) -> PathBuf {
-        if conversation_id == self.conversation_id {
-            return self.conversation_dir.clone();
-        }
-        self.harness
-            .agents_dir()
-            .join(self.agent_id.to_string())
-            .join("conversations")
-            .join(conversation_id.to_string())
-    }
 }
 
 #[async_trait]
@@ -2404,27 +2388,21 @@ impl TurnHandle for BasicTurnHandle {
         Ok(artifact_version)
     }
 
-    async fn snapshot_sandbox(
-        &self,
-        conversation_id: ConversationId,
-        id: SandboxId,
-    ) -> Result<SnapshotId> {
-        let conversation_dir = self.owner_conversation_dir(conversation_id);
+    async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
         let (snapshot_id, event) =
-            snapshot_sandbox_side_effect(&self.harness, &conversation_dir, id).await?;
+            snapshot_sandbox_side_effect(&self.harness, &self.conversation_dir, id).await?;
         self.add_events(vec![event]).await?;
         Ok(snapshot_id)
     }
 
-    async fn start_sandbox(
-        &self,
-        conversation_id: ConversationId,
-        request: StartSandboxRequest,
-    ) -> Result<()> {
-        let conversation_dir = self.owner_conversation_dir(conversation_id);
-        let event =
-            start_sandbox_side_effect(&self.harness, &conversation_dir, conversation_id, request)
-                .await?;
+    async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
+        let event = start_sandbox_side_effect(
+            &self.harness,
+            &self.conversation_dir,
+            self.conversation_id,
+            request,
+        )
+        .await?;
         self.add_events(vec![event]).await?;
         Ok(())
     }

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -710,6 +710,95 @@ struct BasicAgentHandle {
     record: AgentRecord,
 }
 
+trait BasicSandboxScope {
+    fn sandbox_handle(&self) -> BasicScopedSandboxHandle<'_>;
+}
+
+trait BasicFullSandboxScope: BasicSandboxScope {}
+
+#[async_trait]
+impl<T> SnapshotHandle for T
+where
+    T: BasicSandboxScope + Send + Sync,
+{
+    async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
+        self.sandbox_handle().snapshot_sandbox(id).await
+    }
+
+    async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
+        self.sandbox_handle().start_sandbox(request).await
+    }
+}
+
+#[async_trait]
+impl<T> SandboxHandle for T
+where
+    T: BasicFullSandboxScope + Send + Sync,
+{
+    async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
+        self.sandbox_handle().create_sandbox(request).await
+    }
+
+    async fn stop_sandbox(&self, id: SandboxId) -> Result<()> {
+        self.sandbox_handle().stop_sandbox(id).await
+    }
+
+    async fn start_sandbox_process(
+        &self,
+        request: StartSandboxProcessRequest,
+    ) -> Result<SandboxProcessRecord> {
+        self.sandbox_handle().start_sandbox_process(request).await
+    }
+
+    async fn write_sandbox_process_input(
+        &self,
+        request: WriteSandboxProcessInputRequest,
+    ) -> Result<()> {
+        self.sandbox_handle()
+            .write_sandbox_process_input(request)
+            .await
+    }
+
+    async fn close_sandbox_process_input(
+        &self,
+        request: CloseSandboxProcessInputRequest,
+    ) -> Result<()> {
+        self.sandbox_handle()
+            .close_sandbox_process_input(request)
+            .await
+    }
+
+    async fn get_sandbox_process_events(
+        &self,
+        query: SandboxProcessEventQuery,
+    ) -> Result<GetSandboxProcessEventsResult> {
+        self.sandbox_handle()
+            .get_sandbox_process_events(query)
+            .await
+    }
+
+    async fn wait_sandbox_process(
+        &self,
+        request: WaitSandboxProcessRequest,
+    ) -> Result<SandboxProcessStatus> {
+        self.sandbox_handle().wait_sandbox_process(request).await
+    }
+
+    async fn cancel_sandbox_process(
+        &self,
+        request: CancelSandboxProcessRequest,
+    ) -> Result<SandboxProcessStatus> {
+        self.sandbox_handle().cancel_sandbox_process(request).await
+    }
+
+    async fn run_in_sandbox(
+        &self,
+        request: RunInSandboxRequest,
+    ) -> Result<Box<dyn SandboxProcess>> {
+        self.sandbox_handle().run_in_sandbox(request).await
+    }
+}
+
 #[async_trait]
 impl AgentHandle for BasicAgentHandle {
     fn record(&self) -> &AgentRecord {
@@ -972,212 +1061,13 @@ impl AgentHandle for BasicAgentHandle {
     }
 }
 
-#[async_trait]
-impl SnapshotHandle for BasicAgentHandle {
-    async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
-        let (snapshot_id, _event) =
-            snapshot_sandbox_side_effect(&self.harness, &self.agent_dir(), id).await?;
-        Ok(snapshot_id)
-    }
-
-    async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
-        start_sandbox_side_effect(
-            &self.harness,
-            &self.agent_dir(),
-            SandboxOwner::Agent(self.record.id),
-            request,
-        )
-        .await?;
-        Ok(())
+impl BasicSandboxScope for BasicAgentHandle {
+    fn sandbox_handle(&self) -> BasicScopedSandboxHandle<'_> {
+        BasicScopedSandboxHandle::agent(&self.harness, self.record.id)
     }
 }
 
-#[async_trait]
-impl SandboxHandle for BasicAgentHandle {
-    async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
-        if request.name.is_none() {
-            return self.create_new_sandbox(request).await;
-        }
-        let prepared = prepare_sandbox_request(&self.harness, request).await?;
-        let _guard = self.harness.inner.write_lock.lock().await;
-        if let Some((sandbox_id, sandbox)) = find_matching_stored_sandbox(
-            &self.harness.inner.storage,
-            &self.sandboxes_dir(),
-            &prepared,
-        )
-        .await?
-        {
-            active_sandbox_handle(
-                &self.harness,
-                SandboxOwner::Agent(self.record.id),
-                &sandbox_id,
-                &sandbox,
-            )
-            .await?;
-            return Ok(sandbox_id);
-        }
-        self.create_new_sandbox_locked(prepared).await
-    }
-
-    async fn stop_sandbox(&self, id: SandboxId) -> Result<()> {
-        let sandbox_handle = self
-            .harness
-            .inner
-            .running_sandboxes
-            .lock()
-            .await
-            .remove(&id);
-        if let Some(sandbox_handle) = sandbox_handle {
-            sandbox_handle.stop().await?;
-        }
-
-        let _guard = self.harness.inner.write_lock.lock().await;
-        let mut sandbox = self.load_sandbox(&id).await?;
-        if !sandbox.running {
-            return Ok(());
-        }
-        sandbox.running = false;
-        self.harness
-            .inner
-            .storage
-            .put_json(self.sandboxes_dir().join(format!("{id}.json")), &sandbox)
-            .await?;
-        Ok(())
-    }
-
-    async fn start_sandbox_process(
-        &self,
-        request: StartSandboxProcessRequest,
-    ) -> Result<SandboxProcessRecord> {
-        let pending = prepare_sandbox_process(
-            &self.harness,
-            &self.agent_dir(),
-            SandboxOwner::Agent(self.record.id),
-            None,
-            request,
-        )
-        .await?;
-        spawn_pending_sandbox_process(&self.harness, pending).await
-    }
-
-    async fn write_sandbox_process_input(
-        &self,
-        request: WriteSandboxProcessInputRequest,
-    ) -> Result<()> {
-        let process = self
-            .require_sandbox_process(&request.sandbox_id, &request.process_id)
-            .await?;
-        if !sandbox_process_status(&process).await.is_running() {
-            bail!("sandbox process is not running: {}", request.process_id);
-        }
-        let mut stdin = process.stdin.lock().await;
-        let stdin = stdin
-            .as_mut()
-            .ok_or_else(|| anyhow!("sandbox process stdin is closed: {}", request.process_id))?;
-        stdin.write_all(&request.data).await?;
-        stdin.flush().await?;
-        Ok(())
-    }
-
-    async fn close_sandbox_process_input(
-        &self,
-        request: CloseSandboxProcessInputRequest,
-    ) -> Result<()> {
-        let process = self
-            .require_sandbox_process(&request.sandbox_id, &request.process_id)
-            .await?;
-        process.stdin.lock().await.take();
-        Ok(())
-    }
-
-    async fn get_sandbox_process_events(
-        &self,
-        query: SandboxProcessEventQuery,
-    ) -> Result<GetSandboxProcessEventsResult> {
-        let process = self
-            .require_sandbox_process(&query.sandbox_id, &query.process_id)
-            .await?;
-        let after = query.after.unwrap_or_default();
-        let limit = query.limit.unwrap_or(u32::MAX) as usize;
-        let events = process
-            .events
-            .lock()
-            .await
-            .iter()
-            .filter(|event| event.cursor() > after)
-            .take(limit)
-            .cloned()
-            .collect::<Vec<_>>();
-        let cursor = events
-            .last()
-            .map(SandboxProcessEvent::cursor)
-            .or(query.after);
-        Ok(GetSandboxProcessEventsResult {
-            events,
-            cursor,
-            status: sandbox_process_status(&process).await,
-        })
-    }
-
-    async fn wait_sandbox_process(
-        &self,
-        request: WaitSandboxProcessRequest,
-    ) -> Result<SandboxProcessStatus> {
-        let process = self
-            .require_sandbox_process(&request.sandbox_id, &request.process_id)
-            .await?;
-        Ok(wait_for_sandbox_process_terminal_status(&process).await)
-    }
-
-    async fn cancel_sandbox_process(
-        &self,
-        request: CancelSandboxProcessRequest,
-    ) -> Result<SandboxProcessStatus> {
-        let process = self
-            .require_sandbox_process(&request.sandbox_id, &request.process_id)
-            .await?;
-        process.stdin.lock().await.take();
-        if let Some(tasks) = process.tasks.lock().await.take() {
-            tasks.stdout.abort();
-            tasks.stderr.abort();
-            tasks.wait.abort();
-        }
-        push_sandbox_process_event(&process, SandboxProcessEventPayload::Cancelled).await;
-        set_sandbox_process_status(&process, SandboxProcessStatus::Cancelled).await;
-        Ok(SandboxProcessStatus::Cancelled)
-    }
-
-    async fn run_in_sandbox(
-        &self,
-        request: RunInSandboxRequest,
-    ) -> Result<Box<dyn SandboxProcess>> {
-        let sandbox = self.load_sandbox(&request.id).await?;
-        if !sandbox.running {
-            bail!("sandbox is not running: {}", request.id);
-        }
-        if request.command.is_empty() {
-            bail!("sandbox command must not be empty");
-        }
-        let sandbox_handle = active_sandbox_handle(
-            &self.harness,
-            SandboxOwner::Agent(self.record.id),
-            &request.id,
-            &sandbox,
-        )
-        .await?;
-        let parts = sandbox_handle
-            .start_process(&SandboxCommand {
-                argv: request.command.clone(),
-                env: request.env.clone(),
-                display_argv: Some(request.command),
-                cwd: None,
-                timeout: None,
-            })
-            .await
-            .with_context(|| format!("failed to run command in sandbox {}", request.id))?;
-        Ok(Box::new(LiveSandboxProcess::new(parts)))
-    }
-}
+impl BasicFullSandboxScope for BasicAgentHandle {}
 
 impl BasicAgentHandle {
     fn agent_dir(&self) -> PathBuf {
@@ -1198,76 +1088,6 @@ impl BasicAgentHandle {
 
     fn artifacts_dir(&self) -> PathBuf {
         self.agent_dir().join("artifacts")
-    }
-
-    fn sandboxes_dir(&self) -> PathBuf {
-        self.agent_dir().join("sandboxes")
-    }
-
-    async fn load_sandbox(&self, id: &str) -> Result<StoredSandbox> {
-        load_stored_sandbox(&self.harness, &self.agent_dir(), id).await
-    }
-
-    async fn create_new_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
-        let prepared = prepare_sandbox_request(&self.harness, request).await?;
-        let sandbox_id = format!("sandbox-{}", Uuid7::now());
-        let sandbox = prepared.stored_sandbox(sandbox_id.clone());
-        let sandbox_handle = create_sandbox_handle(
-            &self.harness,
-            SandboxOwner::Agent(self.record.id),
-            &sandbox_id,
-            &sandbox,
-        )
-        .await?;
-        let _guard = self.harness.inner.write_lock.lock().await;
-        self.persist_created_sandbox(sandbox, sandbox_handle).await
-    }
-
-    async fn create_new_sandbox_locked(
-        &self,
-        request: PreparedSandboxRequest,
-    ) -> Result<SandboxId> {
-        let sandbox_id = format!("sandbox-{}", Uuid7::now());
-        let sandbox = request.stored_sandbox(sandbox_id.clone());
-        let sandbox_handle = create_sandbox_handle(
-            &self.harness,
-            SandboxOwner::Agent(self.record.id),
-            &sandbox_id,
-            &sandbox,
-        )
-        .await?;
-        self.persist_created_sandbox(sandbox, sandbox_handle).await
-    }
-
-    async fn persist_created_sandbox(
-        &self,
-        sandbox: StoredSandbox,
-        sandbox_handle: Arc<dyn ManagedSandboxHandle>,
-    ) -> Result<SandboxId> {
-        let sandbox_id = sandbox.id.clone();
-        self.harness
-            .inner
-            .storage
-            .put_json(
-                self.sandboxes_dir().join(format!("{sandbox_id}.json")),
-                &sandbox,
-            )
-            .await?;
-        self.harness
-            .inner
-            .running_sandboxes
-            .lock()
-            .await
-            .insert(sandbox_id.clone(), sandbox_handle);
-        Ok(sandbox_id)
-    }
-
-    async fn require_sandbox_process(
-        &self,
-        sandbox_id: &str,
-        process_id: &str,
-    ) -> Result<Arc<RunningSandboxProcess>> {
-        require_running_sandbox_process(&self.harness, sandbox_id, process_id).await
     }
 
     async fn list_conversation_records(
@@ -1341,52 +1161,373 @@ enum SandboxOwner {
     Conversation(ConversationId),
 }
 
-struct BasicConversationHandle {
-    harness: BasicExoHarness,
-    agent_id: AgentId,
-    record: ConversationRecord,
+struct BasicScopedSandboxHandle<'a> {
+    harness: &'a BasicExoHarness,
+    owner_dir: PathBuf,
+    owner: SandboxOwner,
+    event_sink: BasicSandboxEventSink<'a>,
 }
 
-impl BasicConversationHandle {
-    async fn active_sandbox_handle(
-        &self,
-        sandbox_id: &SandboxId,
-        sandbox: &StoredSandbox,
-    ) -> Result<Arc<dyn ManagedSandboxHandle>> {
-        active_sandbox_handle(
-            &self.harness,
-            SandboxOwner::Conversation(self.record.id),
-            sandbox_id,
-            sandbox,
-        )
-        .await
+enum BasicSandboxEventSink<'a> {
+    None,
+    Conversation {
+        conversation_id: ConversationId,
+    },
+    Turn {
+        conversation_id: ConversationId,
+        session_id: SessionId,
+        turn_id: TurnId,
+        state: &'a Mutex<BasicTurnState>,
+    },
+}
+
+impl<'a> BasicScopedSandboxHandle<'a> {
+    fn agent(harness: &'a BasicExoHarness, agent_id: AgentId) -> Self {
+        Self {
+            harness,
+            owner_dir: harness.agents_dir().join(agent_id.to_string()),
+            owner: SandboxOwner::Agent(agent_id),
+            event_sink: BasicSandboxEventSink::None,
+        }
     }
 
-    async fn prepare_sandbox_request(
+    fn conversation(
+        harness: &'a BasicExoHarness,
+        conversation_id: ConversationId,
+        conversation_dir: PathBuf,
+    ) -> Self {
+        Self {
+            harness,
+            owner_dir: conversation_dir,
+            owner: SandboxOwner::Conversation(conversation_id),
+            event_sink: BasicSandboxEventSink::Conversation { conversation_id },
+        }
+    }
+
+    fn turn(
+        harness: &'a BasicExoHarness,
+        conversation_id: ConversationId,
+        conversation_dir: PathBuf,
+        session_id: SessionId,
+        turn_id: TurnId,
+        state: &'a Mutex<BasicTurnState>,
+    ) -> Self {
+        Self {
+            harness,
+            owner_dir: conversation_dir,
+            owner: SandboxOwner::Conversation(conversation_id),
+            event_sink: BasicSandboxEventSink::Turn {
+                conversation_id,
+                session_id,
+                turn_id,
+                state,
+            },
+        }
+    }
+
+    fn sandboxes_dir(&self) -> PathBuf {
+        self.owner_dir.join("sandboxes")
+    }
+
+    async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
+        self.ensure_full_sandbox_scope("create_sandbox")?;
+        if request.name.is_none() {
+            return self.create_new_sandbox(request).await;
+        }
+        let prepared = prepare_sandbox_request(self.harness, request).await?;
+        let _guard = self.harness.inner.write_lock.lock().await;
+        if let Some((sandbox_id, sandbox)) = self.find_matching_sandbox(&prepared).await? {
+            active_sandbox_handle(self.harness, self.owner, &sandbox_id, &sandbox).await?;
+            return Ok(sandbox_id);
+        }
+        self.create_new_sandbox_locked(prepared).await
+    }
+
+    async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
+        let (snapshot_id, event) =
+            snapshot_sandbox_side_effect(self.harness, &self.owner_dir, id).await?;
+        self.append_events(vec![event]).await?;
+        Ok(snapshot_id)
+    }
+
+    async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
+        let event =
+            start_sandbox_side_effect(self.harness, &self.owner_dir, self.owner, request).await?;
+        self.append_events(vec![event]).await?;
+        Ok(())
+    }
+
+    async fn stop_sandbox(&self, id: SandboxId) -> Result<()> {
+        self.ensure_full_sandbox_scope("stop_sandbox")?;
+        let sandbox_handle = self
+            .harness
+            .inner
+            .running_sandboxes
+            .lock()
+            .await
+            .remove(&id);
+        if let Some(sandbox_handle) = sandbox_handle {
+            sandbox_handle.stop().await?;
+        }
+
+        let _guard = self.harness.inner.write_lock.lock().await;
+        let mut sandbox = self.load_sandbox(&id).await?;
+        if !sandbox.running {
+            return Ok(());
+        }
+        sandbox.running = false;
+        self.harness
+            .inner
+            .storage
+            .put_json(self.sandboxes_dir().join(format!("{id}.json")), &sandbox)
+            .await?;
+        self.append_events_locked(vec![EventData::SandboxStopped { sandbox_id: id }])
+            .await?;
+        Ok(())
+    }
+
+    async fn start_sandbox_process(
         &self,
-        request: CreateSandboxRequest,
-    ) -> Result<PreparedSandboxRequest> {
-        prepare_sandbox_request(&self.harness, request).await
+        request: StartSandboxProcessRequest,
+    ) -> Result<SandboxProcessRecord> {
+        self.ensure_full_sandbox_scope("start_sandbox_process")?;
+        let pending = prepare_sandbox_process(
+            self.harness,
+            &self.owner_dir,
+            self.owner,
+            self.process_event_log(),
+            request,
+        )
+        .await?;
+        self.append_events(vec![pending.started_event.clone()])
+            .await?;
+        spawn_pending_sandbox_process(self.harness, pending).await
+    }
+
+    async fn write_sandbox_process_input(
+        &self,
+        request: WriteSandboxProcessInputRequest,
+    ) -> Result<()> {
+        self.ensure_full_sandbox_scope("write_sandbox_process_input")?;
+        let process = self
+            .require_sandbox_process(&request.sandbox_id, &request.process_id)
+            .await?;
+        if !sandbox_process_status(&process).await.is_running() {
+            bail!("sandbox process is not running: {}", request.process_id);
+        }
+        let mut stdin = process.stdin.lock().await;
+        let stdin = stdin
+            .as_mut()
+            .ok_or_else(|| anyhow!("sandbox process stdin is closed: {}", request.process_id))?;
+        stdin.write_all(&request.data).await?;
+        stdin.flush().await?;
+        Ok(())
+    }
+
+    async fn close_sandbox_process_input(
+        &self,
+        request: CloseSandboxProcessInputRequest,
+    ) -> Result<()> {
+        self.ensure_full_sandbox_scope("close_sandbox_process_input")?;
+        let process = self
+            .require_sandbox_process(&request.sandbox_id, &request.process_id)
+            .await?;
+        process.stdin.lock().await.take();
+        Ok(())
+    }
+
+    async fn get_sandbox_process_events(
+        &self,
+        query: SandboxProcessEventQuery,
+    ) -> Result<GetSandboxProcessEventsResult> {
+        self.ensure_full_sandbox_scope("get_sandbox_process_events")?;
+        let process = self
+            .require_sandbox_process(&query.sandbox_id, &query.process_id)
+            .await?;
+        let after = query.after.unwrap_or_default();
+        let limit = query.limit.unwrap_or(u32::MAX) as usize;
+        let events = process
+            .events
+            .lock()
+            .await
+            .iter()
+            .filter(|event| event.cursor() > after)
+            .take(limit)
+            .cloned()
+            .collect::<Vec<_>>();
+        let cursor = events
+            .last()
+            .map(SandboxProcessEvent::cursor)
+            .or(query.after);
+        Ok(GetSandboxProcessEventsResult {
+            events,
+            cursor,
+            status: sandbox_process_status(&process).await,
+        })
+    }
+
+    async fn wait_sandbox_process(
+        &self,
+        request: WaitSandboxProcessRequest,
+    ) -> Result<SandboxProcessStatus> {
+        self.ensure_full_sandbox_scope("wait_sandbox_process")?;
+        let process = self
+            .require_sandbox_process(&request.sandbox_id, &request.process_id)
+            .await?;
+        Ok(wait_for_sandbox_process_terminal_status(&process).await)
+    }
+
+    async fn cancel_sandbox_process(
+        &self,
+        request: CancelSandboxProcessRequest,
+    ) -> Result<SandboxProcessStatus> {
+        self.ensure_full_sandbox_scope("cancel_sandbox_process")?;
+        let process = self
+            .require_sandbox_process(&request.sandbox_id, &request.process_id)
+            .await?;
+        process.stdin.lock().await.take();
+        if let Some(tasks) = process.tasks.lock().await.take() {
+            tasks.stdout.abort();
+            tasks.stderr.abort();
+            tasks.wait.abort();
+        }
+        push_sandbox_process_event(&process, SandboxProcessEventPayload::Cancelled).await;
+        set_sandbox_process_status(&process, SandboxProcessStatus::Cancelled).await;
+        Ok(SandboxProcessStatus::Cancelled)
+    }
+
+    async fn run_in_sandbox(
+        &self,
+        request: RunInSandboxRequest,
+    ) -> Result<Box<dyn SandboxProcess>> {
+        self.ensure_full_sandbox_scope("run_in_sandbox")?;
+        let sandbox = self.load_sandbox(&request.id).await?;
+        if !sandbox.running {
+            bail!("sandbox is not running: {}", request.id);
+        }
+        if request.command.is_empty() {
+            bail!("sandbox command must not be empty");
+        }
+        let sandbox_handle =
+            active_sandbox_handle(self.harness, self.owner, &request.id, &sandbox).await?;
+        let parts = sandbox_handle
+            .start_process(&SandboxCommand {
+                argv: request.command.clone(),
+                env: request.env.clone(),
+                display_argv: Some(request.command),
+                cwd: None,
+                timeout: None,
+            })
+            .await
+            .with_context(|| format!("failed to run command in sandbox {}", request.id))?;
+        Ok(Box::new(LiveSandboxProcess::new(parts)))
+    }
+
+    fn ensure_full_sandbox_scope(&self, operation: &str) -> Result<()> {
+        if matches!(self.event_sink, BasicSandboxEventSink::Turn { .. }) {
+            bail!("{operation} is not supported on a turn scope");
+        }
+        Ok(())
+    }
+
+    async fn create_new_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
+        let prepared = prepare_sandbox_request(self.harness, request).await?;
+        let sandbox_id = format!("sandbox-{}", Uuid7::now());
+        let sandbox = prepared.stored_sandbox(sandbox_id.clone());
+        let sandbox_handle =
+            create_sandbox_handle(self.harness, self.owner, &sandbox_id, &sandbox).await?;
+        let _guard = self.harness.inner.write_lock.lock().await;
+        self.persist_created_sandbox_locked(sandbox, sandbox_handle)
+            .await
+    }
+
+    async fn create_new_sandbox_locked(
+        &self,
+        request: PreparedSandboxRequest,
+    ) -> Result<SandboxId> {
+        let sandbox_id = format!("sandbox-{}", Uuid7::now());
+        let sandbox = request.stored_sandbox(sandbox_id.clone());
+        let sandbox_handle =
+            create_sandbox_handle(self.harness, self.owner, &sandbox_id, &sandbox).await?;
+        self.persist_created_sandbox_locked(sandbox, sandbox_handle)
+            .await
+    }
+
+    async fn persist_created_sandbox_locked(
+        &self,
+        sandbox: StoredSandbox,
+        sandbox_handle: Arc<dyn ManagedSandboxHandle>,
+    ) -> Result<SandboxId> {
+        let sandbox_id = sandbox.id.clone();
+        self.harness
+            .inner
+            .storage
+            .put_json(
+                self.sandboxes_dir().join(format!("{sandbox_id}.json")),
+                &sandbox,
+            )
+            .await?;
+        self.harness
+            .inner
+            .running_sandboxes
+            .lock()
+            .await
+            .insert(sandbox_id.clone(), sandbox_handle);
+        self.append_events_locked(vec![
+            EventData::SandboxCreated {
+                sandbox_id: sandbox_id.clone(),
+                name: sandbox.name,
+                provider: sandbox.provider,
+                image: sandbox.image,
+                default_workdir: sandbox.default_workdir.unwrap_or_default(),
+                file_system_mounts: sandbox.file_system_mounts,
+                enable_networking: sandbox.enable_networking,
+                idle_seconds: sandbox.idle_seconds,
+            },
+            EventData::SandboxStarted {
+                sandbox_id: sandbox_id.clone(),
+                snapshot_id: None,
+            },
+        ])
+        .await?;
+        Ok(sandbox_id)
     }
 
     async fn find_matching_sandbox(
         &self,
         request: &PreparedSandboxRequest,
     ) -> Result<Option<(SandboxId, StoredSandbox)>> {
+        match self.event_sink {
+            BasicSandboxEventSink::None => {
+                find_matching_stored_sandbox(
+                    &self.harness.inner.storage,
+                    &self.sandboxes_dir(),
+                    request,
+                )
+                .await
+            }
+            BasicSandboxEventSink::Conversation { .. } => {
+                self.find_matching_conversation_sandbox(request).await
+            }
+            BasicSandboxEventSink::Turn { .. } => {
+                bail!("create_sandbox is not supported on a turn scope")
+            }
+        }
+    }
+
+    async fn find_matching_conversation_sandbox(
+        &self,
+        request: &PreparedSandboxRequest,
+    ) -> Result<Option<(SandboxId, StoredSandbox)>> {
         let Some(name) = &request.name else {
             return Ok(None);
         };
-        let events = self
-            .get_events(Some(EventQuery {
-                cursor: None,
-                direction: Some(EventQueryDirection::Asc),
-                limit: None,
-                session_id: None,
-                turn_id: None,
-                types: Some(vec![EventKind::SANDBOX_CREATED]),
-            }))
+        let mut events = load_events(&self.harness.inner.storage, &self.owner_dir.join("events"))
             .await?
-            .events;
+            .into_iter()
+            .filter(|event| event.data.kind() == EventKind::SANDBOX_CREATED)
+            .collect::<Vec<_>>();
+        events.sort_by_key(|event| event.id);
 
         for event in events.into_iter().rev() {
             let EventData::SandboxCreated {
@@ -1424,93 +1565,108 @@ impl BasicConversationHandle {
         Ok(None)
     }
 
-    async fn create_new_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
-        let prepared = self.prepare_sandbox_request(request).await?;
-        let sandbox_id = format!("sandbox-{}", Uuid7::now());
-        let sandbox = prepared.stored_sandbox(sandbox_id.clone());
-        let sandbox_handle = self.create_sandbox_handle(&sandbox_id, &sandbox).await?;
+    async fn load_sandbox(&self, id: &str) -> Result<StoredSandbox> {
+        load_stored_sandbox(self.harness, &self.owner_dir, id).await
+    }
+
+    async fn require_sandbox_process(
+        &self,
+        sandbox_id: &str,
+        process_id: &str,
+    ) -> Result<Arc<RunningSandboxProcess>> {
+        require_running_sandbox_process(self.harness, sandbox_id, process_id).await
+    }
+
+    fn process_event_log(&self) -> Option<SandboxProcessEventLog> {
+        match self.event_sink {
+            BasicSandboxEventSink::None | BasicSandboxEventSink::Turn { .. } => None,
+            BasicSandboxEventSink::Conversation { conversation_id } => {
+                Some(SandboxProcessEventLog {
+                    inner: Arc::clone(&self.harness.inner),
+                    conversation_id,
+                    conversation_dir: self.owner_dir.clone(),
+                })
+            }
+        }
+    }
+
+    async fn append_events(&self, data: Vec<EventData>) -> Result<()> {
+        if matches!(self.event_sink, BasicSandboxEventSink::None) {
+            return Ok(());
+        }
         let _guard = self.harness.inner.write_lock.lock().await;
-        self.persist_created_sandbox(sandbox, sandbox_handle).await
+        self.append_events_locked(data).await
     }
 
-    async fn create_new_sandbox_locked(
-        &self,
-        request: PreparedSandboxRequest,
-    ) -> Result<SandboxId> {
-        let sandbox_id = format!("sandbox-{}", Uuid7::now());
-        let sandbox = request.stored_sandbox(sandbox_id.clone());
-        let sandbox_handle = self.create_sandbox_handle(&sandbox_id, &sandbox).await?;
-        self.persist_created_sandbox(sandbox, sandbox_handle).await
+    async fn append_events_locked(&self, data: Vec<EventData>) -> Result<()> {
+        match self.event_sink {
+            BasicSandboxEventSink::None => Ok(()),
+            BasicSandboxEventSink::Conversation { conversation_id } => {
+                let mut record = self
+                    .harness
+                    .inner
+                    .storage
+                    .get_json::<ConversationRecord>(self.owner_dir.join("record.json"))
+                    .await?;
+                append_events_to_conversation(
+                    &self.harness.inner,
+                    &self.owner_dir,
+                    conversation_id,
+                    None,
+                    None,
+                    record.latest_event_id,
+                    data,
+                    &mut record,
+                )
+                .await?;
+                self.harness
+                    .inner
+                    .storage
+                    .put_json(self.owner_dir.join("record.json"), &record)
+                    .await?;
+                Ok(())
+            }
+            BasicSandboxEventSink::Turn {
+                conversation_id,
+                session_id,
+                turn_id,
+                state,
+            } => {
+                let expected_head = state.lock().expect("turn state poisoned").latest_event_id;
+                let mut record = self
+                    .harness
+                    .inner
+                    .storage
+                    .get_json::<ConversationRecord>(self.owner_dir.join("record.json"))
+                    .await?;
+                let add_result = append_events_to_conversation(
+                    &self.harness.inner,
+                    &self.owner_dir,
+                    conversation_id,
+                    Some(session_id),
+                    Some(turn_id),
+                    expected_head,
+                    data,
+                    &mut record,
+                )
+                .await?;
+                self.harness
+                    .inner
+                    .storage
+                    .put_json(self.owner_dir.join("record.json"), &record)
+                    .await?;
+                state.lock().expect("turn state poisoned").latest_event_id =
+                    Some(add_result.latest_event_id);
+                Ok(())
+            }
+        }
     }
+}
 
-    async fn create_sandbox_handle(
-        &self,
-        sandbox_id: &SandboxId,
-        sandbox: &StoredSandbox,
-    ) -> Result<Arc<dyn ManagedSandboxHandle>> {
-        create_sandbox_handle(
-            &self.harness,
-            SandboxOwner::Conversation(self.record.id),
-            sandbox_id,
-            sandbox,
-        )
-        .await
-    }
-
-    async fn persist_created_sandbox(
-        &self,
-        sandbox: StoredSandbox,
-        sandbox_handle: Arc<dyn ManagedSandboxHandle>,
-    ) -> Result<SandboxId> {
-        let sandbox_id = sandbox.id.clone();
-        self.harness
-            .inner
-            .storage
-            .put_json(
-                self.sandboxes_dir().join(format!("{sandbox_id}.json")),
-                &sandbox,
-            )
-            .await?;
-        self.harness
-            .inner
-            .running_sandboxes
-            .lock()
-            .await
-            .insert(sandbox_id.clone(), sandbox_handle);
-        let mut record = self.load_record().await?;
-        append_events_to_conversation(
-            &self.harness.inner,
-            &self.conversation_dir(),
-            self.record.id,
-            None,
-            None,
-            record.latest_event_id,
-            vec![
-                EventData::SandboxCreated {
-                    sandbox_id: sandbox_id.clone(),
-                    name: sandbox.name,
-                    provider: sandbox.provider,
-                    image: sandbox.image,
-                    default_workdir: sandbox.default_workdir.unwrap_or_default(),
-                    file_system_mounts: sandbox.file_system_mounts,
-                    enable_networking: sandbox.enable_networking,
-                    idle_seconds: sandbox.idle_seconds,
-                },
-                EventData::SandboxStarted {
-                    sandbox_id: sandbox_id.clone(),
-                    snapshot_id: None,
-                },
-            ],
-            &mut record,
-        )
-        .await?;
-        self.harness
-            .inner
-            .storage
-            .put_json(self.conversation_dir().join("record.json"), &record)
-            .await?;
-        Ok(sandbox_id)
-    }
+struct BasicConversationHandle {
+    harness: BasicExoHarness,
+    agent_id: AgentId,
+    record: ConversationRecord,
 }
 
 #[async_trait]
@@ -1980,223 +2136,17 @@ impl ConversationHandle for BasicConversationHandle {
     }
 }
 
-#[async_trait]
-impl SnapshotHandle for BasicConversationHandle {
-    async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
-        let (snapshot_id, event) =
-            snapshot_sandbox_side_effect(&self.harness, &self.conversation_dir(), id).await?;
-        self.append_events_internal(None, None, None, vec![event])
-            .await?;
-        Ok(snapshot_id)
-    }
-
-    async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
-        let event = start_sandbox_side_effect(
+impl BasicSandboxScope for BasicConversationHandle {
+    fn sandbox_handle(&self) -> BasicScopedSandboxHandle<'_> {
+        BasicScopedSandboxHandle::conversation(
             &self.harness,
-            &self.conversation_dir(),
-            SandboxOwner::Conversation(self.record.id),
-            request,
-        )
-        .await?;
-        self.append_events_internal(None, None, None, vec![event])
-            .await?;
-        Ok(())
-    }
-}
-
-#[async_trait]
-impl SandboxHandle for BasicConversationHandle {
-    async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
-        if request.name.is_none() {
-            return self.create_new_sandbox(request).await;
-        }
-        let prepared = self.prepare_sandbox_request(request).await?;
-        let _guard = self.harness.inner.write_lock.lock().await;
-        if let Some((sandbox_id, sandbox)) = self.find_matching_sandbox(&prepared).await? {
-            self.active_sandbox_handle(&sandbox_id, &sandbox).await?;
-            return Ok(sandbox_id);
-        }
-        self.create_new_sandbox_locked(prepared).await
-    }
-
-    async fn stop_sandbox(&self, id: SandboxId) -> Result<()> {
-        // Take the handle and stop it before the write lock — stop() is a remote
-        // call and must not block other writers.
-        let sandbox_handle = self
-            .harness
-            .inner
-            .running_sandboxes
-            .lock()
-            .await
-            .remove(&id);
-        if let Some(sandbox_handle) = sandbox_handle {
-            sandbox_handle.stop().await?;
-        }
-
-        let _guard = self.harness.inner.write_lock.lock().await;
-        let mut sandbox = self.load_sandbox(&id).await?;
-        if !sandbox.running {
-            return Ok(());
-        }
-        sandbox.running = false;
-        self.harness
-            .inner
-            .storage
-            .put_json(self.sandboxes_dir().join(format!("{id}.json")), &sandbox)
-            .await?;
-        let mut record = self.load_record().await?;
-        append_events_to_conversation(
-            &self.harness.inner,
-            &self.conversation_dir(),
             self.record.id,
-            None,
-            None,
-            record.latest_event_id,
-            vec![EventData::SandboxStopped { sandbox_id: id }],
-            &mut record,
+            self.conversation_dir(),
         )
-        .await?;
-        self.harness
-            .inner
-            .storage
-            .put_json(self.conversation_dir().join("record.json"), &record)
-            .await?;
-        Ok(())
-    }
-
-    async fn start_sandbox_process(
-        &self,
-        request: StartSandboxProcessRequest,
-    ) -> Result<SandboxProcessRecord> {
-        let pending = prepare_sandbox_process(
-            &self.harness,
-            &self.conversation_dir(),
-            SandboxOwner::Conversation(self.record.id),
-            Some(SandboxProcessEventLog {
-                inner: Arc::clone(&self.harness.inner),
-                conversation_id: self.record.id,
-                conversation_dir: self.conversation_dir(),
-            }),
-            request,
-        )
-        .await?;
-        self.append_events_internal(None, None, None, vec![pending.started_event.clone()])
-            .await?;
-        spawn_pending_sandbox_process(&self.harness, pending).await
-    }
-
-    async fn write_sandbox_process_input(
-        &self,
-        request: WriteSandboxProcessInputRequest,
-    ) -> Result<()> {
-        let process = self
-            .require_sandbox_process(&request.sandbox_id, &request.process_id)
-            .await?;
-        if !sandbox_process_status(&process).await.is_running() {
-            bail!("sandbox process is not running: {}", request.process_id);
-        }
-        let mut stdin = process.stdin.lock().await;
-        let stdin = stdin
-            .as_mut()
-            .ok_or_else(|| anyhow!("sandbox process stdin is closed: {}", request.process_id))?;
-        stdin.write_all(&request.data).await?;
-        stdin.flush().await?;
-        Ok(())
-    }
-
-    async fn close_sandbox_process_input(
-        &self,
-        request: CloseSandboxProcessInputRequest,
-    ) -> Result<()> {
-        let process = self
-            .require_sandbox_process(&request.sandbox_id, &request.process_id)
-            .await?;
-        process.stdin.lock().await.take();
-        Ok(())
-    }
-
-    async fn get_sandbox_process_events(
-        &self,
-        query: SandboxProcessEventQuery,
-    ) -> Result<GetSandboxProcessEventsResult> {
-        let process = self
-            .require_sandbox_process(&query.sandbox_id, &query.process_id)
-            .await?;
-        let after = query.after.unwrap_or_default();
-        let limit = query.limit.unwrap_or(u32::MAX) as usize;
-        let events = process
-            .events
-            .lock()
-            .await
-            .iter()
-            .filter(|event| event.cursor() > after)
-            .take(limit)
-            .cloned()
-            .collect::<Vec<_>>();
-        let cursor = events
-            .last()
-            .map(SandboxProcessEvent::cursor)
-            .or(query.after);
-        Ok(GetSandboxProcessEventsResult {
-            events,
-            cursor,
-            status: sandbox_process_status(&process).await,
-        })
-    }
-
-    async fn wait_sandbox_process(
-        &self,
-        request: WaitSandboxProcessRequest,
-    ) -> Result<SandboxProcessStatus> {
-        let process = self
-            .require_sandbox_process(&request.sandbox_id, &request.process_id)
-            .await?;
-        Ok(wait_for_sandbox_process_terminal_status(&process).await)
-    }
-
-    async fn cancel_sandbox_process(
-        &self,
-        request: CancelSandboxProcessRequest,
-    ) -> Result<SandboxProcessStatus> {
-        let process = self
-            .require_sandbox_process(&request.sandbox_id, &request.process_id)
-            .await?;
-        process.stdin.lock().await.take();
-        if let Some(tasks) = process.tasks.lock().await.take() {
-            tasks.stdout.abort();
-            tasks.stderr.abort();
-            tasks.wait.abort();
-        }
-        push_sandbox_process_event(&process, SandboxProcessEventPayload::Cancelled).await;
-        set_sandbox_process_status(&process, SandboxProcessStatus::Cancelled).await;
-        Ok(SandboxProcessStatus::Cancelled)
-    }
-
-    async fn run_in_sandbox(
-        &self,
-        request: RunInSandboxRequest,
-    ) -> Result<Box<dyn SandboxProcess>> {
-        let sandbox = self.load_sandbox(&request.id).await?;
-        if !sandbox.running {
-            bail!("sandbox is not running: {}", request.id);
-        }
-        if request.command.is_empty() {
-            bail!("sandbox command must not be empty");
-        }
-        let sandbox_handle = self.active_sandbox_handle(&request.id, &sandbox).await?;
-        let parts = sandbox_handle
-            .start_process(&SandboxCommand {
-                argv: request.command.clone(),
-                env: request.env.clone(),
-                display_argv: Some(request.command),
-                cwd: None,
-                timeout: None,
-            })
-            .await
-            .with_context(|| format!("failed to run command in sandbox {}", request.id))?;
-        Ok(Box::new(LiveSandboxProcess::new(parts)))
     }
 }
+
+impl BasicFullSandboxScope for BasicConversationHandle {}
 
 impl BasicConversationHandle {
     fn agent_dir(&self) -> PathBuf {
@@ -2264,34 +2214,6 @@ impl BasicConversationHandle {
             .put_json(conversation_dir.join("record.json"), &record)
             .await?;
         Ok(add_result)
-    }
-
-    async fn load_sandbox(&self, id: &str) -> Result<StoredSandbox> {
-        self.harness
-            .inner
-            .storage
-            .get_json(self.sandboxes_dir().join(format!("{id}.json")))
-            .await
-    }
-
-    async fn require_sandbox_process(
-        &self,
-        sandbox_id: &str,
-        process_id: &str,
-    ) -> Result<Arc<RunningSandboxProcess>> {
-        let process = self
-            .harness
-            .inner
-            .running_processes
-            .lock()
-            .await
-            .get(process_id)
-            .cloned()
-            .ok_or_else(|| anyhow!("sandbox process not found: {process_id}"))?;
-        if process.sandbox_id != sandbox_id {
-            bail!("sandbox process {process_id} does not belong to sandbox {sandbox_id}");
-        }
-        Ok(process)
     }
 }
 
@@ -2570,25 +2492,16 @@ struct BasicTurnState {
     finished: bool,
 }
 
-#[async_trait]
-impl SnapshotHandle for BasicTurnHandle {
-    async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
-        let (snapshot_id, event) =
-            snapshot_sandbox_side_effect(&self.harness, &self.conversation_dir, id).await?;
-        self.add_events(vec![event]).await?;
-        Ok(snapshot_id)
-    }
-
-    async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
-        let event = start_sandbox_side_effect(
+impl BasicSandboxScope for BasicTurnHandle {
+    fn sandbox_handle(&self) -> BasicScopedSandboxHandle<'_> {
+        BasicScopedSandboxHandle::turn(
             &self.harness,
-            &self.conversation_dir,
-            SandboxOwner::Conversation(self.conversation_id),
-            request,
+            self.conversation_id,
+            self.conversation_dir.clone(),
+            self.record.session_id,
+            self.record.id,
+            &self.state,
         )
-        .await?;
-        self.add_events(vec![event]).await?;
-        Ok(())
     }
 }
 

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -38,12 +38,12 @@ use crate::{
     EventId, EventKind, EventQuery, EventQueryDirection, EventStream, ExoHarness, FileSystemMount,
     ForkConversationRequest, GetEventsResult, GetSandboxProcessEventsResult,
     ListConversationsRequest, ListConversationsResult, NewAgentRequest, NewConversationRequest,
-    PutSecretRequest, ReadArtifactRequest, Result, RunInSandboxRequest, SandboxId, SandboxProcess,
-    SandboxProcessEvent, SandboxProcessEventQuery, SandboxProcessId, SandboxProcessMode,
-    SandboxProcessParts, SandboxProcessRecord, SandboxProcessStatus, SandboxProcessStdin,
-    SandboxProvider, SandboxProviderConfig, Secret, SecretId, SecretMetadata, SecretType,
-    SessionId, SnapshotId, StartSandboxProcessRequest, StartSandboxRequest, TurnHandle, TurnId,
-    TurnRecord, Uuid7, WaitSandboxProcessRequest, WriteArtifactRequest,
+    PutSecretRequest, ReadArtifactRequest, Result, RunInSandboxRequest, SandboxHandle, SandboxId,
+    SandboxProcess, SandboxProcessEvent, SandboxProcessEventQuery, SandboxProcessId,
+    SandboxProcessMode, SandboxProcessParts, SandboxProcessRecord, SandboxProcessStatus,
+    SandboxProcessStdin, SandboxProvider, SandboxProviderConfig, Secret, SecretId, SecretMetadata,
+    SecretType, SessionId, SnapshotId, StartSandboxProcessRequest, StartSandboxRequest, TurnHandle,
+    TurnId, TurnRecord, Uuid7, WaitSandboxProcessRequest, WriteArtifactRequest,
     WriteSandboxProcessInputRequest,
 };
 
@@ -972,6 +972,210 @@ impl AgentHandle for BasicAgentHandle {
     }
 }
 
+#[async_trait]
+impl SandboxHandle for BasicAgentHandle {
+    async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
+        if request.name.is_none() {
+            return self.create_new_sandbox(request).await;
+        }
+        let prepared = prepare_sandbox_request(&self.harness, request).await?;
+        let _guard = self.harness.inner.write_lock.lock().await;
+        if let Some((sandbox_id, sandbox)) = find_matching_stored_sandbox(
+            &self.harness.inner.storage,
+            &self.sandboxes_dir(),
+            &prepared,
+        )
+        .await?
+        {
+            active_sandbox_handle(
+                &self.harness,
+                SandboxOwner::Agent(self.record.id),
+                &sandbox_id,
+                &sandbox,
+            )
+            .await?;
+            return Ok(sandbox_id);
+        }
+        self.create_new_sandbox_locked(prepared).await
+    }
+
+    async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
+        let (snapshot_id, _event) =
+            snapshot_sandbox_side_effect(&self.harness, &self.agent_dir(), id).await?;
+        Ok(snapshot_id)
+    }
+
+    async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
+        start_sandbox_side_effect(
+            &self.harness,
+            &self.agent_dir(),
+            SandboxOwner::Agent(self.record.id),
+            request,
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn stop_sandbox(&self, id: SandboxId) -> Result<()> {
+        let sandbox_handle = self
+            .harness
+            .inner
+            .running_sandboxes
+            .lock()
+            .await
+            .remove(&id);
+        if let Some(sandbox_handle) = sandbox_handle {
+            sandbox_handle.stop().await?;
+        }
+
+        let _guard = self.harness.inner.write_lock.lock().await;
+        let mut sandbox = self.load_sandbox(&id).await?;
+        if !sandbox.running {
+            return Ok(());
+        }
+        sandbox.running = false;
+        self.harness
+            .inner
+            .storage
+            .put_json(self.sandboxes_dir().join(format!("{id}.json")), &sandbox)
+            .await?;
+        Ok(())
+    }
+
+    async fn start_sandbox_process(
+        &self,
+        request: StartSandboxProcessRequest,
+    ) -> Result<SandboxProcessRecord> {
+        let pending = prepare_sandbox_process(
+            &self.harness,
+            &self.agent_dir(),
+            SandboxOwner::Agent(self.record.id),
+            None,
+            request,
+        )
+        .await?;
+        spawn_pending_sandbox_process(&self.harness, pending).await
+    }
+
+    async fn write_sandbox_process_input(
+        &self,
+        request: WriteSandboxProcessInputRequest,
+    ) -> Result<()> {
+        let process = self
+            .require_sandbox_process(&request.sandbox_id, &request.process_id)
+            .await?;
+        if !sandbox_process_status(&process).await.is_running() {
+            bail!("sandbox process is not running: {}", request.process_id);
+        }
+        let mut stdin = process.stdin.lock().await;
+        let stdin = stdin
+            .as_mut()
+            .ok_or_else(|| anyhow!("sandbox process stdin is closed: {}", request.process_id))?;
+        stdin.write_all(&request.data).await?;
+        stdin.flush().await?;
+        Ok(())
+    }
+
+    async fn close_sandbox_process_input(
+        &self,
+        request: CloseSandboxProcessInputRequest,
+    ) -> Result<()> {
+        let process = self
+            .require_sandbox_process(&request.sandbox_id, &request.process_id)
+            .await?;
+        process.stdin.lock().await.take();
+        Ok(())
+    }
+
+    async fn get_sandbox_process_events(
+        &self,
+        query: SandboxProcessEventQuery,
+    ) -> Result<GetSandboxProcessEventsResult> {
+        let process = self
+            .require_sandbox_process(&query.sandbox_id, &query.process_id)
+            .await?;
+        let after = query.after.unwrap_or_default();
+        let limit = query.limit.unwrap_or(u32::MAX) as usize;
+        let events = process
+            .events
+            .lock()
+            .await
+            .iter()
+            .filter(|event| event.cursor() > after)
+            .take(limit)
+            .cloned()
+            .collect::<Vec<_>>();
+        let cursor = events
+            .last()
+            .map(SandboxProcessEvent::cursor)
+            .or(query.after);
+        Ok(GetSandboxProcessEventsResult {
+            events,
+            cursor,
+            status: sandbox_process_status(&process).await,
+        })
+    }
+
+    async fn wait_sandbox_process(
+        &self,
+        request: WaitSandboxProcessRequest,
+    ) -> Result<SandboxProcessStatus> {
+        let process = self
+            .require_sandbox_process(&request.sandbox_id, &request.process_id)
+            .await?;
+        Ok(wait_for_sandbox_process_terminal_status(&process).await)
+    }
+
+    async fn cancel_sandbox_process(
+        &self,
+        request: CancelSandboxProcessRequest,
+    ) -> Result<SandboxProcessStatus> {
+        let process = self
+            .require_sandbox_process(&request.sandbox_id, &request.process_id)
+            .await?;
+        process.stdin.lock().await.take();
+        if let Some(tasks) = process.tasks.lock().await.take() {
+            tasks.stdout.abort();
+            tasks.stderr.abort();
+            tasks.wait.abort();
+        }
+        push_sandbox_process_event(&process, SandboxProcessEventPayload::Cancelled).await;
+        set_sandbox_process_status(&process, SandboxProcessStatus::Cancelled).await;
+        Ok(SandboxProcessStatus::Cancelled)
+    }
+
+    async fn run_in_sandbox(
+        &self,
+        request: RunInSandboxRequest,
+    ) -> Result<Box<dyn SandboxProcess>> {
+        let sandbox = self.load_sandbox(&request.id).await?;
+        if !sandbox.running {
+            bail!("sandbox is not running: {}", request.id);
+        }
+        if request.command.is_empty() {
+            bail!("sandbox command must not be empty");
+        }
+        let sandbox_handle = active_sandbox_handle(
+            &self.harness,
+            SandboxOwner::Agent(self.record.id),
+            &request.id,
+            &sandbox,
+        )
+        .await?;
+        let parts = sandbox_handle
+            .start_process(&SandboxCommand {
+                argv: request.command.clone(),
+                env: request.env.clone(),
+                display_argv: Some(request.command),
+                cwd: None,
+                timeout: None,
+            })
+            .await
+            .with_context(|| format!("failed to run command in sandbox {}", request.id))?;
+        Ok(Box::new(LiveSandboxProcess::new(parts)))
+    }
+}
+
 impl BasicAgentHandle {
     fn agent_dir(&self) -> PathBuf {
         self.harness.agents_dir().join(self.record.id.to_string())
@@ -991,6 +1195,76 @@ impl BasicAgentHandle {
 
     fn artifacts_dir(&self) -> PathBuf {
         self.agent_dir().join("artifacts")
+    }
+
+    fn sandboxes_dir(&self) -> PathBuf {
+        self.agent_dir().join("sandboxes")
+    }
+
+    async fn load_sandbox(&self, id: &str) -> Result<StoredSandbox> {
+        load_stored_sandbox(&self.harness, &self.agent_dir(), id).await
+    }
+
+    async fn create_new_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
+        let prepared = prepare_sandbox_request(&self.harness, request).await?;
+        let sandbox_id = format!("sandbox-{}", Uuid7::now());
+        let sandbox = prepared.stored_sandbox(sandbox_id.clone());
+        let sandbox_handle = create_sandbox_handle(
+            &self.harness,
+            SandboxOwner::Agent(self.record.id),
+            &sandbox_id,
+            &sandbox,
+        )
+        .await?;
+        let _guard = self.harness.inner.write_lock.lock().await;
+        self.persist_created_sandbox(sandbox, sandbox_handle).await
+    }
+
+    async fn create_new_sandbox_locked(
+        &self,
+        request: PreparedSandboxRequest,
+    ) -> Result<SandboxId> {
+        let sandbox_id = format!("sandbox-{}", Uuid7::now());
+        let sandbox = request.stored_sandbox(sandbox_id.clone());
+        let sandbox_handle = create_sandbox_handle(
+            &self.harness,
+            SandboxOwner::Agent(self.record.id),
+            &sandbox_id,
+            &sandbox,
+        )
+        .await?;
+        self.persist_created_sandbox(sandbox, sandbox_handle).await
+    }
+
+    async fn persist_created_sandbox(
+        &self,
+        sandbox: StoredSandbox,
+        sandbox_handle: Arc<dyn ManagedSandboxHandle>,
+    ) -> Result<SandboxId> {
+        let sandbox_id = sandbox.id.clone();
+        self.harness
+            .inner
+            .storage
+            .put_json(
+                self.sandboxes_dir().join(format!("{sandbox_id}.json")),
+                &sandbox,
+            )
+            .await?;
+        self.harness
+            .inner
+            .running_sandboxes
+            .lock()
+            .await
+            .insert(sandbox_id.clone(), sandbox_handle);
+        Ok(sandbox_id)
+    }
+
+    async fn require_sandbox_process(
+        &self,
+        sandbox_id: &str,
+        process_id: &str,
+    ) -> Result<Arc<RunningSandboxProcess>> {
+        require_running_sandbox_process(&self.harness, sandbox_id, process_id).await
     }
 
     async fn list_conversation_records(
@@ -1058,6 +1332,12 @@ fn paginate_conversation_records(
     })
 }
 
+#[derive(Debug, Clone, Copy)]
+enum SandboxOwner {
+    Agent(AgentId),
+    Conversation(ConversationId),
+}
+
 struct BasicConversationHandle {
     harness: BasicExoHarness,
     agent_id: AgentId,
@@ -1070,60 +1350,20 @@ impl BasicConversationHandle {
         sandbox_id: &SandboxId,
         sandbox: &StoredSandbox,
     ) -> Result<Arc<dyn ManagedSandboxHandle>> {
-        if let Some(handle) = self
-            .harness
-            .inner
-            .running_sandboxes
-            .lock()
-            .await
-            .get(sandbox_id)
-            .cloned()
-        {
-            return Ok(handle);
-        }
-
-        let handle = self
-            .harness
-            .inner
-            .sandbox_backend_for_provider(sandbox.provider)
-            .await?
-            .acquire(sandbox_request(self.record.id, sandbox_id, sandbox))
-            .await?;
-        self.harness
-            .inner
-            .running_sandboxes
-            .lock()
-            .await
-            .insert(sandbox_id.clone(), Arc::clone(&handle));
-        Ok(handle)
+        active_sandbox_handle(
+            &self.harness,
+            SandboxOwner::Conversation(self.record.id),
+            sandbox_id,
+            sandbox,
+        )
+        .await
     }
 
     async fn prepare_sandbox_request(
         &self,
         request: CreateSandboxRequest,
     ) -> Result<PreparedSandboxRequest> {
-        let image = if !request.image.trim().is_empty() {
-            request.image.clone()
-        } else if let Some(default) = self
-            .harness
-            .inner
-            .binding_default_image(request.provider)
-            .await?
-        {
-            default
-        } else {
-            request.image.clone()
-        };
-
-        Ok(PreparedSandboxRequest {
-            name: request.name,
-            provider: request.provider,
-            image,
-            default_workdir: request.default_workdir,
-            file_system_mounts: request.file_system_mounts.unwrap_or_default(),
-            enable_networking: request.enable_networking.unwrap_or(true),
-            idle_seconds: request.idle_seconds.unwrap_or(60),
-        })
+        prepare_sandbox_request(&self.harness, request).await
     }
 
     async fn find_matching_sandbox(
@@ -1205,12 +1445,13 @@ impl BasicConversationHandle {
         sandbox_id: &SandboxId,
         sandbox: &StoredSandbox,
     ) -> Result<Arc<dyn ManagedSandboxHandle>> {
-        self.harness
-            .inner
-            .sandbox_backend_for_provider(sandbox.provider)
-            .await?
-            .acquire(sandbox_request(self.record.id, sandbox_id, sandbox))
-            .await
+        create_sandbox_handle(
+            &self.harness,
+            SandboxOwner::Conversation(self.record.id),
+            sandbox_id,
+            sandbox,
+        )
+        .await
     }
 
     async fn persist_created_sandbox(
@@ -1616,305 +1857,6 @@ impl ConversationHandle for BasicConversationHandle {
         load_artifact_versions(&self.harness.inner.storage, &self.artifacts_dir()).await
     }
 
-    async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
-        if request.name.is_none() {
-            return self.create_new_sandbox(request).await;
-        }
-        let prepared = self.prepare_sandbox_request(request).await?;
-        let _guard = self.harness.inner.write_lock.lock().await;
-        if let Some((sandbox_id, sandbox)) = self.find_matching_sandbox(&prepared).await? {
-            self.active_sandbox_handle(&sandbox_id, &sandbox).await?;
-            return Ok(sandbox_id);
-        }
-        self.create_new_sandbox_locked(prepared).await
-    }
-
-    async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
-        let (snapshot_id, event) =
-            snapshot_sandbox_side_effect(&self.harness, &self.conversation_dir(), id).await?;
-        self.append_events_internal(None, None, None, vec![event])
-            .await?;
-        Ok(snapshot_id)
-    }
-
-    async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
-        let event = start_sandbox_side_effect(
-            &self.harness,
-            &self.conversation_dir(),
-            self.record.id,
-            request,
-        )
-        .await?;
-        self.append_events_internal(None, None, None, vec![event])
-            .await?;
-        Ok(())
-    }
-
-    async fn stop_sandbox(&self, id: SandboxId) -> Result<()> {
-        // Take the handle and stop it before the write lock — stop() is a remote
-        // call and must not block other writers.
-        let sandbox_handle = self
-            .harness
-            .inner
-            .running_sandboxes
-            .lock()
-            .await
-            .remove(&id);
-        if let Some(sandbox_handle) = sandbox_handle {
-            sandbox_handle.stop().await?;
-        }
-
-        let _guard = self.harness.inner.write_lock.lock().await;
-        let mut sandbox = self.load_sandbox(&id).await?;
-        if !sandbox.running {
-            return Ok(());
-        }
-        sandbox.running = false;
-        self.harness
-            .inner
-            .storage
-            .put_json(self.sandboxes_dir().join(format!("{id}.json")), &sandbox)
-            .await?;
-        let mut record = self.load_record().await?;
-        append_events_to_conversation(
-            &self.harness.inner,
-            &self.conversation_dir(),
-            self.record.id,
-            None,
-            None,
-            record.latest_event_id,
-            vec![EventData::SandboxStopped { sandbox_id: id }],
-            &mut record,
-        )
-        .await?;
-        self.harness
-            .inner
-            .storage
-            .put_json(self.conversation_dir().join("record.json"), &record)
-            .await?;
-        Ok(())
-    }
-
-    async fn start_sandbox_process(
-        &self,
-        request: StartSandboxProcessRequest,
-    ) -> Result<SandboxProcessRecord> {
-        let sandbox = self.load_sandbox(&request.sandbox_id).await?;
-        if !sandbox.running {
-            bail!("sandbox is not running: {}", request.sandbox_id);
-        }
-        if request.command.is_empty() {
-            bail!("sandbox command must not be empty");
-        }
-        if request.mode != SandboxProcessMode::Exec {
-            bail!("basic sandbox backend only supports exec-mode processes");
-        }
-        let sandbox_handle = self
-            .active_sandbox_handle(&request.sandbox_id, &sandbox)
-            .await?;
-        let process_id = format!("process-{}", Uuid7::now());
-        let sandbox_id = request.sandbox_id.clone();
-        let command = request.command.clone();
-        let cwd = request.cwd.clone();
-        let mode = request.mode;
-        let stdin_mode = request.stdin;
-        let output = request.output;
-        let lifecycle = request.lifecycle;
-        let name = request.name.clone();
-        let parts = sandbox_handle
-            .start_process(&SandboxCommand {
-                argv: command.clone(),
-                env: request.env,
-                display_argv: Some(command.clone()),
-                cwd: cwd.clone(),
-                timeout: None,
-            })
-            .await
-            .with_context(|| {
-                format!("failed to start process in sandbox {}", request.sandbox_id)
-            })?;
-        let stdin = match stdin_mode {
-            SandboxProcessStdin::Open => Some(parts.stdin),
-            SandboxProcessStdin::None => None,
-        };
-        let process = Arc::new(RunningSandboxProcess {
-            inner: Arc::clone(&self.harness.inner),
-            conversation_id: self.record.id,
-            conversation_dir: self.conversation_dir(),
-            sandbox_id: sandbox_id.clone(),
-            process_id: process_id.clone(),
-            stdin: AsyncMutex::new(stdin),
-            events: AsyncMutex::new(Vec::new()),
-            status: AsyncMutex::new(SandboxProcessStatus::Running),
-            open_output_streams: AsyncMutex::new(2),
-            output_drained: Notify::new(),
-            tasks: AsyncMutex::new(None),
-            notify: Notify::new(),
-        });
-        self.append_events_internal(
-            None,
-            None,
-            None,
-            vec![EventData::SandboxProcessStarted {
-                sandbox_id: sandbox_id.clone(),
-                process_id: process_id.clone(),
-                name: name.clone(),
-                command,
-                cwd,
-                mode,
-                stdin: stdin_mode,
-                output,
-                lifecycle,
-                status: SandboxProcessStatus::Running,
-                provider_state: None,
-            }],
-        )
-        .await?;
-        let stdout_task = tokio::spawn(record_sandbox_process_output(
-            Arc::clone(&process),
-            SandboxProcessOutputStream::Stdout,
-            parts.stdout,
-        ));
-        let stderr_task = tokio::spawn(record_sandbox_process_output(
-            Arc::clone(&process),
-            SandboxProcessOutputStream::Stderr,
-            parts.stderr,
-        ));
-        let wait_task = tokio::spawn(record_sandbox_process_exit(
-            Arc::clone(&process),
-            parts.wait,
-        ));
-        *process.tasks.lock().await = Some(RunningSandboxProcessTasks {
-            stdout: stdout_task,
-            stderr: stderr_task,
-            wait: wait_task,
-        });
-        self.harness
-            .inner
-            .running_processes
-            .lock()
-            .await
-            .insert(process_id.clone(), process);
-        Ok(SandboxProcessRecord {
-            id: process_id,
-            sandbox_id,
-            name,
-            status: SandboxProcessStatus::Running,
-        })
-    }
-
-    async fn write_sandbox_process_input(
-        &self,
-        request: WriteSandboxProcessInputRequest,
-    ) -> Result<()> {
-        let process = self
-            .require_sandbox_process(&request.sandbox_id, &request.process_id)
-            .await?;
-        if !sandbox_process_status(&process).await.is_running() {
-            bail!("sandbox process is not running: {}", request.process_id);
-        }
-        let mut stdin = process.stdin.lock().await;
-        let stdin = stdin
-            .as_mut()
-            .ok_or_else(|| anyhow!("sandbox process stdin is closed: {}", request.process_id))?;
-        stdin.write_all(&request.data).await?;
-        stdin.flush().await?;
-        Ok(())
-    }
-
-    async fn close_sandbox_process_input(
-        &self,
-        request: CloseSandboxProcessInputRequest,
-    ) -> Result<()> {
-        let process = self
-            .require_sandbox_process(&request.sandbox_id, &request.process_id)
-            .await?;
-        process.stdin.lock().await.take();
-        Ok(())
-    }
-
-    async fn get_sandbox_process_events(
-        &self,
-        query: SandboxProcessEventQuery,
-    ) -> Result<GetSandboxProcessEventsResult> {
-        let process = self
-            .require_sandbox_process(&query.sandbox_id, &query.process_id)
-            .await?;
-        let after = query.after.unwrap_or_default();
-        let limit = query.limit.unwrap_or(u32::MAX) as usize;
-        let events = process
-            .events
-            .lock()
-            .await
-            .iter()
-            .filter(|event| event.cursor() > after)
-            .take(limit)
-            .cloned()
-            .collect::<Vec<_>>();
-        let cursor = events
-            .last()
-            .map(SandboxProcessEvent::cursor)
-            .or(query.after);
-        Ok(GetSandboxProcessEventsResult {
-            events,
-            cursor,
-            status: sandbox_process_status(&process).await,
-        })
-    }
-
-    async fn wait_sandbox_process(
-        &self,
-        request: WaitSandboxProcessRequest,
-    ) -> Result<SandboxProcessStatus> {
-        let process = self
-            .require_sandbox_process(&request.sandbox_id, &request.process_id)
-            .await?;
-        Ok(wait_for_sandbox_process_terminal_status(&process).await)
-    }
-
-    async fn cancel_sandbox_process(
-        &self,
-        request: CancelSandboxProcessRequest,
-    ) -> Result<SandboxProcessStatus> {
-        let process = self
-            .require_sandbox_process(&request.sandbox_id, &request.process_id)
-            .await?;
-        process.stdin.lock().await.take();
-        if let Some(tasks) = process.tasks.lock().await.take() {
-            tasks.stdout.abort();
-            tasks.stderr.abort();
-            tasks.wait.abort();
-        }
-        push_sandbox_process_event(&process, SandboxProcessEventPayload::Cancelled).await;
-        set_sandbox_process_status(&process, SandboxProcessStatus::Cancelled).await;
-        Ok(SandboxProcessStatus::Cancelled)
-    }
-
-    async fn run_in_sandbox(
-        &self,
-        request: RunInSandboxRequest,
-    ) -> Result<Box<dyn SandboxProcess>> {
-        let sandbox = self.load_sandbox(&request.id).await?;
-        if !sandbox.running {
-            bail!("sandbox is not running: {}", request.id);
-        }
-        if request.command.is_empty() {
-            bail!("sandbox command must not be empty");
-        }
-        let sandbox_handle = self.active_sandbox_handle(&request.id, &sandbox).await?;
-        let parts = sandbox_handle
-            .start_process(&SandboxCommand {
-                argv: request.command.clone(),
-                env: request.env.clone(),
-                display_argv: Some(request.command),
-                cwd: None,
-                timeout: None,
-            })
-            .await
-            .with_context(|| format!("failed to run command in sandbox {}", request.id))?;
-        Ok(Box::new(LiveSandboxProcess::new(parts)))
-    }
-
     async fn list_bindings(&self) -> Result<Vec<BindingRecord>> {
         Ok(merge_binding_records(vec![
             list_binding_records(&self.harness.inner.storage, &self.harness.bindings_dir()).await?,
@@ -2035,6 +1977,221 @@ impl ConversationHandle for BasicConversationHandle {
     }
 }
 
+#[async_trait]
+impl SandboxHandle for BasicConversationHandle {
+    async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
+        if request.name.is_none() {
+            return self.create_new_sandbox(request).await;
+        }
+        let prepared = self.prepare_sandbox_request(request).await?;
+        let _guard = self.harness.inner.write_lock.lock().await;
+        if let Some((sandbox_id, sandbox)) = self.find_matching_sandbox(&prepared).await? {
+            self.active_sandbox_handle(&sandbox_id, &sandbox).await?;
+            return Ok(sandbox_id);
+        }
+        self.create_new_sandbox_locked(prepared).await
+    }
+
+    async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
+        let (snapshot_id, event) =
+            snapshot_sandbox_side_effect(&self.harness, &self.conversation_dir(), id).await?;
+        self.append_events_internal(None, None, None, vec![event])
+            .await?;
+        Ok(snapshot_id)
+    }
+
+    async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
+        let event = start_sandbox_side_effect(
+            &self.harness,
+            &self.conversation_dir(),
+            SandboxOwner::Conversation(self.record.id),
+            request,
+        )
+        .await?;
+        self.append_events_internal(None, None, None, vec![event])
+            .await?;
+        Ok(())
+    }
+
+    async fn stop_sandbox(&self, id: SandboxId) -> Result<()> {
+        // Take the handle and stop it before the write lock — stop() is a remote
+        // call and must not block other writers.
+        let sandbox_handle = self
+            .harness
+            .inner
+            .running_sandboxes
+            .lock()
+            .await
+            .remove(&id);
+        if let Some(sandbox_handle) = sandbox_handle {
+            sandbox_handle.stop().await?;
+        }
+
+        let _guard = self.harness.inner.write_lock.lock().await;
+        let mut sandbox = self.load_sandbox(&id).await?;
+        if !sandbox.running {
+            return Ok(());
+        }
+        sandbox.running = false;
+        self.harness
+            .inner
+            .storage
+            .put_json(self.sandboxes_dir().join(format!("{id}.json")), &sandbox)
+            .await?;
+        let mut record = self.load_record().await?;
+        append_events_to_conversation(
+            &self.harness.inner,
+            &self.conversation_dir(),
+            self.record.id,
+            None,
+            None,
+            record.latest_event_id,
+            vec![EventData::SandboxStopped { sandbox_id: id }],
+            &mut record,
+        )
+        .await?;
+        self.harness
+            .inner
+            .storage
+            .put_json(self.conversation_dir().join("record.json"), &record)
+            .await?;
+        Ok(())
+    }
+
+    async fn start_sandbox_process(
+        &self,
+        request: StartSandboxProcessRequest,
+    ) -> Result<SandboxProcessRecord> {
+        let pending = prepare_sandbox_process(
+            &self.harness,
+            &self.conversation_dir(),
+            SandboxOwner::Conversation(self.record.id),
+            Some(SandboxProcessEventLog {
+                inner: Arc::clone(&self.harness.inner),
+                conversation_id: self.record.id,
+                conversation_dir: self.conversation_dir(),
+            }),
+            request,
+        )
+        .await?;
+        self.append_events_internal(None, None, None, vec![pending.started_event.clone()])
+            .await?;
+        spawn_pending_sandbox_process(&self.harness, pending).await
+    }
+
+    async fn write_sandbox_process_input(
+        &self,
+        request: WriteSandboxProcessInputRequest,
+    ) -> Result<()> {
+        let process = self
+            .require_sandbox_process(&request.sandbox_id, &request.process_id)
+            .await?;
+        if !sandbox_process_status(&process).await.is_running() {
+            bail!("sandbox process is not running: {}", request.process_id);
+        }
+        let mut stdin = process.stdin.lock().await;
+        let stdin = stdin
+            .as_mut()
+            .ok_or_else(|| anyhow!("sandbox process stdin is closed: {}", request.process_id))?;
+        stdin.write_all(&request.data).await?;
+        stdin.flush().await?;
+        Ok(())
+    }
+
+    async fn close_sandbox_process_input(
+        &self,
+        request: CloseSandboxProcessInputRequest,
+    ) -> Result<()> {
+        let process = self
+            .require_sandbox_process(&request.sandbox_id, &request.process_id)
+            .await?;
+        process.stdin.lock().await.take();
+        Ok(())
+    }
+
+    async fn get_sandbox_process_events(
+        &self,
+        query: SandboxProcessEventQuery,
+    ) -> Result<GetSandboxProcessEventsResult> {
+        let process = self
+            .require_sandbox_process(&query.sandbox_id, &query.process_id)
+            .await?;
+        let after = query.after.unwrap_or_default();
+        let limit = query.limit.unwrap_or(u32::MAX) as usize;
+        let events = process
+            .events
+            .lock()
+            .await
+            .iter()
+            .filter(|event| event.cursor() > after)
+            .take(limit)
+            .cloned()
+            .collect::<Vec<_>>();
+        let cursor = events
+            .last()
+            .map(SandboxProcessEvent::cursor)
+            .or(query.after);
+        Ok(GetSandboxProcessEventsResult {
+            events,
+            cursor,
+            status: sandbox_process_status(&process).await,
+        })
+    }
+
+    async fn wait_sandbox_process(
+        &self,
+        request: WaitSandboxProcessRequest,
+    ) -> Result<SandboxProcessStatus> {
+        let process = self
+            .require_sandbox_process(&request.sandbox_id, &request.process_id)
+            .await?;
+        Ok(wait_for_sandbox_process_terminal_status(&process).await)
+    }
+
+    async fn cancel_sandbox_process(
+        &self,
+        request: CancelSandboxProcessRequest,
+    ) -> Result<SandboxProcessStatus> {
+        let process = self
+            .require_sandbox_process(&request.sandbox_id, &request.process_id)
+            .await?;
+        process.stdin.lock().await.take();
+        if let Some(tasks) = process.tasks.lock().await.take() {
+            tasks.stdout.abort();
+            tasks.stderr.abort();
+            tasks.wait.abort();
+        }
+        push_sandbox_process_event(&process, SandboxProcessEventPayload::Cancelled).await;
+        set_sandbox_process_status(&process, SandboxProcessStatus::Cancelled).await;
+        Ok(SandboxProcessStatus::Cancelled)
+    }
+
+    async fn run_in_sandbox(
+        &self,
+        request: RunInSandboxRequest,
+    ) -> Result<Box<dyn SandboxProcess>> {
+        let sandbox = self.load_sandbox(&request.id).await?;
+        if !sandbox.running {
+            bail!("sandbox is not running: {}", request.id);
+        }
+        if request.command.is_empty() {
+            bail!("sandbox command must not be empty");
+        }
+        let sandbox_handle = self.active_sandbox_handle(&request.id, &sandbox).await?;
+        let parts = sandbox_handle
+            .start_process(&SandboxCommand {
+                argv: request.command.clone(),
+                env: request.env.clone(),
+                display_argv: Some(request.command),
+                cwd: None,
+                timeout: None,
+            })
+            .await
+            .with_context(|| format!("failed to run command in sandbox {}", request.id))?;
+        Ok(Box::new(LiveSandboxProcess::new(parts)))
+    }
+}
+
 impl BasicConversationHandle {
     fn agent_dir(&self) -> PathBuf {
         self.harness.agents_dir().join(self.agent_id.to_string())
@@ -2134,7 +2291,7 @@ impl BasicConversationHandle {
 
 async fn snapshot_sandbox_side_effect(
     harness: &BasicExoHarness,
-    conversation_dir: &Path,
+    owner_dir: &Path,
     id: SandboxId,
 ) -> Result<(SnapshotId, EventData)> {
     // Capture the payload before taking the write lock. Backends may need to
@@ -2150,7 +2307,7 @@ async fn snapshot_sandbox_side_effect(
     let payload = handle.snapshot().await?;
 
     let _guard = harness.inner.write_lock.lock().await;
-    let mut sandbox = load_stored_sandbox(harness, conversation_dir, &id).await?;
+    let mut sandbox = load_stored_sandbox(harness, owner_dir, &id).await?;
     let snapshot_id = Uuid7::now();
 
     let manifest = StoredSnapshotManifest {
@@ -2160,9 +2317,7 @@ async fn snapshot_sandbox_side_effect(
         created_at: Utc::now(),
         payload_size_bytes: payload.bytes.len() as u64,
     };
-    let snapshot_dir = conversation_dir
-        .join("snapshots")
-        .join(snapshot_id.to_string());
+    let snapshot_dir = owner_dir.join("snapshots").join(snapshot_id.to_string());
     let storage = &harness.inner.storage;
     tokio::try_join!(
         storage.put_bytes(snapshot_dir.join("payload.bin"), payload.bytes.to_vec()),
@@ -2174,9 +2329,7 @@ async fn snapshot_sandbox_side_effect(
         .inner
         .storage
         .put_json(
-            conversation_dir
-                .join("sandboxes")
-                .join(format!("{id}.json")),
+            owner_dir.join("sandboxes").join(format!("{id}.json")),
             &sandbox,
         )
         .await?;
@@ -2191,13 +2344,13 @@ async fn snapshot_sandbox_side_effect(
 
 async fn start_sandbox_side_effect(
     harness: &BasicExoHarness,
-    conversation_dir: &Path,
-    conversation_id: ConversationId,
+    owner_dir: &Path,
+    owner: SandboxOwner,
     request: StartSandboxRequest,
 ) -> Result<EventData> {
     // Load the snapshot payload before acquiring the write lock. It can be
     // large, and we don't want to block writers while we read.
-    let snapshot_dir = conversation_dir
+    let snapshot_dir = owner_dir
         .join("snapshots")
         .join(request.snapshot_id.to_string());
     let storage = &harness.inner.storage;
@@ -2218,7 +2371,7 @@ async fn start_sandbox_side_effect(
         bytes: Bytes::from(payload_bytes),
     };
 
-    let mut sandbox = load_stored_sandbox(harness, conversation_dir, &request.id).await?;
+    let mut sandbox = load_stored_sandbox(harness, owner_dir, &request.id).await?;
     sandbox.running = true;
     sandbox.latest_snapshot_id = Some(request.snapshot_id);
     if let Some(idle_seconds) = request.idle_seconds {
@@ -2240,10 +2393,7 @@ async fn start_sandbox_side_effect(
         .inner
         .sandbox_backend_for_provider(sandbox.provider)
         .await?
-        .acquire_from_snapshot(
-            sandbox_request(conversation_id, &request.id, &sandbox),
-            payload,
-        )
+        .acquire_from_snapshot(sandbox_request(owner, &request.id, &sandbox), payload)
         .await?;
 
     let _guard = harness.inner.write_lock.lock().await;
@@ -2251,7 +2401,7 @@ async fn start_sandbox_side_effect(
         .inner
         .storage
         .put_json(
-            conversation_dir
+            owner_dir
                 .join("sandboxes")
                 .join(format!("{}.json", request.id)),
             &sandbox,
@@ -2271,18 +2421,134 @@ async fn start_sandbox_side_effect(
 
 async fn load_stored_sandbox(
     harness: &BasicExoHarness,
-    conversation_dir: &Path,
+    owner_dir: &Path,
     id: &str,
 ) -> Result<StoredSandbox> {
     harness
         .inner
         .storage
-        .get_json(
-            conversation_dir
-                .join("sandboxes")
-                .join(format!("{id}.json")),
-        )
+        .get_json(owner_dir.join("sandboxes").join(format!("{id}.json")))
         .await
+}
+
+async fn prepare_sandbox_request(
+    harness: &BasicExoHarness,
+    request: CreateSandboxRequest,
+) -> Result<PreparedSandboxRequest> {
+    let image = if !request.image.trim().is_empty() {
+        request.image.clone()
+    } else if let Some(default) = harness
+        .inner
+        .binding_default_image(request.provider)
+        .await?
+    {
+        default
+    } else {
+        request.image.clone()
+    };
+
+    Ok(PreparedSandboxRequest {
+        name: request.name,
+        provider: request.provider,
+        image,
+        default_workdir: request.default_workdir,
+        file_system_mounts: request.file_system_mounts.unwrap_or_default(),
+        enable_networking: request.enable_networking.unwrap_or(true),
+        idle_seconds: request.idle_seconds.unwrap_or(60),
+    })
+}
+
+async fn find_matching_stored_sandbox(
+    storage: &BasicObjectStore,
+    sandboxes_dir: &Path,
+    request: &PreparedSandboxRequest,
+) -> Result<Option<(SandboxId, StoredSandbox)>> {
+    let Some(name) = &request.name else {
+        return Ok(None);
+    };
+    let mut sandboxes = storage
+        .list_json_matching_suffix::<StoredSandbox>(sandboxes_dir, ".json")
+        .await?;
+    sandboxes.sort_by_key(|sandbox| sandbox.id.clone());
+    for sandbox in sandboxes.into_iter().rev() {
+        if sandbox.name.as_ref() != Some(name) {
+            continue;
+        }
+        if !sandbox.running {
+            continue;
+        }
+        if sandbox.provider != request.provider
+            || sandbox.image != request.image
+            || sandbox.default_workdir != request.default_workdir
+            || sandbox.file_system_mounts != request.file_system_mounts
+            || sandbox.enable_networking != request.enable_networking
+            || sandbox.idle_seconds != request.idle_seconds
+        {
+            bail!("sandbox name {name:?} already exists with a different configuration");
+        }
+        return Ok(Some((sandbox.id.clone(), sandbox)));
+    }
+    Ok(None)
+}
+
+async fn active_sandbox_handle(
+    harness: &BasicExoHarness,
+    owner: SandboxOwner,
+    sandbox_id: &SandboxId,
+    sandbox: &StoredSandbox,
+) -> Result<Arc<dyn ManagedSandboxHandle>> {
+    if let Some(handle) = harness
+        .inner
+        .running_sandboxes
+        .lock()
+        .await
+        .get(sandbox_id)
+        .cloned()
+    {
+        return Ok(handle);
+    }
+
+    let handle = create_sandbox_handle(harness, owner, sandbox_id, sandbox).await?;
+    harness
+        .inner
+        .running_sandboxes
+        .lock()
+        .await
+        .insert(sandbox_id.clone(), Arc::clone(&handle));
+    Ok(handle)
+}
+
+async fn create_sandbox_handle(
+    harness: &BasicExoHarness,
+    owner: SandboxOwner,
+    sandbox_id: &SandboxId,
+    sandbox: &StoredSandbox,
+) -> Result<Arc<dyn ManagedSandboxHandle>> {
+    harness
+        .inner
+        .sandbox_backend_for_provider(sandbox.provider)
+        .await?
+        .acquire(sandbox_request(owner, sandbox_id, sandbox))
+        .await
+}
+
+async fn require_running_sandbox_process(
+    harness: &BasicExoHarness,
+    sandbox_id: &str,
+    process_id: &str,
+) -> Result<Arc<RunningSandboxProcess>> {
+    let process = harness
+        .inner
+        .running_processes
+        .lock()
+        .await
+        .get(process_id)
+        .cloned()
+        .ok_or_else(|| anyhow!("sandbox process not found: {process_id}"))?;
+    if process.sandbox_id != sandbox_id {
+        bail!("sandbox process {process_id} does not belong to sandbox {sandbox_id}");
+    }
+    Ok(process)
 }
 
 struct BasicTurnHandle {
@@ -2399,7 +2665,7 @@ impl TurnHandle for BasicTurnHandle {
         let event = start_sandbox_side_effect(
             &self.harness,
             &self.conversation_dir,
-            self.conversation_id,
+            SandboxOwner::Conversation(self.conversation_id),
             request,
         )
         .await?;
@@ -2508,10 +2774,142 @@ impl PreparedSandboxRequest {
     }
 }
 
+struct PendingSandboxProcess {
+    record: SandboxProcessRecord,
+    process: Arc<RunningSandboxProcess>,
+    stdout: BoxAsyncRead,
+    stderr: BoxAsyncRead,
+    wait: BoxFuture<'static, Result<i32>>,
+    started_event: EventData,
+}
+
+async fn prepare_sandbox_process(
+    harness: &BasicExoHarness,
+    owner_dir: &Path,
+    owner: SandboxOwner,
+    event_log: Option<SandboxProcessEventLog>,
+    request: StartSandboxProcessRequest,
+) -> Result<PendingSandboxProcess> {
+    let sandbox = load_stored_sandbox(harness, owner_dir, &request.sandbox_id).await?;
+    if !sandbox.running {
+        bail!("sandbox is not running: {}", request.sandbox_id);
+    }
+    if request.command.is_empty() {
+        bail!("sandbox command must not be empty");
+    }
+    if request.mode != SandboxProcessMode::Exec {
+        bail!("basic sandbox backend only supports exec-mode processes");
+    }
+    let sandbox_handle =
+        active_sandbox_handle(harness, owner, &request.sandbox_id, &sandbox).await?;
+    let process_id = format!("process-{}", Uuid7::now());
+    let sandbox_id = request.sandbox_id.clone();
+    let command = request.command.clone();
+    let cwd = request.cwd.clone();
+    let mode = request.mode;
+    let stdin_mode = request.stdin;
+    let output = request.output;
+    let lifecycle = request.lifecycle;
+    let name = request.name.clone();
+    let parts = sandbox_handle
+        .start_process(&SandboxCommand {
+            argv: command.clone(),
+            env: request.env,
+            display_argv: Some(command.clone()),
+            cwd: cwd.clone(),
+            timeout: None,
+        })
+        .await
+        .with_context(|| format!("failed to start process in sandbox {}", request.sandbox_id))?;
+    let SandboxProcessParts {
+        stdout,
+        stderr,
+        stdin,
+        wait,
+    } = parts;
+    let stdin = match stdin_mode {
+        SandboxProcessStdin::Open => Some(stdin),
+        SandboxProcessStdin::None => None,
+    };
+    let process = Arc::new(RunningSandboxProcess {
+        event_log,
+        sandbox_id: sandbox_id.clone(),
+        process_id: process_id.clone(),
+        stdin: AsyncMutex::new(stdin),
+        events: AsyncMutex::new(Vec::new()),
+        status: AsyncMutex::new(SandboxProcessStatus::Running),
+        open_output_streams: AsyncMutex::new(2),
+        output_drained: Notify::new(),
+        tasks: AsyncMutex::new(None),
+        notify: Notify::new(),
+    });
+    Ok(PendingSandboxProcess {
+        record: SandboxProcessRecord {
+            id: process_id.clone(),
+            sandbox_id: sandbox_id.clone(),
+            name: name.clone(),
+            status: SandboxProcessStatus::Running,
+        },
+        process,
+        stdout,
+        stderr,
+        wait,
+        started_event: EventData::SandboxProcessStarted {
+            sandbox_id,
+            process_id,
+            name,
+            command,
+            cwd,
+            mode,
+            stdin: stdin_mode,
+            output,
+            lifecycle,
+            status: SandboxProcessStatus::Running,
+            provider_state: None,
+        },
+    })
+}
+
+async fn spawn_pending_sandbox_process(
+    harness: &BasicExoHarness,
+    pending: PendingSandboxProcess,
+) -> Result<SandboxProcessRecord> {
+    let PendingSandboxProcess {
+        record,
+        process,
+        stdout,
+        stderr,
+        wait,
+        ..
+    } = pending;
+    let process_id = record.id.clone();
+    let stdout_task = tokio::spawn(record_sandbox_process_output(
+        Arc::clone(&process),
+        SandboxProcessOutputStream::Stdout,
+        stdout,
+    ));
+    let stderr_task = tokio::spawn(record_sandbox_process_output(
+        Arc::clone(&process),
+        SandboxProcessOutputStream::Stderr,
+        stderr,
+    ));
+    let wait_task = tokio::spawn(record_sandbox_process_exit(Arc::clone(&process), wait));
+    *process.tasks.lock().await = Some(RunningSandboxProcessTasks {
+        stdout: stdout_task,
+        stderr: stderr_task,
+        wait: wait_task,
+    });
+    harness
+        .inner
+        .running_processes
+        .lock()
+        .await
+        .insert(process_id, process);
+    Ok(record)
+}
+
 struct RunningSandboxProcess {
-    inner: Arc<BasicExoHarnessInner>,
-    conversation_id: ConversationId,
-    conversation_dir: PathBuf,
+    event_log: Option<SandboxProcessEventLog>,
     sandbox_id: SandboxId,
     process_id: SandboxProcessId,
     stdin: AsyncMutex<Option<BoxAsyncWrite>>,
@@ -2521,6 +2919,12 @@ struct RunningSandboxProcess {
     output_drained: Notify,
     tasks: AsyncMutex<Option<RunningSandboxProcessTasks>>,
     notify: Notify,
+}
+
+struct SandboxProcessEventLog {
+    inner: Arc<BasicExoHarnessInner>,
+    conversation_id: ConversationId,
+    conversation_dir: PathBuf,
 }
 
 struct RunningSandboxProcessTasks {
@@ -2725,17 +3129,20 @@ async fn set_sandbox_process_status(
 async fn append_sandbox_process_data(
     process: &Arc<RunningSandboxProcess>,
     data: Vec<EventData>,
-) -> Result<AddEventsResult> {
-    let _guard = process.inner.write_lock.lock().await;
-    let mut record = process
+) -> Result<()> {
+    let Some(event_log) = &process.event_log else {
+        return Ok(());
+    };
+    let _guard = event_log.inner.write_lock.lock().await;
+    let mut record = event_log
         .inner
         .storage
-        .get_json::<ConversationRecord>(process.conversation_dir.join("record.json"))
+        .get_json::<ConversationRecord>(event_log.conversation_dir.join("record.json"))
         .await?;
-    let result = append_events_to_conversation(
-        &process.inner,
-        &process.conversation_dir,
-        process.conversation_id,
+    append_events_to_conversation(
+        &event_log.inner,
+        &event_log.conversation_dir,
+        event_log.conversation_id,
         None,
         None,
         record.latest_event_id,
@@ -2743,12 +3150,12 @@ async fn append_sandbox_process_data(
         &mut record,
     )
     .await?;
-    process
+    event_log
         .inner
         .storage
-        .put_json(process.conversation_dir.join("record.json"), &record)
+        .put_json(event_log.conversation_dir.join("record.json"), &record)
         .await?;
-    Ok(result)
+    Ok(())
 }
 
 async fn sandbox_process_status(process: &Arc<RunningSandboxProcess>) -> SandboxProcessStatus {
@@ -2804,14 +3211,20 @@ impl SandboxProcess for LiveSandboxProcess {
 }
 
 fn sandbox_request(
-    conversation_id: ConversationId,
+    owner: SandboxOwner,
     sandbox_id: &str,
     sandbox: &StoredSandbox,
 ) -> SandboxRequest {
     SandboxRequest {
-        key: SandboxKey::ConversationSandbox {
-            conversation_id: conversation_id.to_string(),
-            sandbox_id: sandbox_id.to_string(),
+        key: match owner {
+            SandboxOwner::Agent(agent_id) => SandboxKey::AgentSandbox {
+                agent_id: agent_id.to_string(),
+                sandbox_id: sandbox_id.to_string(),
+            },
+            SandboxOwner::Conversation(conversation_id) => SandboxKey::ConversationSandbox {
+                conversation_id: conversation_id.to_string(),
+                sandbox_id: sandbox_id.to_string(),
+            },
         },
         spec: SandboxSpec {
             image: sandbox.image.clone(),

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::fmt::{self, Display, Formatter};
 use std::ops::Bound;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -820,7 +819,6 @@ impl AgentHandle for BasicAgentHandle {
             record.id,
             None,
             None,
-            None,
             vec![EventData::ConversationCreated {
                 slug: record.slug.clone(),
                 name: record.name.clone(),
@@ -866,7 +864,6 @@ impl AgentHandle for BasicAgentHandle {
                 record.id,
                 None,
                 None,
-                record.latest_event_id,
                 vec![EventData::ConversationDeleted],
                 &mut record,
             )
@@ -1269,7 +1266,6 @@ impl BasicConversationHandle {
             self.record.id,
             None,
             None,
-            record.latest_event_id,
             vec![
                 EventData::SandboxCreated {
                     sandbox_id: sandbox_id.clone(),
@@ -1307,18 +1303,13 @@ impl ConversationHandle for BasicConversationHandle {
 
     async fn start_session(&self) -> Result<SessionId> {
         let session_id = Uuid7::now();
-        self.append_events_internal(
-            Some(session_id),
-            None,
-            None,
-            vec![EventData::SessionStarted],
-        )
-        .await?;
+        self.append_events_internal(Some(session_id), None, vec![EventData::SessionStarted])
+            .await?;
         Ok(session_id)
     }
 
     async fn end_session(&self, id: SessionId) -> Result<()> {
-        self.append_events_internal(Some(id), None, None, vec![EventData::SessionEnded])
+        self.append_events_internal(Some(id), None, vec![EventData::SessionEnded])
             .await?;
         Ok(())
     }
@@ -1353,7 +1344,6 @@ impl ConversationHandle for BasicConversationHandle {
             self.record.id,
             Some(session_id),
             Some(turn_record.id),
-            record.latest_event_id,
             events_to_append,
             &mut record,
         )
@@ -1473,13 +1463,8 @@ impl ConversationHandle for BasicConversationHandle {
     }
 
     async fn add_events(&self, request: AddEventsRequest) -> Result<AddEventsResult> {
-        self.append_events_internal(
-            request.session_id,
-            request.turn_id,
-            request.expected_head,
-            request.data,
-        )
-        .await
+        self.append_events_internal(request.session_id, request.turn_id, request.data)
+            .await
     }
 
     async fn fork(&self, request: ForkConversationRequest) -> Result<Arc<dyn ConversationHandle>> {
@@ -1568,7 +1553,6 @@ impl ConversationHandle for BasicConversationHandle {
             record.id,
             None,
             None,
-            fork_record.latest_event_id,
             vec![EventData::ConversationForked {
                 source_conversation_id: self.record.id,
                 up_to_inclusive: request.up_to_inclusive,
@@ -1600,7 +1584,6 @@ impl ConversationHandle for BasicConversationHandle {
             self.record.id,
             None,
             None,
-            record.latest_event_id,
             vec![EventData::ArtifactWritten {
                 artifact_id: artifact_version.artifact_id,
                 path: artifact_version.path.clone(),
@@ -1717,7 +1700,6 @@ impl ConversationHandle for BasicConversationHandle {
             self.record.id,
             None,
             None,
-            record.latest_event_id,
             vec![EventData::SandboxSnapshotted {
                 sandbox_id: id,
                 snapshot_id,
@@ -1809,7 +1791,6 @@ impl ConversationHandle for BasicConversationHandle {
             self.record.id,
             None,
             None,
-            record.latest_event_id,
             vec![EventData::SandboxStarted {
                 sandbox_id: request.id,
                 snapshot_id: Some(request.snapshot_id),
@@ -1857,7 +1838,6 @@ impl ConversationHandle for BasicConversationHandle {
             self.record.id,
             None,
             None,
-            record.latest_event_id,
             vec![EventData::SandboxStopped { sandbox_id: id }],
             &mut record,
         )
@@ -1927,7 +1907,6 @@ impl ConversationHandle for BasicConversationHandle {
             notify: Notify::new(),
         });
         self.append_events_internal(
-            None,
             None,
             None,
             vec![EventData::SandboxProcessStarted {
@@ -2261,7 +2240,6 @@ impl BasicConversationHandle {
         &self,
         session_id: Option<SessionId>,
         turn_id: Option<TurnId>,
-        expected_head: Option<EventId>,
         data: Vec<EventData>,
     ) -> Result<AddEventsResult> {
         let _guard = self.harness.inner.write_lock.lock().await;
@@ -2273,7 +2251,6 @@ impl BasicConversationHandle {
             self.record.id,
             session_id,
             turn_id,
-            expected_head,
             data,
             &mut record,
         )
@@ -2342,14 +2319,12 @@ impl TurnHandle for BasicTurnHandle {
             .storage
             .get_json::<ConversationRecord>(self.conversation_dir.join("record.json"))
             .await?;
-        let expected_head = record.latest_event_id;
         let add_result = append_events_to_conversation(
             &self.harness.inner,
             &self.conversation_dir,
             self.conversation_id,
             Some(self.record.session_id),
             Some(self.record.id),
-            expected_head,
             data,
             &mut record,
         )
@@ -2368,23 +2343,12 @@ impl TurnHandle for BasicTurnHandle {
 
     async fn write_artifact(&self, request: WriteArtifactRequest) -> Result<ArtifactVersion> {
         let _guard = self.harness.inner.write_lock.lock().await;
-        let expected_head = self
-            .state
-            .lock()
-            .expect("turn state poisoned")
-            .latest_event_id;
         let mut record = self
             .harness
             .inner
             .storage
             .get_json::<ConversationRecord>(self.conversation_dir.join("record.json"))
             .await?;
-        ensure_conversation_head(
-            record.latest_event_id,
-            expected_head,
-            Some(self.record.session_id),
-            Some(self.record.id),
-        )?;
         let artifact_version = write_artifact_version(
             &self.harness.inner,
             &self.conversation_dir.join("artifacts"),
@@ -2397,7 +2361,6 @@ impl TurnHandle for BasicTurnHandle {
             self.conversation_id,
             Some(self.record.session_id),
             Some(self.record.id),
-            expected_head,
             vec![EventData::ArtifactWritten {
                 artifact_id: artifact_version.artifact_id,
                 path: artifact_version.path.clone(),
@@ -2434,14 +2397,12 @@ impl TurnHandle for BasicTurnHandle {
             .storage
             .get_json::<ConversationRecord>(self.conversation_dir.join("record.json"))
             .await?;
-        let expected_head = record.latest_event_id;
         let add_result = append_events_to_conversation(
             &self.harness.inner,
             &self.conversation_dir,
             self.conversation_id,
             Some(self.record.session_id),
             Some(self.record.id),
-            expected_head,
             vec![EventData::TurnEnded],
             &mut record,
         )
@@ -2752,7 +2713,6 @@ async fn append_sandbox_process_data(
         process.conversation_id,
         None,
         None,
-        record.latest_event_id,
         data,
         &mut record,
     )
@@ -2865,20 +2825,11 @@ async fn append_events_to_conversation(
     conversation_id: ConversationId,
     session_id: Option<SessionId>,
     turn_id: Option<TurnId>,
-    expected_head: Option<EventId>,
     data: Vec<EventData>,
     record: &mut ConversationRecord,
 ) -> Result<AddEventsResult> {
     if data.is_empty() {
         bail!("cannot append zero events");
-    }
-    if let Some(expected_head) = expected_head {
-        ensure_conversation_head(
-            record.latest_event_id,
-            Some(expected_head),
-            session_id,
-            turn_id,
-        )?;
     }
     let mut event_ids = Vec::new();
     let mut latest_event_id = None;
@@ -2911,66 +2862,6 @@ async fn append_events_to_conversation(
         event_ids,
         latest_event_id,
     })
-}
-
-fn ensure_conversation_head(
-    current_head: Option<EventId>,
-    expected_head: Option<EventId>,
-    session_id: Option<SessionId>,
-    turn_id: Option<TurnId>,
-) -> Result<()> {
-    if current_head == expected_head {
-        return Ok(());
-    }
-    Err(ConversationHeadMismatch {
-        current_head,
-        expected_head,
-        session_id,
-        turn_id,
-    }
-    .into())
-}
-
-#[derive(Debug, Clone)]
-struct ConversationHeadMismatch {
-    current_head: Option<EventId>,
-    expected_head: Option<EventId>,
-    session_id: Option<SessionId>,
-    turn_id: Option<TurnId>,
-}
-
-impl Display for ConversationHeadMismatch {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        let expected = format_event_head_timestamp(self.expected_head);
-        let current = format_event_head_timestamp(self.current_head);
-        if let Some(turn_id) = self.turn_id {
-            let session = self
-                .session_id
-                .map(|session_id| session_id.to_string())
-                .unwrap_or_else(|| "none".to_string());
-            return write!(
-                f,
-                "turn is stale and cannot be resumed: conversation head advanced outside this turn \
-                 (turn_id: {turn_id}, session_id: {session}, expected_head_at: {expected}, \
-                 current_head_at: {current})"
-            );
-        }
-        write!(
-            f,
-            "conversation head mismatch: expected_head_at: {expected}, current_head_at: {current}"
-        )
-    }
-}
-
-impl std::error::Error for ConversationHeadMismatch {}
-
-fn format_event_head_timestamp(head: Option<EventId>) -> String {
-    let Some(id) = head else {
-        return "none".to_string();
-    };
-    id.timestamp()
-        .map(|timestamp| timestamp.to_rfc3339_opts(chrono::SecondsFormat::Millis, true))
-        .unwrap_or_else(|| "unknown".to_string())
 }
 
 fn notify_subscribers(inner: &BasicExoHarnessInner, conversation_id: ConversationId, event: Event) {

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -34,17 +34,17 @@ use crate::{
     AddEventsRequest, AddEventsResult, AgentHandle, AgentId, AgentRecord, Artifact,
     ArtifactVersion, BeginTurnRequest, Binding, BindingId, BindingRecord, BindingType,
     BoxAsyncRead, BoxAsyncWrite, CancelSandboxProcessRequest, CloseSandboxProcessInputRequest,
-    ConversationHandle, ConversationId, ConversationRecord, CreateSandboxRequest, Event, EventData,
-    EventId, EventKind, EventQuery, EventQueryDirection, EventStream, ExoHarness, FileSystemMount,
-    ForkConversationRequest, GetEventsResult, GetSandboxProcessEventsResult,
-    ListConversationsRequest, ListConversationsResult, NewAgentRequest, NewConversationRequest,
-    PutSecretRequest, ReadArtifactRequest, Result, RunInSandboxRequest, SandboxHandle, SandboxId,
-    SandboxProcess, SandboxProcessEvent, SandboxProcessEventQuery, SandboxProcessId,
-    SandboxProcessMode, SandboxProcessParts, SandboxProcessRecord, SandboxProcessStatus,
-    SandboxProcessStdin, SandboxProvider, SandboxProviderConfig, Secret, SecretId, SecretMetadata,
-    SecretType, SessionId, SnapshotHandle, SnapshotId, StartSandboxProcessRequest,
-    StartSandboxRequest, TurnHandle, TurnId, TurnRecord, Uuid7, WaitSandboxProcessRequest,
-    WriteArtifactRequest, WriteSandboxProcessInputRequest,
+    ConversationHandle, ConversationId, ConversationRecord, CreateSandboxRequest,
+    DurableFileSystem, Event, EventData, EventId, EventKind, EventQuery, EventQueryDirection,
+    EventStream, ExoHarness, FileSystemMount, ForkConversationRequest, GetEventsResult,
+    GetSandboxProcessEventsResult, ListConversationsRequest, ListConversationsResult,
+    NewAgentRequest, NewConversationRequest, PutSecretRequest, ReadArtifactRequest, Result,
+    RunInSandboxRequest, SandboxHandle, SandboxId, SandboxProcess, SandboxProcessEvent,
+    SandboxProcessEventQuery, SandboxProcessId, SandboxProcessMode, SandboxProcessParts,
+    SandboxProcessRecord, SandboxProcessStatus, SandboxProcessStdin, SandboxProvider,
+    SandboxProviderConfig, Secret, SecretId, SecretMetadata, SecretType, SessionId, SnapshotHandle,
+    SnapshotId, StartSandboxProcessRequest, StartSandboxRequest, TurnHandle, TurnId, TurnRecord,
+    Uuid7, WaitSandboxProcessRequest, WriteArtifactRequest, WriteSandboxProcessInputRequest,
 };
 
 #[derive(Debug, Clone)]
@@ -65,6 +65,8 @@ pub enum SandboxBackendChoice {
     Docker,
     LocalProcess,
     Daytona(DaytonaBackendSpec),
+    E2b(E2bBackendSpec),
+    Sprites(SpritesBackendSpec),
     Vercel(VercelBackendSpec),
     AwsAgentCore,
 }
@@ -76,6 +78,8 @@ impl SandboxBackendChoice {
             Self::Docker => SandboxProvider::Docker,
             Self::LocalProcess => SandboxProvider::LocalProcess,
             Self::Daytona(_) => SandboxProvider::Daytona,
+            Self::E2b(_) => SandboxProvider::E2b,
+            Self::Sprites(_) => SandboxProvider::Sprites,
             Self::Vercel(_) => SandboxProvider::Vercel,
             Self::AwsAgentCore => SandboxProvider::AwsAgentCore,
         }
@@ -104,6 +108,48 @@ impl DaytonaBackendSpec {
             api_key_secret: "DAYTONA_API_KEY".to_string(),
             organization_id_secret: Some("DAYTONA_ORGANIZATION_ID".to_string()),
             target_secret: Some("DAYTONA_TARGET".to_string()),
+        }
+    }
+}
+
+/// E2B connection config plus secret-store names for credentials, resolved
+/// lazily on first use.
+#[derive(Debug, Clone)]
+pub struct E2bBackendSpec {
+    pub api_url: String,
+    pub api_key_secret: String,
+    pub template_id: String,
+}
+
+impl Default for E2bBackendSpec {
+    fn default() -> Self {
+        Self {
+            api_url: crate::DEFAULT_E2B_API_URL.to_string(),
+            api_key_secret: "E2B_API_KEY".to_string(),
+            template_id: crate::default_e2b_template(),
+        }
+    }
+}
+
+/// Sprites connection config plus secret-store name for the bearer token,
+/// resolved lazily on first use.
+#[derive(Debug, Clone)]
+pub struct SpritesBackendSpec {
+    pub api_url: String,
+    pub token_secret: String,
+    pub url_auth: Option<String>,
+    pub organization: Option<String>,
+    pub labels: Vec<String>,
+}
+
+impl Default for SpritesBackendSpec {
+    fn default() -> Self {
+        Self {
+            api_url: crate::DEFAULT_SPRITES_API_URL.to_string(),
+            token_secret: "SPRITES_TOKEN".to_string(),
+            url_auth: None,
+            organization: None,
+            labels: Vec::new(),
         }
     }
 }
@@ -201,6 +247,20 @@ impl BasicExoHarnessInner {
                 };
                 Arc::new(crate::DaytonaSandboxBackend::new(config)?)
             }
+            SandboxBackendChoice::E2b(spec) => {
+                let config = match self.e2b_config_from_binding().await? {
+                    Some(config) => config,
+                    None => self.e2b_config_from_spec(spec).await?,
+                };
+                Arc::new(crate::E2bSandboxBackend::new(config)?)
+            }
+            SandboxBackendChoice::Sprites(spec) => {
+                let config = match self.sprites_config_from_binding().await? {
+                    Some(config) => config,
+                    None => self.sprites_config_from_spec(spec).await?,
+                };
+                Arc::new(crate::SpritesSandboxBackend::new(config)?)
+            }
             SandboxBackendChoice::Vercel(spec) => {
                 let config = match self.vercel_config_from_binding().await? {
                     Some(config) => config,
@@ -258,6 +318,122 @@ impl BasicExoHarnessInner {
             target,
             organization_id,
         })
+    }
+
+    async fn e2b_config_from_spec(&self, spec: &E2bBackendSpec) -> Result<crate::E2bConfig> {
+        let api_key = self
+            .secret_key(&spec.api_key_secret)
+            .await?
+            .ok_or_else(|| {
+                anyhow!(
+                    "e2b sandbox requested but secret {:?} is not set",
+                    spec.api_key_secret
+                )
+            })?;
+        Ok(crate::E2bConfig {
+            api_key,
+            api_url: spec.api_url.clone(),
+            template_id: spec.template_id.clone(),
+            envd_port: crate::DEFAULT_E2B_ENVD_PORT,
+            envd_base_url: None,
+            secure: false,
+        })
+    }
+
+    async fn e2b_config_from_binding(&self) -> Result<Option<crate::E2bConfig>> {
+        let bindings = list_binding_records(&self.storage, Path::new("bindings")).await?;
+        let Some((api_key_secret_id, api_url, default_image)) = bindings
+            .into_iter()
+            .rev()
+            .find_map(|record| match record.binding {
+                Binding::Sandbox {
+                    config:
+                        SandboxProviderConfig::E2b {
+                            api_key_secret_id,
+                            api_url,
+                            default_image,
+                        },
+                    ..
+                } => Some((api_key_secret_id, api_url, default_image)),
+                _ => None,
+            })
+        else {
+            return Ok(None);
+        };
+        let api_key = self
+            .secret_key_by_id(api_key_secret_id)
+            .await?
+            .ok_or_else(|| {
+                anyhow!(
+                    "e2b sandbox binding references secret id {api_key_secret_id}, which is not set"
+                )
+            })?;
+        Ok(Some(crate::E2bConfig {
+            api_key,
+            api_url: api_url.unwrap_or_else(|| crate::DEFAULT_E2B_API_URL.to_string()),
+            template_id: default_image,
+            envd_port: crate::DEFAULT_E2B_ENVD_PORT,
+            envd_base_url: None,
+            secure: false,
+        }))
+    }
+
+    async fn sprites_config_from_spec(
+        &self,
+        spec: &SpritesBackendSpec,
+    ) -> Result<crate::SpritesConfig> {
+        let token = self.secret_key(&spec.token_secret).await?.ok_or_else(|| {
+            anyhow!(
+                "sprites sandbox requested but secret {:?} is not set",
+                spec.token_secret
+            )
+        })?;
+        Ok(crate::SpritesConfig {
+            token,
+            api_url: spec.api_url.clone(),
+            url_auth: spec.url_auth.clone(),
+            organization: spec.organization.clone(),
+            extra_labels: spec.labels.clone(),
+        })
+    }
+
+    async fn sprites_config_from_binding(&self) -> Result<Option<crate::SpritesConfig>> {
+        let bindings = list_binding_records(&self.storage, Path::new("bindings")).await?;
+        let Some((token_secret_id, api_url, url_auth, organization, labels)) = bindings
+            .into_iter()
+            .rev()
+            .find_map(|record| match record.binding {
+                Binding::Sandbox {
+                    config:
+                        SandboxProviderConfig::Sprites {
+                            token_secret_id,
+                            api_url,
+                            url_auth,
+                            organization,
+                            labels,
+                        },
+                    ..
+                } => Some((token_secret_id, api_url, url_auth, organization, labels)),
+                _ => None,
+            })
+        else {
+            return Ok(None);
+        };
+        let token = self
+            .secret_key_by_id(token_secret_id)
+            .await?
+            .ok_or_else(|| {
+                anyhow!(
+                    "sprites sandbox binding references secret id {token_secret_id}, which is not set"
+                )
+            })?;
+        Ok(Some(crate::SpritesConfig {
+            token,
+            api_url: api_url.unwrap_or_else(|| crate::DEFAULT_SPRITES_API_URL.to_string()),
+            url_auth,
+            organization,
+            extra_labels: labels,
+        }))
     }
 
     /// `VercelConfig` from the conventional `VERCEL_*` secret-name spec.
@@ -459,7 +635,9 @@ impl BasicExoHarnessInner {
             let Binding::Sandbox { config, .. } = record.binding else {
                 return None;
             };
-            (config.provider() == provider).then(|| config.default_image().to_string())
+            (config.provider() == provider)
+                .then(|| config.default_image().map(str::to_string))
+                .flatten()
         }))
     }
 }
@@ -1481,6 +1659,7 @@ impl<'a> BasicScopedSandboxHandle<'a> {
                 image: sandbox.image,
                 default_workdir: sandbox.default_workdir.unwrap_or_default(),
                 file_system_mounts: sandbox.file_system_mounts,
+                durable_file_systems: sandbox.durable_file_systems,
                 enable_networking: sandbox.enable_networking,
                 idle_seconds: sandbox.idle_seconds,
             },
@@ -1537,6 +1716,7 @@ impl<'a> BasicScopedSandboxHandle<'a> {
                 image,
                 default_workdir,
                 file_system_mounts,
+                durable_file_systems,
                 enable_networking,
                 idle_seconds,
                 ..
@@ -1555,6 +1735,7 @@ impl<'a> BasicScopedSandboxHandle<'a> {
                 || image != request.image
                 || default_workdir != request.default_workdir.clone().unwrap_or_default()
                 || file_system_mounts != request.file_system_mounts
+                || durable_file_systems != request.durable_file_systems
                 || enable_networking != request.enable_networking
                 || idle_seconds != request.idle_seconds
             {
@@ -1843,13 +2024,8 @@ impl ConversationHandle for BasicConversationHandle {
     }
 
     async fn add_events(&self, request: AddEventsRequest) -> Result<AddEventsResult> {
-        self.append_events_internal(
-            request.session_id,
-            request.turn_id,
-            request.expected_head,
-            request.data,
-        )
-        .await
+        self.append_events_internal(request.session_id, request.turn_id, None, request.data)
+            .await
     }
 
     async fn fork(&self, request: ForkConversationRequest) -> Result<Arc<dyn ConversationHandle>> {
@@ -2381,6 +2557,7 @@ async fn prepare_sandbox_request(
         image,
         default_workdir: request.default_workdir,
         file_system_mounts: request.file_system_mounts.unwrap_or_default(),
+        durable_file_systems: request.durable_file_systems.unwrap_or_default(),
         enable_networking: request.enable_networking.unwrap_or(true),
         idle_seconds: request.idle_seconds.unwrap_or(60),
     })
@@ -2409,6 +2586,7 @@ async fn find_matching_stored_sandbox(
             || sandbox.image != request.image
             || sandbox.default_workdir != request.default_workdir
             || sandbox.file_system_mounts != request.file_system_mounts
+            || sandbox.durable_file_systems != request.durable_file_systems
             || sandbox.enable_networking != request.enable_networking
             || sandbox.idle_seconds != request.idle_seconds
         {
@@ -2662,6 +2840,8 @@ struct StoredSandbox {
     image: String,
     default_workdir: Option<String>,
     file_system_mounts: Vec<FileSystemMount>,
+    #[serde(default)]
+    durable_file_systems: Vec<DurableFileSystem>,
     enable_networking: bool,
     idle_seconds: u64,
     running: bool,
@@ -2675,6 +2855,7 @@ struct PreparedSandboxRequest {
     image: String,
     default_workdir: Option<String>,
     file_system_mounts: Vec<FileSystemMount>,
+    durable_file_systems: Vec<DurableFileSystem>,
     enable_networking: bool,
     idle_seconds: u64,
 }
@@ -2688,6 +2869,7 @@ impl PreparedSandboxRequest {
             image: self.image.clone(),
             default_workdir: self.default_workdir.clone(),
             file_system_mounts: self.file_system_mounts.clone(),
+            durable_file_systems: self.durable_file_systems.clone(),
             enable_networking: self.enable_networking,
             idle_seconds: self.idle_seconds,
             running: true,
@@ -3163,6 +3345,7 @@ fn sandbox_request(
                     internal: mount.internal.unwrap_or(false),
                 })
                 .collect(),
+            durable_file_systems: sandbox.durable_file_systems.clone(),
             network: if sandbox.enable_networking {
                 SandboxNetworkPolicy::Enabled
             } else {

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -98,10 +98,10 @@ pub struct DaytonaBackendSpec {
     pub target_secret: Option<String>,
 }
 
-impl DaytonaBackendSpec {
+impl Default for DaytonaBackendSpec {
     /// Official endpoints; credentials read from the conventional `DAYTONA_*`
     /// secret names.
-    pub fn with_conventional_secrets() -> Self {
+    fn default() -> Self {
         Self {
             api_url: crate::DEFAULT_DAYTONA_API_URL.to_string(),
             toolbox_url: crate::DEFAULT_DAYTONA_TOOLBOX_URL.to_string(),
@@ -109,6 +109,14 @@ impl DaytonaBackendSpec {
             organization_id_secret: Some("DAYTONA_ORGANIZATION_ID".to_string()),
             target_secret: Some("DAYTONA_TARGET".to_string()),
         }
+    }
+}
+
+impl DaytonaBackendSpec {
+    /// Official endpoints; credentials read from the conventional `DAYTONA_*`
+    /// secret names.
+    pub fn with_conventional_secrets() -> Self {
+        Self::default()
     }
 }
 

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -960,6 +960,7 @@ async fn agent_scoped_sandbox_is_shared_without_conversation_ownership() {
         image: "basic-local-process".to_string(),
         default_workdir: Some(tempdir.path().display().to_string()),
         file_system_mounts: None,
+        durable_file_systems: None,
         enable_networking: Some(true),
         idle_seconds: Some(60),
     };
@@ -1079,6 +1080,7 @@ async fn conversation_create_sandbox_is_not_turn_scoped() {
             image: "basic-local-process".to_string(),
             default_workdir: Some(tempdir.path().display().to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -516,7 +516,7 @@ async fn turn_events_continue_after_artifact_writes() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn stale_turn_artifact_write_reports_unresumable_turn() {
+async fn turn_artifact_write_allows_interleaved_conversation_writes() {
     let tempdir = TempDir::new().expect("tempdir");
     let harness = BasicExoHarness::new(local_test_config(tempdir.path()))
         .await
@@ -546,15 +546,14 @@ async fn stale_turn_artifact_write_reports_unresumable_turn() {
             contents: b"outside".to_vec(),
         })
         .await
-        .expect("advance conversation head outside turn");
-    let error = turn
-        .write_artifact(WriteArtifactRequest {
-            path: "tool-results/example.json".to_string(),
-            contents: br#"{"ok":true}"#.to_vec(),
-        })
-        .await
-        .expect_err("stale turn should fail");
-    let message = error.to_string();
+        .expect("write outside-turn artifact");
+    turn.write_artifact(WriteArtifactRequest {
+        path: "tool-results/example.json".to_string(),
+        contents: br#"{"ok":true}"#.to_vec(),
+    })
+    .await
+    .expect("turn artifact write should allow interleaved conversation writes");
+
     let events = conversation
         .get_events(Some(EventQuery {
             cursor: None,
@@ -567,42 +566,32 @@ async fn stale_turn_artifact_write_reports_unresumable_turn() {
         .await
         .expect("events")
         .events;
-    let expected_head_event = events
+    let outside_artifact_event = events
         .iter()
-        .rfind(|event| event.turn_id == Some(turn.record().id))
-        .expect("expected head event");
-    let current_head_event = events.last().expect("current head event");
-    let expected_at = expected_head_event
-        .id
-        .timestamp()
-        .expect("expected head timestamp")
-        .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
-    let current_at = current_head_event
-        .id
-        .timestamp()
-        .expect("current head timestamp")
-        .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
-    assert!(
-        message.contains("turn is stale and cannot be resumed"),
-        "{message}"
+        .find(|event| {
+            matches!(
+                &event.data,
+                EventData::ArtifactWritten { path, .. } if path == "outside-turn.txt"
+            )
+        })
+        .expect("outside artifact event");
+    assert_eq!(outside_artifact_event.session_id, None);
+    assert_eq!(outside_artifact_event.turn_id, None);
+
+    let turn_artifact_event = events
+        .iter()
+        .find(|event| {
+            matches!(
+                &event.data,
+                EventData::ArtifactWritten { path, .. } if path == "tool-results/example.json"
+            )
+        })
+        .expect("turn artifact event");
+    assert_eq!(
+        turn_artifact_event.session_id,
+        Some(turn.record().session_id)
     );
-    assert!(message.contains(&turn.record().id.to_string()), "{message}");
-    assert!(
-        message.contains(&format!("expected_head_at: {expected_at}")),
-        "{message}"
-    );
-    assert!(
-        message.contains(&format!("current_head_at: {current_at}")),
-        "{message}"
-    );
-    assert!(
-        !message.contains(&expected_head_event.id.to_string()),
-        "{message}"
-    );
-    assert!(
-        !message.contains(&current_head_event.id.to_string()),
-        "{message}"
-    );
+    assert_eq!(turn_artifact_event.turn_id, Some(turn.record().id));
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -19,15 +19,20 @@ use tokio::time::{sleep, timeout};
 use crate::test_support::{local_test_config, local_test_config_with_daytona};
 use crate::{
     Artifact, ArtifactVersion, BasicExoHarness, BeginTurnRequest, Binding, BoxAsyncRead,
-    BoxAsyncWrite, CloseSandboxProcessInputRequest, CreateSandboxRequest, EventData, EventKind,
-    EventQuery, EventQueryDirection, ExoHarness, ForkConversationRequest, ManagedSandboxBackend,
-    ManagedSandboxHandle, NewAgentRequest, NewConversationRequest, PutSecretRequest,
-    RunInSandboxRequest, SandboxCommand, SandboxCommandOutput, SandboxKey, SandboxLifecycleConfig,
-    SandboxNetworkPolicy, SandboxProcessEvent, SandboxProcessEventQuery, SandboxProcessParts,
-    SandboxProcessStatus, SandboxProcessStdin, SandboxProvider, SandboxProviderConfig,
-    SandboxRequest, SandboxSpec, Secret, SnapshotPayload, StartSandboxProcessRequest, Uuid7,
-    WaitSandboxProcessRequest, WriteArtifactRequest, WriteSandboxProcessInputRequest,
+    BoxAsyncWrite, CloseSandboxProcessInputRequest, CreateSandboxRequest, DurableFileSystem,
+    EventData, EventKind, EventQuery, EventQueryDirection, ExoHarness, FileSystemMountMode,
+    ForkConversationRequest, ManagedSandboxBackend, ManagedSandboxHandle, NewAgentRequest,
+    NewConversationRequest, PutSecretRequest, RunInSandboxRequest, SandboxCommand,
+    SandboxCommandOutput, SandboxKey, SandboxLifecycleConfig, SandboxNetworkPolicy,
+    SandboxProcessEvent, SandboxProcessEventQuery, SandboxProcessParts, SandboxProcessStatus,
+    SandboxProcessStdin, SandboxProvider, SandboxProviderConfig, SandboxRequest, SandboxSpec,
+    Secret, SnapshotPayload, StartSandboxProcessRequest, Uuid7, WaitSandboxProcessRequest,
+    WriteArtifactRequest, WriteSandboxProcessInputRequest,
 };
+
+const DEFAULT_DURABLE_CONTRACT_MOUNT_PATH: &str = "/home/exo/workspace";
+#[cfg(feature = "aws-agentcore")]
+const DEFAULT_AGENTCORE_DURABLE_CONTRACT_MOUNT_PATH: &str = "/mnt/workspace";
 
 #[tokio::test(flavor = "current_thread")]
 async fn basic_backend_supports_agent_and_conversation_crud() {
@@ -108,6 +113,32 @@ async fn local_process_sandbox_contract_start_process_long_running_protocol() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn local_process_sandbox_rejects_durable_file_systems() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let backend: Arc<dyn ManagedSandboxBackend> =
+        Arc::new(crate::LocalProcessSandboxBackend::new());
+    let result = backend
+        .acquire(durable_provider_contract_request(
+            "local-process",
+            "durable-file-system",
+            "local-process".to_string(),
+            &tempdir.path().display().to_string(),
+        ))
+        .await;
+    match result {
+        Ok(handle) => panic!(
+            "local-process unexpectedly acquired durable filesystem sandbox {}",
+            handle.id()
+        ),
+        Err(error) => assert!(
+            error
+                .to_string()
+                .contains("does not support durable file systems")
+        ),
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
 #[ignore = "uses a real Daytona sandbox; source sandbox-vars.sh and run this test explicitly"]
 async fn daytona_sandbox_contract_start_process_stdio_and_env() {
     let Some(handle) = daytona_contract_handle("stdio-and-env").await else {
@@ -155,6 +186,71 @@ async fn vercel_sandbox_contract_start_process_long_running_protocol() {
     .expect("Vercel sandbox long-running protocol contract");
 }
 
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "uses a real Docker sandbox; run this test explicitly"]
+async fn docker_sandbox_contract_durable_file_system_survives_stop_and_reacquire() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let backend: Arc<dyn ManagedSandboxBackend> = Arc::new(
+        crate::CliContainerSandboxBackend::docker()
+            .with_durable_file_system_root(tempdir.path().join("durable-filesystems")),
+    );
+    let mount_path = durable_contract_mount_path();
+    crate::contract_tests::sandbox_backend_durable_file_system_survives_stop_and_reacquire(
+        backend,
+        durable_provider_contract_request(
+            "docker",
+            "durable-file-system",
+            env_or("DOCKER_IMAGE", &crate::default_docker_image()),
+            &mount_path,
+        ),
+    )
+    .await
+    .expect("Docker sandbox durable filesystem contract");
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "uses a real Apple container sandbox; run this test explicitly"]
+async fn apple_container_sandbox_contract_durable_file_system_survives_stop_and_reacquire() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let backend: Arc<dyn ManagedSandboxBackend> = Arc::new(
+        crate::CliContainerSandboxBackend::apple_container()
+            .with_durable_file_system_root(tempdir.path().join("durable-filesystems")),
+    );
+    let mount_path = durable_contract_mount_path();
+    crate::contract_tests::sandbox_backend_durable_file_system_survives_stop_and_reacquire(
+        backend,
+        durable_provider_contract_request(
+            "apple-container",
+            "durable-file-system",
+            env_or("APPLE_CONTAINER_IMAGE", &crate::default_docker_image()),
+            &mount_path,
+        ),
+    )
+    .await
+    .expect("Apple container sandbox durable filesystem contract");
+}
+
+#[cfg(feature = "aws-agentcore")]
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "uses a real AgentCore runtime configured with managed session storage at EXO_AGENTCORE_DURABLE_CONTRACT_MOUNT_PATH or /mnt/workspace; run this test explicitly"]
+async fn aws_agentcore_sandbox_contract_durable_file_system_survives_stop_and_reacquire() {
+    let Some(backend) = aws_agentcore_contract_backend().await else {
+        return;
+    };
+    let mount_path = agentcore_durable_contract_mount_path();
+    crate::contract_tests::sandbox_backend_durable_file_system_survives_stop_and_reacquire(
+        backend,
+        durable_provider_contract_request(
+            "aws-agentcore",
+            "durable-file-system",
+            env_or("AGENTCORE_IMAGE", &crate::default_aws_agentcore_image()),
+            &mount_path,
+        ),
+    )
+    .await
+    .expect("AgentCore sandbox durable filesystem contract");
+}
+
 async fn local_process_contract_handle(
     tempdir: &TempDir,
     sandbox_id: &str,
@@ -170,6 +266,7 @@ async fn local_process_contract_handle(
             spec: SandboxSpec {
                 image: "local-process".to_string(),
                 mounts: Vec::new(),
+                durable_file_systems: Vec::new(),
                 network: SandboxNetworkPolicy::Enabled,
                 default_workdir: tempdir.path().display().to_string(),
             },
@@ -245,6 +342,57 @@ async fn vercel_contract_handle(contract: &str) -> Option<Arc<dyn ManagedSandbox
     )
 }
 
+#[cfg(feature = "aws-agentcore")]
+async fn aws_agentcore_contract_backend() -> Option<Arc<dyn ManagedSandboxBackend>> {
+    let Some(runtime_arn) =
+        nonempty_env("AGENTCORE_RUNTIME_ARN").or_else(|| nonempty_env("AWS_AGENTCORE_RUNTIME_ARN"))
+    else {
+        eprintln!(
+            "skipping real AgentCore sandbox contract: AGENTCORE_RUNTIME_ARN or AWS_AGENTCORE_RUNTIME_ARN is not set"
+        );
+        return None;
+    };
+    let Some(region) = nonempty_env("AWS_AGENTCORE_REGION")
+        .or_else(|| nonempty_env("AWS_REGION"))
+        .or_else(|| nonempty_env("AWS_DEFAULT_REGION"))
+    else {
+        eprintln!(
+            "skipping real AgentCore sandbox contract: AWS_AGENTCORE_REGION or AWS_REGION is not set"
+        );
+        return None;
+    };
+    let credentials = match (
+        nonempty_env("AWS_ACCESS_KEY_ID"),
+        nonempty_env("AWS_SECRET_ACCESS_KEY"),
+    ) {
+        (Some(access_key_id), Some(secret_access_key)) => Some(crate::AwsAgentCoreCredentials {
+            access_key_id,
+            secret_access_key,
+            session_token: nonempty_env("AWS_SESSION_TOKEN"),
+        }),
+        (None, None) => None,
+        _ => {
+            eprintln!(
+                "skipping real AgentCore sandbox contract: set both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, or neither"
+            );
+            return None;
+        }
+    };
+    let backend = crate::AwsAgentCoreSandboxBackend::new(crate::AwsAgentCoreConfig {
+        runtime_arn,
+        region,
+        qualifier: nonempty_env("AGENTCORE_QUALIFIER")
+            .or_else(|| nonempty_env("AWS_AGENTCORE_QUALIFIER")),
+        endpoint_url: nonempty_env("AGENTCORE_ENDPOINT_URL")
+            .or_else(|| nonempty_env("AWS_AGENTCORE_ENDPOINT_URL")),
+        credentials,
+        session_storage_mount_path: Some(agentcore_durable_contract_mount_path()),
+    })
+    .await
+    .expect("AwsAgentCoreSandboxBackend::new");
+    Some(Arc::new(backend))
+}
+
 fn nonempty_env(name: &str) -> Option<String> {
     env::var(name)
         .ok()
@@ -270,6 +418,7 @@ fn provider_contract_request(
         spec: SandboxSpec {
             image,
             mounts: Vec::new(),
+            durable_file_systems: Vec::new(),
             network: SandboxNetworkPolicy::Enabled,
             default_workdir: default_workdir.to_string(),
         },
@@ -277,6 +426,36 @@ fn provider_contract_request(
             idle_ttl: Some(Duration::from_secs(300)),
         },
     }
+}
+
+fn durable_provider_contract_request(
+    provider: &str,
+    contract: &str,
+    image: String,
+    mount_path: &str,
+) -> SandboxRequest {
+    let mut request = provider_contract_request(provider, contract, image, mount_path);
+    request.spec.durable_file_systems = vec![DurableFileSystem {
+        name: "workspace".to_string(),
+        mount_path: mount_path.to_string(),
+        mode: FileSystemMountMode::ReadWrite,
+    }];
+    request
+}
+
+fn durable_contract_mount_path() -> String {
+    env_or(
+        "EXO_DURABLE_CONTRACT_MOUNT_PATH",
+        DEFAULT_DURABLE_CONTRACT_MOUNT_PATH,
+    )
+}
+
+#[cfg(feature = "aws-agentcore")]
+fn agentcore_durable_contract_mount_path() -> String {
+    nonempty_env("EXO_AGENTCORE_DURABLE_CONTRACT_MOUNT_PATH")
+        .or_else(|| nonempty_env("AWS_AGENTCORE_SESSION_STORAGE_MOUNT_PATH"))
+        .or_else(|| nonempty_env("AGENTCORE_SESSION_STORAGE_MOUNT_PATH"))
+        .unwrap_or_else(|| DEFAULT_AGENTCORE_DURABLE_CONTRACT_MOUNT_PATH.to_string())
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -722,6 +901,7 @@ async fn basic_backend_runs_commands_in_created_sandbox() {
             image: "basic-local-process".to_string(),
             default_workdir: Some(tempdir.path().display().to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })
@@ -781,6 +961,7 @@ async fn basic_backend_reuses_named_sandbox() {
         image: "basic-local-process".to_string(),
         default_workdir: Some(tempdir.path().display().to_string()),
         file_system_mounts: None,
+        durable_file_systems: None,
         enable_networking: Some(true),
         idle_seconds: Some(60),
     };
@@ -831,6 +1012,7 @@ async fn basic_backend_reattaches_running_sandbox_in_new_harness_process() {
             image: "basic-local-process".to_string(),
             default_workdir: Some(tempdir.path().display().to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })
@@ -909,6 +1091,7 @@ async fn basic_backend_exposes_process_events_and_input() {
             image: "basic-local-process".to_string(),
             default_workdir: Some(tempdir.path().display().to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })
@@ -1033,6 +1216,7 @@ async fn basic_backend_records_process_name_metadata() {
             image: "basic-local-process".to_string(),
             default_workdir: Some(tempdir.path().display().to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })
@@ -1239,6 +1423,7 @@ async fn test_sandbox(conversation: &Arc<dyn crate::ConversationHandle>) -> Stri
             image: "test-sandbox".to_string(),
             default_workdir: Some("/".to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })
@@ -1285,6 +1470,7 @@ async fn basic_backend_rejects_daytona_provider() {
             image: "test-sandbox".to_string(),
             default_workdir: Some("/".to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })
@@ -1323,6 +1509,7 @@ async fn advertised_daytona_without_secret_errors_at_first_use() {
             image: "test-sandbox".to_string(),
             default_workdir: Some("/".to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -758,6 +758,66 @@ async fn basic_backend_runs_commands_in_created_sandbox() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn conversation_create_sandbox_is_not_turn_scoped() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let harness = BasicExoHarness::new(local_test_config(tempdir.path()))
+        .await
+        .expect("harness should initialize");
+    let agent = harness
+        .new_agent(NewAgentRequest {
+            slug: "agent".to_string(),
+            name: "Agent".to_string(),
+        })
+        .await
+        .expect("agent");
+    let conversation = agent
+        .new_conversation(NewConversationRequest::default())
+        .await
+        .expect("conversation");
+    let turn = conversation
+        .begin_turn(BeginTurnRequest {
+            session_id: None,
+            input: vec![user_message("start turn")],
+        })
+        .await
+        .expect("turn should begin");
+
+    conversation
+        .create_sandbox(CreateSandboxRequest {
+            name: None,
+            provider: SandboxProvider::LocalProcess,
+            image: "basic-local-process".to_string(),
+            default_workdir: Some(tempdir.path().display().to_string()),
+            file_system_mounts: None,
+            enable_networking: Some(true),
+            idle_seconds: Some(60),
+        })
+        .await
+        .expect("sandbox should be created");
+
+    let events = conversation
+        .get_events(Some(EventQuery {
+            cursor: None,
+            direction: Some(EventQueryDirection::Asc),
+            limit: None,
+            session_id: None,
+            turn_id: None,
+            types: Some(vec![EventKind::SANDBOX_CREATED, EventKind::SANDBOX_STARTED]),
+        }))
+        .await
+        .expect("sandbox lifecycle events")
+        .events;
+
+    assert_eq!(events.len(), 2);
+    for event in events {
+        assert_ne!(event.session_id, Some(turn.record().session_id));
+        assert_ne!(event.turn_id, Some(turn.record().id));
+        assert_eq!(event.session_id, None);
+        assert_eq!(event.turn_id, None);
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn basic_backend_reuses_named_sandbox() {
     let tempdir = TempDir::new().expect("tempdir");
     let harness = BasicExoHarness::new(local_test_config(tempdir.path()))

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -19,15 +19,20 @@ use tokio::time::{sleep, timeout};
 use crate::test_support::{local_test_config, local_test_config_with_daytona};
 use crate::{
     Artifact, ArtifactVersion, BasicExoHarness, BeginTurnRequest, Binding, BoxAsyncRead,
-    BoxAsyncWrite, CloseSandboxProcessInputRequest, CreateSandboxRequest, EventData, EventKind,
-    EventQuery, EventQueryDirection, ExoHarness, ForkConversationRequest, ManagedSandboxBackend,
-    ManagedSandboxHandle, NewAgentRequest, NewConversationRequest, PutSecretRequest,
-    RunInSandboxRequest, SandboxCommand, SandboxCommandOutput, SandboxKey, SandboxLifecycleConfig,
-    SandboxNetworkPolicy, SandboxProcessEvent, SandboxProcessEventQuery, SandboxProcessParts,
-    SandboxProcessStatus, SandboxProcessStdin, SandboxProvider, SandboxProviderConfig,
-    SandboxRequest, SandboxSpec, Secret, SnapshotPayload, StartSandboxProcessRequest, Uuid7,
-    WaitSandboxProcessRequest, WriteArtifactRequest, WriteSandboxProcessInputRequest,
+    BoxAsyncWrite, CloseSandboxProcessInputRequest, CreateSandboxRequest, DurableFileSystem,
+    EventData, EventKind, EventQuery, EventQueryDirection, ExoHarness, FileSystemMountMode,
+    ForkConversationRequest, ManagedSandboxBackend, ManagedSandboxHandle, NewAgentRequest,
+    NewConversationRequest, PutSecretRequest, RunInSandboxRequest, SandboxCommand,
+    SandboxCommandOutput, SandboxKey, SandboxLifecycleConfig, SandboxNetworkPolicy,
+    SandboxProcessEvent, SandboxProcessEventQuery, SandboxProcessParts, SandboxProcessStatus,
+    SandboxProcessStdin, SandboxProvider, SandboxProviderConfig, SandboxRequest, SandboxSpec,
+    Secret, SnapshotPayload, StartSandboxProcessRequest, Uuid7, WaitSandboxProcessRequest,
+    WriteArtifactRequest, WriteSandboxProcessInputRequest,
 };
+
+const DEFAULT_DURABLE_CONTRACT_MOUNT_PATH: &str = "/home/exo/workspace";
+#[cfg(feature = "aws-agentcore")]
+const DEFAULT_AGENTCORE_DURABLE_CONTRACT_MOUNT_PATH: &str = "/mnt/workspace";
 
 #[tokio::test(flavor = "current_thread")]
 async fn basic_backend_supports_agent_and_conversation_crud() {
@@ -108,6 +113,32 @@ async fn local_process_sandbox_contract_start_process_long_running_protocol() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn local_process_sandbox_rejects_durable_file_systems() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let backend: Arc<dyn ManagedSandboxBackend> =
+        Arc::new(crate::LocalProcessSandboxBackend::new());
+    let result = backend
+        .acquire(durable_provider_contract_request(
+            "local-process",
+            "durable-file-system",
+            "local-process".to_string(),
+            &tempdir.path().display().to_string(),
+        ))
+        .await;
+    match result {
+        Ok(handle) => panic!(
+            "local-process unexpectedly acquired durable filesystem sandbox {}",
+            handle.id()
+        ),
+        Err(error) => assert!(
+            error
+                .to_string()
+                .contains("does not support durable file systems")
+        ),
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
 #[ignore = "uses a real Daytona sandbox; source sandbox-vars.sh and run this test explicitly"]
 async fn daytona_sandbox_contract_start_process_stdio_and_env() {
     let Some(handle) = daytona_contract_handle("stdio-and-env").await else {
@@ -155,6 +186,71 @@ async fn vercel_sandbox_contract_start_process_long_running_protocol() {
     .expect("Vercel sandbox long-running protocol contract");
 }
 
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "uses a real Docker sandbox; run this test explicitly"]
+async fn docker_sandbox_contract_durable_file_system_survives_stop_and_reacquire() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let backend: Arc<dyn ManagedSandboxBackend> = Arc::new(
+        crate::CliContainerSandboxBackend::docker()
+            .with_durable_file_system_root(tempdir.path().join("durable-filesystems")),
+    );
+    let mount_path = durable_contract_mount_path();
+    crate::contract_tests::sandbox_backend_durable_file_system_survives_stop_and_reacquire(
+        backend,
+        durable_provider_contract_request(
+            "docker",
+            "durable-file-system",
+            env_or("DOCKER_IMAGE", &crate::default_docker_image()),
+            &mount_path,
+        ),
+    )
+    .await
+    .expect("Docker sandbox durable filesystem contract");
+}
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "uses a real Apple container sandbox; run this test explicitly"]
+async fn apple_container_sandbox_contract_durable_file_system_survives_stop_and_reacquire() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let backend: Arc<dyn ManagedSandboxBackend> = Arc::new(
+        crate::CliContainerSandboxBackend::apple_container()
+            .with_durable_file_system_root(tempdir.path().join("durable-filesystems")),
+    );
+    let mount_path = durable_contract_mount_path();
+    crate::contract_tests::sandbox_backend_durable_file_system_survives_stop_and_reacquire(
+        backend,
+        durable_provider_contract_request(
+            "apple-container",
+            "durable-file-system",
+            env_or("APPLE_CONTAINER_IMAGE", &crate::default_docker_image()),
+            &mount_path,
+        ),
+    )
+    .await
+    .expect("Apple container sandbox durable filesystem contract");
+}
+
+#[cfg(feature = "aws-agentcore")]
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "uses a real AgentCore runtime configured with managed session storage at EXO_AGENTCORE_DURABLE_CONTRACT_MOUNT_PATH or /mnt/workspace; run this test explicitly"]
+async fn aws_agentcore_sandbox_contract_durable_file_system_survives_stop_and_reacquire() {
+    let Some(backend) = aws_agentcore_contract_backend().await else {
+        return;
+    };
+    let mount_path = agentcore_durable_contract_mount_path();
+    crate::contract_tests::sandbox_backend_durable_file_system_survives_stop_and_reacquire(
+        backend,
+        durable_provider_contract_request(
+            "aws-agentcore",
+            "durable-file-system",
+            env_or("AGENTCORE_IMAGE", &crate::default_aws_agentcore_image()),
+            &mount_path,
+        ),
+    )
+    .await
+    .expect("AgentCore sandbox durable filesystem contract");
+}
+
 async fn local_process_contract_handle(
     tempdir: &TempDir,
     sandbox_id: &str,
@@ -170,6 +266,7 @@ async fn local_process_contract_handle(
             spec: SandboxSpec {
                 image: "local-process".to_string(),
                 mounts: Vec::new(),
+                durable_file_systems: Vec::new(),
                 network: SandboxNetworkPolicy::Enabled,
                 default_workdir: tempdir.path().display().to_string(),
             },
@@ -245,6 +342,57 @@ async fn vercel_contract_handle(contract: &str) -> Option<Arc<dyn ManagedSandbox
     )
 }
 
+#[cfg(feature = "aws-agentcore")]
+async fn aws_agentcore_contract_backend() -> Option<Arc<dyn ManagedSandboxBackend>> {
+    let Some(runtime_arn) =
+        nonempty_env("AGENTCORE_RUNTIME_ARN").or_else(|| nonempty_env("AWS_AGENTCORE_RUNTIME_ARN"))
+    else {
+        eprintln!(
+            "skipping real AgentCore sandbox contract: AGENTCORE_RUNTIME_ARN or AWS_AGENTCORE_RUNTIME_ARN is not set"
+        );
+        return None;
+    };
+    let Some(region) = nonempty_env("AWS_AGENTCORE_REGION")
+        .or_else(|| nonempty_env("AWS_REGION"))
+        .or_else(|| nonempty_env("AWS_DEFAULT_REGION"))
+    else {
+        eprintln!(
+            "skipping real AgentCore sandbox contract: AWS_AGENTCORE_REGION or AWS_REGION is not set"
+        );
+        return None;
+    };
+    let credentials = match (
+        nonempty_env("AWS_ACCESS_KEY_ID"),
+        nonempty_env("AWS_SECRET_ACCESS_KEY"),
+    ) {
+        (Some(access_key_id), Some(secret_access_key)) => Some(crate::AwsAgentCoreCredentials {
+            access_key_id,
+            secret_access_key,
+            session_token: nonempty_env("AWS_SESSION_TOKEN"),
+        }),
+        (None, None) => None,
+        _ => {
+            eprintln!(
+                "skipping real AgentCore sandbox contract: set both AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY, or neither"
+            );
+            return None;
+        }
+    };
+    let backend = crate::AwsAgentCoreSandboxBackend::new(crate::AwsAgentCoreConfig {
+        runtime_arn,
+        region,
+        qualifier: nonempty_env("AGENTCORE_QUALIFIER")
+            .or_else(|| nonempty_env("AWS_AGENTCORE_QUALIFIER")),
+        endpoint_url: nonempty_env("AGENTCORE_ENDPOINT_URL")
+            .or_else(|| nonempty_env("AWS_AGENTCORE_ENDPOINT_URL")),
+        credentials,
+        session_storage_mount_path: Some(agentcore_durable_contract_mount_path()),
+    })
+    .await
+    .expect("AwsAgentCoreSandboxBackend::new");
+    Some(Arc::new(backend))
+}
+
 fn nonempty_env(name: &str) -> Option<String> {
     env::var(name)
         .ok()
@@ -270,6 +418,7 @@ fn provider_contract_request(
         spec: SandboxSpec {
             image,
             mounts: Vec::new(),
+            durable_file_systems: Vec::new(),
             network: SandboxNetworkPolicy::Enabled,
             default_workdir: default_workdir.to_string(),
         },
@@ -277,6 +426,36 @@ fn provider_contract_request(
             idle_ttl: Some(Duration::from_secs(300)),
         },
     }
+}
+
+fn durable_provider_contract_request(
+    provider: &str,
+    contract: &str,
+    image: String,
+    mount_path: &str,
+) -> SandboxRequest {
+    let mut request = provider_contract_request(provider, contract, image, mount_path);
+    request.spec.durable_file_systems = vec![DurableFileSystem {
+        name: "workspace".to_string(),
+        mount_path: mount_path.to_string(),
+        mode: FileSystemMountMode::ReadWrite,
+    }];
+    request
+}
+
+fn durable_contract_mount_path() -> String {
+    env_or(
+        "EXO_DURABLE_CONTRACT_MOUNT_PATH",
+        DEFAULT_DURABLE_CONTRACT_MOUNT_PATH,
+    )
+}
+
+#[cfg(feature = "aws-agentcore")]
+fn agentcore_durable_contract_mount_path() -> String {
+    nonempty_env("EXO_AGENTCORE_DURABLE_CONTRACT_MOUNT_PATH")
+        .or_else(|| nonempty_env("AWS_AGENTCORE_SESSION_STORAGE_MOUNT_PATH"))
+        .or_else(|| nonempty_env("AGENTCORE_SESSION_STORAGE_MOUNT_PATH"))
+        .unwrap_or_else(|| DEFAULT_AGENTCORE_DURABLE_CONTRACT_MOUNT_PATH.to_string())
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -337,7 +516,7 @@ async fn turn_events_continue_after_artifact_writes() {
 }
 
 #[tokio::test(flavor = "current_thread")]
-async fn stale_turn_artifact_write_reports_unresumable_turn() {
+async fn turn_artifact_write_allows_interleaved_conversation_writes() {
     let tempdir = TempDir::new().expect("tempdir");
     let harness = BasicExoHarness::new(local_test_config(tempdir.path()))
         .await
@@ -367,15 +546,14 @@ async fn stale_turn_artifact_write_reports_unresumable_turn() {
             contents: b"outside".to_vec(),
         })
         .await
-        .expect("advance conversation head outside turn");
-    let error = turn
-        .write_artifact(WriteArtifactRequest {
-            path: "tool-results/example.json".to_string(),
-            contents: br#"{"ok":true}"#.to_vec(),
-        })
-        .await
-        .expect_err("stale turn should fail");
-    let message = error.to_string();
+        .expect("write outside-turn artifact");
+    turn.write_artifact(WriteArtifactRequest {
+        path: "tool-results/example.json".to_string(),
+        contents: br#"{"ok":true}"#.to_vec(),
+    })
+    .await
+    .expect("turn artifact write should allow interleaved conversation writes");
+
     let events = conversation
         .get_events(Some(EventQuery {
             cursor: None,
@@ -388,42 +566,32 @@ async fn stale_turn_artifact_write_reports_unresumable_turn() {
         .await
         .expect("events")
         .events;
-    let expected_head_event = events
+    let outside_artifact_event = events
         .iter()
-        .rfind(|event| event.turn_id == Some(turn.record().id))
-        .expect("expected head event");
-    let current_head_event = events.last().expect("current head event");
-    let expected_at = expected_head_event
-        .id
-        .timestamp()
-        .expect("expected head timestamp")
-        .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
-    let current_at = current_head_event
-        .id
-        .timestamp()
-        .expect("current head timestamp")
-        .to_rfc3339_opts(chrono::SecondsFormat::Millis, true);
-    assert!(
-        message.contains("turn is stale and cannot be resumed"),
-        "{message}"
+        .find(|event| {
+            matches!(
+                &event.data,
+                EventData::ArtifactWritten { path, .. } if path == "outside-turn.txt"
+            )
+        })
+        .expect("outside artifact event");
+    assert_eq!(outside_artifact_event.session_id, None);
+    assert_eq!(outside_artifact_event.turn_id, None);
+
+    let turn_artifact_event = events
+        .iter()
+        .find(|event| {
+            matches!(
+                &event.data,
+                EventData::ArtifactWritten { path, .. } if path == "tool-results/example.json"
+            )
+        })
+        .expect("turn artifact event");
+    assert_eq!(
+        turn_artifact_event.session_id,
+        Some(turn.record().session_id)
     );
-    assert!(message.contains(&turn.record().id.to_string()), "{message}");
-    assert!(
-        message.contains(&format!("expected_head_at: {expected_at}")),
-        "{message}"
-    );
-    assert!(
-        message.contains(&format!("current_head_at: {current_at}")),
-        "{message}"
-    );
-    assert!(
-        !message.contains(&expected_head_event.id.to_string()),
-        "{message}"
-    );
-    assert!(
-        !message.contains(&current_head_event.id.to_string()),
-        "{message}"
-    );
+    assert_eq!(turn_artifact_event.turn_id, Some(turn.record().id));
 }
 
 #[tokio::test(flavor = "current_thread")]
@@ -722,6 +890,7 @@ async fn basic_backend_runs_commands_in_created_sandbox() {
             image: "basic-local-process".to_string(),
             default_workdir: Some(tempdir.path().display().to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })
@@ -962,6 +1131,7 @@ async fn basic_backend_reuses_named_sandbox() {
         image: "basic-local-process".to_string(),
         default_workdir: Some(tempdir.path().display().to_string()),
         file_system_mounts: None,
+        durable_file_systems: None,
         enable_networking: Some(true),
         idle_seconds: Some(60),
     };
@@ -1012,6 +1182,7 @@ async fn basic_backend_reattaches_running_sandbox_in_new_harness_process() {
             image: "basic-local-process".to_string(),
             default_workdir: Some(tempdir.path().display().to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })
@@ -1090,6 +1261,7 @@ async fn basic_backend_exposes_process_events_and_input() {
             image: "basic-local-process".to_string(),
             default_workdir: Some(tempdir.path().display().to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })
@@ -1214,6 +1386,7 @@ async fn basic_backend_records_process_name_metadata() {
             image: "basic-local-process".to_string(),
             default_workdir: Some(tempdir.path().display().to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })
@@ -1420,6 +1593,7 @@ async fn test_sandbox(conversation: &Arc<dyn crate::ConversationHandle>) -> Stri
             image: "test-sandbox".to_string(),
             default_workdir: Some("/".to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })
@@ -1466,6 +1640,7 @@ async fn basic_backend_rejects_daytona_provider() {
             image: "test-sandbox".to_string(),
             default_workdir: Some("/".to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })
@@ -1504,6 +1679,7 @@ async fn advertised_daytona_without_secret_errors_at_first_use() {
             image: "test-sandbox".to_string(),
             default_workdir: Some("/".to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -758,6 +758,127 @@ async fn basic_backend_runs_commands_in_created_sandbox() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn agent_scoped_sandbox_is_shared_without_conversation_ownership() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let harness = BasicExoHarness::new(local_test_config(tempdir.path()))
+        .await
+        .expect("harness should initialize");
+    let agent = harness
+        .new_agent(NewAgentRequest {
+            slug: "agent".to_string(),
+            name: "Agent".to_string(),
+        })
+        .await
+        .expect("agent");
+    let first_conversation = agent
+        .new_conversation(NewConversationRequest {
+            slug: Some("first".to_string()),
+            name: Some("First".to_string()),
+        })
+        .await
+        .expect("first conversation");
+    let second_conversation = agent
+        .new_conversation(NewConversationRequest {
+            slug: Some("second".to_string()),
+            name: Some("Second".to_string()),
+        })
+        .await
+        .expect("second conversation");
+
+    let create_request = CreateSandboxRequest {
+        name: Some("shared-agent-sandbox".to_string()),
+        provider: SandboxProvider::LocalProcess,
+        image: "basic-local-process".to_string(),
+        default_workdir: Some(tempdir.path().display().to_string()),
+        file_system_mounts: None,
+        enable_networking: Some(true),
+        idle_seconds: Some(60),
+    };
+    let sandbox_id = agent
+        .create_sandbox(create_request.clone())
+        .await
+        .expect("agent sandbox should be created");
+    let write_process = agent
+        .run_in_sandbox(RunInSandboxRequest {
+            id: sandbox_id.clone(),
+            command: vec![
+                "/bin/sh".to_string(),
+                "-lc".to_string(),
+                "printf agent-owned > agent-sandbox-proof".to_string(),
+            ],
+            env: Default::default(),
+        })
+        .await
+        .expect("agent sandbox command should run");
+    assert_eq!(
+        write_process
+            .into_parts()
+            .wait
+            .await
+            .expect("write should exit"),
+        0
+    );
+
+    let reacquired = agent
+        .create_sandbox(create_request)
+        .await
+        .expect("named agent sandbox should reacquire");
+    assert_eq!(reacquired, sandbox_id);
+    let read_process = agent
+        .run_in_sandbox(RunInSandboxRequest {
+            id: reacquired.clone(),
+            command: vec![
+                "/bin/sh".to_string(),
+                "-lc".to_string(),
+                "cat agent-sandbox-proof".to_string(),
+            ],
+            env: Default::default(),
+        })
+        .await
+        .expect("agent sandbox should retain filesystem state");
+    let parts = read_process.into_parts();
+    let mut stdout = parts.stdout;
+    let mut stdout_bytes = Vec::new();
+    drop(parts.stdin);
+    let (stdout_result, wait_result) =
+        tokio::join!(stdout.read_to_end(&mut stdout_bytes), parts.wait);
+    stdout_result.expect("stdout should read");
+    assert_eq!(wait_result.expect("read should exit"), 0);
+    assert_eq!(String::from_utf8_lossy(&stdout_bytes), "agent-owned");
+
+    let conversation_process = first_conversation
+        .run_in_sandbox(RunInSandboxRequest {
+            id: reacquired,
+            command: vec!["true".to_string()],
+            env: Default::default(),
+        })
+        .await;
+    assert!(conversation_process.is_err());
+
+    for conversation in [first_conversation, second_conversation] {
+        let events = conversation
+            .get_events(Some(EventQuery {
+                cursor: None,
+                direction: Some(EventQueryDirection::Asc),
+                limit: None,
+                session_id: None,
+                turn_id: None,
+                types: Some(vec![
+                    EventKind::SANDBOX_CREATED,
+                    EventKind::SANDBOX_STARTED,
+                    EventKind::SANDBOX_PROCESS_STARTED,
+                    EventKind::SANDBOX_PROCESS_EVENT,
+                    EventKind::SANDBOX_PROCESS_STATE_UPDATED,
+                ]),
+            }))
+            .await
+            .expect("conversation events should load")
+            .events;
+        assert!(events.is_empty());
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn conversation_create_sandbox_is_not_turn_scoped() {
     let tempdir = TempDir::new().expect("tempdir");
     let harness = BasicExoHarness::new(local_test_config(tempdir.path()))

--- a/crates/exoharness/src/contract_tests.rs
+++ b/crates/exoharness/src/contract_tests.rs
@@ -10,8 +10,8 @@ use tokio::time::timeout;
 use crate::{
     AddEventsRequest, BeginTurnRequest, Binding, EventData, EventKind, EventQuery,
     EventQueryDirection, ExoHarness, ForkConversationRequest, ListConversationsRequest,
-    ManagedSandboxHandle, NewAgentRequest, NewConversationRequest, SandboxCommand, Uuid7,
-    WriteArtifactRequest,
+    ManagedSandboxBackend, ManagedSandboxHandle, NewAgentRequest, NewConversationRequest,
+    SandboxCommand, SandboxRequest, Uuid7, WriteArtifactRequest,
 };
 
 pub async fn supports_agent_and_conversation_crud(harness: Arc<dyn ExoHarness>) {
@@ -110,7 +110,6 @@ pub async fn list_conversations_returns_recent_first_and_paginates(harness: Arc<
         .add_events(AddEventsRequest {
             session_id: None,
             turn_id: None,
-            expected_head: None,
             data: vec![EventData::Custom {
                 event_type: "touch".to_string(),
                 payload: serde_json::Value::Null,
@@ -388,6 +387,44 @@ pub async fn sandbox_handle_start_process_supports_long_running_request_response
     }
 }
 
+pub async fn sandbox_backend_durable_file_system_survives_stop_and_reacquire(
+    backend: Arc<dyn ManagedSandboxBackend>,
+    request: SandboxRequest,
+) -> crate::Result<()> {
+    let mount_path = request
+        .spec
+        .durable_file_systems
+        .first()
+        .context("durable filesystem contract requires a durable filesystem")?
+        .mount_path
+        .clone();
+    let marker = format!("durable-{}", Uuid7::now());
+
+    let first = backend
+        .acquire(request.clone())
+        .await
+        .context("acquire sandbox for durable filesystem write")?;
+    let write_result = write_durable_marker(Arc::clone(&first), &mount_path, &marker).await;
+    stop_after_contract(
+        first,
+        write_result,
+        "stop sandbox after durable filesystem write",
+    )
+    .await?;
+
+    let second = backend
+        .acquire(request)
+        .await
+        .context("reacquire sandbox for durable filesystem read")?;
+    let read_result = read_durable_marker(Arc::clone(&second), &mount_path, &marker).await;
+    stop_after_contract(
+        second,
+        read_result,
+        "stop sandbox after durable filesystem read",
+    )
+    .await
+}
+
 async fn sandbox_handle_start_process_supports_interactive_stdio_and_env_inner(
     handle: Arc<dyn ManagedSandboxHandle>,
 ) -> crate::Result<()> {
@@ -400,7 +437,7 @@ async fn sandbox_handle_start_process_supports_interactive_stdio_and_env_inner(
         .start_process(&SandboxCommand {
             argv: vec![
                 "/bin/sh".to_string(),
-                "-lc".to_string(),
+                "-c".to_string(),
                 "printf 'ready\\n'; IFS= read -r line; printf 'env=%s input=%s\\n' \"$EXO_CONTRACT_ENV\" \"$line\"".to_string(),
             ],
             env,
@@ -469,6 +506,96 @@ async fn sandbox_handle_start_process_supports_interactive_stdio_and_env_inner(
     Ok(())
 }
 
+async fn write_durable_marker(
+    handle: Arc<dyn ManagedSandboxHandle>,
+    mount_path: &str,
+    marker: &str,
+) -> crate::Result<()> {
+    let mut env = std::collections::HashMap::new();
+    env.insert("EXO_DURABLE_MOUNT".to_string(), mount_path.to_string());
+    env.insert("EXO_DURABLE_MARKER".to_string(), marker.to_string());
+    let output = handle
+        .exec(&SandboxCommand {
+            argv: vec![
+                "/bin/sh".to_string(),
+                "-lc".to_string(),
+                "test \"$(pwd)\" = \"$EXO_DURABLE_MOUNT\" && mkdir -p .codex-smoke && printf '%s' \"$EXO_DURABLE_MARKER\" > .codex-smoke/marker.txt"
+                    .to_string(),
+            ],
+            env,
+            display_argv: None,
+            cwd: None,
+            timeout: Some(Duration::from_secs(30)),
+        })
+        .await
+        .context("write durable filesystem marker")?;
+    if !output.ok {
+        bail!(
+            "write durable filesystem marker failed with exit code {:?}: {}{}",
+            output.exit_code,
+            output.stdout,
+            output.stderr
+        );
+    }
+    Ok(())
+}
+
+async fn read_durable_marker(
+    handle: Arc<dyn ManagedSandboxHandle>,
+    mount_path: &str,
+    expected_marker: &str,
+) -> crate::Result<()> {
+    let mut env = std::collections::HashMap::new();
+    env.insert("EXO_DURABLE_MOUNT".to_string(), mount_path.to_string());
+    let output = handle
+        .exec(&SandboxCommand {
+            argv: vec![
+                "/bin/sh".to_string(),
+                "-lc".to_string(),
+                "test \"$(pwd)\" = \"$EXO_DURABLE_MOUNT\" && cat .codex-smoke/marker.txt"
+                    .to_string(),
+            ],
+            env,
+            display_argv: None,
+            cwd: None,
+            timeout: Some(Duration::from_secs(30)),
+        })
+        .await
+        .context("read durable filesystem marker")?;
+    if !output.ok {
+        bail!(
+            "read durable filesystem marker failed with exit code {:?}: {}{}",
+            output.exit_code,
+            output.stdout,
+            output.stderr
+        );
+    }
+    if output.stdout != expected_marker {
+        bail!(
+            "durable filesystem marker mismatch: expected {:?}, got {:?}",
+            expected_marker,
+            output.stdout
+        );
+    }
+    Ok(())
+}
+
+async fn stop_after_contract(
+    handle: Arc<dyn ManagedSandboxHandle>,
+    result: crate::Result<()>,
+    context: &str,
+) -> crate::Result<()> {
+    let stop_result = handle.stop().await.with_context(|| context.to_string());
+    match (result, stop_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) => Err(error),
+        (Ok(()), Err(error)) => Err(error),
+        (Err(error), Err(stop_error)) => Err(anyhow!(
+            "{error:#}; also failed to stop sandbox after contract: {stop_error:#}"
+        )),
+    }
+}
+
 async fn sandbox_handle_start_process_supports_long_running_request_response_protocol_inner(
     handle: Arc<dyn ManagedSandboxHandle>,
 ) -> crate::Result<()> {
@@ -476,7 +603,7 @@ async fn sandbox_handle_start_process_supports_long_running_request_response_pro
         .start_process(&SandboxCommand {
             argv: vec![
                 "/bin/sh".to_string(),
-                "-lc".to_string(),
+                "-c".to_string(),
                 [
                     "printf 'protocol-ready\\n'",
                     "while IFS= read -r line; do",

--- a/crates/exoharness/src/contract_tests.rs
+++ b/crates/exoharness/src/contract_tests.rs
@@ -437,7 +437,7 @@ async fn sandbox_handle_start_process_supports_interactive_stdio_and_env_inner(
         .start_process(&SandboxCommand {
             argv: vec![
                 "/bin/sh".to_string(),
-                "-lc".to_string(),
+                "-c".to_string(),
                 "printf 'ready\\n'; IFS= read -r line; printf 'env=%s input=%s\\n' \"$EXO_CONTRACT_ENV\" \"$line\"".to_string(),
             ],
             env,
@@ -603,7 +603,7 @@ async fn sandbox_handle_start_process_supports_long_running_request_response_pro
         .start_process(&SandboxCommand {
             argv: vec![
                 "/bin/sh".to_string(),
-                "-lc".to_string(),
+                "-c".to_string(),
                 [
                     "printf 'protocol-ready\\n'",
                     "while IFS= read -r line; do",

--- a/crates/exoharness/src/contract_tests.rs
+++ b/crates/exoharness/src/contract_tests.rs
@@ -10,8 +10,8 @@ use tokio::time::timeout;
 use crate::{
     AddEventsRequest, BeginTurnRequest, Binding, EventData, EventKind, EventQuery,
     EventQueryDirection, ExoHarness, ForkConversationRequest, ListConversationsRequest,
-    ManagedSandboxHandle, NewAgentRequest, NewConversationRequest, SandboxCommand, Uuid7,
-    WriteArtifactRequest,
+    ManagedSandboxBackend, ManagedSandboxHandle, NewAgentRequest, NewConversationRequest,
+    SandboxCommand, SandboxRequest, Uuid7, WriteArtifactRequest,
 };
 
 pub async fn supports_agent_and_conversation_crud(harness: Arc<dyn ExoHarness>) {
@@ -388,6 +388,44 @@ pub async fn sandbox_handle_start_process_supports_long_running_request_response
     }
 }
 
+pub async fn sandbox_backend_durable_file_system_survives_stop_and_reacquire(
+    backend: Arc<dyn ManagedSandboxBackend>,
+    request: SandboxRequest,
+) -> crate::Result<()> {
+    let mount_path = request
+        .spec
+        .durable_file_systems
+        .first()
+        .context("durable filesystem contract requires a durable filesystem")?
+        .mount_path
+        .clone();
+    let marker = format!("durable-{}", Uuid7::now());
+
+    let first = backend
+        .acquire(request.clone())
+        .await
+        .context("acquire sandbox for durable filesystem write")?;
+    let write_result = write_durable_marker(Arc::clone(&first), &mount_path, &marker).await;
+    stop_after_contract(
+        first,
+        write_result,
+        "stop sandbox after durable filesystem write",
+    )
+    .await?;
+
+    let second = backend
+        .acquire(request)
+        .await
+        .context("reacquire sandbox for durable filesystem read")?;
+    let read_result = read_durable_marker(Arc::clone(&second), &mount_path, &marker).await;
+    stop_after_contract(
+        second,
+        read_result,
+        "stop sandbox after durable filesystem read",
+    )
+    .await
+}
+
 async fn sandbox_handle_start_process_supports_interactive_stdio_and_env_inner(
     handle: Arc<dyn ManagedSandboxHandle>,
 ) -> crate::Result<()> {
@@ -467,6 +505,96 @@ async fn sandbox_handle_start_process_supports_interactive_stdio_and_env_inner(
         bail!("unexpected stderr: {stderr:?}");
     }
     Ok(())
+}
+
+async fn write_durable_marker(
+    handle: Arc<dyn ManagedSandboxHandle>,
+    mount_path: &str,
+    marker: &str,
+) -> crate::Result<()> {
+    let mut env = std::collections::HashMap::new();
+    env.insert("EXO_DURABLE_MOUNT".to_string(), mount_path.to_string());
+    env.insert("EXO_DURABLE_MARKER".to_string(), marker.to_string());
+    let output = handle
+        .exec(&SandboxCommand {
+            argv: vec![
+                "/bin/sh".to_string(),
+                "-lc".to_string(),
+                "test \"$(pwd)\" = \"$EXO_DURABLE_MOUNT\" && mkdir -p .codex-smoke && printf '%s' \"$EXO_DURABLE_MARKER\" > .codex-smoke/marker.txt"
+                    .to_string(),
+            ],
+            env,
+            display_argv: None,
+            cwd: None,
+            timeout: Some(Duration::from_secs(30)),
+        })
+        .await
+        .context("write durable filesystem marker")?;
+    if !output.ok {
+        bail!(
+            "write durable filesystem marker failed with exit code {:?}: {}{}",
+            output.exit_code,
+            output.stdout,
+            output.stderr
+        );
+    }
+    Ok(())
+}
+
+async fn read_durable_marker(
+    handle: Arc<dyn ManagedSandboxHandle>,
+    mount_path: &str,
+    expected_marker: &str,
+) -> crate::Result<()> {
+    let mut env = std::collections::HashMap::new();
+    env.insert("EXO_DURABLE_MOUNT".to_string(), mount_path.to_string());
+    let output = handle
+        .exec(&SandboxCommand {
+            argv: vec![
+                "/bin/sh".to_string(),
+                "-lc".to_string(),
+                "test \"$(pwd)\" = \"$EXO_DURABLE_MOUNT\" && cat .codex-smoke/marker.txt"
+                    .to_string(),
+            ],
+            env,
+            display_argv: None,
+            cwd: None,
+            timeout: Some(Duration::from_secs(30)),
+        })
+        .await
+        .context("read durable filesystem marker")?;
+    if !output.ok {
+        bail!(
+            "read durable filesystem marker failed with exit code {:?}: {}{}",
+            output.exit_code,
+            output.stdout,
+            output.stderr
+        );
+    }
+    if output.stdout != expected_marker {
+        bail!(
+            "durable filesystem marker mismatch: expected {:?}, got {:?}",
+            expected_marker,
+            output.stdout
+        );
+    }
+    Ok(())
+}
+
+async fn stop_after_contract(
+    handle: Arc<dyn ManagedSandboxHandle>,
+    result: crate::Result<()>,
+    context: &str,
+) -> crate::Result<()> {
+    let stop_result = handle.stop().await.with_context(|| context.to_string());
+    match (result, stop_result) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) => Err(error),
+        (Ok(()), Err(error)) => Err(error),
+        (Err(error), Err(stop_error)) => Err(anyhow!(
+            "{error:#}; also failed to stop sandbox after contract: {stop_error:#}"
+        )),
+    }
 }
 
 async fn sandbox_handle_start_process_supports_long_running_request_response_protocol_inner(

--- a/crates/exoharness/src/contract_tests.rs
+++ b/crates/exoharness/src/contract_tests.rs
@@ -110,7 +110,6 @@ pub async fn list_conversations_returns_recent_first_and_paginates(harness: Arc<
         .add_events(AddEventsRequest {
             session_id: None,
             turn_id: None,
-            expected_head: None,
             data: vec![EventData::Custom {
                 event_type: "touch".to_string(),
                 payload: serde_json::Value::Null,

--- a/crates/exoharness/src/http/client.rs
+++ b/crates/exoharness/src/http/client.rs
@@ -24,8 +24,8 @@ use crate::{
     NewAgentRequest, NewConversationRequest, PutSecretRequest, ReadArtifactRequest, Result,
     RunInSandboxRequest, SandboxHandle, SandboxId, SandboxProcess, SandboxProcessEventQuery,
     SandboxProcessParts, SandboxProcessRecord, SandboxProcessStatus, Secret, SecretId,
-    SecretMetadata, SessionId, SnapshotId, StartSandboxProcessRequest, StartSandboxRequest,
-    TurnHandle, TurnRecord, WaitSandboxProcessRequest, WriteArtifactRequest,
+    SecretMetadata, SessionId, SnapshotHandle, SnapshotId, StartSandboxProcessRequest,
+    StartSandboxRequest, TurnHandle, TurnRecord, WaitSandboxProcessRequest, WriteArtifactRequest,
     WriteSandboxProcessInputRequest,
 };
 
@@ -797,17 +797,20 @@ impl AgentHandle for HttpAgentHandle {
 }
 
 #[async_trait]
-impl SandboxHandle for HttpAgentHandle {
-    async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
-        http_create_sandbox(&self.harness, self.sandbox_scope(), request).await
-    }
-
+impl SnapshotHandle for HttpAgentHandle {
     async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
         http_snapshot_sandbox(&self.harness, self.sandbox_scope(), id).await
     }
 
     async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
         http_start_sandbox(&self.harness, self.sandbox_scope(), request).await
+    }
+}
+
+#[async_trait]
+impl SandboxHandle for HttpAgentHandle {
+    async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
+        http_create_sandbox(&self.harness, self.sandbox_scope(), request).await
     }
 
     async fn stop_sandbox(&self, id: SandboxId) -> Result<()> {
@@ -1162,17 +1165,20 @@ impl ConversationHandle for HttpConversationHandle {
 }
 
 #[async_trait]
-impl SandboxHandle for HttpConversationHandle {
-    async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
-        http_create_sandbox(&self.harness, self.sandbox_scope(), request).await
-    }
-
+impl SnapshotHandle for HttpConversationHandle {
     async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
         http_snapshot_sandbox(&self.harness, self.sandbox_scope(), id).await
     }
 
     async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
         http_start_sandbox(&self.harness, self.sandbox_scope(), request).await
+    }
+}
+
+#[async_trait]
+impl SandboxHandle for HttpConversationHandle {
+    async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
+        http_create_sandbox(&self.harness, self.sandbox_scope(), request).await
     }
 
     async fn stop_sandbox(&self, id: SandboxId) -> Result<()> {
@@ -1252,6 +1258,43 @@ impl HttpTurnHandle {
 }
 
 #[async_trait]
+impl SnapshotHandle for HttpTurnHandle {
+    async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
+        match self
+            .harness
+            .request(Request::TurnSnapshotSandbox {
+                agent_id: self.agent_id,
+                conversation_id: self.conversation_id,
+                session_id: self.record.session_id,
+                turn_id: self.record.id,
+                sandbox_id: id,
+            })
+            .await?
+        {
+            Response::SnapshotId { snapshot_id } => Ok(snapshot_id),
+            response => unexpected_response(response, "snapshot_id"),
+        }
+    }
+
+    async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
+        match self
+            .harness
+            .request(Request::TurnStartSandbox {
+                agent_id: self.agent_id,
+                conversation_id: self.conversation_id,
+                session_id: self.record.session_id,
+                turn_id: self.record.id,
+                request,
+            })
+            .await?
+        {
+            Response::Unit => Ok(()),
+            response => unexpected_response(response, "unit"),
+        }
+    }
+}
+
+#[async_trait]
 impl TurnHandle for HttpTurnHandle {
     fn record(&self) -> &TurnRecord {
         &self.record
@@ -1288,40 +1331,6 @@ impl TurnHandle for HttpTurnHandle {
         {
             Response::ArtifactVersion { artifact } => Ok(artifact),
             response => unexpected_response(response, "artifact_version"),
-        }
-    }
-
-    async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
-        match self
-            .harness
-            .request(Request::TurnSnapshotSandbox {
-                agent_id: self.agent_id,
-                conversation_id: self.conversation_id,
-                session_id: self.record.session_id,
-                turn_id: self.record.id,
-                sandbox_id: id,
-            })
-            .await?
-        {
-            Response::SnapshotId { snapshot_id } => Ok(snapshot_id),
-            response => unexpected_response(response, "snapshot_id"),
-        }
-    }
-
-    async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
-        match self
-            .harness
-            .request(Request::TurnStartSandbox {
-                agent_id: self.agent_id,
-                conversation_id: self.conversation_id,
-                session_id: self.record.session_id,
-                turn_id: self.record.id,
-                request,
-            })
-            .await?
-        {
-            Response::Unit => Ok(()),
-            response => unexpected_response(response, "unit"),
         }
     }
 

--- a/crates/exoharness/src/http/client.rs
+++ b/crates/exoharness/src/http/client.rs
@@ -10,10 +10,12 @@ use url::Url;
 
 use super::HTTP_EXOHARNESS_REQUEST_PATH;
 use super::process::{
-    HttpSandboxProcessScope, LiveHttpSandboxProcess, spawn_http_sandbox_process_event_poller,
+    LiveHttpSandboxProcess, spawn_http_sandbox_process_event_poller,
     spawn_http_sandbox_process_stdin_forwarder,
 };
-use crate::protocol::{ClientMessage, ConversationHandleInfo, Request, Response, ServerMessage};
+use crate::protocol::{
+    ClientMessage, ConversationHandleInfo, Request, Response, SandboxScope, ServerMessage,
+};
 use crate::{
     AddEventsRequest, AddEventsResult, AgentHandle, AgentId, AgentRecord, Artifact,
     ArtifactVersion, BeginTurnRequest, Binding, BindingId, BindingRecord,
@@ -193,204 +195,20 @@ impl HttpAgentHandle {
         Self { harness, record }
     }
 
-    fn sandbox_scope(&self) -> HttpSandboxScope {
-        HttpSandboxScope::Agent {
+    fn sandbox_scope(&self) -> SandboxScope {
+        SandboxScope::Agent {
             agent_id: self.record.id,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy)]
-enum HttpSandboxScope {
-    Agent {
-        agent_id: AgentId,
-    },
-    Conversation {
-        agent_id: AgentId,
-        conversation_id: ConversationId,
-    },
-}
-
-impl HttpSandboxScope {
-    fn agent_id(self) -> AgentId {
-        match self {
-            Self::Agent { agent_id } | Self::Conversation { agent_id, .. } => agent_id,
-        }
-    }
-
-    fn process_scope(self) -> HttpSandboxProcessScope {
-        match self {
-            Self::Agent { .. } => HttpSandboxProcessScope::Agent,
-            Self::Conversation {
-                conversation_id, ..
-            } => HttpSandboxProcessScope::Conversation { conversation_id },
-        }
-    }
-
-    fn create_sandbox_request(self, request: CreateSandboxRequest) -> Request {
-        match self {
-            Self::Agent { agent_id } => Request::AgentCreateSandbox { agent_id, request },
-            Self::Conversation {
-                agent_id,
-                conversation_id,
-            } => Request::ConversationCreateSandbox {
-                agent_id,
-                conversation_id,
-                request,
-            },
-        }
-    }
-
-    fn snapshot_sandbox_request(self, sandbox_id: SandboxId) -> Request {
-        match self {
-            Self::Agent { agent_id } => Request::AgentSnapshotSandbox {
-                agent_id,
-                sandbox_id,
-            },
-            Self::Conversation {
-                agent_id,
-                conversation_id,
-            } => Request::ConversationSnapshotSandbox {
-                agent_id,
-                conversation_id,
-                sandbox_id,
-            },
-        }
-    }
-
-    fn start_sandbox_request(self, request: StartSandboxRequest) -> Request {
-        match self {
-            Self::Agent { agent_id } => Request::AgentStartSandbox { agent_id, request },
-            Self::Conversation {
-                agent_id,
-                conversation_id,
-            } => Request::ConversationStartSandbox {
-                agent_id,
-                conversation_id,
-                request,
-            },
-        }
-    }
-
-    fn stop_sandbox_request(self, sandbox_id: SandboxId) -> Request {
-        match self {
-            Self::Agent { agent_id } => Request::AgentStopSandbox {
-                agent_id,
-                sandbox_id,
-            },
-            Self::Conversation {
-                agent_id,
-                conversation_id,
-            } => Request::ConversationStopSandbox {
-                agent_id,
-                conversation_id,
-                sandbox_id,
-            },
-        }
-    }
-
-    fn start_sandbox_process_request(self, request: StartSandboxProcessRequest) -> Request {
-        match self {
-            Self::Agent { agent_id } => Request::AgentStartSandboxProcess { agent_id, request },
-            Self::Conversation {
-                agent_id,
-                conversation_id,
-            } => Request::ConversationStartSandboxProcess {
-                agent_id,
-                conversation_id,
-                request,
-            },
-        }
-    }
-
-    fn write_sandbox_process_input_request(
-        self,
-        request: WriteSandboxProcessInputRequest,
-    ) -> Request {
-        match self {
-            Self::Agent { agent_id } => {
-                Request::AgentWriteSandboxProcessInput { agent_id, request }
-            }
-            Self::Conversation {
-                agent_id,
-                conversation_id,
-            } => Request::ConversationWriteSandboxProcessInput {
-                agent_id,
-                conversation_id,
-                request,
-            },
-        }
-    }
-
-    fn close_sandbox_process_input_request(
-        self,
-        request: CloseSandboxProcessInputRequest,
-    ) -> Request {
-        match self {
-            Self::Agent { agent_id } => {
-                Request::AgentCloseSandboxProcessInput { agent_id, request }
-            }
-            Self::Conversation {
-                agent_id,
-                conversation_id,
-            } => Request::ConversationCloseSandboxProcessInput {
-                agent_id,
-                conversation_id,
-                request,
-            },
-        }
-    }
-
-    fn get_sandbox_process_events_request(self, query: SandboxProcessEventQuery) -> Request {
-        match self {
-            Self::Agent { agent_id } => Request::AgentGetSandboxProcessEvents { agent_id, query },
-            Self::Conversation {
-                agent_id,
-                conversation_id,
-            } => Request::ConversationGetSandboxProcessEvents {
-                agent_id,
-                conversation_id,
-                query,
-            },
-        }
-    }
-
-    fn wait_sandbox_process_request(self, request: WaitSandboxProcessRequest) -> Request {
-        match self {
-            Self::Agent { agent_id } => Request::AgentWaitSandboxProcess { agent_id, request },
-            Self::Conversation {
-                agent_id,
-                conversation_id,
-            } => Request::ConversationWaitSandboxProcess {
-                agent_id,
-                conversation_id,
-                request,
-            },
-        }
-    }
-
-    fn cancel_sandbox_process_request(self, request: CancelSandboxProcessRequest) -> Request {
-        match self {
-            Self::Agent { agent_id } => Request::AgentCancelSandboxProcess { agent_id, request },
-            Self::Conversation {
-                agent_id,
-                conversation_id,
-            } => Request::ConversationCancelSandboxProcess {
-                agent_id,
-                conversation_id,
-                request,
-            },
         }
     }
 }
 
 async fn http_create_sandbox(
     harness: &HttpExoHarness,
-    scope: HttpSandboxScope,
+    scope: SandboxScope,
     request: CreateSandboxRequest,
 ) -> Result<SandboxId> {
     match harness
-        .request(scope.create_sandbox_request(request))
+        .request(Request::CreateSandbox { scope, request })
         .await?
     {
         Response::SandboxId { sandbox_id } => Ok(sandbox_id),
@@ -400,10 +218,16 @@ async fn http_create_sandbox(
 
 async fn http_snapshot_sandbox(
     harness: &HttpExoHarness,
-    scope: HttpSandboxScope,
+    scope: SandboxScope,
     id: SandboxId,
 ) -> Result<SnapshotId> {
-    match harness.request(scope.snapshot_sandbox_request(id)).await? {
+    match harness
+        .request(Request::SnapshotSandbox {
+            scope,
+            sandbox_id: id,
+        })
+        .await?
+    {
         Response::SnapshotId { snapshot_id } => Ok(snapshot_id),
         response => unexpected_response(response, "snapshot_id"),
     }
@@ -411,11 +235,11 @@ async fn http_snapshot_sandbox(
 
 async fn http_start_sandbox(
     harness: &HttpExoHarness,
-    scope: HttpSandboxScope,
+    scope: SandboxScope,
     request: StartSandboxRequest,
 ) -> Result<()> {
     match harness
-        .request(scope.start_sandbox_request(request))
+        .request(Request::StartSandbox { scope, request })
         .await?
     {
         Response::Unit => Ok(()),
@@ -425,10 +249,16 @@ async fn http_start_sandbox(
 
 async fn http_stop_sandbox(
     harness: &HttpExoHarness,
-    scope: HttpSandboxScope,
+    scope: SandboxScope,
     id: SandboxId,
 ) -> Result<()> {
-    match harness.request(scope.stop_sandbox_request(id)).await? {
+    match harness
+        .request(Request::StopSandbox {
+            scope,
+            sandbox_id: id,
+        })
+        .await?
+    {
         Response::Unit => Ok(()),
         response => unexpected_response(response, "unit"),
     }
@@ -436,11 +266,11 @@ async fn http_stop_sandbox(
 
 async fn http_start_sandbox_process(
     harness: &HttpExoHarness,
-    scope: HttpSandboxScope,
+    scope: SandboxScope,
     request: StartSandboxProcessRequest,
 ) -> Result<SandboxProcessRecord> {
     match harness
-        .request(scope.start_sandbox_process_request(request))
+        .request(Request::StartSandboxProcess { scope, request })
         .await?
     {
         Response::SandboxProcess { process } => Ok(process),
@@ -450,11 +280,11 @@ async fn http_start_sandbox_process(
 
 async fn http_write_sandbox_process_input(
     harness: &HttpExoHarness,
-    scope: HttpSandboxScope,
+    scope: SandboxScope,
     request: WriteSandboxProcessInputRequest,
 ) -> Result<()> {
     match harness
-        .request(scope.write_sandbox_process_input_request(request))
+        .request(Request::WriteSandboxProcessInput { scope, request })
         .await?
     {
         Response::Unit => Ok(()),
@@ -464,11 +294,11 @@ async fn http_write_sandbox_process_input(
 
 async fn http_close_sandbox_process_input(
     harness: &HttpExoHarness,
-    scope: HttpSandboxScope,
+    scope: SandboxScope,
     request: CloseSandboxProcessInputRequest,
 ) -> Result<()> {
     match harness
-        .request(scope.close_sandbox_process_input_request(request))
+        .request(Request::CloseSandboxProcessInput { scope, request })
         .await?
     {
         Response::Unit => Ok(()),
@@ -478,11 +308,11 @@ async fn http_close_sandbox_process_input(
 
 async fn http_get_sandbox_process_events(
     harness: &HttpExoHarness,
-    scope: HttpSandboxScope,
+    scope: SandboxScope,
     query: SandboxProcessEventQuery,
 ) -> Result<GetSandboxProcessEventsResult> {
     match harness
-        .request(scope.get_sandbox_process_events_request(query))
+        .request(Request::GetSandboxProcessEvents { scope, query })
         .await?
     {
         Response::SandboxProcessEvents { result } => Ok(result),
@@ -492,11 +322,11 @@ async fn http_get_sandbox_process_events(
 
 async fn http_wait_sandbox_process(
     harness: &HttpExoHarness,
-    scope: HttpSandboxScope,
+    scope: SandboxScope,
     request: WaitSandboxProcessRequest,
 ) -> Result<SandboxProcessStatus> {
     match harness
-        .request(scope.wait_sandbox_process_request(request))
+        .request(Request::WaitSandboxProcess { scope, request })
         .await?
     {
         Response::SandboxProcessStatus { status } => Ok(status),
@@ -506,11 +336,11 @@ async fn http_wait_sandbox_process(
 
 async fn http_cancel_sandbox_process(
     harness: &HttpExoHarness,
-    scope: HttpSandboxScope,
+    scope: SandboxScope,
     request: CancelSandboxProcessRequest,
 ) -> Result<SandboxProcessStatus> {
     match harness
-        .request(scope.cancel_sandbox_process_request(request))
+        .request(Request::CancelSandboxProcess { scope, request })
         .await?
     {
         Response::SandboxProcessStatus { status } => Ok(status),
@@ -520,7 +350,7 @@ async fn http_cancel_sandbox_process(
 
 async fn http_run_in_sandbox(
     harness: &HttpExoHarness,
-    scope: HttpSandboxScope,
+    scope: SandboxScope,
     request: RunInSandboxRequest,
 ) -> Result<Box<dyn SandboxProcess>> {
     let sandbox_id = request.id;
@@ -546,8 +376,7 @@ async fn http_run_in_sandbox(
     let (wait_tx, wait_rx) = oneshot::channel();
     spawn_http_sandbox_process_event_poller(
         harness.clone(),
-        scope.agent_id(),
-        scope.process_scope(),
+        scope,
         sandbox_id.clone(),
         process.id.clone(),
         stdout_writer,
@@ -556,8 +385,7 @@ async fn http_run_in_sandbox(
     );
     spawn_http_sandbox_process_stdin_forwarder(
         harness.clone(),
-        scope.agent_id(),
-        scope.process_scope(),
+        scope,
         sandbox_id,
         process.id,
         stdin_reader,
@@ -889,8 +717,8 @@ impl HttpConversationHandle {
         }
     }
 
-    fn sandbox_scope(&self) -> HttpSandboxScope {
-        HttpSandboxScope::Conversation {
+    fn sandbox_scope(&self) -> SandboxScope {
+        SandboxScope::Conversation {
             agent_id: self.agent_id,
             conversation_id: self.record.id,
         }
@@ -1255,42 +1083,25 @@ impl HttpTurnHandle {
             record,
         }
     }
+
+    fn sandbox_scope(&self) -> SandboxScope {
+        SandboxScope::Turn {
+            agent_id: self.agent_id,
+            conversation_id: self.conversation_id,
+            session_id: self.record.session_id,
+            turn_id: self.record.id,
+        }
+    }
 }
 
 #[async_trait]
 impl SnapshotHandle for HttpTurnHandle {
     async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
-        match self
-            .harness
-            .request(Request::TurnSnapshotSandbox {
-                agent_id: self.agent_id,
-                conversation_id: self.conversation_id,
-                session_id: self.record.session_id,
-                turn_id: self.record.id,
-                sandbox_id: id,
-            })
-            .await?
-        {
-            Response::SnapshotId { snapshot_id } => Ok(snapshot_id),
-            response => unexpected_response(response, "snapshot_id"),
-        }
+        http_snapshot_sandbox(&self.harness, self.sandbox_scope(), id).await
     }
 
     async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
-        match self
-            .harness
-            .request(Request::TurnStartSandbox {
-                agent_id: self.agent_id,
-                conversation_id: self.conversation_id,
-                session_id: self.record.session_id,
-                turn_id: self.record.id,
-                request,
-            })
-            .await?
-        {
-            Response::Unit => Ok(()),
-            response => unexpected_response(response, "unit"),
-        }
+        http_start_sandbox(&self.harness, self.sandbox_scope(), request).await
     }
 }
 

--- a/crates/exoharness/src/http/client.rs
+++ b/crates/exoharness/src/http/client.rs
@@ -10,7 +10,7 @@ use url::Url;
 
 use super::HTTP_EXOHARNESS_REQUEST_PATH;
 use super::process::{
-    LiveHttpSandboxProcess, spawn_http_sandbox_process_event_poller,
+    HttpSandboxProcessScope, LiveHttpSandboxProcess, spawn_http_sandbox_process_event_poller,
     spawn_http_sandbox_process_stdin_forwarder,
 };
 use crate::protocol::{ClientMessage, ConversationHandleInfo, Request, Response, ServerMessage};
@@ -22,10 +22,11 @@ use crate::{
     EventQuery, EventStream, ExoHarness, ForkConversationRequest, GetEventsResult,
     GetSandboxProcessEventsResult, ListConversationsRequest, ListConversationsResult,
     NewAgentRequest, NewConversationRequest, PutSecretRequest, ReadArtifactRequest, Result,
-    RunInSandboxRequest, SandboxId, SandboxProcess, SandboxProcessEventQuery, SandboxProcessParts,
-    SandboxProcessRecord, SandboxProcessStatus, Secret, SecretId, SecretMetadata, SessionId,
-    SnapshotId, StartSandboxProcessRequest, StartSandboxRequest, TurnHandle, TurnRecord,
-    WaitSandboxProcessRequest, WriteArtifactRequest, WriteSandboxProcessInputRequest,
+    RunInSandboxRequest, SandboxHandle, SandboxId, SandboxProcess, SandboxProcessEventQuery,
+    SandboxProcessParts, SandboxProcessRecord, SandboxProcessStatus, Secret, SecretId,
+    SecretMetadata, SessionId, SnapshotId, StartSandboxProcessRequest, StartSandboxRequest,
+    TurnHandle, TurnRecord, WaitSandboxProcessRequest, WriteArtifactRequest,
+    WriteSandboxProcessInputRequest,
 };
 
 #[derive(Clone)]
@@ -191,6 +192,388 @@ impl HttpAgentHandle {
     fn new(harness: HttpExoHarness, record: AgentRecord) -> Self {
         Self { harness, record }
     }
+
+    fn sandbox_scope(&self) -> HttpSandboxScope {
+        HttpSandboxScope::Agent {
+            agent_id: self.record.id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum HttpSandboxScope {
+    Agent {
+        agent_id: AgentId,
+    },
+    Conversation {
+        agent_id: AgentId,
+        conversation_id: ConversationId,
+    },
+}
+
+impl HttpSandboxScope {
+    fn agent_id(self) -> AgentId {
+        match self {
+            Self::Agent { agent_id } | Self::Conversation { agent_id, .. } => agent_id,
+        }
+    }
+
+    fn process_scope(self) -> HttpSandboxProcessScope {
+        match self {
+            Self::Agent { .. } => HttpSandboxProcessScope::Agent,
+            Self::Conversation {
+                conversation_id, ..
+            } => HttpSandboxProcessScope::Conversation { conversation_id },
+        }
+    }
+
+    fn create_sandbox_request(self, request: CreateSandboxRequest) -> Request {
+        match self {
+            Self::Agent { agent_id } => Request::AgentCreateSandbox { agent_id, request },
+            Self::Conversation {
+                agent_id,
+                conversation_id,
+            } => Request::ConversationCreateSandbox {
+                agent_id,
+                conversation_id,
+                request,
+            },
+        }
+    }
+
+    fn snapshot_sandbox_request(self, sandbox_id: SandboxId) -> Request {
+        match self {
+            Self::Agent { agent_id } => Request::AgentSnapshotSandbox {
+                agent_id,
+                sandbox_id,
+            },
+            Self::Conversation {
+                agent_id,
+                conversation_id,
+            } => Request::ConversationSnapshotSandbox {
+                agent_id,
+                conversation_id,
+                sandbox_id,
+            },
+        }
+    }
+
+    fn start_sandbox_request(self, request: StartSandboxRequest) -> Request {
+        match self {
+            Self::Agent { agent_id } => Request::AgentStartSandbox { agent_id, request },
+            Self::Conversation {
+                agent_id,
+                conversation_id,
+            } => Request::ConversationStartSandbox {
+                agent_id,
+                conversation_id,
+                request,
+            },
+        }
+    }
+
+    fn stop_sandbox_request(self, sandbox_id: SandboxId) -> Request {
+        match self {
+            Self::Agent { agent_id } => Request::AgentStopSandbox {
+                agent_id,
+                sandbox_id,
+            },
+            Self::Conversation {
+                agent_id,
+                conversation_id,
+            } => Request::ConversationStopSandbox {
+                agent_id,
+                conversation_id,
+                sandbox_id,
+            },
+        }
+    }
+
+    fn start_sandbox_process_request(self, request: StartSandboxProcessRequest) -> Request {
+        match self {
+            Self::Agent { agent_id } => Request::AgentStartSandboxProcess { agent_id, request },
+            Self::Conversation {
+                agent_id,
+                conversation_id,
+            } => Request::ConversationStartSandboxProcess {
+                agent_id,
+                conversation_id,
+                request,
+            },
+        }
+    }
+
+    fn write_sandbox_process_input_request(
+        self,
+        request: WriteSandboxProcessInputRequest,
+    ) -> Request {
+        match self {
+            Self::Agent { agent_id } => {
+                Request::AgentWriteSandboxProcessInput { agent_id, request }
+            }
+            Self::Conversation {
+                agent_id,
+                conversation_id,
+            } => Request::ConversationWriteSandboxProcessInput {
+                agent_id,
+                conversation_id,
+                request,
+            },
+        }
+    }
+
+    fn close_sandbox_process_input_request(
+        self,
+        request: CloseSandboxProcessInputRequest,
+    ) -> Request {
+        match self {
+            Self::Agent { agent_id } => {
+                Request::AgentCloseSandboxProcessInput { agent_id, request }
+            }
+            Self::Conversation {
+                agent_id,
+                conversation_id,
+            } => Request::ConversationCloseSandboxProcessInput {
+                agent_id,
+                conversation_id,
+                request,
+            },
+        }
+    }
+
+    fn get_sandbox_process_events_request(self, query: SandboxProcessEventQuery) -> Request {
+        match self {
+            Self::Agent { agent_id } => Request::AgentGetSandboxProcessEvents { agent_id, query },
+            Self::Conversation {
+                agent_id,
+                conversation_id,
+            } => Request::ConversationGetSandboxProcessEvents {
+                agent_id,
+                conversation_id,
+                query,
+            },
+        }
+    }
+
+    fn wait_sandbox_process_request(self, request: WaitSandboxProcessRequest) -> Request {
+        match self {
+            Self::Agent { agent_id } => Request::AgentWaitSandboxProcess { agent_id, request },
+            Self::Conversation {
+                agent_id,
+                conversation_id,
+            } => Request::ConversationWaitSandboxProcess {
+                agent_id,
+                conversation_id,
+                request,
+            },
+        }
+    }
+
+    fn cancel_sandbox_process_request(self, request: CancelSandboxProcessRequest) -> Request {
+        match self {
+            Self::Agent { agent_id } => Request::AgentCancelSandboxProcess { agent_id, request },
+            Self::Conversation {
+                agent_id,
+                conversation_id,
+            } => Request::ConversationCancelSandboxProcess {
+                agent_id,
+                conversation_id,
+                request,
+            },
+        }
+    }
+}
+
+async fn http_create_sandbox(
+    harness: &HttpExoHarness,
+    scope: HttpSandboxScope,
+    request: CreateSandboxRequest,
+) -> Result<SandboxId> {
+    match harness
+        .request(scope.create_sandbox_request(request))
+        .await?
+    {
+        Response::SandboxId { sandbox_id } => Ok(sandbox_id),
+        response => unexpected_response(response, "sandbox_id"),
+    }
+}
+
+async fn http_snapshot_sandbox(
+    harness: &HttpExoHarness,
+    scope: HttpSandboxScope,
+    id: SandboxId,
+) -> Result<SnapshotId> {
+    match harness.request(scope.snapshot_sandbox_request(id)).await? {
+        Response::SnapshotId { snapshot_id } => Ok(snapshot_id),
+        response => unexpected_response(response, "snapshot_id"),
+    }
+}
+
+async fn http_start_sandbox(
+    harness: &HttpExoHarness,
+    scope: HttpSandboxScope,
+    request: StartSandboxRequest,
+) -> Result<()> {
+    match harness
+        .request(scope.start_sandbox_request(request))
+        .await?
+    {
+        Response::Unit => Ok(()),
+        response => unexpected_response(response, "unit"),
+    }
+}
+
+async fn http_stop_sandbox(
+    harness: &HttpExoHarness,
+    scope: HttpSandboxScope,
+    id: SandboxId,
+) -> Result<()> {
+    match harness.request(scope.stop_sandbox_request(id)).await? {
+        Response::Unit => Ok(()),
+        response => unexpected_response(response, "unit"),
+    }
+}
+
+async fn http_start_sandbox_process(
+    harness: &HttpExoHarness,
+    scope: HttpSandboxScope,
+    request: StartSandboxProcessRequest,
+) -> Result<SandboxProcessRecord> {
+    match harness
+        .request(scope.start_sandbox_process_request(request))
+        .await?
+    {
+        Response::SandboxProcess { process } => Ok(process),
+        response => unexpected_response(response, "sandbox_process"),
+    }
+}
+
+async fn http_write_sandbox_process_input(
+    harness: &HttpExoHarness,
+    scope: HttpSandboxScope,
+    request: WriteSandboxProcessInputRequest,
+) -> Result<()> {
+    match harness
+        .request(scope.write_sandbox_process_input_request(request))
+        .await?
+    {
+        Response::Unit => Ok(()),
+        response => unexpected_response(response, "unit"),
+    }
+}
+
+async fn http_close_sandbox_process_input(
+    harness: &HttpExoHarness,
+    scope: HttpSandboxScope,
+    request: CloseSandboxProcessInputRequest,
+) -> Result<()> {
+    match harness
+        .request(scope.close_sandbox_process_input_request(request))
+        .await?
+    {
+        Response::Unit => Ok(()),
+        response => unexpected_response(response, "unit"),
+    }
+}
+
+async fn http_get_sandbox_process_events(
+    harness: &HttpExoHarness,
+    scope: HttpSandboxScope,
+    query: SandboxProcessEventQuery,
+) -> Result<GetSandboxProcessEventsResult> {
+    match harness
+        .request(scope.get_sandbox_process_events_request(query))
+        .await?
+    {
+        Response::SandboxProcessEvents { result } => Ok(result),
+        response => unexpected_response(response, "sandbox_process_events"),
+    }
+}
+
+async fn http_wait_sandbox_process(
+    harness: &HttpExoHarness,
+    scope: HttpSandboxScope,
+    request: WaitSandboxProcessRequest,
+) -> Result<SandboxProcessStatus> {
+    match harness
+        .request(scope.wait_sandbox_process_request(request))
+        .await?
+    {
+        Response::SandboxProcessStatus { status } => Ok(status),
+        response => unexpected_response(response, "sandbox_process_status"),
+    }
+}
+
+async fn http_cancel_sandbox_process(
+    harness: &HttpExoHarness,
+    scope: HttpSandboxScope,
+    request: CancelSandboxProcessRequest,
+) -> Result<SandboxProcessStatus> {
+    match harness
+        .request(scope.cancel_sandbox_process_request(request))
+        .await?
+    {
+        Response::SandboxProcessStatus { status } => Ok(status),
+        response => unexpected_response(response, "sandbox_process_status"),
+    }
+}
+
+async fn http_run_in_sandbox(
+    harness: &HttpExoHarness,
+    scope: HttpSandboxScope,
+    request: RunInSandboxRequest,
+) -> Result<Box<dyn SandboxProcess>> {
+    let sandbox_id = request.id;
+    let process = http_start_sandbox_process(
+        harness,
+        scope,
+        StartSandboxProcessRequest {
+            sandbox_id: sandbox_id.clone(),
+            name: None,
+            command: request.command,
+            env: request.env,
+            cwd: None,
+            mode: Default::default(),
+            stdin: Default::default(),
+            output: Default::default(),
+            lifecycle: Default::default(),
+        },
+    )
+    .await?;
+    let (stdout_reader, stdout_writer) = tokio::io::duplex(64 * 1024);
+    let (stderr_reader, stderr_writer) = tokio::io::duplex(64 * 1024);
+    let (stdin_reader, stdin_writer) = tokio::io::duplex(64 * 1024);
+    let (wait_tx, wait_rx) = oneshot::channel();
+    spawn_http_sandbox_process_event_poller(
+        harness.clone(),
+        scope.agent_id(),
+        scope.process_scope(),
+        sandbox_id.clone(),
+        process.id.clone(),
+        stdout_writer,
+        stderr_writer,
+        wait_tx,
+    );
+    spawn_http_sandbox_process_stdin_forwarder(
+        harness.clone(),
+        scope.agent_id(),
+        scope.process_scope(),
+        sandbox_id,
+        process.id,
+        stdin_reader,
+    );
+    Ok(Box::new(LiveHttpSandboxProcess {
+        parts: Some(SandboxProcessParts {
+            stdout: Box::pin(stdout_reader.compat()),
+            stderr: Box::pin(stderr_reader.compat()),
+            stdin: Box::pin(stdin_writer.compat_write()),
+            wait: Box::pin(async move {
+                wait_rx
+                    .await
+                    .unwrap_or_else(|_| Err(anyhow!("HTTP sandbox process poller stopped")))
+            }),
+        }),
+    }))
 }
 
 #[async_trait]
@@ -413,6 +796,74 @@ impl AgentHandle for HttpAgentHandle {
     }
 }
 
+#[async_trait]
+impl SandboxHandle for HttpAgentHandle {
+    async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
+        http_create_sandbox(&self.harness, self.sandbox_scope(), request).await
+    }
+
+    async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
+        http_snapshot_sandbox(&self.harness, self.sandbox_scope(), id).await
+    }
+
+    async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
+        http_start_sandbox(&self.harness, self.sandbox_scope(), request).await
+    }
+
+    async fn stop_sandbox(&self, id: SandboxId) -> Result<()> {
+        http_stop_sandbox(&self.harness, self.sandbox_scope(), id).await
+    }
+
+    async fn start_sandbox_process(
+        &self,
+        request: StartSandboxProcessRequest,
+    ) -> Result<SandboxProcessRecord> {
+        http_start_sandbox_process(&self.harness, self.sandbox_scope(), request).await
+    }
+
+    async fn write_sandbox_process_input(
+        &self,
+        request: WriteSandboxProcessInputRequest,
+    ) -> Result<()> {
+        http_write_sandbox_process_input(&self.harness, self.sandbox_scope(), request).await
+    }
+
+    async fn close_sandbox_process_input(
+        &self,
+        request: CloseSandboxProcessInputRequest,
+    ) -> Result<()> {
+        http_close_sandbox_process_input(&self.harness, self.sandbox_scope(), request).await
+    }
+
+    async fn get_sandbox_process_events(
+        &self,
+        query: SandboxProcessEventQuery,
+    ) -> Result<GetSandboxProcessEventsResult> {
+        http_get_sandbox_process_events(&self.harness, self.sandbox_scope(), query).await
+    }
+
+    async fn wait_sandbox_process(
+        &self,
+        request: WaitSandboxProcessRequest,
+    ) -> Result<SandboxProcessStatus> {
+        http_wait_sandbox_process(&self.harness, self.sandbox_scope(), request).await
+    }
+
+    async fn cancel_sandbox_process(
+        &self,
+        request: CancelSandboxProcessRequest,
+    ) -> Result<SandboxProcessStatus> {
+        http_cancel_sandbox_process(&self.harness, self.sandbox_scope(), request).await
+    }
+
+    async fn run_in_sandbox(
+        &self,
+        request: RunInSandboxRequest,
+    ) -> Result<Box<dyn SandboxProcess>> {
+        http_run_in_sandbox(&self.harness, self.sandbox_scope(), request).await
+    }
+}
+
 struct HttpConversationHandle {
     harness: HttpExoHarness,
     agent_id: AgentId,
@@ -432,6 +883,13 @@ impl HttpConversationHandle {
         ConversationHandleInfo {
             agent_id: self.agent_id,
             record: self.record.clone(),
+        }
+    }
+
+    fn sandbox_scope(&self) -> HttpSandboxScope {
+        HttpSandboxScope::Conversation {
+            agent_id: self.agent_id,
+            conversation_id: self.record.id,
         }
     }
 }
@@ -614,228 +1072,6 @@ impl ConversationHandle for HttpConversationHandle {
         }
     }
 
-    async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
-        match self
-            .harness
-            .request(Request::ConversationCreateSandbox {
-                agent_id: self.agent_id,
-                conversation_id: self.record.id,
-                request,
-            })
-            .await?
-        {
-            Response::SandboxId { sandbox_id } => Ok(sandbox_id),
-            response => unexpected_response(response, "sandbox_id"),
-        }
-    }
-
-    async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
-        match self
-            .harness
-            .request(Request::ConversationSnapshotSandbox {
-                agent_id: self.agent_id,
-                conversation_id: self.record.id,
-                sandbox_id: id,
-            })
-            .await?
-        {
-            Response::SnapshotId { snapshot_id } => Ok(snapshot_id),
-            response => unexpected_response(response, "snapshot_id"),
-        }
-    }
-
-    async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
-        match self
-            .harness
-            .request(Request::ConversationStartSandbox {
-                agent_id: self.agent_id,
-                conversation_id: self.record.id,
-                request,
-            })
-            .await?
-        {
-            Response::Unit => Ok(()),
-            response => unexpected_response(response, "unit"),
-        }
-    }
-
-    async fn stop_sandbox(&self, id: SandboxId) -> Result<()> {
-        match self
-            .harness
-            .request(Request::ConversationStopSandbox {
-                agent_id: self.agent_id,
-                conversation_id: self.record.id,
-                sandbox_id: id,
-            })
-            .await?
-        {
-            Response::Unit => Ok(()),
-            response => unexpected_response(response, "unit"),
-        }
-    }
-
-    async fn start_sandbox_process(
-        &self,
-        request: StartSandboxProcessRequest,
-    ) -> Result<SandboxProcessRecord> {
-        match self
-            .harness
-            .request(Request::ConversationStartSandboxProcess {
-                agent_id: self.agent_id,
-                conversation_id: self.record.id,
-                request,
-            })
-            .await?
-        {
-            Response::SandboxProcess { process } => Ok(process),
-            response => unexpected_response(response, "sandbox_process"),
-        }
-    }
-
-    async fn write_sandbox_process_input(
-        &self,
-        request: WriteSandboxProcessInputRequest,
-    ) -> Result<()> {
-        match self
-            .harness
-            .request(Request::ConversationWriteSandboxProcessInput {
-                agent_id: self.agent_id,
-                conversation_id: self.record.id,
-                request,
-            })
-            .await?
-        {
-            Response::Unit => Ok(()),
-            response => unexpected_response(response, "unit"),
-        }
-    }
-
-    async fn close_sandbox_process_input(
-        &self,
-        request: CloseSandboxProcessInputRequest,
-    ) -> Result<()> {
-        match self
-            .harness
-            .request(Request::ConversationCloseSandboxProcessInput {
-                agent_id: self.agent_id,
-                conversation_id: self.record.id,
-                request,
-            })
-            .await?
-        {
-            Response::Unit => Ok(()),
-            response => unexpected_response(response, "unit"),
-        }
-    }
-
-    async fn get_sandbox_process_events(
-        &self,
-        query: SandboxProcessEventQuery,
-    ) -> Result<GetSandboxProcessEventsResult> {
-        match self
-            .harness
-            .request(Request::ConversationGetSandboxProcessEvents {
-                agent_id: self.agent_id,
-                conversation_id: self.record.id,
-                query,
-            })
-            .await?
-        {
-            Response::SandboxProcessEvents { result } => Ok(result),
-            response => unexpected_response(response, "sandbox_process_events"),
-        }
-    }
-
-    async fn wait_sandbox_process(
-        &self,
-        request: WaitSandboxProcessRequest,
-    ) -> Result<SandboxProcessStatus> {
-        match self
-            .harness
-            .request(Request::ConversationWaitSandboxProcess {
-                agent_id: self.agent_id,
-                conversation_id: self.record.id,
-                request,
-            })
-            .await?
-        {
-            Response::SandboxProcessStatus { status } => Ok(status),
-            response => unexpected_response(response, "sandbox_process_status"),
-        }
-    }
-
-    async fn cancel_sandbox_process(
-        &self,
-        request: CancelSandboxProcessRequest,
-    ) -> Result<SandboxProcessStatus> {
-        match self
-            .harness
-            .request(Request::ConversationCancelSandboxProcess {
-                agent_id: self.agent_id,
-                conversation_id: self.record.id,
-                request,
-            })
-            .await?
-        {
-            Response::SandboxProcessStatus { status } => Ok(status),
-            response => unexpected_response(response, "sandbox_process_status"),
-        }
-    }
-
-    async fn run_in_sandbox(
-        &self,
-        request: RunInSandboxRequest,
-    ) -> Result<Box<dyn SandboxProcess>> {
-        let sandbox_id = request.id;
-        let process = self
-            .start_sandbox_process(StartSandboxProcessRequest {
-                sandbox_id: sandbox_id.clone(),
-                name: None,
-                command: request.command,
-                env: request.env,
-                cwd: None,
-                mode: Default::default(),
-                stdin: Default::default(),
-                output: Default::default(),
-                lifecycle: Default::default(),
-            })
-            .await?;
-        let (stdout_reader, stdout_writer) = tokio::io::duplex(64 * 1024);
-        let (stderr_reader, stderr_writer) = tokio::io::duplex(64 * 1024);
-        let (stdin_reader, stdin_writer) = tokio::io::duplex(64 * 1024);
-        let (wait_tx, wait_rx) = oneshot::channel();
-        spawn_http_sandbox_process_event_poller(
-            self.harness.clone(),
-            self.agent_id,
-            self.record.id,
-            sandbox_id.clone(),
-            process.id.clone(),
-            stdout_writer,
-            stderr_writer,
-            wait_tx,
-        );
-        spawn_http_sandbox_process_stdin_forwarder(
-            self.harness.clone(),
-            self.agent_id,
-            self.record.id,
-            sandbox_id,
-            process.id,
-            stdin_reader,
-        );
-        Ok(Box::new(LiveHttpSandboxProcess {
-            parts: Some(SandboxProcessParts {
-                stdout: Box::pin(stdout_reader.compat()),
-                stderr: Box::pin(stderr_reader.compat()),
-                stdin: Box::pin(stdin_writer.compat_write()),
-                wait: Box::pin(async move {
-                    wait_rx
-                        .await
-                        .unwrap_or_else(|_| Err(anyhow!("HTTP sandbox process poller stopped")))
-                }),
-            }),
-        }))
-    }
-
     async fn list_bindings(&self) -> Result<Vec<BindingRecord>> {
         match self
             .harness
@@ -922,6 +1158,74 @@ impl ConversationHandle for HttpConversationHandle {
             Response::Secret { secret } => Ok(secret),
             response => unexpected_response(response, "secret"),
         }
+    }
+}
+
+#[async_trait]
+impl SandboxHandle for HttpConversationHandle {
+    async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
+        http_create_sandbox(&self.harness, self.sandbox_scope(), request).await
+    }
+
+    async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
+        http_snapshot_sandbox(&self.harness, self.sandbox_scope(), id).await
+    }
+
+    async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
+        http_start_sandbox(&self.harness, self.sandbox_scope(), request).await
+    }
+
+    async fn stop_sandbox(&self, id: SandboxId) -> Result<()> {
+        http_stop_sandbox(&self.harness, self.sandbox_scope(), id).await
+    }
+
+    async fn start_sandbox_process(
+        &self,
+        request: StartSandboxProcessRequest,
+    ) -> Result<SandboxProcessRecord> {
+        http_start_sandbox_process(&self.harness, self.sandbox_scope(), request).await
+    }
+
+    async fn write_sandbox_process_input(
+        &self,
+        request: WriteSandboxProcessInputRequest,
+    ) -> Result<()> {
+        http_write_sandbox_process_input(&self.harness, self.sandbox_scope(), request).await
+    }
+
+    async fn close_sandbox_process_input(
+        &self,
+        request: CloseSandboxProcessInputRequest,
+    ) -> Result<()> {
+        http_close_sandbox_process_input(&self.harness, self.sandbox_scope(), request).await
+    }
+
+    async fn get_sandbox_process_events(
+        &self,
+        query: SandboxProcessEventQuery,
+    ) -> Result<GetSandboxProcessEventsResult> {
+        http_get_sandbox_process_events(&self.harness, self.sandbox_scope(), query).await
+    }
+
+    async fn wait_sandbox_process(
+        &self,
+        request: WaitSandboxProcessRequest,
+    ) -> Result<SandboxProcessStatus> {
+        http_wait_sandbox_process(&self.harness, self.sandbox_scope(), request).await
+    }
+
+    async fn cancel_sandbox_process(
+        &self,
+        request: CancelSandboxProcessRequest,
+    ) -> Result<SandboxProcessStatus> {
+        http_cancel_sandbox_process(&self.harness, self.sandbox_scope(), request).await
+    }
+
+    async fn run_in_sandbox(
+        &self,
+        request: RunInSandboxRequest,
+    ) -> Result<Box<dyn SandboxProcess>> {
+        http_run_in_sandbox(&self.harness, self.sandbox_scope(), request).await
     }
 }
 

--- a/crates/exoharness/src/http/client.rs
+++ b/crates/exoharness/src/http/client.rs
@@ -987,6 +987,40 @@ impl TurnHandle for HttpTurnHandle {
         }
     }
 
+    async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
+        match self
+            .harness
+            .request(Request::TurnSnapshotSandbox {
+                agent_id: self.agent_id,
+                conversation_id: self.conversation_id,
+                session_id: self.record.session_id,
+                turn_id: self.record.id,
+                sandbox_id: id,
+            })
+            .await?
+        {
+            Response::SnapshotId { snapshot_id } => Ok(snapshot_id),
+            response => unexpected_response(response, "snapshot_id"),
+        }
+    }
+
+    async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
+        match self
+            .harness
+            .request(Request::TurnStartSandbox {
+                agent_id: self.agent_id,
+                conversation_id: self.conversation_id,
+                session_id: self.record.session_id,
+                turn_id: self.record.id,
+                request,
+            })
+            .await?
+        {
+            Response::Unit => Ok(()),
+            response => unexpected_response(response, "unit"),
+        }
+    }
+
     async fn finish(&self) -> Result<EventId> {
         match self
             .harness

--- a/crates/exoharness/src/http/process.rs
+++ b/crates/exoharness/src/http/process.rs
@@ -24,10 +24,16 @@ impl SandboxProcess for LiveHttpSandboxProcess {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub(super) enum HttpSandboxProcessScope {
+    Agent,
+    Conversation { conversation_id: ConversationId },
+}
+
 pub(super) fn spawn_http_sandbox_process_event_poller(
     harness: HttpExoHarness,
     agent_id: AgentId,
-    conversation_id: ConversationId,
+    scope: HttpSandboxProcessScope,
     sandbox_id: SandboxId,
     process_id: SandboxProcessId,
     mut stdout: tokio::io::DuplexStream,
@@ -38,19 +44,29 @@ pub(super) fn spawn_http_sandbox_process_event_poller(
         let mut cursor = None;
         let mut wait_tx = Some(wait_tx);
         loop {
-            let response = harness
-                .request(Request::ConversationGetSandboxProcessEvents {
-                    agent_id,
-                    conversation_id,
-                    query: SandboxProcessEventQuery {
-                        sandbox_id: sandbox_id.clone(),
-                        process_id: process_id.clone(),
-                        after: cursor,
-                        limit: None,
-                        follow: None,
-                    },
-                })
-                .await;
+            let query = SandboxProcessEventQuery {
+                sandbox_id: sandbox_id.clone(),
+                process_id: process_id.clone(),
+                after: cursor,
+                limit: None,
+                follow: None,
+            };
+            let response = match scope {
+                HttpSandboxProcessScope::Agent => {
+                    harness
+                        .request(Request::AgentGetSandboxProcessEvents { agent_id, query })
+                        .await
+                }
+                HttpSandboxProcessScope::Conversation { conversation_id } => {
+                    harness
+                        .request(Request::ConversationGetSandboxProcessEvents {
+                            agent_id,
+                            conversation_id,
+                            query,
+                        })
+                        .await
+                }
+            };
             let result = match response {
                 Ok(Response::SandboxProcessEvents { result }) => result,
                 Ok(response) => {
@@ -129,7 +145,7 @@ pub(super) fn spawn_http_sandbox_process_event_poller(
 pub(super) fn spawn_http_sandbox_process_stdin_forwarder(
     harness: HttpExoHarness,
     agent_id: AgentId,
-    conversation_id: ConversationId,
+    scope: HttpSandboxProcessScope,
     sandbox_id: SandboxId,
     process_id: SandboxProcessId,
     mut stdin: tokio::io::DuplexStream,
@@ -139,16 +155,29 @@ pub(super) fn spawn_http_sandbox_process_stdin_forwarder(
         loop {
             match stdin.read(&mut buffer).await {
                 Ok(0) => {
-                    let response = harness
-                        .request(Request::ConversationCloseSandboxProcessInput {
-                            agent_id,
-                            conversation_id,
-                            request: CloseSandboxProcessInputRequest {
-                                sandbox_id: sandbox_id.clone(),
-                                process_id: process_id.clone(),
-                            },
-                        })
-                        .await;
+                    let request = CloseSandboxProcessInputRequest {
+                        sandbox_id: sandbox_id.clone(),
+                        process_id: process_id.clone(),
+                    };
+                    let response = match scope {
+                        HttpSandboxProcessScope::Agent => {
+                            harness
+                                .request(Request::AgentCloseSandboxProcessInput {
+                                    agent_id,
+                                    request,
+                                })
+                                .await
+                        }
+                        HttpSandboxProcessScope::Conversation { conversation_id } => {
+                            harness
+                                .request(Request::ConversationCloseSandboxProcessInput {
+                                    agent_id,
+                                    conversation_id,
+                                    request,
+                                })
+                                .await
+                        }
+                    };
                     if let Err(error) = response {
                         tracing::warn!(
                             target: HTTP_EXOHARNESS_TRACING_TARGET,
@@ -159,17 +188,30 @@ pub(super) fn spawn_http_sandbox_process_stdin_forwarder(
                     return;
                 }
                 Ok(length) => {
-                    let response = harness
-                        .request(Request::ConversationWriteSandboxProcessInput {
-                            agent_id,
-                            conversation_id,
-                            request: WriteSandboxProcessInputRequest {
-                                sandbox_id: sandbox_id.clone(),
-                                process_id: process_id.clone(),
-                                data: buffer[..length].to_vec(),
-                            },
-                        })
-                        .await;
+                    let request = WriteSandboxProcessInputRequest {
+                        sandbox_id: sandbox_id.clone(),
+                        process_id: process_id.clone(),
+                        data: buffer[..length].to_vec(),
+                    };
+                    let response = match scope {
+                        HttpSandboxProcessScope::Agent => {
+                            harness
+                                .request(Request::AgentWriteSandboxProcessInput {
+                                    agent_id,
+                                    request,
+                                })
+                                .await
+                        }
+                        HttpSandboxProcessScope::Conversation { conversation_id } => {
+                            harness
+                                .request(Request::ConversationWriteSandboxProcessInput {
+                                    agent_id,
+                                    conversation_id,
+                                    request,
+                                })
+                                .await
+                        }
+                    };
                     if let Err(error) = response {
                         tracing::warn!(
                             target: HTTP_EXOHARNESS_TRACING_TARGET,

--- a/crates/exoharness/src/http/process.rs
+++ b/crates/exoharness/src/http/process.rs
@@ -5,11 +5,11 @@ use tokio::time::{self, Duration};
 
 use super::HTTP_EXOHARNESS_TRACING_TARGET;
 use super::client::HttpExoHarness;
-use crate::protocol::{Request, Response};
+use crate::protocol::{Request, Response, SandboxScope};
 use crate::{
-    AgentId, CloseSandboxProcessInputRequest, ConversationId, Result, SandboxId, SandboxProcess,
-    SandboxProcessEvent, SandboxProcessEventQuery, SandboxProcessId, SandboxProcessParts,
-    SandboxProcessStatus, WriteSandboxProcessInputRequest,
+    CloseSandboxProcessInputRequest, Result, SandboxId, SandboxProcess, SandboxProcessEvent,
+    SandboxProcessEventQuery, SandboxProcessId, SandboxProcessParts, SandboxProcessStatus,
+    WriteSandboxProcessInputRequest,
 };
 
 pub(super) struct LiveHttpSandboxProcess {
@@ -24,16 +24,9 @@ impl SandboxProcess for LiveHttpSandboxProcess {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
-pub(super) enum HttpSandboxProcessScope {
-    Agent,
-    Conversation { conversation_id: ConversationId },
-}
-
 pub(super) fn spawn_http_sandbox_process_event_poller(
     harness: HttpExoHarness,
-    agent_id: AgentId,
-    scope: HttpSandboxProcessScope,
+    scope: SandboxScope,
     sandbox_id: SandboxId,
     process_id: SandboxProcessId,
     mut stdout: tokio::io::DuplexStream,
@@ -51,22 +44,9 @@ pub(super) fn spawn_http_sandbox_process_event_poller(
                 limit: None,
                 follow: None,
             };
-            let response = match scope {
-                HttpSandboxProcessScope::Agent => {
-                    harness
-                        .request(Request::AgentGetSandboxProcessEvents { agent_id, query })
-                        .await
-                }
-                HttpSandboxProcessScope::Conversation { conversation_id } => {
-                    harness
-                        .request(Request::ConversationGetSandboxProcessEvents {
-                            agent_id,
-                            conversation_id,
-                            query,
-                        })
-                        .await
-                }
-            };
+            let response = harness
+                .request(Request::GetSandboxProcessEvents { scope, query })
+                .await;
             let result = match response {
                 Ok(Response::SandboxProcessEvents { result }) => result,
                 Ok(response) => {
@@ -144,8 +124,7 @@ pub(super) fn spawn_http_sandbox_process_event_poller(
 
 pub(super) fn spawn_http_sandbox_process_stdin_forwarder(
     harness: HttpExoHarness,
-    agent_id: AgentId,
-    scope: HttpSandboxProcessScope,
+    scope: SandboxScope,
     sandbox_id: SandboxId,
     process_id: SandboxProcessId,
     mut stdin: tokio::io::DuplexStream,
@@ -159,25 +138,9 @@ pub(super) fn spawn_http_sandbox_process_stdin_forwarder(
                         sandbox_id: sandbox_id.clone(),
                         process_id: process_id.clone(),
                     };
-                    let response = match scope {
-                        HttpSandboxProcessScope::Agent => {
-                            harness
-                                .request(Request::AgentCloseSandboxProcessInput {
-                                    agent_id,
-                                    request,
-                                })
-                                .await
-                        }
-                        HttpSandboxProcessScope::Conversation { conversation_id } => {
-                            harness
-                                .request(Request::ConversationCloseSandboxProcessInput {
-                                    agent_id,
-                                    conversation_id,
-                                    request,
-                                })
-                                .await
-                        }
-                    };
+                    let response = harness
+                        .request(Request::CloseSandboxProcessInput { scope, request })
+                        .await;
                     if let Err(error) = response {
                         tracing::warn!(
                             target: HTTP_EXOHARNESS_TRACING_TARGET,
@@ -193,25 +156,9 @@ pub(super) fn spawn_http_sandbox_process_stdin_forwarder(
                         process_id: process_id.clone(),
                         data: buffer[..length].to_vec(),
                     };
-                    let response = match scope {
-                        HttpSandboxProcessScope::Agent => {
-                            harness
-                                .request(Request::AgentWriteSandboxProcessInput {
-                                    agent_id,
-                                    request,
-                                })
-                                .await
-                        }
-                        HttpSandboxProcessScope::Conversation { conversation_id } => {
-                            harness
-                                .request(Request::ConversationWriteSandboxProcessInput {
-                                    agent_id,
-                                    conversation_id,
-                                    request,
-                                })
-                                .await
-                        }
-                    };
+                    let response = harness
+                        .request(Request::WriteSandboxProcessInput { scope, request })
+                        .await;
                     if let Err(error) = response {
                         tracing::warn!(
                             target: HTTP_EXOHARNESS_TRACING_TARGET,

--- a/crates/exoharness/src/http_tests.rs
+++ b/crates/exoharness/src/http_tests.rs
@@ -164,6 +164,76 @@ async fn http_exoharness_runs_noninteractive_sandbox_commands() {
 }
 
 #[actix_web::test]
+async fn http_exoharness_runs_agent_scoped_sandbox_commands() {
+    let fixture = http_harness().await;
+    let agent = fixture
+        .harness
+        .new_agent(crate::NewAgentRequest {
+            slug: "agent".to_string(),
+            name: "Agent".to_string(),
+        })
+        .await
+        .expect("agent");
+    let conversation = agent
+        .new_conversation(crate::NewConversationRequest::default())
+        .await
+        .expect("conversation");
+    let sandbox_id = agent
+        .create_sandbox(CreateSandboxRequest {
+            name: Some("agent-http".to_string()),
+            provider: SandboxProvider::LocalProcess,
+            image: "local".to_string(),
+            default_workdir: Some("/".to_string()),
+            file_system_mounts: None,
+            enable_networking: Some(true),
+            idle_seconds: Some(60),
+        })
+        .await
+        .expect("agent sandbox");
+    let process = agent
+        .run_in_sandbox(RunInSandboxRequest {
+            id: sandbox_id.clone(),
+            command: vec![
+                "/bin/sh".to_string(),
+                "-lc".to_string(),
+                "printf agent-http".to_string(),
+            ],
+            env: Default::default(),
+        })
+        .await
+        .expect("agent sandbox command");
+    let parts = process.into_parts();
+    let mut stdout = parts.stdout;
+    let mut output = Vec::new();
+    stdout.read_to_end(&mut output).await.expect("stdout");
+    assert_eq!(output, b"agent-http");
+    assert_eq!(parts.wait.await.expect("exit"), 0);
+
+    let events = conversation
+        .get_events(Some(EventQuery {
+            cursor: None,
+            direction: Some(EventQueryDirection::Asc),
+            limit: None,
+            session_id: None,
+            turn_id: None,
+            types: Some(vec![EventKind::SANDBOX_CREATED, EventKind::SANDBOX_STARTED]),
+        }))
+        .await
+        .expect("events")
+        .events;
+    assert!(events.is_empty());
+
+    let conversation_process = conversation
+        .run_in_sandbox(RunInSandboxRequest {
+            id: sandbox_id,
+            command: vec!["true".to_string()],
+            env: Default::default(),
+        })
+        .await;
+    assert!(conversation_process.is_err());
+}
+
+#[actix_web::test]
 async fn http_exoharness_supports_sandbox_process_events() {
     let fixture = http_harness().await;
     let agent = fixture

--- a/crates/exoharness/src/http_tests.rs
+++ b/crates/exoharness/src/http_tests.rs
@@ -1,15 +1,21 @@
 use std::net::{SocketAddr, TcpListener};
 use std::sync::Arc;
 
+use anyhow::bail;
+use async_trait::async_trait;
+use bytes::Bytes;
 use futures::io::AsyncReadExt;
 use tempfile::TempDir;
 
 use crate::test_support::local_test_config;
 use crate::{
-    BasicExoHarness, CreateSandboxRequest, ExoHarness, HttpExoHarness, RunInSandboxRequest,
-    SandboxProcessEvent, SandboxProcessEventQuery, SandboxProcessStatus, SandboxProcessStdin,
-    SandboxProvider, StartSandboxProcessRequest, WaitSandboxProcessRequest,
-    WriteSandboxProcessInputRequest, serve_exoharness_http_listener,
+    BasicExoHarness, BeginTurnRequest, CreateSandboxRequest, EventData, EventKind, EventQuery,
+    EventQueryDirection, ExoHarness, HttpExoHarness, ManagedSandboxBackend, ManagedSandboxHandle,
+    RunInSandboxRequest, SandboxCommand, SandboxCommandOutput, SandboxProcessEvent,
+    SandboxProcessEventQuery, SandboxProcessParts, SandboxProcessStatus, SandboxProcessStdin,
+    SandboxProvider, SandboxRequest, SnapshotKind, SnapshotPayload, StartSandboxProcessRequest,
+    StartSandboxRequest, WaitSandboxProcessRequest, WriteSandboxProcessInputRequest,
+    serve_exoharness_http_listener,
 };
 
 struct HttpHarnessFixture {
@@ -29,6 +35,27 @@ async fn http_harness() -> HttpHarnessFixture {
     let basic = BasicExoHarness::new(local_test_config(tempdir.path()))
         .await
         .expect("basic harness");
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))).expect("listener");
+    let addr = listener.local_addr().expect("local addr");
+    let server = actix_web::rt::spawn(serve_exoharness_http_listener(listener, Arc::new(basic)));
+    let harness: Arc<dyn ExoHarness> =
+        Arc::new(HttpExoHarness::new(format!("http://{addr}")).expect("http harness"));
+
+    HttpHarnessFixture {
+        harness,
+        server,
+        _tempdir: tempdir,
+    }
+}
+
+async fn http_harness_with_sandbox_backend(
+    backend: Arc<dyn ManagedSandboxBackend>,
+) -> HttpHarnessFixture {
+    let tempdir = TempDir::new().expect("tempdir");
+    let basic =
+        BasicExoHarness::new_with_sandbox_backend(local_test_config(tempdir.path()), backend)
+            .await
+            .expect("basic harness");
     let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))).expect("listener");
     let addr = listener.local_addr().expect("local addr");
     let server = actix_web::rt::spawn(serve_exoharness_http_listener(listener, Arc::new(basic)));
@@ -220,6 +247,144 @@ async fn http_exoharness_supports_sandbox_process_events() {
         events.events.last(),
         Some(SandboxProcessEvent::Exit { exit_code: 0, .. })
     ));
+}
+
+#[actix_web::test]
+async fn http_exoharness_supports_turn_scoped_sandbox_snapshot_and_start() {
+    let fixture = http_harness_with_sandbox_backend(Arc::new(SnapshotTestSandboxBackend)).await;
+    let agent = fixture
+        .harness
+        .new_agent(crate::NewAgentRequest {
+            slug: "agent".to_string(),
+            name: "Agent".to_string(),
+        })
+        .await
+        .expect("agent");
+    let conversation = agent
+        .new_conversation(crate::NewConversationRequest::default())
+        .await
+        .expect("conversation");
+    let sandbox_id = conversation
+        .create_sandbox(CreateSandboxRequest {
+            name: None,
+            provider: SandboxProvider::LocalProcess,
+            image: "local".to_string(),
+            default_workdir: Some("/".to_string()),
+            file_system_mounts: None,
+            enable_networking: Some(true),
+            idle_seconds: Some(60),
+        })
+        .await
+        .expect("sandbox");
+    let turn = conversation
+        .begin_turn(BeginTurnRequest {
+            session_id: None,
+            input: Vec::new(),
+        })
+        .await
+        .expect("turn");
+
+    let snapshot_id = turn
+        .snapshot_sandbox(sandbox_id.clone())
+        .await
+        .expect("turn snapshot");
+    turn.start_sandbox(StartSandboxRequest {
+        id: sandbox_id.clone(),
+        snapshot_id,
+        idle_seconds: Some(60),
+    })
+    .await
+    .expect("turn start from snapshot");
+
+    let events = conversation
+        .get_events(Some(EventQuery {
+            cursor: None,
+            direction: Some(EventQueryDirection::Asc),
+            limit: None,
+            session_id: None,
+            turn_id: None,
+            types: Some(vec![
+                EventKind::SANDBOX_SNAPSHOTTED,
+                EventKind::SANDBOX_STARTED,
+            ]),
+        }))
+        .await
+        .expect("events")
+        .events;
+
+    let snapshot_event = events
+        .iter()
+        .find(|event| matches!(event.data, EventData::SandboxSnapshotted { .. }))
+        .expect("snapshot event");
+    assert_eq!(snapshot_event.session_id, Some(turn.record().session_id));
+    assert_eq!(snapshot_event.turn_id, Some(turn.record().id));
+
+    let restored_start_event = events
+        .iter()
+        .find(|event| {
+            matches!(
+                event.data,
+                EventData::SandboxStarted {
+                    snapshot_id: Some(_),
+                    ..
+                }
+            )
+        })
+        .expect("snapshot-backed start event");
+    assert_eq!(
+        restored_start_event.session_id,
+        Some(turn.record().session_id)
+    );
+    assert_eq!(restored_start_event.turn_id, Some(turn.record().id));
+}
+
+struct SnapshotTestSandboxBackend;
+
+#[async_trait]
+impl ManagedSandboxBackend for SnapshotTestSandboxBackend {
+    async fn acquire(
+        &self,
+        _request: SandboxRequest,
+    ) -> crate::Result<Arc<dyn ManagedSandboxHandle>> {
+        Ok(Arc::new(SnapshotTestSandboxHandle))
+    }
+
+    async fn acquire_from_snapshot(
+        &self,
+        _request: SandboxRequest,
+        payload: SnapshotPayload,
+    ) -> crate::Result<Arc<dyn ManagedSandboxHandle>> {
+        assert_eq!(payload.bytes, Bytes::from_static(b"snapshot"));
+        Ok(Arc::new(SnapshotTestSandboxHandle))
+    }
+}
+
+struct SnapshotTestSandboxHandle;
+
+#[async_trait]
+impl ManagedSandboxHandle for SnapshotTestSandboxHandle {
+    fn id(&self) -> &str {
+        "snapshot-test-sandbox"
+    }
+
+    async fn exec(&self, _command: &SandboxCommand) -> crate::Result<SandboxCommandOutput> {
+        bail!("snapshot test sandbox does not support exec")
+    }
+
+    async fn start_process(&self, _command: &SandboxCommand) -> crate::Result<SandboxProcessParts> {
+        bail!("snapshot test sandbox does not support start_process")
+    }
+
+    async fn stop(&self) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn snapshot(&self) -> crate::Result<SnapshotPayload> {
+        Ok(SnapshotPayload {
+            kind: SnapshotKind::DaytonaSnapshot,
+            bytes: Bytes::from_static(b"snapshot"),
+        })
+    }
 }
 
 fn hosted_harness_from_env() -> Arc<dyn ExoHarness> {

--- a/crates/exoharness/src/http_tests.rs
+++ b/crates/exoharness/src/http_tests.rs
@@ -186,6 +186,7 @@ async fn http_exoharness_runs_agent_scoped_sandbox_commands() {
             image: "local".to_string(),
             default_workdir: Some("/".to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })
@@ -343,6 +344,7 @@ async fn http_exoharness_supports_turn_scoped_sandbox_snapshot_and_start() {
             image: "local".to_string(),
             default_workdir: Some("/".to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })

--- a/crates/exoharness/src/http_tests.rs
+++ b/crates/exoharness/src/http_tests.rs
@@ -138,6 +138,7 @@ async fn http_exoharness_runs_noninteractive_sandbox_commands() {
             image: "local".to_string(),
             default_workdir: Some("/".to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })
@@ -255,6 +256,7 @@ async fn http_exoharness_supports_sandbox_process_events() {
             image: "local".to_string(),
             default_workdir: Some("/".to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })

--- a/crates/exoharness/src/http_tests.rs
+++ b/crates/exoharness/src/http_tests.rs
@@ -111,6 +111,7 @@ async fn http_exoharness_runs_noninteractive_sandbox_commands() {
             image: "local".to_string(),
             default_workdir: Some("/".to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })
@@ -158,6 +159,7 @@ async fn http_exoharness_supports_sandbox_process_events() {
             image: "local".to_string(),
             default_workdir: Some("/".to_string()),
             file_system_mounts: None,
+            durable_file_systems: None,
             enable_networking: Some(true),
             idle_seconds: Some(60),
         })

--- a/crates/exoharness/src/protocol.rs
+++ b/crates/exoharness/src/protocol.rs
@@ -95,6 +95,46 @@ pub enum Request {
         agent_id: AgentId,
         request: WriteArtifactRequest,
     },
+    AgentCreateSandbox {
+        agent_id: AgentId,
+        request: CreateSandboxRequest,
+    },
+    AgentSnapshotSandbox {
+        agent_id: AgentId,
+        sandbox_id: SandboxId,
+    },
+    AgentStartSandbox {
+        agent_id: AgentId,
+        request: StartSandboxRequest,
+    },
+    AgentStopSandbox {
+        agent_id: AgentId,
+        sandbox_id: SandboxId,
+    },
+    AgentStartSandboxProcess {
+        agent_id: AgentId,
+        request: StartSandboxProcessRequest,
+    },
+    AgentWriteSandboxProcessInput {
+        agent_id: AgentId,
+        request: WriteSandboxProcessInputRequest,
+    },
+    AgentCloseSandboxProcessInput {
+        agent_id: AgentId,
+        request: CloseSandboxProcessInputRequest,
+    },
+    AgentGetSandboxProcessEvents {
+        agent_id: AgentId,
+        query: SandboxProcessEventQuery,
+    },
+    AgentWaitSandboxProcess {
+        agent_id: AgentId,
+        request: WaitSandboxProcessRequest,
+    },
+    AgentCancelSandboxProcess {
+        agent_id: AgentId,
+        request: CancelSandboxProcessRequest,
+    },
     AgentListBindings {
         agent_id: AgentId,
     },
@@ -299,6 +339,16 @@ impl Request {
             Self::AgentListArtifacts { .. } => "agent_list_artifacts",
             Self::AgentReadArtifact { .. } => "agent_read_artifact",
             Self::AgentWriteArtifact { .. } => "agent_write_artifact",
+            Self::AgentCreateSandbox { .. } => "agent_create_sandbox",
+            Self::AgentSnapshotSandbox { .. } => "agent_snapshot_sandbox",
+            Self::AgentStartSandbox { .. } => "agent_start_sandbox",
+            Self::AgentStopSandbox { .. } => "agent_stop_sandbox",
+            Self::AgentStartSandboxProcess { .. } => "agent_start_sandbox_process",
+            Self::AgentWriteSandboxProcessInput { .. } => "agent_write_sandbox_process_input",
+            Self::AgentCloseSandboxProcessInput { .. } => "agent_close_sandbox_process_input",
+            Self::AgentGetSandboxProcessEvents { .. } => "agent_get_sandbox_process_events",
+            Self::AgentWaitSandboxProcess { .. } => "agent_wait_sandbox_process",
+            Self::AgentCancelSandboxProcess { .. } => "agent_cancel_sandbox_process",
             Self::AgentListBindings { .. } => "agent_list_bindings",
             Self::AgentPutBinding { .. } => "agent_put_binding",
             Self::AgentGetBinding { .. } => "agent_get_binding",

--- a/crates/exoharness/src/protocol.rs
+++ b/crates/exoharness/src/protocol.rs
@@ -24,6 +24,34 @@ pub struct TurnHandleInfo {
     pub record: TurnRecord,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SandboxScope {
+    Agent {
+        agent_id: AgentId,
+    },
+    Conversation {
+        agent_id: AgentId,
+        conversation_id: ConversationId,
+    },
+    Turn {
+        agent_id: AgentId,
+        conversation_id: ConversationId,
+        session_id: SessionId,
+        turn_id: TurnId,
+    },
+}
+
+impl SandboxScope {
+    pub fn agent_id(self) -> AgentId {
+        match self {
+            Self::Agent { agent_id }
+            | Self::Conversation { agent_id, .. }
+            | Self::Turn { agent_id, .. } => agent_id,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ClientMessage {
@@ -95,44 +123,44 @@ pub enum Request {
         agent_id: AgentId,
         request: WriteArtifactRequest,
     },
-    AgentCreateSandbox {
-        agent_id: AgentId,
+    CreateSandbox {
+        scope: SandboxScope,
         request: CreateSandboxRequest,
     },
-    AgentSnapshotSandbox {
-        agent_id: AgentId,
+    SnapshotSandbox {
+        scope: SandboxScope,
         sandbox_id: SandboxId,
     },
-    AgentStartSandbox {
-        agent_id: AgentId,
+    StartSandbox {
+        scope: SandboxScope,
         request: StartSandboxRequest,
     },
-    AgentStopSandbox {
-        agent_id: AgentId,
+    StopSandbox {
+        scope: SandboxScope,
         sandbox_id: SandboxId,
     },
-    AgentStartSandboxProcess {
-        agent_id: AgentId,
+    StartSandboxProcess {
+        scope: SandboxScope,
         request: StartSandboxProcessRequest,
     },
-    AgentWriteSandboxProcessInput {
-        agent_id: AgentId,
+    WriteSandboxProcessInput {
+        scope: SandboxScope,
         request: WriteSandboxProcessInputRequest,
     },
-    AgentCloseSandboxProcessInput {
-        agent_id: AgentId,
+    CloseSandboxProcessInput {
+        scope: SandboxScope,
         request: CloseSandboxProcessInputRequest,
     },
-    AgentGetSandboxProcessEvents {
-        agent_id: AgentId,
+    GetSandboxProcessEvents {
+        scope: SandboxScope,
         query: SandboxProcessEventQuery,
     },
-    AgentWaitSandboxProcess {
-        agent_id: AgentId,
+    WaitSandboxProcess {
+        scope: SandboxScope,
         request: WaitSandboxProcessRequest,
     },
-    AgentCancelSandboxProcess {
-        agent_id: AgentId,
+    CancelSandboxProcess {
+        scope: SandboxScope,
         request: CancelSandboxProcessRequest,
     },
     AgentListBindings {
@@ -205,56 +233,6 @@ pub enum Request {
         conversation_id: ConversationId,
         request: WriteArtifactRequest,
     },
-    ConversationCreateSandbox {
-        agent_id: AgentId,
-        conversation_id: ConversationId,
-        request: CreateSandboxRequest,
-    },
-    ConversationSnapshotSandbox {
-        agent_id: AgentId,
-        conversation_id: ConversationId,
-        sandbox_id: SandboxId,
-    },
-    ConversationStartSandbox {
-        agent_id: AgentId,
-        conversation_id: ConversationId,
-        request: StartSandboxRequest,
-    },
-    ConversationStopSandbox {
-        agent_id: AgentId,
-        conversation_id: ConversationId,
-        sandbox_id: SandboxId,
-    },
-    ConversationStartSandboxProcess {
-        agent_id: AgentId,
-        conversation_id: ConversationId,
-        request: StartSandboxProcessRequest,
-    },
-    ConversationWriteSandboxProcessInput {
-        agent_id: AgentId,
-        conversation_id: ConversationId,
-        request: WriteSandboxProcessInputRequest,
-    },
-    ConversationCloseSandboxProcessInput {
-        agent_id: AgentId,
-        conversation_id: ConversationId,
-        request: CloseSandboxProcessInputRequest,
-    },
-    ConversationGetSandboxProcessEvents {
-        agent_id: AgentId,
-        conversation_id: ConversationId,
-        query: SandboxProcessEventQuery,
-    },
-    ConversationWaitSandboxProcess {
-        agent_id: AgentId,
-        conversation_id: ConversationId,
-        request: WaitSandboxProcessRequest,
-    },
-    ConversationCancelSandboxProcess {
-        agent_id: AgentId,
-        conversation_id: ConversationId,
-        request: CancelSandboxProcessRequest,
-    },
     ConversationListBindings {
         agent_id: AgentId,
         conversation_id: ConversationId,
@@ -297,20 +275,6 @@ pub enum Request {
         turn_id: TurnId,
         request: WriteArtifactRequest,
     },
-    TurnSnapshotSandbox {
-        agent_id: AgentId,
-        conversation_id: ConversationId,
-        session_id: SessionId,
-        turn_id: TurnId,
-        sandbox_id: SandboxId,
-    },
-    TurnStartSandbox {
-        agent_id: AgentId,
-        conversation_id: ConversationId,
-        session_id: SessionId,
-        turn_id: TurnId,
-        request: StartSandboxRequest,
-    },
     TurnFinish {
         agent_id: AgentId,
         conversation_id: ConversationId,
@@ -339,16 +303,16 @@ impl Request {
             Self::AgentListArtifacts { .. } => "agent_list_artifacts",
             Self::AgentReadArtifact { .. } => "agent_read_artifact",
             Self::AgentWriteArtifact { .. } => "agent_write_artifact",
-            Self::AgentCreateSandbox { .. } => "agent_create_sandbox",
-            Self::AgentSnapshotSandbox { .. } => "agent_snapshot_sandbox",
-            Self::AgentStartSandbox { .. } => "agent_start_sandbox",
-            Self::AgentStopSandbox { .. } => "agent_stop_sandbox",
-            Self::AgentStartSandboxProcess { .. } => "agent_start_sandbox_process",
-            Self::AgentWriteSandboxProcessInput { .. } => "agent_write_sandbox_process_input",
-            Self::AgentCloseSandboxProcessInput { .. } => "agent_close_sandbox_process_input",
-            Self::AgentGetSandboxProcessEvents { .. } => "agent_get_sandbox_process_events",
-            Self::AgentWaitSandboxProcess { .. } => "agent_wait_sandbox_process",
-            Self::AgentCancelSandboxProcess { .. } => "agent_cancel_sandbox_process",
+            Self::CreateSandbox { .. } => "create_sandbox",
+            Self::SnapshotSandbox { .. } => "snapshot_sandbox",
+            Self::StartSandbox { .. } => "start_sandbox",
+            Self::StopSandbox { .. } => "stop_sandbox",
+            Self::StartSandboxProcess { .. } => "start_sandbox_process",
+            Self::WriteSandboxProcessInput { .. } => "write_sandbox_process_input",
+            Self::CloseSandboxProcessInput { .. } => "close_sandbox_process_input",
+            Self::GetSandboxProcessEvents { .. } => "get_sandbox_process_events",
+            Self::WaitSandboxProcess { .. } => "wait_sandbox_process",
+            Self::CancelSandboxProcess { .. } => "cancel_sandbox_process",
             Self::AgentListBindings { .. } => "agent_list_bindings",
             Self::AgentPutBinding { .. } => "agent_put_binding",
             Self::AgentGetBinding { .. } => "agent_get_binding",
@@ -365,22 +329,6 @@ impl Request {
             Self::ConversationListArtifacts { .. } => "conversation_list_artifacts",
             Self::ConversationReadArtifact { .. } => "conversation_read_artifact",
             Self::ConversationWriteArtifact { .. } => "conversation_write_artifact",
-            Self::ConversationCreateSandbox { .. } => "conversation_create_sandbox",
-            Self::ConversationSnapshotSandbox { .. } => "conversation_snapshot_sandbox",
-            Self::ConversationStartSandbox { .. } => "conversation_start_sandbox",
-            Self::ConversationStopSandbox { .. } => "conversation_stop_sandbox",
-            Self::ConversationStartSandboxProcess { .. } => "conversation_start_sandbox_process",
-            Self::ConversationWriteSandboxProcessInput { .. } => {
-                "conversation_write_sandbox_process_input"
-            }
-            Self::ConversationCloseSandboxProcessInput { .. } => {
-                "conversation_close_sandbox_process_input"
-            }
-            Self::ConversationGetSandboxProcessEvents { .. } => {
-                "conversation_get_sandbox_process_events"
-            }
-            Self::ConversationWaitSandboxProcess { .. } => "conversation_wait_sandbox_process",
-            Self::ConversationCancelSandboxProcess { .. } => "conversation_cancel_sandbox_process",
             Self::ConversationListBindings { .. } => "conversation_list_bindings",
             Self::ConversationPutBinding { .. } => "conversation_put_binding",
             Self::ConversationGetBinding { .. } => "conversation_get_binding",
@@ -389,8 +337,6 @@ impl Request {
             Self::ConversationGetSecret { .. } => "conversation_get_secret",
             Self::TurnAddEvents { .. } => "turn_add_events",
             Self::TurnWriteArtifact { .. } => "turn_write_artifact",
-            Self::TurnSnapshotSandbox { .. } => "turn_snapshot_sandbox",
-            Self::TurnStartSandbox { .. } => "turn_start_sandbox",
             Self::TurnFinish { .. } => "turn_finish",
         }
     }

--- a/crates/exoharness/src/protocol.rs
+++ b/crates/exoharness/src/protocol.rs
@@ -257,6 +257,20 @@ pub enum Request {
         turn_id: TurnId,
         request: WriteArtifactRequest,
     },
+    TurnSnapshotSandbox {
+        agent_id: AgentId,
+        conversation_id: ConversationId,
+        session_id: SessionId,
+        turn_id: TurnId,
+        sandbox_id: SandboxId,
+    },
+    TurnStartSandbox {
+        agent_id: AgentId,
+        conversation_id: ConversationId,
+        session_id: SessionId,
+        turn_id: TurnId,
+        request: StartSandboxRequest,
+    },
     TurnFinish {
         agent_id: AgentId,
         conversation_id: ConversationId,
@@ -325,6 +339,8 @@ impl Request {
             Self::ConversationGetSecret { .. } => "conversation_get_secret",
             Self::TurnAddEvents { .. } => "turn_add_events",
             Self::TurnWriteArtifact { .. } => "turn_write_artifact",
+            Self::TurnSnapshotSandbox { .. } => "turn_snapshot_sandbox",
+            Self::TurnStartSandbox { .. } => "turn_start_sandbox",
             Self::TurnFinish { .. } => "turn_finish",
         }
     }

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -2047,6 +2047,7 @@ mod tests {
         let backend = CliContainerSandboxBackend {
             cli: ContainerCliFlavor::Docker,
             container_bin: script_path,
+            durable_file_system_root: None,
             system_started: Mutex::new(false),
             network_created: Mutex::new(false),
             warm_sandboxes: Arc::new(Mutex::new(HashMap::new())),
@@ -2059,6 +2060,7 @@ mod tests {
             spec: SandboxSpec {
                 image: "docker.io/library/ubuntu:24.04".to_string(),
                 mounts: Vec::new(),
+                durable_file_systems: Vec::new(),
                 network: SandboxNetworkPolicy::Disabled,
                 default_workdir: "/".to_string(),
             },

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use anyhow::{Context, Result, anyhow, bail};
 use async_trait::async_trait;
 use bytes::Bytes;
+use chrono::{DateTime, Utc};
 use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
 use tokio::process::{Child, Command};
@@ -211,6 +212,30 @@ struct ContainerListConfiguration {
     labels: HashMap<String, String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct DockerInspectItem {
+    #[serde(rename = "Id")]
+    id: String,
+    #[serde(rename = "State")]
+    state: DockerInspectState,
+    #[serde(rename = "Config")]
+    config: DockerInspectConfiguration,
+}
+
+#[derive(Debug, Deserialize)]
+struct DockerInspectState {
+    #[serde(rename = "Status")]
+    status: Option<String>,
+    #[serde(rename = "StartedAt")]
+    started_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DockerInspectConfiguration {
+    #[serde(rename = "Labels", default)]
+    labels: HashMap<String, String>,
+}
+
 #[derive(Debug)]
 pub struct CliContainerSandboxBackend {
     cli: ContainerCliFlavor,
@@ -247,29 +272,28 @@ impl CliContainerSandboxBackend {
     }
 
     async fn ensure_system_started(&self) -> Result<()> {
-        if !self.cli.requires_system_start() {
-            return Ok(());
-        }
         let mut started = self.system_started.lock().await;
         if *started {
             return Ok(());
         }
 
-        let output = Command::new(&self.container_bin)
-            .arg("system")
-            .arg("start")
-            .kill_on_drop(true)
-            .output()
-            .await
-            .with_context(|| missing_container_cli_message(self.cli, &self.container_bin))?;
-        if !output.status.success() {
-            return Err(anyhow!(
-                "failed to start container system: {}",
-                String::from_utf8_lossy(&output.stderr).trim()
-            ));
+        if self.cli.requires_system_start() {
+            let output = Command::new(&self.container_bin)
+                .arg("system")
+                .arg("start")
+                .kill_on_drop(true)
+                .output()
+                .await
+                .with_context(|| missing_container_cli_message(self.cli, &self.container_bin))?;
+            if !output.status.success() {
+                return Err(anyhow!(
+                    "failed to start container system: {}",
+                    String::from_utf8_lossy(&output.stderr).trim()
+                ));
+            }
         }
 
-        if let Err(error) = reap_orphaned_warm_sandboxes(&self.container_bin).await {
+        if let Err(error) = reap_orphaned_warm_sandboxes(&self.container_bin, self.cli).await {
             tracing::warn!(%error, "failed to reap orphaned warm sandboxes");
         }
         *started = true;
@@ -1488,6 +1512,15 @@ async fn kill_named_container_if_present(container_bin: &Path, name: &str) -> Re
     Ok(())
 }
 
+async fn reap_orphaned_warm_sandboxes(container_bin: &Path, cli: ContainerCliFlavor) -> Result<()> {
+    match cli {
+        ContainerCliFlavor::AppleContainer => {
+            reap_orphaned_apple_warm_sandboxes(container_bin).await
+        }
+        ContainerCliFlavor::Docker => reap_orphaned_docker_warm_sandboxes(container_bin).await,
+    }
+}
+
 async fn wait_for_apple_container_not_running(container_bin: &Path, name: &str) -> Result<()> {
     let deadline = Instant::now() + WARM_SANDBOX_CLEANUP_TIMEOUT;
     loop {
@@ -1525,7 +1558,7 @@ async fn apple_container_status(container_bin: &Path, name: &str) -> Result<Opti
         .and_then(|container| container.status))
 }
 
-async fn reap_orphaned_warm_sandboxes(container_bin: &Path) -> Result<()> {
+async fn reap_orphaned_apple_warm_sandboxes(container_bin: &Path) -> Result<()> {
     let output = run_container_admin_command(
         container_bin,
         WARM_SANDBOX_CLEANUP_TIMEOUT,
@@ -1588,9 +1621,96 @@ async fn reap_orphaned_warm_sandboxes(container_bin: &Path) -> Result<()> {
     Ok(())
 }
 
+async fn reap_orphaned_docker_warm_sandboxes(container_bin: &Path) -> Result<()> {
+    let output = run_container_admin_command(
+        container_bin,
+        WARM_SANDBOX_CLEANUP_TIMEOUT,
+        [
+            "ps",
+            "-aq",
+            "--no-trunc",
+            "--filter",
+            "label=exo.sandbox.key",
+        ],
+    )
+    .await?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "failed to list warm sandboxes: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+
+    let ids = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    if ids.is_empty() {
+        return Ok(());
+    }
+
+    let mut inspect_args = Vec::with_capacity(ids.len() + 1);
+    inspect_args.push("inspect".to_string());
+    inspect_args.extend(ids);
+    let inspect = run_container_admin_command(
+        container_bin,
+        WARM_SANDBOX_CLEANUP_TIMEOUT,
+        inspect_args.iter().map(String::as_str),
+    )
+    .await?;
+    if !inspect.status.success() {
+        return Err(anyhow!(
+            "failed to inspect warm sandboxes: {}",
+            String::from_utf8_lossy(&inspect.stderr).trim()
+        ));
+    }
+
+    let now = Utc::now();
+    let min_age = chrono::Duration::from_std(ORPHANED_WARM_SANDBOX_MIN_AGE)
+        .expect("orphaned warm sandbox age fits in chrono duration");
+    let containers: Vec<DockerInspectItem> = serde_json::from_slice(&inspect.stdout)?;
+    for container in containers {
+        if !container.config.labels.contains_key(WARM_SANDBOX_KEY_LABEL) {
+            continue;
+        }
+        if let Some(owner_pid) = container.config.labels.get(WARM_SANDBOX_OWNER_PID_LABEL)
+            && owner_pid_is_alive(owner_pid)
+        {
+            continue;
+        }
+        if container.state.status.as_deref() != Some("running") {
+            continue;
+        }
+        let Some(started_at) = container.state.started_at.as_deref() else {
+            continue;
+        };
+        let started_at = parse_docker_timestamp(started_at)?;
+        if now.signed_duration_since(started_at) < min_age {
+            continue;
+        }
+        if let Err(error) =
+            cleanup_named_container(container_bin, ContainerCliFlavor::Docker, &container.id).await
+        {
+            tracing::warn!(
+                container_id = %container.id,
+                %error,
+                "failed to clean up orphaned warm sandbox"
+            );
+        }
+    }
+
+    Ok(())
+}
+
 fn apple_absolute_time_now() -> Result<f64> {
     let unix_now = SystemTime::now().duration_since(UNIX_EPOCH)?;
     Ok(unix_now.as_secs_f64() - APPLE_ABSOLUTE_TIME_UNIX_OFFSET_SECONDS)
+}
+
+fn parse_docker_timestamp(value: &str) -> Result<DateTime<Utc>> {
+    Ok(DateTime::parse_from_rfc3339(value)?.with_timezone(&Utc))
 }
 
 fn owner_pid_is_alive(pid: &str) -> bool {
@@ -1895,6 +2015,80 @@ mod tests {
                 spec_filter.as_str(),
                 "--format",
                 "{{.Names}}",
+            ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn docker_prepare_request_reaps_orphaned_warm_sandboxes_with_real_cli_commands() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let script_path = temp_dir.path().join("docker");
+        let args_path = temp_dir.path().join("args");
+        fs::write(
+            &script_path,
+            format!(
+                "#!/bin/sh\nfor arg in \"$@\"; do\n  printf '%s\\n' \"$arg\" >> '{}'\ndone\nprintf '%s\\n' '---' >> '{}'\ncase \"$1\" in\n  ps)\n    printf 'docker-container-id\\n'\n    ;;\n  inspect)\n    printf '%s\\n' '[{{\"Id\":\"docker-container-id\",\"Config\":{{\"Labels\":{{\"{}\":\"conversation:conversation:sandbox\"}}}},\"State\":{{\"Status\":\"running\",\"StartedAt\":\"2024-01-01T00:00:00Z\"}}}}]'\n    ;;\n  rm)\n    ;;\nesac\n",
+                args_path.display(),
+                args_path.display(),
+                WARM_SANDBOX_KEY_LABEL,
+            ),
+        )
+        .expect("write fake docker script");
+        let mut permissions = fs::metadata(&script_path)
+            .expect("fake docker metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script_path, permissions).expect("chmod fake docker");
+
+        let backend = CliContainerSandboxBackend {
+            cli: ContainerCliFlavor::Docker,
+            container_bin: script_path,
+            system_started: Mutex::new(false),
+            network_created: Mutex::new(false),
+            warm_sandboxes: Arc::new(Mutex::new(HashMap::new())),
+        };
+        let request = SandboxRequest {
+            key: SandboxKey::ConversationSandbox {
+                conversation_id: "conversation".to_string(),
+                sandbox_id: "sandbox".to_string(),
+            },
+            spec: SandboxSpec {
+                image: "docker.io/library/ubuntu:24.04".to_string(),
+                mounts: Vec::new(),
+                network: SandboxNetworkPolicy::Disabled,
+                default_workdir: "/".to_string(),
+            },
+            lifecycle: SandboxLifecycleConfig {
+                idle_ttl: Some(Duration::from_secs(60)),
+            },
+        };
+
+        backend
+            .prepare_request(request)
+            .await
+            .expect("prepare request");
+
+        let args = fs::read_to_string(&args_path).expect("read fake docker args");
+        assert_eq!(
+            args.lines().collect::<Vec<_>>(),
+            vec![
+                "ps",
+                "-aq",
+                "--no-trunc",
+                "--filter",
+                "label=exo.sandbox.key",
+                "---",
+                "inspect",
+                "docker-container-id",
+                "---",
+                "rm",
+                "-f",
+                "docker-container-id",
+                "---",
             ]
         );
     }

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -122,6 +122,12 @@ pub enum SnapshotKind {
     /// JSON manifest pointing at a named snapshot in Daytona's registry; the
     /// filesystem bytes live in Daytona, not in the payload.
     DaytonaSnapshot,
+    /// Reference to an E2B snapshot template id. Payload bytes are a small JSON
+    /// manifest; restoring is `POST /sandboxes { templateID: <snapshot_id> }`.
+    E2bSnapshot,
+    /// Reference to a Sprites checkpoint id on a named sprite. Payload bytes are
+    /// a small JSON manifest; restoring is `POST .../checkpoints/{id}/restore`.
+    SpritesSnapshot,
 }
 
 #[async_trait]
@@ -494,6 +500,14 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
             (_, SnapshotKind::DaytonaSnapshot) => {
                 bail!("restoring a Daytona snapshot on a container backend is not implemented yet")
             }
+            (_, SnapshotKind::E2bSnapshot) => bail!(
+                "E2bSnapshot payloads can only be restored by the E2B sandbox provider; \
+                 select provider e2b to rewind this snapshot"
+            ),
+            (_, SnapshotKind::SpritesSnapshot) => bail!(
+                "SpritesSnapshot payloads can only be restored by the Sprites sandbox provider; \
+                 select provider sprites to rewind this snapshot"
+            ),
         }
 
         let image_tag = docker_load_image(&self.container_bin, &payload.bytes).await?;

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -20,6 +20,10 @@ use uuid::Uuid;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SandboxKey {
+    AgentSandbox {
+        agent_id: String,
+        sandbox_id: String,
+    },
     ConversationSandbox {
         conversation_id: String,
         sandbox_id: String,
@@ -29,6 +33,10 @@ pub enum SandboxKey {
 impl fmt::Display for SandboxKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::AgentSandbox {
+                agent_id,
+                sandbox_id,
+            } => write!(f, "agent:{agent_id}:{sandbox_id}"),
             Self::ConversationSandbox {
                 conversation_id,
                 sandbox_id,
@@ -1741,6 +1749,8 @@ mod tests {
                 key_filter.as_str(),
                 "--filter",
                 spec_filter.as_str(),
+                "--filter",
+                "status=running",
                 "--format",
                 "{{.Names}}",
             ]

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use anyhow::{Context, Result, anyhow, bail};
 use async_trait::async_trait;
 use bytes::Bytes;
+use chrono::{DateTime, Utc};
 use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
 use tokio::process::{Child, Command};
@@ -17,6 +18,8 @@ use tokio::sync::Mutex;
 use tokio::time;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use uuid::Uuid;
+
+use crate::DurableFileSystem;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SandboxKey {
@@ -74,6 +77,7 @@ pub enum SandboxNetworkPolicy {
 pub struct SandboxSpec {
     pub image: String,
     pub mounts: Vec<SandboxMount>,
+    pub durable_file_systems: Vec<DurableFileSystem>,
     pub network: SandboxNetworkPolicy,
     pub default_workdir: String,
 }
@@ -126,6 +130,12 @@ pub enum SnapshotKind {
     /// JSON manifest pointing at a named snapshot in Daytona's registry; the
     /// filesystem bytes live in Daytona, not in the payload.
     DaytonaSnapshot,
+    /// Reference to an E2B snapshot template id. Payload bytes are a small JSON
+    /// manifest; restoring is `POST /sandboxes { templateID: <snapshot_id> }`.
+    E2bSnapshot,
+    /// Reference to a Sprites checkpoint id on a named sprite. Payload bytes are
+    /// a small JSON manifest; restoring is `POST .../checkpoints/{id}/restore`.
+    SpritesSnapshot,
 }
 
 #[async_trait]
@@ -191,6 +201,7 @@ pub(crate) const WARM_SANDBOX_KEY_LABEL: &str = "exo.sandbox.key";
 pub(crate) const WARM_SANDBOX_SPEC_HASH_LABEL: &str = "exo.sandbox.spec-hash";
 const WARM_SANDBOX_OWNER_PID_LABEL: &str = "exo.sandbox.owner-pid";
 const APPLE_ABSOLUTE_TIME_UNIX_OFFSET_SECONDS: f64 = 978_307_200.0;
+const DURABLE_FILE_SYSTEM_ROOT_ENV: &str = "EXO_DURABLE_FILE_SYSTEM_ROOT";
 
 #[derive(Debug, Clone)]
 struct WarmSandboxEntry {
@@ -215,10 +226,35 @@ struct ContainerListConfiguration {
     labels: HashMap<String, String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct DockerInspectItem {
+    #[serde(rename = "Id")]
+    id: String,
+    #[serde(rename = "State")]
+    state: DockerInspectState,
+    #[serde(rename = "Config")]
+    config: DockerInspectConfiguration,
+}
+
+#[derive(Debug, Deserialize)]
+struct DockerInspectState {
+    #[serde(rename = "Status")]
+    status: Option<String>,
+    #[serde(rename = "StartedAt")]
+    started_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DockerInspectConfiguration {
+    #[serde(rename = "Labels", default)]
+    labels: HashMap<String, String>,
+}
+
 #[derive(Debug)]
 pub struct CliContainerSandboxBackend {
     cli: ContainerCliFlavor,
     container_bin: PathBuf,
+    durable_file_system_root: Option<PathBuf>,
     system_started: Mutex<bool>,
     network_created: Mutex<bool>,
     warm_sandboxes: Arc<Mutex<HashMap<SandboxKey, WarmSandboxEntry>>>,
@@ -233,10 +269,16 @@ impl CliContainerSandboxBackend {
         Self::new(ContainerCliFlavor::Docker)
     }
 
+    pub fn with_durable_file_system_root(mut self, root: impl Into<PathBuf>) -> Self {
+        self.durable_file_system_root = Some(root.into());
+        self
+    }
+
     fn new(cli: ContainerCliFlavor) -> Self {
         Self {
             cli,
             container_bin: PathBuf::from(cli.default_binary()),
+            durable_file_system_root: None,
             system_started: Mutex::new(false),
             network_created: Mutex::new(false),
             warm_sandboxes: Arc::new(Mutex::new(HashMap::new())),
@@ -244,29 +286,28 @@ impl CliContainerSandboxBackend {
     }
 
     async fn ensure_system_started(&self) -> Result<()> {
-        if !self.cli.requires_system_start() {
-            return Ok(());
-        }
         let mut started = self.system_started.lock().await;
         if *started {
             return Ok(());
         }
 
-        let output = Command::new(&self.container_bin)
-            .arg("system")
-            .arg("start")
-            .kill_on_drop(true)
-            .output()
-            .await
-            .with_context(|| missing_container_cli_message(self.cli, &self.container_bin))?;
-        if !output.status.success() {
-            return Err(anyhow!(
-                "failed to start container system: {}",
-                String::from_utf8_lossy(&output.stderr).trim()
-            ));
+        if self.cli.requires_system_start() {
+            let output = Command::new(&self.container_bin)
+                .arg("system")
+                .arg("start")
+                .kill_on_drop(true)
+                .output()
+                .await
+                .with_context(|| missing_container_cli_message(self.cli, &self.container_bin))?;
+            if !output.status.success() {
+                return Err(anyhow!(
+                    "failed to start container system: {}",
+                    String::from_utf8_lossy(&output.stderr).trim()
+                ));
+            }
         }
 
-        if let Err(error) = reap_orphaned_warm_sandboxes(&self.container_bin).await {
+        if let Err(error) = reap_orphaned_warm_sandboxes(&self.container_bin, self.cli).await {
             tracing::warn!(%error, "failed to reap orphaned warm sandboxes");
         }
         *started = true;
@@ -300,12 +341,16 @@ impl CliContainerSandboxBackend {
     }
 
     async fn prepare_request(&self, request: SandboxRequest) -> Result<SandboxRequest> {
+        validate_durable_file_system_mounts(
+            &request.spec.mounts,
+            &request.spec.durable_file_systems,
+        )?;
         self.ensure_system_started().await?;
         if matches!(request.spec.network, SandboxNetworkPolicy::Enabled) {
             self.ensure_default_network_created().await?;
         }
 
-        let mounts = request
+        let mut mounts = request
             .spec
             .mounts
             .into_iter()
@@ -320,6 +365,11 @@ impl CliContainerSandboxBackend {
                 Ok(SandboxMount { host_path, ..mount })
             })
             .collect::<Result<Vec<_>>>()?;
+        mounts.extend(materialize_durable_file_systems(
+            &request.key,
+            &request.spec.durable_file_systems,
+            self.durable_file_system_root.as_deref(),
+        )?);
 
         Ok(SandboxRequest {
             key: request.key,
@@ -330,6 +380,7 @@ impl CliContainerSandboxBackend {
                     request.spec.image
                 },
                 mounts,
+                durable_file_systems: request.spec.durable_file_systems,
                 network: request.spec.network,
                 default_workdir: request.spec.default_workdir,
             },
@@ -457,6 +508,14 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
             (_, SnapshotKind::DaytonaSnapshot) => {
                 bail!("restoring a Daytona snapshot on a container backend is not implemented yet")
             }
+            (_, SnapshotKind::E2bSnapshot) => bail!(
+                "E2bSnapshot payloads can only be restored by the E2B sandbox provider; \
+                 select provider e2b to rewind this snapshot"
+            ),
+            (_, SnapshotKind::SpritesSnapshot) => bail!(
+                "SpritesSnapshot payloads can only be restored by the Sprites sandbox provider; \
+                 select provider sprites to rewind this snapshot"
+            ),
         }
 
         let image_tag = docker_load_image(&self.container_bin, &payload.bytes).await?;
@@ -640,6 +699,9 @@ impl LocalProcessSandboxBackend {
 #[async_trait]
 impl ManagedSandboxBackend for LocalProcessSandboxBackend {
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
+        if !request.spec.durable_file_systems.is_empty() {
+            bail!("local-process sandbox backend does not support durable file systems");
+        }
         Ok(Arc::new(LocalProcessSandboxHandle {
             id: format!("local:{}", request.key),
             request,
@@ -729,6 +791,139 @@ fn resolve_local_workdir(spec: &SandboxSpec, cwd: &str) -> Option<PathBuf> {
         .iter()
         .find(|mount| mount.guest_path == cwd)
         .map(|mount| mount.host_path.clone())
+}
+
+fn materialize_durable_file_systems(
+    key: &SandboxKey,
+    file_systems: &[DurableFileSystem],
+    configured_root: Option<&Path>,
+) -> Result<Vec<SandboxMount>> {
+    if file_systems.is_empty() {
+        return Ok(Vec::new());
+    }
+    let root = durable_file_system_root(configured_root)?;
+    file_systems
+        .iter()
+        .map(|file_system| {
+            let host_path = root.join(stable_fnv1a_hex(&format!("{}\n{}", key, file_system.name)));
+            std::fs::create_dir_all(&host_path).with_context(|| {
+                format!(
+                    "creating durable file system {} at {}",
+                    file_system.name,
+                    host_path.display()
+                )
+            })?;
+            let host_path = std::fs::canonicalize(&host_path).with_context(|| {
+                format!(
+                    "canonicalizing durable file system {} at {}",
+                    file_system.name,
+                    host_path.display()
+                )
+            })?;
+            Ok(SandboxMount {
+                host_path,
+                guest_path: file_system.mount_path.clone(),
+                access: match file_system.mode {
+                    crate::FileSystemMountMode::ReadOnly => SandboxMountAccess::ReadOnly,
+                    crate::FileSystemMountMode::ReadWrite => SandboxMountAccess::ReadWrite,
+                },
+                internal: true,
+            })
+        })
+        .collect()
+}
+
+fn validate_durable_file_system_mounts(
+    mounts: &[SandboxMount],
+    file_systems: &[DurableFileSystem],
+) -> Result<()> {
+    validate_durable_file_systems(file_systems)?;
+    for mount in mounts {
+        for file_system in file_systems {
+            if mount.guest_path == file_system.mount_path {
+                bail!(
+                    "sandbox mount path is used by both a host mount and durable file system: {}",
+                    file_system.mount_path
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_durable_file_systems(file_systems: &[DurableFileSystem]) -> Result<()> {
+    for (index, file_system) in file_systems.iter().enumerate() {
+        if file_system.name.trim().is_empty() {
+            bail!("durable file system name must not be empty");
+        }
+        if file_system.name.contains('/') || file_system.name.contains('\0') {
+            bail!(
+                "durable file system name must not contain path separators or NUL bytes: {}",
+                file_system.name
+            );
+        }
+        if !file_system.mount_path.starts_with('/') {
+            bail!(
+                "durable file system mount path must be absolute: {}",
+                file_system.mount_path
+            );
+        }
+        if file_system.mount_path.trim() == "/" {
+            bail!("durable file system mount path must not be /");
+        }
+        for prior in &file_systems[..index] {
+            if prior.name == file_system.name {
+                bail!("duplicate durable file system name: {}", file_system.name);
+            }
+            if prior.mount_path == file_system.mount_path {
+                bail!(
+                    "duplicate durable file system mount path: {}",
+                    file_system.mount_path
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn durable_file_system_root(configured_root: Option<&Path>) -> Result<PathBuf> {
+    if let Some(value) = std::env::var_os(DURABLE_FILE_SYSTEM_ROOT_ENV) {
+        let path = PathBuf::from(value);
+        if !path.as_os_str().is_empty() {
+            return Ok(path);
+        }
+    }
+    if let Some(root) = configured_root {
+        return Ok(root.to_path_buf());
+    }
+    if let Some(value) = std::env::var_os("XDG_DATA_HOME") {
+        let path = PathBuf::from(value);
+        if !path.as_os_str().is_empty() {
+            return Ok(path.join("exo").join("durable-filesystems"));
+        }
+    }
+    if let Some(value) = std::env::var_os("HOME") {
+        let path = PathBuf::from(value);
+        if !path.as_os_str().is_empty() {
+            return Ok(path
+                .join(".local")
+                .join("share")
+                .join("exo")
+                .join("durable-filesystems"));
+        }
+    }
+    bail!(
+        "could not determine durable file system root: set {DURABLE_FILE_SYSTEM_ROOT_ENV}, XDG_DATA_HOME, or HOME"
+    )
+}
+
+pub(crate) fn stable_fnv1a_hex(input: &str) -> String {
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in input.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{hash:016x}")
 }
 
 async fn touch_warm_sandbox(
@@ -1341,6 +1536,15 @@ async fn kill_named_container_if_present(container_bin: &Path, name: &str) -> Re
     Ok(())
 }
 
+async fn reap_orphaned_warm_sandboxes(container_bin: &Path, cli: ContainerCliFlavor) -> Result<()> {
+    match cli {
+        ContainerCliFlavor::AppleContainer => {
+            reap_orphaned_apple_warm_sandboxes(container_bin).await
+        }
+        ContainerCliFlavor::Docker => reap_orphaned_docker_warm_sandboxes(container_bin).await,
+    }
+}
+
 async fn wait_for_apple_container_not_running(container_bin: &Path, name: &str) -> Result<()> {
     let deadline = Instant::now() + WARM_SANDBOX_CLEANUP_TIMEOUT;
     loop {
@@ -1378,7 +1582,7 @@ async fn apple_container_status(container_bin: &Path, name: &str) -> Result<Opti
         .and_then(|container| container.status))
 }
 
-async fn reap_orphaned_warm_sandboxes(container_bin: &Path) -> Result<()> {
+async fn reap_orphaned_apple_warm_sandboxes(container_bin: &Path) -> Result<()> {
     let output = run_container_admin_command(
         container_bin,
         WARM_SANDBOX_CLEANUP_TIMEOUT,
@@ -1441,9 +1645,96 @@ async fn reap_orphaned_warm_sandboxes(container_bin: &Path) -> Result<()> {
     Ok(())
 }
 
+async fn reap_orphaned_docker_warm_sandboxes(container_bin: &Path) -> Result<()> {
+    let output = run_container_admin_command(
+        container_bin,
+        WARM_SANDBOX_CLEANUP_TIMEOUT,
+        [
+            "ps",
+            "-aq",
+            "--no-trunc",
+            "--filter",
+            "label=exo.sandbox.key",
+        ],
+    )
+    .await?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "failed to list warm sandboxes: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+
+    let ids = String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+        .map(ToOwned::to_owned)
+        .collect::<Vec<_>>();
+    if ids.is_empty() {
+        return Ok(());
+    }
+
+    let mut inspect_args = Vec::with_capacity(ids.len() + 1);
+    inspect_args.push("inspect".to_string());
+    inspect_args.extend(ids);
+    let inspect = run_container_admin_command(
+        container_bin,
+        WARM_SANDBOX_CLEANUP_TIMEOUT,
+        inspect_args.iter().map(String::as_str),
+    )
+    .await?;
+    if !inspect.status.success() {
+        return Err(anyhow!(
+            "failed to inspect warm sandboxes: {}",
+            String::from_utf8_lossy(&inspect.stderr).trim()
+        ));
+    }
+
+    let now = Utc::now();
+    let min_age = chrono::Duration::from_std(ORPHANED_WARM_SANDBOX_MIN_AGE)
+        .expect("orphaned warm sandbox age fits in chrono duration");
+    let containers: Vec<DockerInspectItem> = serde_json::from_slice(&inspect.stdout)?;
+    for container in containers {
+        if !container.config.labels.contains_key(WARM_SANDBOX_KEY_LABEL) {
+            continue;
+        }
+        if let Some(owner_pid) = container.config.labels.get(WARM_SANDBOX_OWNER_PID_LABEL)
+            && owner_pid_is_alive(owner_pid)
+        {
+            continue;
+        }
+        if container.state.status.as_deref() != Some("running") {
+            continue;
+        }
+        let Some(started_at) = container.state.started_at.as_deref() else {
+            continue;
+        };
+        let started_at = parse_docker_timestamp(started_at)?;
+        if now.signed_duration_since(started_at) < min_age {
+            continue;
+        }
+        if let Err(error) =
+            cleanup_named_container(container_bin, ContainerCliFlavor::Docker, &container.id).await
+        {
+            tracing::warn!(
+                container_id = %container.id,
+                %error,
+                "failed to clean up orphaned warm sandbox"
+            );
+        }
+    }
+
+    Ok(())
+}
+
 fn apple_absolute_time_now() -> Result<f64> {
     let unix_now = SystemTime::now().duration_since(UNIX_EPOCH)?;
     Ok(unix_now.as_secs_f64() - APPLE_ABSOLUTE_TIME_UNIX_OFFSET_SECONDS)
+}
+
+fn parse_docker_timestamp(value: &str) -> Result<DateTime<Utc>> {
+    Ok(DateTime::parse_from_rfc3339(value)?.with_timezone(&Utc))
 }
 
 fn owner_pid_is_alive(pid: &str) -> bool {
@@ -1724,6 +2015,7 @@ mod tests {
             spec: SandboxSpec {
                 image: "docker.io/library/ubuntu:24.04".to_string(),
                 mounts: Vec::new(),
+                durable_file_systems: Vec::new(),
                 network: SandboxNetworkPolicy::Disabled,
                 default_workdir: "/".to_string(),
             },
@@ -1757,6 +2049,82 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn docker_prepare_request_reaps_orphaned_warm_sandboxes_with_real_cli_commands() {
+        use std::fs;
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let script_path = temp_dir.path().join("docker");
+        let args_path = temp_dir.path().join("args");
+        fs::write(
+            &script_path,
+            format!(
+                "#!/bin/sh\nfor arg in \"$@\"; do\n  printf '%s\\n' \"$arg\" >> '{}'\ndone\nprintf '%s\\n' '---' >> '{}'\ncase \"$1\" in\n  ps)\n    printf 'docker-container-id\\n'\n    ;;\n  inspect)\n    printf '%s\\n' '[{{\"Id\":\"docker-container-id\",\"Config\":{{\"Labels\":{{\"{}\":\"conversation:conversation:sandbox\"}}}},\"State\":{{\"Status\":\"running\",\"StartedAt\":\"2024-01-01T00:00:00Z\"}}}}]'\n    ;;\n  rm)\n    ;;\nesac\n",
+                args_path.display(),
+                args_path.display(),
+                WARM_SANDBOX_KEY_LABEL,
+            ),
+        )
+        .expect("write fake docker script");
+        let mut permissions = fs::metadata(&script_path)
+            .expect("fake docker metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&script_path, permissions).expect("chmod fake docker");
+
+        let backend = CliContainerSandboxBackend {
+            cli: ContainerCliFlavor::Docker,
+            container_bin: script_path,
+            durable_file_system_root: None,
+            system_started: Mutex::new(false),
+            network_created: Mutex::new(false),
+            warm_sandboxes: Arc::new(Mutex::new(HashMap::new())),
+        };
+        let request = SandboxRequest {
+            key: SandboxKey::ConversationSandbox {
+                conversation_id: "conversation".to_string(),
+                sandbox_id: "sandbox".to_string(),
+            },
+            spec: SandboxSpec {
+                image: "docker.io/library/ubuntu:24.04".to_string(),
+                mounts: Vec::new(),
+                durable_file_systems: Vec::new(),
+                network: SandboxNetworkPolicy::Disabled,
+                default_workdir: "/".to_string(),
+            },
+            lifecycle: SandboxLifecycleConfig {
+                idle_ttl: Some(Duration::from_secs(60)),
+            },
+        };
+
+        backend
+            .prepare_request(request)
+            .await
+            .expect("prepare request");
+
+        let args = fs::read_to_string(&args_path).expect("read fake docker args");
+        assert_eq!(
+            args.lines().collect::<Vec<_>>(),
+            vec![
+                "ps",
+                "-aq",
+                "--no-trunc",
+                "--filter",
+                "label=exo.sandbox.key",
+                "---",
+                "inspect",
+                "docker-container-id",
+                "---",
+                "rm",
+                "-f",
+                "docker-container-id",
+                "---",
+            ]
+        );
+    }
+
     #[tokio::test]
     async fn apple_container_backend_names_missing_container_cli() {
         let missing_bin = std::env::temp_dir().join(format!(
@@ -1766,6 +2134,7 @@ mod tests {
         let backend = CliContainerSandboxBackend {
             cli: ContainerCliFlavor::AppleContainer,
             container_bin: missing_bin,
+            durable_file_system_root: None,
             system_started: Mutex::new(false),
             network_created: Mutex::new(false),
             warm_sandboxes: Arc::new(Mutex::new(HashMap::new())),

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -18,6 +18,8 @@ use tokio::time;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use uuid::Uuid;
 
+use crate::DurableFileSystem;
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum SandboxKey {
     ConversationSandbox {
@@ -66,6 +68,7 @@ pub enum SandboxNetworkPolicy {
 pub struct SandboxSpec {
     pub image: String,
     pub mounts: Vec<SandboxMount>,
+    pub durable_file_systems: Vec<DurableFileSystem>,
     pub network: SandboxNetworkPolicy,
     pub default_workdir: String,
 }
@@ -183,6 +186,7 @@ pub(crate) const WARM_SANDBOX_KEY_LABEL: &str = "exo.sandbox.key";
 pub(crate) const WARM_SANDBOX_SPEC_HASH_LABEL: &str = "exo.sandbox.spec-hash";
 const WARM_SANDBOX_OWNER_PID_LABEL: &str = "exo.sandbox.owner-pid";
 const APPLE_ABSOLUTE_TIME_UNIX_OFFSET_SECONDS: f64 = 978_307_200.0;
+const DURABLE_FILE_SYSTEM_ROOT_ENV: &str = "EXO_DURABLE_FILE_SYSTEM_ROOT";
 
 #[derive(Debug, Clone)]
 struct WarmSandboxEntry {
@@ -211,6 +215,7 @@ struct ContainerListConfiguration {
 pub struct CliContainerSandboxBackend {
     cli: ContainerCliFlavor,
     container_bin: PathBuf,
+    durable_file_system_root: Option<PathBuf>,
     system_started: Mutex<bool>,
     network_created: Mutex<bool>,
     warm_sandboxes: Arc<Mutex<HashMap<SandboxKey, WarmSandboxEntry>>>,
@@ -225,10 +230,16 @@ impl CliContainerSandboxBackend {
         Self::new(ContainerCliFlavor::Docker)
     }
 
+    pub fn with_durable_file_system_root(mut self, root: impl Into<PathBuf>) -> Self {
+        self.durable_file_system_root = Some(root.into());
+        self
+    }
+
     fn new(cli: ContainerCliFlavor) -> Self {
         Self {
             cli,
             container_bin: PathBuf::from(cli.default_binary()),
+            durable_file_system_root: None,
             system_started: Mutex::new(false),
             network_created: Mutex::new(false),
             warm_sandboxes: Arc::new(Mutex::new(HashMap::new())),
@@ -292,12 +303,16 @@ impl CliContainerSandboxBackend {
     }
 
     async fn prepare_request(&self, request: SandboxRequest) -> Result<SandboxRequest> {
+        validate_durable_file_system_mounts(
+            &request.spec.mounts,
+            &request.spec.durable_file_systems,
+        )?;
         self.ensure_system_started().await?;
         if matches!(request.spec.network, SandboxNetworkPolicy::Enabled) {
             self.ensure_default_network_created().await?;
         }
 
-        let mounts = request
+        let mut mounts = request
             .spec
             .mounts
             .into_iter()
@@ -312,6 +327,11 @@ impl CliContainerSandboxBackend {
                 Ok(SandboxMount { host_path, ..mount })
             })
             .collect::<Result<Vec<_>>>()?;
+        mounts.extend(materialize_durable_file_systems(
+            &request.key,
+            &request.spec.durable_file_systems,
+            self.durable_file_system_root.as_deref(),
+        )?);
 
         Ok(SandboxRequest {
             key: request.key,
@@ -322,6 +342,7 @@ impl CliContainerSandboxBackend {
                     request.spec.image
                 },
                 mounts,
+                durable_file_systems: request.spec.durable_file_systems,
                 network: request.spec.network,
                 default_workdir: request.spec.default_workdir,
             },
@@ -632,6 +653,9 @@ impl LocalProcessSandboxBackend {
 #[async_trait]
 impl ManagedSandboxBackend for LocalProcessSandboxBackend {
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
+        if !request.spec.durable_file_systems.is_empty() {
+            bail!("local-process sandbox backend does not support durable file systems");
+        }
         Ok(Arc::new(LocalProcessSandboxHandle {
             id: format!("local:{}", request.key),
             request,
@@ -721,6 +745,139 @@ fn resolve_local_workdir(spec: &SandboxSpec, cwd: &str) -> Option<PathBuf> {
         .iter()
         .find(|mount| mount.guest_path == cwd)
         .map(|mount| mount.host_path.clone())
+}
+
+fn materialize_durable_file_systems(
+    key: &SandboxKey,
+    file_systems: &[DurableFileSystem],
+    configured_root: Option<&Path>,
+) -> Result<Vec<SandboxMount>> {
+    if file_systems.is_empty() {
+        return Ok(Vec::new());
+    }
+    let root = durable_file_system_root(configured_root)?;
+    file_systems
+        .iter()
+        .map(|file_system| {
+            let host_path = root.join(stable_fnv1a_hex(&format!("{}\n{}", key, file_system.name)));
+            std::fs::create_dir_all(&host_path).with_context(|| {
+                format!(
+                    "creating durable file system {} at {}",
+                    file_system.name,
+                    host_path.display()
+                )
+            })?;
+            let host_path = std::fs::canonicalize(&host_path).with_context(|| {
+                format!(
+                    "canonicalizing durable file system {} at {}",
+                    file_system.name,
+                    host_path.display()
+                )
+            })?;
+            Ok(SandboxMount {
+                host_path,
+                guest_path: file_system.mount_path.clone(),
+                access: match file_system.mode {
+                    crate::FileSystemMountMode::ReadOnly => SandboxMountAccess::ReadOnly,
+                    crate::FileSystemMountMode::ReadWrite => SandboxMountAccess::ReadWrite,
+                },
+                internal: true,
+            })
+        })
+        .collect()
+}
+
+fn validate_durable_file_system_mounts(
+    mounts: &[SandboxMount],
+    file_systems: &[DurableFileSystem],
+) -> Result<()> {
+    validate_durable_file_systems(file_systems)?;
+    for mount in mounts {
+        for file_system in file_systems {
+            if mount.guest_path == file_system.mount_path {
+                bail!(
+                    "sandbox mount path is used by both a host mount and durable file system: {}",
+                    file_system.mount_path
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn validate_durable_file_systems(file_systems: &[DurableFileSystem]) -> Result<()> {
+    for (index, file_system) in file_systems.iter().enumerate() {
+        if file_system.name.trim().is_empty() {
+            bail!("durable file system name must not be empty");
+        }
+        if file_system.name.contains('/') || file_system.name.contains('\0') {
+            bail!(
+                "durable file system name must not contain path separators or NUL bytes: {}",
+                file_system.name
+            );
+        }
+        if !file_system.mount_path.starts_with('/') {
+            bail!(
+                "durable file system mount path must be absolute: {}",
+                file_system.mount_path
+            );
+        }
+        if file_system.mount_path.trim() == "/" {
+            bail!("durable file system mount path must not be /");
+        }
+        for prior in &file_systems[..index] {
+            if prior.name == file_system.name {
+                bail!("duplicate durable file system name: {}", file_system.name);
+            }
+            if prior.mount_path == file_system.mount_path {
+                bail!(
+                    "duplicate durable file system mount path: {}",
+                    file_system.mount_path
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+fn durable_file_system_root(configured_root: Option<&Path>) -> Result<PathBuf> {
+    if let Some(value) = std::env::var_os(DURABLE_FILE_SYSTEM_ROOT_ENV) {
+        let path = PathBuf::from(value);
+        if !path.as_os_str().is_empty() {
+            return Ok(path);
+        }
+    }
+    if let Some(root) = configured_root {
+        return Ok(root.to_path_buf());
+    }
+    if let Some(value) = std::env::var_os("XDG_DATA_HOME") {
+        let path = PathBuf::from(value);
+        if !path.as_os_str().is_empty() {
+            return Ok(path.join("exo").join("durable-filesystems"));
+        }
+    }
+    if let Some(value) = std::env::var_os("HOME") {
+        let path = PathBuf::from(value);
+        if !path.as_os_str().is_empty() {
+            return Ok(path
+                .join(".local")
+                .join("share")
+                .join("exo")
+                .join("durable-filesystems"));
+        }
+    }
+    bail!(
+        "could not determine durable file system root: set {DURABLE_FILE_SYSTEM_ROOT_ENV}, XDG_DATA_HOME, or HOME"
+    )
+}
+
+pub(crate) fn stable_fnv1a_hex(input: &str) -> String {
+    let mut hash = 0xcbf29ce484222325u64;
+    for byte in input.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!("{hash:016x}")
 }
 
 async fn touch_warm_sandbox(
@@ -1710,6 +1867,7 @@ mod tests {
             spec: SandboxSpec {
                 image: "docker.io/library/ubuntu:24.04".to_string(),
                 mounts: Vec::new(),
+                durable_file_systems: Vec::new(),
                 network: SandboxNetworkPolicy::Disabled,
                 default_workdir: "/".to_string(),
             },
@@ -1750,6 +1908,7 @@ mod tests {
         let backend = CliContainerSandboxBackend {
             cli: ContainerCliFlavor::AppleContainer,
             container_bin: missing_bin,
+            durable_file_system_root: None,
             system_started: Mutex::new(false),
             network_created: Mutex::new(false),
             warm_sandboxes: Arc::new(Mutex::new(HashMap::new())),

--- a/crates/exoharness/src/sandbox_provider/aws_agentcore.rs
+++ b/crates/exoharness/src/sandbox_provider/aws_agentcore.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use crate::sandbox::{
     ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand, SandboxCommandOutput,
     SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotPayload, sandbox_spec_hash,
+    validate_durable_file_systems,
 };
 use crate::sandbox_provider::process_bridge;
 
@@ -25,6 +26,7 @@ pub struct AwsAgentCoreConfig {
     pub qualifier: Option<String>,
     pub endpoint_url: Option<String>,
     pub credentials: Option<AwsAgentCoreCredentials>,
+    pub session_storage_mount_path: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -39,6 +41,7 @@ pub struct AwsAgentCoreSandboxBackend {
     runtime_arn: String,
     invoke_target: AwsAgentCoreInvokeTarget,
     qualifier: Option<String>,
+    session_storage_mount_path: Option<String>,
 }
 
 impl AwsAgentCoreSandboxBackend {
@@ -71,11 +74,17 @@ impl AwsAgentCoreSandboxBackend {
         }
         let service_config = service_config_builder.build();
         let invoke_target = agentcore_invoke_target(&config.runtime_arn)?;
+        let session_storage_mount_path = config
+            .session_storage_mount_path
+            .as_deref()
+            .map(normalize_agentcore_session_storage_mount_path)
+            .transpose()?;
         Ok(Self {
             client: Client::from_conf(service_config),
             runtime_arn: config.runtime_arn,
             invoke_target,
             qualifier: config.qualifier,
+            session_storage_mount_path,
         })
     }
 }
@@ -83,7 +92,7 @@ impl AwsAgentCoreSandboxBackend {
 #[async_trait]
 impl ManagedSandboxBackend for AwsAgentCoreSandboxBackend {
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
-        reject_unsupported_request(&request)?;
+        reject_unsupported_request(&request, self.session_storage_mount_path.as_deref())?;
         let spec_hash = sandbox_spec_hash(&request.spec);
         let runtime_session_id = agentcore_runtime_session_id(&request, &spec_hash);
         Ok(Arc::new(AwsAgentCoreSandboxHandle {
@@ -341,16 +350,73 @@ fn agentcore_invoke_target(runtime_arn: &str) -> Result<AwsAgentCoreInvokeTarget
     }
 }
 
-fn reject_unsupported_request(request: &SandboxRequest) -> Result<()> {
+fn reject_unsupported_request(
+    request: &SandboxRequest,
+    session_storage_mount_path: Option<&str>,
+) -> Result<()> {
     if !request.spec.mounts.is_empty() {
         bail!(
             "AgentCore sandbox backend does not support host bind-mounts; remove conversation mounts or use a local sandbox provider"
         );
     }
+    validate_durable_file_systems(&request.spec.durable_file_systems)?;
+    match request.spec.durable_file_systems.as_slice() {
+        [] => {}
+        [file_system] => {
+            if matches!(file_system.mode, crate::FileSystemMountMode::ReadOnly) {
+                bail!("AgentCore sandbox backend does not support read-only durable file systems");
+            }
+            let requested_mount_path =
+                normalize_agentcore_session_storage_mount_path(&file_system.mount_path)?;
+            // AgentCore managed session storage is provisioned on the runtime by
+            // create/update-agent-runtime, not on InvokeAgentRuntime. Exo stores
+            // the mount path it expects here so a durable FS request fails before
+            // we run work against a runtime that was built without matching
+            // filesystemConfigurations.
+            let Some(configured_mount_path) = session_storage_mount_path else {
+                bail!(
+                    "AgentCore sandbox backend was not configured with a managed session storage mount path; configure the runtime with filesystemConfigurations and set session_storage_mount_path"
+                );
+            };
+            if requested_mount_path != configured_mount_path {
+                bail!(
+                    "AgentCore sandbox durable file system mount path {requested_mount_path:?} does not match configured managed session storage mount path {configured_mount_path:?}"
+                );
+            }
+        }
+        _ => {
+            bail!("AgentCore sandbox backend supports at most one durable file system");
+        }
+    }
     if matches!(request.spec.network, SandboxNetworkPolicy::Disabled) {
         bail!("AgentCore sandbox backend cannot enforce disabled networking");
     }
     Ok(())
+}
+
+fn normalize_agentcore_session_storage_mount_path(path: &str) -> Result<String> {
+    let trimmed = path.trim();
+    if !(6..=200).contains(&trimmed.len()) {
+        bail!("AgentCore session storage mount path must be between 6 and 200 characters: {path}");
+    }
+    let Some(suffix) = trimmed.strip_prefix("/mnt/") else {
+        bail!("AgentCore session storage mount path must be under /mnt/: {path}");
+    };
+    let suffix = suffix.trim_end_matches('/');
+    if suffix.is_empty() || suffix.contains('/') {
+        bail!(
+            "AgentCore session storage mount path must have exactly one subdirectory under /mnt/: {path}"
+        );
+    }
+    if !suffix
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+    {
+        bail!(
+            "AgentCore session storage mount path may only contain letters, numbers, '.', '_', and '-' after /mnt/: {path}"
+        );
+    }
+    Ok(format!("/mnt/{suffix}"))
 }
 
 fn agentcore_runtime_session_id(request: &SandboxRequest, spec_hash: &str) -> String {
@@ -418,4 +484,71 @@ struct AgentCoreExecResponse {
     cwd: Option<String>,
     #[serde(default)]
     error: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        DurableFileSystem, FileSystemMountMode, SandboxKey, SandboxLifecycleConfig,
+        SandboxNetworkPolicy, SandboxSpec,
+    };
+
+    #[test]
+    fn durable_file_system_requires_configured_session_storage_mount_path() {
+        let request = durable_request("/mnt/workspace", FileSystemMountMode::ReadWrite);
+        let error = reject_unsupported_request(&request, None).expect_err("missing mount path");
+        assert!(
+            error
+                .to_string()
+                .contains("was not configured with a managed session storage mount path")
+        );
+    }
+
+    #[test]
+    fn durable_file_system_must_match_configured_session_storage_mount_path() {
+        let request = durable_request("/mnt/workspace", FileSystemMountMode::ReadWrite);
+        let error =
+            reject_unsupported_request(&request, Some("/mnt/other")).expect_err("mount mismatch");
+        assert!(
+            error
+                .to_string()
+                .contains("does not match configured managed session storage mount path")
+        );
+    }
+
+    #[test]
+    fn durable_file_system_accepts_matching_session_storage_mount_path() {
+        let request = durable_request("/mnt/workspace", FileSystemMountMode::ReadWrite);
+        reject_unsupported_request(&request, Some("/mnt/workspace")).expect("matching mount path");
+    }
+
+    #[test]
+    fn durable_file_system_rejects_non_agentcore_mount_path_shape() {
+        let request = durable_request("/home/exo/workspace", FileSystemMountMode::ReadWrite);
+        let error =
+            reject_unsupported_request(&request, Some("/mnt/workspace")).expect_err("bad path");
+        assert!(error.to_string().contains("must be under /mnt/"));
+    }
+
+    fn durable_request(mount_path: &str, mode: FileSystemMountMode) -> SandboxRequest {
+        SandboxRequest {
+            key: SandboxKey::ConversationSandbox {
+                conversation_id: "conversation".to_string(),
+                sandbox_id: "sandbox".to_string(),
+            },
+            spec: SandboxSpec {
+                image: "agentcore".to_string(),
+                mounts: Vec::new(),
+                durable_file_systems: vec![DurableFileSystem {
+                    name: "workspace".to_string(),
+                    mount_path: mount_path.to_string(),
+                    mode,
+                }],
+                network: SandboxNetworkPolicy::Enabled,
+                default_workdir: "/mnt/workspace".to_string(),
+            },
+            lifecycle: SandboxLifecycleConfig::default(),
+        }
+    }
 }

--- a/crates/exoharness/src/sandbox_provider/daytona.rs
+++ b/crates/exoharness/src/sandbox_provider/daytona.rs
@@ -238,7 +238,7 @@ impl DaytonaSandboxBackend {
 #[async_trait]
 impl ManagedSandboxBackend for DaytonaSandboxBackend {
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
-        reject_host_mounts(&request)?;
+        reject_unsupported_mounts(&request)?;
         let spec_hash = sandbox_spec_hash(&request.spec);
 
         // Reuse a matching sandbox if one exists (also how we recover across exo
@@ -927,14 +927,17 @@ async fn stop_via_backend(backend: &DaytonaBackendHandle, id: &str) -> Result<()
     Ok(())
 }
 
-fn reject_host_mounts(request: &SandboxRequest) -> Result<()> {
-    if request.spec.mounts.is_empty() {
-        return Ok(());
+fn reject_unsupported_mounts(request: &SandboxRequest) -> Result<()> {
+    if !request.spec.mounts.is_empty() {
+        bail!(
+            "Daytona sandbox backend does not support host bind-mounts; \
+         remove conversation mounts or use a local sandbox provider"
+        );
     }
-    bail!(
-        "Daytona sandbox backend does not support host bind-mounts; \
-     remove conversation mounts or use a local sandbox provider"
-    )
+    if !request.spec.durable_file_systems.is_empty() {
+        bail!("Daytona sandbox backend does not support durable file systems");
+    }
+    Ok(())
 }
 
 fn idle_ttl_to_minutes(ttl: Duration) -> u32 {

--- a/crates/exoharness/src/sandbox_provider/e2b.rs
+++ b/crates/exoharness/src/sandbox_provider/e2b.rs
@@ -1,0 +1,1130 @@
+//! E2B remote sandbox backend.
+//!
+//! Uses E2B's platform REST API (`api.e2b.app`) for lifecycle and the per-sandbox
+//! envd Connect API for command execution. Cross-process resume uses sandbox
+//! `metadata` (same keys as Docker/Daytona labels). Snapshots are bytes-by-reference
+//! via [`SnapshotKind::E2bSnapshot`] manifests pointing at an E2B snapshot template id.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow, bail};
+use async_trait::async_trait;
+use base64::Engine;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use bytes::Bytes;
+use futures::StreamExt;
+use futures::future::BoxFuture;
+use reqwest::header::{HeaderMap, HeaderValue};
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+use uuid::Uuid;
+
+use crate::sandbox::{
+    DEFAULT_SANDBOX_IMAGE, ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand,
+    SandboxCommandOutput, SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotKind,
+    SnapshotPayload, WARM_SANDBOX_KEY_LABEL, WARM_SANDBOX_SPEC_HASH_LABEL, sandbox_spec_hash,
+};
+
+pub const DEFAULT_E2B_API_URL: &str = "https://api.e2b.app";
+pub const DEFAULT_E2B_ENVD_PORT: u16 = 49_983;
+
+const PROCESS_PIPE_BUFFER_SIZE: usize = 64 * 1024;
+
+/// Connect envelope flag: payload is gzip-compressed (unsupported here).
+const CONNECT_FLAG_COMPRESSED: u8 = 0x01;
+/// Connect envelope flag: final message carrying stream status / errors.
+const CONNECT_FLAG_END_STREAM: u8 = 0x02;
+const CONNECT_MAX_ENVELOPE_BYTES: usize = 16 * 1024 * 1024;
+
+#[derive(Debug, Clone)]
+pub struct E2bConfig {
+    pub api_key: String,
+    pub api_url: String,
+    pub template_id: String,
+    pub envd_port: u16,
+    /// When set (tests), envd requests go to this base URL instead of `{port}-{sandboxID}.e2b.app`.
+    pub envd_base_url: Option<String>,
+    /// When false, envd endpoints do not require `X-Access-Token` (E2B default for SDK is true).
+    pub secure: bool,
+}
+
+/// JSON persisted for [`SnapshotKind::E2bSnapshot`]. Filesystem state lives in E2B;
+/// we only store the snapshot template id returned by `POST /sandboxes/{id}/snapshots`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct E2bSnapshotManifest {
+    snapshot_id: String,
+    base_template: String,
+}
+
+pub struct E2bSandboxBackend {
+    client: reqwest::Client,
+    api_url: String,
+    template_id: String,
+    envd_port: u16,
+    envd_base_url: Option<String>,
+    secure: bool,
+}
+
+impl E2bSandboxBackend {
+    pub fn new(config: E2bConfig) -> Result<Self> {
+        let mut headers = HeaderMap::new();
+        let api_key = HeaderValue::from_str(&config.api_key)
+            .context("E2B_API_KEY contains characters that aren't valid in an HTTP header")?;
+        headers.insert("X-API-Key", api_key);
+        let client = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()
+            .context("building E2B HTTP client")?;
+        Ok(Self {
+            client,
+            api_url: config.api_url.trim_end_matches('/').to_string(),
+            template_id: config.template_id,
+            envd_port: config.envd_port,
+            envd_base_url: config.envd_base_url,
+            secure: config.secure,
+        })
+    }
+
+    fn api_endpoint(&self, path: &str) -> String {
+        format!("{}{}", self.api_url, path)
+    }
+
+    async fn find_sandbox_by_metadata(
+        &self,
+        key_label: &str,
+        spec_hash: &str,
+    ) -> Result<Option<E2bListedSandbox>> {
+        let metadata = metadata_filter_query(key_label, spec_hash);
+        // OpenAPI `state` uses style=form, explode=false → `state=running,paused`.
+        // Two `state=` query params are not accepted reliably by the API.
+        if let Some(found) = self.list_sandboxes_with_metadata(&metadata, true).await? {
+            return Ok(Some(found));
+        }
+        // Fallback: metadata only (e.g. API ignores unknown state serialization).
+        self.list_sandboxes_with_metadata(&metadata, false).await
+    }
+
+    async fn list_sandboxes_with_metadata(
+        &self,
+        metadata: &str,
+        with_state_filter: bool,
+    ) -> Result<Option<E2bListedSandbox>> {
+        let mut query: Vec<(&str, &str)> = vec![("metadata", metadata)];
+        if with_state_filter {
+            query.push(("state", "running,paused"));
+        }
+        let response = self
+            .client
+            .get(self.api_endpoint("/v2/sandboxes"))
+            .query(&query)
+            .send()
+            .await
+            .context("listing E2B sandboxes")?
+            .error_for_status()
+            .context("E2B list sandboxes returned an error status")?;
+        let mut sandboxes: Vec<E2bListedSandbox> = response
+            .json()
+            .await
+            .context("decoding E2B sandbox list response")?;
+        sandboxes.sort_by(|a, b| b.started_at.cmp(&a.started_at));
+        Ok(sandboxes.into_iter().next())
+    }
+
+    async fn create_sandbox(
+        &self,
+        request: &SandboxRequest,
+        spec_hash: &str,
+        template_id: &str,
+    ) -> Result<E2bSandboxCreated> {
+        let mut metadata = HashMap::new();
+        metadata.insert(WARM_SANDBOX_KEY_LABEL.to_string(), request.key.to_string());
+        metadata.insert(
+            WARM_SANDBOX_SPEC_HASH_LABEL.to_string(),
+            spec_hash.to_string(),
+        );
+
+        let (timeout_secs, auto_pause) = idle_ttl_to_e2b_lifecycle(&request.lifecycle.idle_ttl);
+
+        let body = E2bCreateRequest {
+            template_id: template_id.to_string(),
+            timeout: timeout_secs,
+            auto_pause,
+            secure: self.secure,
+            allow_internet_access: !matches!(request.spec.network, SandboxNetworkPolicy::Disabled),
+            metadata,
+        };
+
+        let response = self
+            .client
+            .post(self.api_endpoint("/sandboxes"))
+            .json(&body)
+            .send()
+            .await
+            .context("creating E2B sandbox")?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            bail!("E2B create-sandbox failed ({status}): {text}");
+        }
+        let sandbox: E2bSandboxCreated = response
+            .json()
+            .await
+            .context("decoding E2B create-sandbox response")?;
+        Ok(sandbox)
+    }
+
+    async fn connect_sandbox(
+        &self,
+        sandbox_id: &str,
+        timeout_secs: u32,
+    ) -> Result<E2bSandboxCreated> {
+        let body = E2bConnectRequest {
+            timeout: timeout_secs,
+        };
+        let response = self
+            .client
+            .post(self.api_endpoint(&format!("/sandboxes/{sandbox_id}/connect")))
+            .json(&body)
+            .send()
+            .await
+            .with_context(|| format!("connecting to E2B sandbox {sandbox_id}"))?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            bail!("E2B connect-sandbox failed ({status}): {text}");
+        }
+        response
+            .json()
+            .await
+            .context("decoding E2B connect-sandbox response")
+    }
+
+    fn handle_backend(&self) -> E2bBackendHandle {
+        E2bBackendHandle {
+            client: self.client.clone(),
+            api_url: self.api_url.clone(),
+            template_id: self.template_id.clone(),
+            envd_port: self.envd_port,
+            envd_base_url: self.envd_base_url.clone(),
+            secure: self.secure,
+        }
+    }
+}
+
+#[async_trait]
+impl ManagedSandboxBackend for E2bSandboxBackend {
+    async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
+        reject_host_mounts(&request)?;
+        let spec_hash = sandbox_spec_hash(&request.spec);
+        let key_label = request.key.to_string();
+        let template_id = resolve_template_id(&request.spec, &self.template_id);
+
+        if let Some(existing) = self
+            .find_sandbox_by_metadata(&key_label, &spec_hash)
+            .await?
+        {
+            let mut envd_access_token = None;
+            if existing.state == "paused" {
+                let timeout_secs = idle_ttl_to_e2b_lifecycle(&request.lifecycle.idle_ttl).0;
+                let connected = self
+                    .connect_sandbox(&existing.sandbox_id, timeout_secs)
+                    .await?;
+                envd_access_token = connected.envd_access_token;
+            }
+            return Ok(Arc::new(E2bSandboxHandle {
+                id: format!("e2b:{}", request.key),
+                sandbox_id: existing.sandbox_id,
+                envd_access_token,
+                request,
+                backend: self.handle_backend(),
+            }));
+        }
+
+        let sandbox = self
+            .create_sandbox(&request, &spec_hash, &template_id)
+            .await?;
+        Ok(Arc::new(E2bSandboxHandle {
+            id: format!("e2b:{}", request.key),
+            sandbox_id: sandbox.sandbox_id,
+            envd_access_token: sandbox.envd_access_token,
+            request,
+            backend: self.handle_backend(),
+        }))
+    }
+
+    async fn acquire_from_snapshot(
+        &self,
+        request: SandboxRequest,
+        payload: SnapshotPayload,
+    ) -> Result<Arc<dyn ManagedSandboxHandle>> {
+        reject_host_mounts(&request)?;
+        if !matches!(payload.kind, SnapshotKind::E2bSnapshot) {
+            bail!(
+                "E2B sandbox backend can only restore from SnapshotKind::E2bSnapshot, got {:?}",
+                payload.kind
+            );
+        }
+        let manifest: E2bSnapshotManifest =
+            serde_json::from_slice(&payload.bytes).context("decoding E2bSnapshot manifest")?;
+        let spec_hash = sandbox_spec_hash(&request.spec);
+        let sandbox = self
+            .create_sandbox(&request, &spec_hash, &manifest.snapshot_id)
+            .await?;
+        Ok(Arc::new(E2bSandboxHandle {
+            id: format!("e2b-restored:{}", request.key),
+            sandbox_id: sandbox.sandbox_id,
+            envd_access_token: sandbox.envd_access_token,
+            request,
+            backend: self.handle_backend(),
+        }))
+    }
+}
+
+#[derive(Clone)]
+struct E2bBackendHandle {
+    client: reqwest::Client,
+    api_url: String,
+    template_id: String,
+    envd_port: u16,
+    envd_base_url: Option<String>,
+    secure: bool,
+}
+
+impl E2bBackendHandle {
+    fn api_endpoint(&self, path: &str) -> String {
+        format!("{}{}", self.api_url, path)
+    }
+
+    fn envd_endpoint(&self, sandbox_id: &str, path: &str) -> String {
+        envd_endpoint_url(
+            self.envd_base_url.as_deref(),
+            self.envd_port,
+            sandbox_id,
+            path,
+        )
+    }
+}
+
+fn envd_endpoint_url(
+    envd_base_url: Option<&str>,
+    envd_port: u16,
+    sandbox_id: &str,
+    path: &str,
+) -> String {
+    if let Some(base) = envd_base_url {
+        format!("{}{}", base.trim_end_matches('/'), path)
+    } else {
+        format!("https://{envd_port}-{sandbox_id}.e2b.app{path}")
+    }
+}
+
+struct E2bSandboxHandle {
+    id: String,
+    sandbox_id: String,
+    envd_access_token: Option<String>,
+    request: SandboxRequest,
+    backend: E2bBackendHandle,
+}
+
+#[async_trait]
+impl ManagedSandboxHandle for E2bSandboxHandle {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    async fn exec(&self, command: &SandboxCommand) -> Result<SandboxCommandOutput> {
+        exec_in_sandbox(
+            &self.backend,
+            &self.sandbox_id,
+            self.envd_access_token.as_deref(),
+            &self.request.spec,
+            command,
+        )
+        .await
+    }
+
+    async fn start_process(&self, command: &SandboxCommand) -> Result<crate::SandboxProcessParts> {
+        start_process_in_sandbox(
+            &self.backend,
+            &self.sandbox_id,
+            self.envd_access_token.as_deref(),
+            &self.request.spec,
+            command,
+        )
+        .await
+    }
+
+    async fn stop(&self) -> Result<()> {
+        pause_via_backend(&self.backend, &self.sandbox_id).await
+    }
+
+    async fn snapshot(&self) -> Result<SnapshotPayload> {
+        let base_template = resolve_template_id(&self.request.spec, &self.backend.template_id);
+        save_snapshot_via_backend(&self.backend, &self.sandbox_id, base_template).await
+    }
+}
+
+async fn start_process_in_sandbox(
+    backend: &E2bBackendHandle,
+    sandbox_id: &str,
+    envd_access_token: Option<&str>,
+    spec: &SandboxSpec,
+    command: &SandboxCommand,
+) -> Result<crate::SandboxProcessParts> {
+    if command.argv.is_empty() {
+        bail!("sandbox command requires at least one argv entry");
+    }
+    let cwd = command
+        .cwd
+        .clone()
+        .unwrap_or_else(|| spec.default_workdir.clone());
+    let (cmd, args) = command.argv.split_first().expect("checked non-empty");
+
+    let (stdout_reader, stdout_writer) = tokio::io::duplex(PROCESS_PIPE_BUFFER_SIZE);
+    let (stderr_reader, stderr_writer) = tokio::io::duplex(PROCESS_PIPE_BUFFER_SIZE);
+    let (stdin_reader, stdin_writer) = tokio::io::duplex(PROCESS_PIPE_BUFFER_SIZE);
+    let (wait_tx, wait_rx) = oneshot::channel();
+    let (pid_tx, pid_rx) = oneshot::channel();
+    let (stdin_error_tx, stdin_error_rx) = mpsc::unbounded_channel();
+
+    let process = E2bRunningProcess {
+        backend: backend.clone(),
+        sandbox_id: sandbox_id.to_string(),
+        envd_access_token: envd_access_token.map(str::to_string),
+    };
+
+    spawn_e2b_process_stream_poller(E2bProcessStreamPoller {
+        process: process.clone(),
+        cmd: cmd.to_string(),
+        args: args.to_vec(),
+        cwd,
+        env: command.env.clone(),
+        stdout_writer,
+        stderr_writer,
+        stdin_error_rx,
+        pid_tx,
+        wait_tx,
+    });
+    spawn_e2b_process_stdin_forwarder(process, stdin_reader, pid_rx, stdin_error_tx);
+
+    let wait: BoxFuture<'static, crate::Result<i32>> = Box::pin(async move {
+        match wait_rx.await {
+            Ok(result) => result,
+            Err(_) => Err(anyhow!("E2B process stream stopped before reporting exit")),
+        }
+    });
+
+    Ok(crate::SandboxProcessParts {
+        stdout: Box::pin(stdout_reader.compat()),
+        stderr: Box::pin(stderr_reader.compat()),
+        stdin: Box::pin(stdin_writer.compat_write()),
+        wait,
+    })
+}
+
+async fn exec_in_sandbox(
+    backend: &E2bBackendHandle,
+    sandbox_id: &str,
+    envd_access_token: Option<&str>,
+    spec: &SandboxSpec,
+    command: &SandboxCommand,
+) -> Result<SandboxCommandOutput> {
+    let cwd = command
+        .cwd
+        .clone()
+        .unwrap_or_else(|| spec.default_workdir.clone());
+    exec_command_in_sandbox(backend, sandbox_id, envd_access_token, cwd, command).await
+}
+
+async fn exec_command_in_sandbox(
+    backend: &E2bBackendHandle,
+    sandbox_id: &str,
+    envd_access_token: Option<&str>,
+    cwd: String,
+    command: &SandboxCommand,
+) -> Result<SandboxCommandOutput> {
+    if command.argv.is_empty() {
+        bail!("sandbox command requires at least one argv entry");
+    }
+    let (cmd, args) = command.argv.split_first().expect("checked non-empty");
+
+    let start_request = serde_json::json!({
+        "process": {
+            "cmd": cmd,
+            "args": args,
+            "envs": command.env,
+            "cwd": cwd,
+        },
+        "stdin": false,
+    });
+    let request_payload =
+        serde_json::to_vec(&start_request).context("encoding E2B StartRequest")?;
+    let request_body = connect_encode_envelope(0, &request_payload)?;
+
+    let mut request = backend
+        .client
+        .post(backend.envd_endpoint(sandbox_id, "/process.Process/Start"))
+        .header("Connect-Protocol-Version", "1")
+        .header("Content-Type", "application/connect+json")
+        .body(request_body);
+    if backend.secure {
+        let token = envd_access_token.ok_or_else(|| {
+            anyhow!(
+                "E2B sandbox {sandbox_id} requires envdAccessToken for command execution \
+                 (create with secure: false via E2B_SECURE=0, or reconnect to refresh the token)"
+            )
+        })?;
+        request = request.header("X-Access-Token", token);
+    }
+
+    let response = request
+        .send()
+        .await
+        .with_context(|| format!("exec in E2B sandbox {sandbox_id}"))?;
+    let status = response.status();
+    let bytes = response
+        .bytes()
+        .await
+        .context("reading E2B exec response")?;
+    if !status.is_success() {
+        bail!(
+            "E2B exec failed ({status}): {}",
+            String::from_utf8_lossy(&bytes)
+        );
+    }
+
+    let (stdout, stderr, exit_code) = parse_connect_start_response(&bytes)?;
+    Ok(SandboxCommandOutput {
+        ok: exit_code == 0,
+        exit_code: Some(exit_code),
+        stdout,
+        stderr,
+        command: command
+            .display_argv
+            .clone()
+            .unwrap_or_else(|| command.argv.clone()),
+        cwd,
+    })
+}
+
+#[derive(Clone)]
+struct E2bRunningProcess {
+    backend: E2bBackendHandle,
+    sandbox_id: String,
+    envd_access_token: Option<String>,
+}
+
+struct E2bProcessStreamPoller {
+    process: E2bRunningProcess,
+    cmd: String,
+    args: Vec<String>,
+    cwd: String,
+    env: HashMap<String, String>,
+    stdout_writer: tokio::io::DuplexStream,
+    stderr_writer: tokio::io::DuplexStream,
+    stdin_error_rx: mpsc::UnboundedReceiver<anyhow::Error>,
+    pid_tx: oneshot::Sender<i32>,
+    wait_tx: oneshot::Sender<crate::Result<i32>>,
+}
+
+fn spawn_e2b_process_stream_poller(poller: E2bProcessStreamPoller) {
+    tokio::spawn(async move {
+        let E2bProcessStreamPoller {
+            process,
+            cmd,
+            args,
+            cwd,
+            env,
+            stdout_writer,
+            stderr_writer,
+            mut stdin_error_rx,
+            pid_tx,
+            wait_tx,
+        } = poller;
+        let sandbox_id = process.sandbox_id.clone();
+        let result = poll_e2b_process_stream(
+            process,
+            cmd,
+            args,
+            cwd,
+            env,
+            stdout_writer,
+            stderr_writer,
+            &mut stdin_error_rx,
+            pid_tx,
+        )
+        .await;
+        if wait_tx.send(result).is_err() {
+            tracing::debug!(
+                sandbox_id = %sandbox_id,
+                "E2B process waiter dropped before completion"
+            );
+        }
+    });
+}
+
+fn spawn_e2b_process_stdin_forwarder(
+    process: E2bRunningProcess,
+    stdin_reader: tokio::io::DuplexStream,
+    pid_rx: oneshot::Receiver<i32>,
+    stdin_error_tx: mpsc::UnboundedSender<anyhow::Error>,
+) {
+    tokio::spawn(async move {
+        let sandbox_id = process.sandbox_id.clone();
+        if let Err(error) = forward_e2b_process_stdin(process, stdin_reader, pid_rx).await {
+            tracing::warn!(
+                sandbox_id = %sandbox_id,
+                error = %error,
+                "E2B process stdin forwarder stopped"
+            );
+            if stdin_error_tx.send(error).is_err() {
+                tracing::debug!(
+                    sandbox_id = %sandbox_id,
+                    "E2B process stream stopped before stdin error could be reported"
+                );
+            }
+        }
+    });
+}
+
+async fn poll_e2b_process_stream(
+    process: E2bRunningProcess,
+    cmd: String,
+    args: Vec<String>,
+    cwd: String,
+    env: HashMap<String, String>,
+    mut stdout_writer: tokio::io::DuplexStream,
+    mut stderr_writer: tokio::io::DuplexStream,
+    stdin_error_rx: &mut mpsc::UnboundedReceiver<anyhow::Error>,
+    pid_tx: oneshot::Sender<i32>,
+) -> crate::Result<i32> {
+    let start_request = serde_json::json!({
+        "process": {
+            "cmd": cmd,
+            "args": args,
+            "envs": env,
+            "cwd": cwd,
+        },
+        "stdin": true,
+    });
+    let request_payload =
+        serde_json::to_vec(&start_request).context("encoding E2B StartRequest")?;
+    let request_body = connect_encode_envelope(0, &request_payload)?;
+
+    let mut request = process
+        .backend
+        .client
+        .post(
+            process
+                .backend
+                .envd_endpoint(&process.sandbox_id, "/process.Process/Start"),
+        )
+        .header("Connect-Protocol-Version", "1")
+        .header("Content-Type", "application/connect+json")
+        .body(request_body);
+    request = apply_envd_access_token(
+        request,
+        &process.backend,
+        &process.sandbox_id,
+        process.envd_access_token.as_deref(),
+    )?;
+
+    let response = request
+        .send()
+        .await
+        .with_context(|| format!("starting E2B process in sandbox {}", process.sandbox_id))?;
+    let status = response.status();
+    if !status.is_success() {
+        let bytes = response.bytes().await.unwrap_or_default();
+        bail!(
+            "E2B process start failed ({status}): {}",
+            String::from_utf8_lossy(&bytes)
+        );
+    }
+
+    let mut reader = ConnectEnvelopeReader::default();
+    let mut pid_tx = Some(pid_tx);
+    let mut exit_code = None;
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        if let Ok(error) = stdin_error_rx.try_recv() {
+            return Err(error.context("E2B process stdin forwarding failed"));
+        }
+        let chunk = chunk.context("reading E2B process stream chunk")?;
+        reader.push(&chunk);
+        while let Some((flags, payload)) = reader.pop_envelope()? {
+            if flags & CONNECT_FLAG_END_STREAM != 0 {
+                let end: serde_json::Value = serde_json::from_slice(&payload)
+                    .context("decoding Connect end-stream message")?;
+                if let Some(err) = end.get("error") {
+                    let code = err
+                        .get("code")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown");
+                    let message = err
+                        .get("message")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("unknown error");
+                    bail!("E2B process stream error ({code}): {message}");
+                }
+                continue;
+            }
+
+            let message: serde_json::Value =
+                serde_json::from_slice(&payload).context("decoding Connect stream message")?;
+            let Some(event) = message.get("event") else {
+                continue;
+            };
+            if let Some(start) = event.get("start")
+                && let Some(pid) = start.get("pid").and_then(|v| v.as_i64())
+                && let Some(sender) = pid_tx.take()
+                && sender.send(pid as i32).is_err()
+            {
+                tracing::debug!(
+                    sandbox_id = %process.sandbox_id,
+                    pid,
+                    "E2B process stdin forwarder dropped before pid was delivered"
+                );
+            }
+            if let Some(data) = event.get("data") {
+                if let Some(chunk) = data.get("stdout").and_then(|v| v.as_str()) {
+                    let decoded = decode_process_bytes(chunk);
+                    stdout_writer
+                        .write_all(decoded.as_bytes())
+                        .await
+                        .context("writing E2B process stdout pipe")?;
+                }
+                if let Some(chunk) = data.get("stderr").and_then(|v| v.as_str()) {
+                    let decoded = decode_process_bytes(chunk);
+                    stderr_writer
+                        .write_all(decoded.as_bytes())
+                        .await
+                        .context("writing E2B process stderr pipe")?;
+                }
+            }
+            if let Some(end) = event.get("end") {
+                exit_code = Some(parse_exit_code(end));
+            }
+        }
+    }
+
+    exit_code.ok_or_else(|| anyhow!("E2B process stream ended without an exit event"))
+}
+
+async fn forward_e2b_process_stdin(
+    process: E2bRunningProcess,
+    mut stdin_reader: tokio::io::DuplexStream,
+    pid_rx: oneshot::Receiver<i32>,
+) -> Result<()> {
+    let pid = pid_rx
+        .await
+        .map_err(|_| anyhow!("E2B process stream stopped before reporting pid"))?;
+    let mut buffer = vec![0u8; PROCESS_PIPE_BUFFER_SIZE];
+    loop {
+        let bytes_read = stdin_reader
+            .read(&mut buffer)
+            .await
+            .context("reading E2B process stdin pipe")?;
+        if bytes_read == 0 {
+            e2b_close_stdin(&process, pid).await?;
+            return Ok(());
+        }
+        e2b_send_stdin(&process, pid, &buffer[..bytes_read]).await?;
+    }
+}
+
+async fn e2b_send_stdin(process: &E2bRunningProcess, pid: i32, data: &[u8]) -> Result<()> {
+    let body = serde_json::json!({
+        "process": { "pid": pid },
+        "input": { "stdin": BASE64.encode(data) },
+    });
+    let mut request = process
+        .backend
+        .client
+        .post(
+            process
+                .backend
+                .envd_endpoint(&process.sandbox_id, "/process.Process/SendInput"),
+        )
+        .header("Connect-Protocol-Version", "1")
+        .header("Content-Type", "application/json")
+        .json(&body);
+    request = apply_envd_access_token(
+        request,
+        &process.backend,
+        &process.sandbox_id,
+        process.envd_access_token.as_deref(),
+    )?;
+    let response = request
+        .send()
+        .await
+        .with_context(|| format!("sending stdin to E2B process {pid}"))?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        bail!("E2B SendInput failed ({status}): {text}");
+    }
+    Ok(())
+}
+
+async fn e2b_close_stdin(process: &E2bRunningProcess, pid: i32) -> Result<()> {
+    let body = serde_json::json!({
+        "process": { "pid": pid },
+    });
+    let mut request = process
+        .backend
+        .client
+        .post(
+            process
+                .backend
+                .envd_endpoint(&process.sandbox_id, "/process.Process/CloseStdin"),
+        )
+        .header("Connect-Protocol-Version", "1")
+        .header("Content-Type", "application/json")
+        .json(&body);
+    request = apply_envd_access_token(
+        request,
+        &process.backend,
+        &process.sandbox_id,
+        process.envd_access_token.as_deref(),
+    )?;
+    let response = request
+        .send()
+        .await
+        .with_context(|| format!("closing stdin for E2B process {pid}"))?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        bail!("E2B CloseStdin failed ({status}): {text}");
+    }
+    Ok(())
+}
+
+fn apply_envd_access_token(
+    request: reqwest::RequestBuilder,
+    backend: &E2bBackendHandle,
+    sandbox_id: &str,
+    envd_access_token: Option<&str>,
+) -> Result<reqwest::RequestBuilder> {
+    if !backend.secure {
+        return Ok(request);
+    }
+    let token = envd_access_token.ok_or_else(|| {
+        anyhow!(
+            "E2B sandbox {sandbox_id} requires envdAccessToken for command execution \
+             (create with secure: false via E2B_SECURE=0, or reconnect to refresh the token)"
+        )
+    })?;
+    Ok(request.header("X-Access-Token", token))
+}
+
+#[derive(Default)]
+struct ConnectEnvelopeReader {
+    buffer: Vec<u8>,
+}
+
+impl ConnectEnvelopeReader {
+    fn push(&mut self, chunk: &[u8]) {
+        self.buffer.extend_from_slice(chunk);
+    }
+
+    fn pop_envelope(&mut self) -> Result<Option<(u8, Vec<u8>)>> {
+        if self.buffer.len() < 5 {
+            return Ok(None);
+        }
+        let len =
+            u32::from_be_bytes(self.buffer[1..5].try_into().expect("four length bytes")) as usize;
+        if len > CONNECT_MAX_ENVELOPE_BYTES {
+            bail!("connect envelope length {len} exceeds max {CONNECT_MAX_ENVELOPE_BYTES}");
+        }
+        if self.buffer.len() < 5 + len {
+            return Ok(None);
+        }
+        let flags = self.buffer[0];
+        if flags & CONNECT_FLAG_COMPRESSED != 0 {
+            bail!("compressed Connect envelopes are not supported");
+        }
+        let payload = self.buffer[5..5 + len].to_vec();
+        self.buffer.drain(..5 + len);
+        Ok(Some((flags, payload)))
+    }
+}
+
+/// Wrap a JSON payload in a Connect binary envelope (1-byte flags + 4-byte BE length).
+fn connect_encode_envelope(flags: u8, payload: &[u8]) -> Result<Vec<u8>> {
+    if payload.len() > CONNECT_MAX_ENVELOPE_BYTES {
+        bail!(
+            "connect envelope payload is {} bytes (max {CONNECT_MAX_ENVELOPE_BYTES})",
+            payload.len()
+        );
+    }
+    let mut out = Vec::with_capacity(5 + payload.len());
+    out.push(flags);
+    out.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+    out.extend_from_slice(payload);
+    Ok(out)
+}
+
+fn connect_decode_envelopes(bytes: &[u8]) -> Result<Vec<(u8, Vec<u8>)>> {
+    let mut remaining = bytes;
+    let mut envelopes = Vec::new();
+    while !remaining.is_empty() {
+        if remaining.len() < 5 {
+            bail!("truncated Connect envelope header");
+        }
+        let flags = remaining[0];
+        let len =
+            u32::from_be_bytes(remaining[1..5].try_into().expect("four length bytes")) as usize;
+        remaining = &remaining[5..];
+        if len > CONNECT_MAX_ENVELOPE_BYTES {
+            bail!("connect envelope length {len} exceeds max {CONNECT_MAX_ENVELOPE_BYTES}");
+        }
+        if remaining.len() < len {
+            bail!(
+                "truncated Connect envelope payload: expected {len} bytes, got {}",
+                remaining.len()
+            );
+        }
+        let payload = remaining[..len].to_vec();
+        remaining = &remaining[len..];
+        if flags & CONNECT_FLAG_COMPRESSED != 0 {
+            bail!("compressed Connect envelopes are not supported");
+        }
+        envelopes.push((flags, payload));
+    }
+    Ok(envelopes)
+}
+
+/// Parse a Connect server-streaming `application/connect+json` body into stdout/stderr/exit.
+fn parse_connect_start_response(bytes: &[u8]) -> Result<(String, String, i32)> {
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    let mut exit_code = 0i32;
+
+    for (flags, payload) in connect_decode_envelopes(bytes)? {
+        if flags & CONNECT_FLAG_END_STREAM != 0 {
+            let end: serde_json::Value =
+                serde_json::from_slice(&payload).context("decoding Connect end-stream message")?;
+            if let Some(err) = end.get("error") {
+                let code = err
+                    .get("code")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown");
+                let message = err
+                    .get("message")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown error");
+                bail!("E2B process stream error ({code}): {message}");
+            }
+            continue;
+        }
+
+        let message: serde_json::Value =
+            serde_json::from_slice(&payload).context("decoding Connect stream message")?;
+        let Some(event) = message.get("event") else {
+            continue;
+        };
+        if let Some(data) = event.get("data") {
+            if let Some(chunk) = data.get("stdout").and_then(|v| v.as_str()) {
+                stdout.push_str(&decode_process_bytes(chunk));
+            }
+            if let Some(chunk) = data.get("stderr").and_then(|v| v.as_str()) {
+                stderr.push_str(&decode_process_bytes(chunk));
+            }
+        }
+        if let Some(end) = event.get("end") {
+            exit_code = parse_exit_code(end);
+        }
+    }
+
+    Ok((stdout, stderr, exit_code))
+}
+
+#[cfg(test)]
+mod connect_tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_envelope_header() {
+        let payload = br#"{"event":{"data":{"stdout":"hi"}}}"#;
+        let encoded = connect_encode_envelope(0, payload).unwrap();
+        let decoded = connect_decode_envelopes(&encoded).unwrap();
+        assert_eq!(decoded.len(), 1);
+        assert_eq!(decoded[0].0, 0);
+        assert_eq!(decoded[0].1, payload);
+    }
+
+    #[test]
+    fn decode_process_bytes_handles_base64_stdout() {
+        assert_eq!(
+            super::decode_process_bytes("ZXhvLWUyYi1saXZlCg=="),
+            "exo-e2b-live\n"
+        );
+    }
+}
+
+/// E2B envd encodes stdout/stderr chunks as standard base64 in Connect JSON events.
+fn decode_process_bytes(raw: &str) -> String {
+    if let Ok(decoded) = BASE64.decode(raw.trim().as_bytes())
+        && let Ok(text) = String::from_utf8(decoded)
+    {
+        return text;
+    }
+    raw.to_string()
+}
+
+fn parse_exit_code(end: &serde_json::Value) -> i32 {
+    if let Some(code) = end.get("exitCode").and_then(|v| v.as_i64()) {
+        return code as i32;
+    }
+    if let Some(status) = end.get("status").and_then(|v| v.as_str())
+        && let Some(rest) = status.strip_prefix("exit status ")
+        && let Ok(code) = rest.trim().parse::<i32>()
+    {
+        return code;
+    }
+    0
+}
+
+async fn pause_via_backend(backend: &E2bBackendHandle, sandbox_id: &str) -> Result<()> {
+    let response = backend
+        .client
+        .post(backend.api_endpoint(&format!("/sandboxes/{sandbox_id}/pause")))
+        .send()
+        .await
+        .with_context(|| format!("pausing E2B sandbox {sandbox_id}"))?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        bail!("E2B pause-sandbox failed ({status}): {text}");
+    }
+    Ok(())
+}
+
+async fn save_snapshot_via_backend(
+    backend: &E2bBackendHandle,
+    sandbox_id: &str,
+    base_template: String,
+) -> Result<SnapshotPayload> {
+    let snapshot_name = format!("exo-snap-{}", Uuid::new_v4().simple());
+    let body = E2bSnapshotCreateRequest {
+        name: Some(snapshot_name),
+    };
+    let response = backend
+        .client
+        .post(backend.api_endpoint(&format!("/sandboxes/{sandbox_id}/snapshots")))
+        .json(&body)
+        .send()
+        .await
+        .with_context(|| format!("snapshotting E2B sandbox {sandbox_id}"))?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        bail!("E2B snapshot failed ({status}): {text}");
+    }
+    let info: E2bSnapshotInfo = response
+        .json()
+        .await
+        .context("decoding E2B snapshot response")?;
+    let manifest = E2bSnapshotManifest {
+        snapshot_id: info.snapshot_id,
+        base_template,
+    };
+    let bytes = serde_json::to_vec(&manifest).context("serializing E2bSnapshot manifest")?;
+    Ok(SnapshotPayload {
+        kind: SnapshotKind::E2bSnapshot,
+        bytes: Bytes::from(bytes),
+    })
+}
+
+fn reject_host_mounts(request: &SandboxRequest) -> Result<()> {
+    if request.spec.mounts.is_empty() {
+        return Ok(());
+    }
+    bail!(
+        "E2B sandbox backend does not support host bind-mounts; \
+         remove conversation mounts or use a local sandbox provider"
+    )
+}
+
+fn resolve_template_id(spec: &SandboxSpec, default_template: &str) -> String {
+    if spec.image.trim().is_empty() {
+        if default_template.is_empty() {
+            DEFAULT_SANDBOX_IMAGE.to_string()
+        } else {
+            default_template.to_string()
+        }
+    } else {
+        spec.image.clone()
+    }
+}
+
+/// Builds the `metadata` query value for `GET /v2/sandboxes`.
+///
+/// E2B expects `key=value&key2=value2` with URL encoding applied once at the
+/// HTTP layer. Pre-encoding here and then passing through reqwest's `.query()`
+/// double-encodes colons (`%253A`), so list filters never match created sandboxes.
+fn metadata_filter_query(key_label: &str, spec_hash: &str) -> String {
+    format!(
+        "{}={}&{}={}",
+        WARM_SANDBOX_KEY_LABEL, key_label, WARM_SANDBOX_SPEC_HASH_LABEL, spec_hash,
+    )
+}
+
+fn idle_ttl_to_e2b_lifecycle(idle_ttl: &Option<Duration>) -> (u32, bool) {
+    let Some(ttl) = idle_ttl else {
+        return (300, false);
+    };
+    let secs = ttl.as_secs().clamp(1, u32::MAX as u64) as u32;
+    (secs, true)
+}
+
+#[derive(Debug, Serialize)]
+struct E2bCreateRequest {
+    #[serde(rename = "templateID")]
+    template_id: String,
+    timeout: u32,
+    #[serde(rename = "autoPause")]
+    auto_pause: bool,
+    secure: bool,
+    allow_internet_access: bool,
+    metadata: HashMap<String, String>,
+}
+
+#[derive(Debug, Serialize)]
+struct E2bConnectRequest {
+    timeout: u32,
+}
+
+#[derive(Debug, Serialize)]
+struct E2bSnapshotCreateRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct E2bSandboxCreated {
+    #[serde(rename = "sandboxID")]
+    sandbox_id: String,
+    #[serde(default, rename = "envdAccessToken")]
+    envd_access_token: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct E2bListedSandbox {
+    #[serde(rename = "sandboxID")]
+    sandbox_id: String,
+    state: String,
+    #[serde(default, rename = "startedAt")]
+    started_at: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct E2bSnapshotInfo {
+    #[serde(rename = "snapshotID")]
+    snapshot_id: String,
+}

--- a/crates/exoharness/src/sandbox_provider/mod.rs
+++ b/crates/exoharness/src/sandbox_provider/mod.rs
@@ -27,7 +27,11 @@ mod aws_agentcore {
     }
 }
 #[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
+mod e2b;
+#[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
 mod process_bridge;
+#[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
+mod sprites;
 #[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
 mod vercel;
 #[cfg(not(all(not(target_arch = "wasm32"), feature = "basic-backend")))]
@@ -52,6 +56,10 @@ pub use daytona::{
 #[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
 pub(crate) use docker::DEFAULT_DOCKER_IMAGE;
 pub use docker::default_docker_image;
+#[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
+pub use e2b::{DEFAULT_E2B_API_URL, DEFAULT_E2B_ENVD_PORT, E2bConfig, E2bSandboxBackend};
+#[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
+pub use sprites::{DEFAULT_SPRITES_API_URL, SpritesConfig, SpritesSandboxBackend};
 pub use vercel::default_vercel_image;
 #[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
 pub use vercel::{DEFAULT_VERCEL_API_URL, VercelConfig, VercelSandboxBackend};

--- a/crates/exoharness/src/sandbox_provider/sprites.rs
+++ b/crates/exoharness/src/sandbox_provider/sprites.rs
@@ -1,0 +1,820 @@
+//! Sprites.dev remote sandbox backend.
+//!
+//! Uses the Sprites platform REST API (`api.sprites.dev`) for lifecycle, HTTP
+//! exec for one-shot commands, WebSocket exec for streaming processes, and
+//! checkpoint/restore snapshots. Cross-process resume uses a
+//! deterministic sprite name derived from [`SandboxKey`] + spec hash (same role
+//! as Docker labels / E2B metadata). Snapshots are bytes-by-reference via
+//! [`SnapshotKind::SpritesSnapshot`] manifests pointing at a checkpoint id.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use anyhow::{Context, Result, anyhow, bail};
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::future::BoxFuture;
+use futures::{SinkExt, StreamExt};
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::oneshot;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+use url::Url;
+
+use crate::sandbox::{
+    ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand, SandboxCommandOutput,
+    SandboxRequest, SandboxSpec, SnapshotKind, SnapshotPayload, WARM_SANDBOX_KEY_LABEL,
+    WARM_SANDBOX_SPEC_HASH_LABEL, sandbox_spec_hash,
+};
+
+pub const DEFAULT_SPRITES_API_URL: &str = "https://api.sprites.dev";
+
+const PROCESS_PIPE_BUFFER_SIZE: usize = 64 * 1024;
+const SPRITES_STREAM_STDIN: u8 = 0;
+const SPRITES_STREAM_STDOUT: u8 = 1;
+const SPRITES_STREAM_STDERR: u8 = 2;
+const SPRITES_STREAM_EXIT: u8 = 3;
+const SPRITES_STREAM_STDIN_EOF: u8 = 4;
+
+#[derive(Debug, Clone)]
+pub struct SpritesConfig {
+    pub token: String,
+    pub api_url: String,
+    /// Sprite HTTP URL auth: `sprite` or `public`. `None` lets Sprites default to `sprite`.
+    pub url_auth: Option<String>,
+    /// Organization slug for multi-org tokens.
+    pub organization: Option<String>,
+    /// Binding-level labels; exo resume labels are always merged in on create.
+    pub extra_labels: Vec<String>,
+}
+
+/// JSON persisted for [`SnapshotKind::SpritesSnapshot`]. Filesystem state lives on
+/// the sprite; we only store the checkpoint id and sprite name.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SpritesSnapshotManifest {
+    checkpoint_id: String,
+    sprite_name: String,
+}
+
+pub struct SpritesSandboxBackend {
+    client: reqwest::Client,
+    api_url: String,
+    token: String,
+    url_auth: Option<String>,
+    organization: Option<String>,
+    extra_labels: Vec<String>,
+}
+
+impl SpritesSandboxBackend {
+    pub fn new(config: SpritesConfig) -> Result<Self> {
+        let mut headers = HeaderMap::new();
+        let mut auth = HeaderValue::from_str(&format!("Bearer {}", config.token))
+            .context("SPRITES_TOKEN contains characters that aren't valid in an HTTP header")?;
+        auth.set_sensitive(true);
+        headers.insert(AUTHORIZATION, auth);
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+        let client = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()
+            .context("building Sprites HTTP client")?;
+        if let Some(url_auth) = config.url_auth.as_deref() {
+            validate_url_auth(url_auth)?;
+        }
+        Ok(Self {
+            client,
+            api_url: config.api_url.trim_end_matches('/').to_string(),
+            token: config.token,
+            url_auth: config.url_auth,
+            organization: config.organization,
+            extra_labels: config.extra_labels,
+        })
+    }
+
+    fn api_endpoint(&self, path: &str) -> String {
+        format!("{}{}", self.api_url, path)
+    }
+
+    async fn get_sprite(&self, name: &str) -> Result<Option<()>> {
+        let response = self
+            .client
+            .get(self.api_endpoint(&format!("/v1/sprites/{name}")))
+            .send()
+            .await
+            .with_context(|| format!("fetching Sprites sprite {name}"))?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        if !response.status().is_success() {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            bail!("Sprites get-sprite failed ({status}): {text}");
+        }
+        Ok(Some(()))
+    }
+
+    async fn create_sprite(&self, name: &str, request: &SandboxRequest) -> Result<()> {
+        let spec_hash = sandbox_spec_hash(&request.spec);
+        let labels = sprite_labels_for_request(request, &spec_hash, &self.extra_labels);
+        let body = SpritesCreateRequest {
+            name: name.to_string(),
+            organization: self.organization.clone(),
+            url_settings: self
+                .url_auth
+                .as_ref()
+                .map(|auth| SpritesUrlSettings { auth: auth.clone() }),
+            labels,
+        };
+        let response = self
+            .client
+            .post(self.api_endpoint("/v1/sprites"))
+            .json(&body)
+            .send()
+            .await
+            .context("creating Sprites sprite")?;
+        if response.status().is_success() {
+            return Ok(());
+        }
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        if status == reqwest::StatusCode::CONFLICT
+            || (status == reqwest::StatusCode::BAD_REQUEST && text.contains("exists"))
+        {
+            return Ok(());
+        }
+        bail!("Sprites create-sprite failed ({status}): {text}");
+    }
+
+    async fn ensure_sprite(&self, name: &str, request: &SandboxRequest) -> Result<()> {
+        if self.get_sprite(name).await?.is_some() {
+            return Ok(());
+        }
+        self.create_sprite(name, request).await
+    }
+
+    fn handle_backend(&self) -> SpritesBackendHandle {
+        SpritesBackendHandle {
+            client: self.client.clone(),
+            api_url: self.api_url.clone(),
+            token: self.token.clone(),
+        }
+    }
+}
+
+#[async_trait]
+impl ManagedSandboxBackend for SpritesSandboxBackend {
+    async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
+        reject_host_mounts(&request)?;
+        let sprite_name = sprite_name_for_request(&request);
+        self.ensure_sprite(&sprite_name, &request).await?;
+        Ok(Arc::new(SpritesSandboxHandle {
+            id: format!("sprites:{}", request.key),
+            sprite_name,
+            request,
+            backend: self.handle_backend(),
+        }))
+    }
+
+    async fn acquire_from_snapshot(
+        &self,
+        request: SandboxRequest,
+        payload: SnapshotPayload,
+    ) -> Result<Arc<dyn ManagedSandboxHandle>> {
+        reject_host_mounts(&request)?;
+        if !matches!(payload.kind, SnapshotKind::SpritesSnapshot) {
+            bail!(
+                "Sprites sandbox backend can only restore from SnapshotKind::SpritesSnapshot, \
+                 got {:?}",
+                payload.kind
+            );
+        }
+        let manifest: SpritesSnapshotManifest =
+            serde_json::from_slice(&payload.bytes).context("decoding SpritesSnapshot manifest")?;
+        let sprite_name = sprite_name_for_request(&request);
+        if manifest.sprite_name != sprite_name {
+            bail!(
+                "Sprites snapshot belongs to sprite {}, but this sandbox key maps to {}",
+                manifest.sprite_name,
+                sprite_name
+            );
+        }
+        self.ensure_sprite(&sprite_name, &request).await?;
+        restore_checkpoint_via_backend(
+            &self.handle_backend(),
+            &sprite_name,
+            &manifest.checkpoint_id,
+        )
+        .await?;
+        Ok(Arc::new(SpritesSandboxHandle {
+            id: format!("sprites-restored:{}", request.key),
+            sprite_name,
+            request,
+            backend: self.handle_backend(),
+        }))
+    }
+}
+
+#[derive(Clone)]
+struct SpritesBackendHandle {
+    client: reqwest::Client,
+    api_url: String,
+    token: String,
+}
+
+impl SpritesBackendHandle {
+    fn api_endpoint(&self, path: &str) -> String {
+        format!("{}{}", self.api_url, path)
+    }
+
+    fn websocket_endpoint(&self, path: &str) -> Result<Url> {
+        let origin = if let Some(rest) = self.api_url.strip_prefix("https://") {
+            format!("wss://{rest}")
+        } else if let Some(rest) = self.api_url.strip_prefix("http://") {
+            format!("ws://{rest}")
+        } else {
+            bail!(
+                "Sprites api_url must be an http(s) URL, got {}",
+                self.api_url
+            );
+        };
+        Url::parse(&format!("{origin}{path}")).context("parsing Sprites WebSocket URL")
+    }
+}
+
+struct SpritesSandboxHandle {
+    id: String,
+    sprite_name: String,
+    request: SandboxRequest,
+    backend: SpritesBackendHandle,
+}
+
+#[async_trait]
+impl ManagedSandboxHandle for SpritesSandboxHandle {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    async fn exec(&self, command: &SandboxCommand) -> Result<SandboxCommandOutput> {
+        exec_in_sprite(
+            &self.backend,
+            &self.sprite_name,
+            &self.request.spec,
+            command,
+        )
+        .await
+    }
+
+    async fn start_process(&self, command: &SandboxCommand) -> Result<crate::SandboxProcessParts> {
+        start_process_in_sprite(
+            &self.backend,
+            &self.sprite_name,
+            &self.request.spec,
+            command,
+        )
+        .await
+    }
+
+    async fn stop(&self) -> Result<()> {
+        // Sprites hibernate when idle; do not DELETE — the next session resumes the
+        // same sprite by deterministic name via `acquire`.
+        Ok(())
+    }
+
+    async fn snapshot(&self) -> Result<SnapshotPayload> {
+        save_checkpoint_via_backend(&self.backend, &self.sprite_name).await
+    }
+}
+
+async fn start_process_in_sprite(
+    backend: &SpritesBackendHandle,
+    sprite_name: &str,
+    spec: &SandboxSpec,
+    command: &SandboxCommand,
+) -> Result<crate::SandboxProcessParts> {
+    if command.argv.is_empty() {
+        bail!("sandbox command requires at least one argv entry");
+    }
+    let cwd = command
+        .cwd
+        .clone()
+        .unwrap_or_else(|| spec.default_workdir.clone());
+
+    let mut url = backend.websocket_endpoint(&format!("/v1/sprites/{sprite_name}/exec"))?;
+    {
+        let mut query = url.query_pairs_mut();
+        for arg in &command.argv {
+            query.append_pair("cmd", arg);
+        }
+        query.append_pair("stdin", "true");
+        if !cwd.is_empty() {
+            query.append_pair("dir", &cwd);
+        }
+        for (key, value) in &command.env {
+            query.append_pair("env", &format!("{key}={value}"));
+        }
+    }
+
+    let mut request = url
+        .as_str()
+        .into_client_request()
+        .context("building Sprites exec WebSocket request")?;
+    let auth = HeaderValue::from_str(&format!("Bearer {}", backend.token))
+        .context("SPRITES_TOKEN contains characters that aren't valid in an HTTP header")?;
+    request.headers_mut().insert(AUTHORIZATION, auth);
+
+    let (ws_stream, _) = connect_async(request)
+        .await
+        .with_context(|| format!("connecting Sprites exec WebSocket for sprite {sprite_name}"))?;
+
+    let (stdout_reader, stdout_writer) = tokio::io::duplex(PROCESS_PIPE_BUFFER_SIZE);
+    let (stderr_reader, stderr_writer) = tokio::io::duplex(PROCESS_PIPE_BUFFER_SIZE);
+    let (stdin_reader, stdin_writer) = tokio::io::duplex(PROCESS_PIPE_BUFFER_SIZE);
+    let (wait_tx, wait_rx) = oneshot::channel();
+
+    let sprite_name_owned = sprite_name.to_string();
+    tokio::spawn(async move {
+        let result =
+            run_sprites_exec_websocket(ws_stream, stdin_reader, stdout_writer, stderr_writer).await;
+        if wait_tx.send(result).is_err() {
+            tracing::debug!(
+                sprite_name = %sprite_name_owned,
+                "Sprites process waiter dropped before completion"
+            );
+        }
+    });
+
+    let wait: BoxFuture<'static, crate::Result<i32>> = Box::pin(async move {
+        match wait_rx.await {
+            Ok(result) => result,
+            Err(_) => Err(anyhow!(
+                "Sprites exec WebSocket stopped before reporting exit"
+            )),
+        }
+    });
+
+    Ok(crate::SandboxProcessParts {
+        stdout: Box::pin(stdout_reader.compat()),
+        stderr: Box::pin(stderr_reader.compat()),
+        stdin: Box::pin(stdin_writer.compat_write()),
+        wait,
+    })
+}
+
+async fn run_sprites_exec_websocket(
+    ws_stream: tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+    mut stdin_reader: tokio::io::DuplexStream,
+    mut stdout_writer: tokio::io::DuplexStream,
+    mut stderr_writer: tokio::io::DuplexStream,
+) -> crate::Result<i32> {
+    let (mut ws_write, mut ws_read) = ws_stream.split();
+    let mut exit_code = None;
+    let mut stdin_buffer = vec![0u8; PROCESS_PIPE_BUFFER_SIZE];
+    let mut stdin_closed = false;
+
+    loop {
+        if exit_code.is_some() {
+            break;
+        }
+
+        tokio::select! {
+            message = ws_read.next() => {
+                let Some(message) = message else {
+                    break;
+                };
+                let message = message.context("reading Sprites exec WebSocket message")?;
+                match message {
+                    Message::Binary(data) => {
+                        if data.is_empty() {
+                            continue;
+                        }
+                        let stream_id = data[0];
+                        let payload = &data[1..];
+                        match stream_id {
+                            SPRITES_STREAM_STDOUT => {
+                                stdout_writer
+                                    .write_all(payload)
+                                    .await
+                                    .context("writing Sprites process stdout pipe")?;
+                            }
+                            SPRITES_STREAM_STDERR => {
+                                stderr_writer
+                                    .write_all(payload)
+                                    .await
+                                    .context("writing Sprites process stderr pipe")?;
+                            }
+                            SPRITES_STREAM_EXIT => {
+                                exit_code = Some(parse_sprites_binary_exit_code(payload));
+                            }
+                            _ => {}
+                        }
+                    }
+                    Message::Text(text) => {
+                        if let Ok(event) = serde_json::from_str::<SpritesExecJsonMessage>(&text)
+                            && event.message_type == "exit"
+                            && let Some(code) = event.exit_code
+                        {
+                            exit_code = Some(code);
+                        }
+                    }
+                    Message::Close(_) => break,
+                    Message::Ping(payload) => {
+                        ws_write
+                            .send(Message::Pong(payload))
+                            .await
+                            .context("responding to Sprites exec WebSocket ping")?;
+                    }
+                    Message::Pong(_) | Message::Frame(_) => {}
+                }
+            }
+            read_result = stdin_reader.read(&mut stdin_buffer), if !stdin_closed => {
+                let bytes_read = read_result.context("reading Sprites process stdin pipe")?;
+                if bytes_read == 0 {
+                    ws_write
+                        .send(Message::Binary(Bytes::from_static(&[
+                            SPRITES_STREAM_STDIN_EOF,
+                        ])))
+                        .await
+                        .context("sending Sprites stdin EOF")?;
+                    stdin_closed = true;
+                } else {
+                    let mut frame = Vec::with_capacity(1 + bytes_read);
+                    frame.push(SPRITES_STREAM_STDIN);
+                    frame.extend_from_slice(&stdin_buffer[..bytes_read]);
+                    ws_write
+                        .send(Message::Binary(Bytes::from(frame)))
+                        .await
+                        .context("sending Sprites process stdin")?;
+                }
+            }
+        }
+    }
+
+    exit_code.ok_or_else(|| anyhow!("Sprites exec WebSocket closed without an exit event"))
+}
+
+fn parse_sprites_binary_exit_code(payload: &[u8]) -> i32 {
+    if payload.is_empty() {
+        return 0;
+    }
+    if payload.len() == 1 {
+        return payload[0] as i32;
+    }
+    if let Ok(text) = std::str::from_utf8(payload)
+        && let Ok(code) = text.trim().parse::<i32>()
+    {
+        return code;
+    }
+    payload.last().copied().unwrap_or(0) as i32
+}
+
+#[derive(Debug, Deserialize)]
+struct SpritesExecJsonMessage {
+    #[serde(rename = "type")]
+    message_type: String,
+    #[serde(rename = "exit_code")]
+    exit_code: Option<i32>,
+}
+
+async fn exec_in_sprite(
+    backend: &SpritesBackendHandle,
+    sprite_name: &str,
+    spec: &SandboxSpec,
+    command: &SandboxCommand,
+) -> Result<SandboxCommandOutput> {
+    let cwd = command
+        .cwd
+        .clone()
+        .unwrap_or_else(|| spec.default_workdir.clone());
+    exec_command_in_sprite(backend, sprite_name, cwd, command).await
+}
+
+async fn exec_command_in_sprite(
+    backend: &SpritesBackendHandle,
+    sprite_name: &str,
+    cwd: String,
+    command: &SandboxCommand,
+) -> Result<SandboxCommandOutput> {
+    if command.argv.is_empty() {
+        bail!("sandbox command requires at least one argv entry");
+    }
+
+    let mut query: Vec<(&str, String)> = Vec::new();
+    for arg in &command.argv {
+        query.push(("cmd", arg.clone()));
+    }
+    query.push(("stdin", "false".to_string()));
+    if !cwd.is_empty() {
+        query.push(("dir", cwd.clone()));
+    }
+    for (key, value) in &command.env {
+        query.push(("env", format!("{key}={value}")));
+    }
+
+    let response = backend
+        .client
+        .post(backend.api_endpoint(&format!("/v1/sprites/{sprite_name}/exec")))
+        .query(&query)
+        .send()
+        .await
+        .with_context(|| format!("exec in Sprites sprite {sprite_name}"))?;
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .context("reading Sprites exec response body")?;
+    if !status.is_success() {
+        bail!("Sprites exec failed ({status}): {body}");
+    }
+
+    let (exit_code, stdout, stderr) = parse_exec_response(&body)?;
+    Ok(SandboxCommandOutput {
+        ok: exit_code == 0,
+        exit_code: Some(exit_code),
+        stdout,
+        stderr,
+        command: command
+            .display_argv
+            .clone()
+            .unwrap_or_else(|| command.argv.clone()),
+        cwd,
+    })
+}
+
+fn parse_exec_response(body: &str) -> Result<(i32, String, String)> {
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return Ok((0, String::new(), String::new()));
+    }
+
+    // Some deployments return a single JSON object; others stream NDJSON or raw stdout.
+    if trimmed.starts_with('{')
+        && !trimmed.contains('\n')
+        && let Ok(parsed) = serde_json::from_str::<SpritesHttpExecResponse>(trimmed)
+    {
+        return Ok(parsed.into_parts());
+    }
+
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    let mut exit_code = None;
+    let mut parsed_stream_event = false;
+    let mut raw_lines = String::new();
+
+    for line in trimmed.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(event) = serde_json::from_str::<SpritesStreamEvent>(line) else {
+            raw_lines.push_str(line);
+            raw_lines.push('\n');
+            continue;
+        };
+        parsed_stream_event = true;
+        match event.event_type.as_str() {
+            "stdout" => {
+                if let Some(data) = event.data {
+                    stdout.push_str(&data);
+                }
+            }
+            "stderr" => {
+                if let Some(data) = event.data {
+                    stderr.push_str(&data);
+                }
+            }
+            "complete" | "exit" => {
+                if let Some(code) = event.exit_code {
+                    exit_code = Some(code);
+                }
+            }
+            "error" => {
+                let message = event
+                    .error
+                    .or(event.message)
+                    .unwrap_or_else(|| "Sprites exec stream error".into());
+                bail!("{message}");
+            }
+            _ => {}
+        }
+    }
+
+    if parsed_stream_event {
+        return Ok((exit_code.unwrap_or(0), stdout, stderr));
+    }
+
+    if !raw_lines.is_empty() {
+        return Ok((exit_code.unwrap_or(0), raw_lines, stderr));
+    }
+
+    // Plain-text body (common for simple HTTP exec, e.g. `curl ... | python`).
+    Ok((exit_code.unwrap_or(0), trimmed.to_string(), stderr))
+}
+
+async fn save_checkpoint_via_backend(
+    backend: &SpritesBackendHandle,
+    sprite_name: &str,
+) -> Result<SnapshotPayload> {
+    let body = serde_json::json!({ "comment": "exo snapshot" });
+    let response = backend
+        .client
+        .post(backend.api_endpoint(&format!("/v1/sprites/{sprite_name}/checkpoint")))
+        .json(&body)
+        .send()
+        .await
+        .with_context(|| format!("creating Sprites checkpoint for {sprite_name}"))?;
+    let status = response.status();
+    let text = response
+        .text()
+        .await
+        .context("reading Sprites checkpoint response")?;
+    if !status.is_success() {
+        bail!("Sprites checkpoint failed ({status}): {text}");
+    }
+    let checkpoint_id = parse_checkpoint_id_from_stream(&text)?;
+    let manifest = SpritesSnapshotManifest {
+        checkpoint_id,
+        sprite_name: sprite_name.to_string(),
+    };
+    let bytes = serde_json::to_vec(&manifest).context("serializing Sprites snapshot manifest")?;
+    Ok(SnapshotPayload {
+        kind: SnapshotKind::SpritesSnapshot,
+        bytes: Bytes::from(bytes),
+    })
+}
+
+async fn restore_checkpoint_via_backend(
+    backend: &SpritesBackendHandle,
+    sprite_name: &str,
+    checkpoint_id: &str,
+) -> Result<()> {
+    let response = backend
+        .client
+        .post(backend.api_endpoint(&format!(
+            "/v1/sprites/{sprite_name}/checkpoints/{checkpoint_id}/restore"
+        )))
+        .send()
+        .await
+        .with_context(|| {
+            format!("restoring Sprites checkpoint {checkpoint_id} on {sprite_name}")
+        })?;
+    let status = response.status();
+    let text = response
+        .text()
+        .await
+        .context("reading Sprites restore response")?;
+    if !status.is_success() {
+        bail!("Sprites checkpoint restore failed ({status}): {text}");
+    }
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let event: SpritesStreamEvent =
+            serde_json::from_str(line).context("decoding Sprites restore NDJSON line")?;
+        if event.event_type == "error" {
+            let message = event
+                .error
+                .or(event.message)
+                .unwrap_or_else(|| "Sprites restore stream error".into());
+            bail!("{message}");
+        }
+    }
+    Ok(())
+}
+
+fn parse_checkpoint_id_from_stream(body: &str) -> Result<String> {
+    let mut checkpoint_id = None;
+    for line in body.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let event: SpritesStreamEvent =
+            serde_json::from_str(line).context("decoding Sprites checkpoint NDJSON line")?;
+        if event.event_type == "error" {
+            let message = event
+                .error
+                .or(event.message)
+                .unwrap_or_else(|| "Sprites checkpoint stream error".into());
+            bail!("{message}");
+        }
+        if let Some(data) = event.data {
+            if let Some(id) = data.strip_prefix("  ID: ") {
+                checkpoint_id = Some(id.trim().to_string());
+            }
+            if let Some(rest) = data.strip_prefix("Checkpoint ")
+                && let Some(id) = rest.split_whitespace().next()
+            {
+                checkpoint_id = Some(id.to_string());
+            }
+        }
+    }
+    checkpoint_id.ok_or_else(|| anyhow!("Sprites checkpoint stream did not report a checkpoint id"))
+}
+
+/// Deterministic sprite name for a sandbox key + spec. Sprites names must be unique
+/// per organization; hashing the exo key and spec hash gives stable cross-process resume.
+fn sprite_name_for_request(request: &SandboxRequest) -> String {
+    let spec_hash = sandbox_spec_hash(&request.spec);
+    let mut hasher = DefaultHasher::new();
+    request.key.hash(&mut hasher);
+    spec_hash.hash(&mut hasher);
+    format!("exo-{:016x}", hasher.finish())
+}
+
+fn reject_host_mounts(request: &SandboxRequest) -> Result<()> {
+    if request.spec.mounts.is_empty() {
+        return Ok(());
+    }
+    bail!(
+        "Sprites sandbox backend does not support host bind-mounts; \
+         remove conversation mounts or use a local sandbox provider"
+    )
+}
+
+fn validate_url_auth(url_auth: &str) -> Result<()> {
+    match url_auth {
+        "sprite" | "public" => Ok(()),
+        other => bail!("Sprites url_auth must be `sprite` or `public`, got {other:?}"),
+    }
+}
+
+fn sprite_label(key: &str, value: &str) -> String {
+    format!("{key}={value}")
+}
+
+fn sprite_labels_for_request(
+    request: &SandboxRequest,
+    spec_hash: &str,
+    extra_labels: &[String],
+) -> Vec<String> {
+    let mut labels = Vec::with_capacity(extra_labels.len() + 2);
+    labels.push(sprite_label(
+        WARM_SANDBOX_KEY_LABEL,
+        &request.key.to_string(),
+    ));
+    labels.push(sprite_label(WARM_SANDBOX_SPEC_HASH_LABEL, spec_hash));
+    labels.extend(extra_labels.iter().cloned());
+    labels
+}
+
+#[derive(Debug, Serialize)]
+struct SpritesUrlSettings {
+    auth: String,
+}
+
+#[derive(Debug, Serialize)]
+struct SpritesCreateRequest {
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    organization: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    url_settings: Option<SpritesUrlSettings>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    labels: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SpritesHttpExecResponse {
+    #[serde(default, alias = "exitCode")]
+    exit_code: Option<i32>,
+    #[serde(default)]
+    stdout: String,
+    #[serde(default)]
+    stderr: String,
+    #[serde(default)]
+    output: String,
+}
+
+impl SpritesHttpExecResponse {
+    fn into_parts(self) -> (i32, String, String) {
+        let exit_code = self.exit_code.unwrap_or(0);
+        let stdout = if self.stdout.is_empty() {
+            self.output
+        } else {
+            self.stdout
+        };
+        (exit_code, stdout, self.stderr)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SpritesStreamEvent {
+    #[serde(rename = "type")]
+    event_type: String,
+    #[serde(default)]
+    data: Option<String>,
+    #[serde(default)]
+    message: Option<String>,
+    #[serde(default)]
+    error: Option<String>,
+    #[serde(default, alias = "exitCode")]
+    exit_code: Option<i32>,
+}

--- a/crates/exoharness/src/sandbox_provider/vercel.rs
+++ b/crates/exoharness/src/sandbox_provider/vercel.rs
@@ -151,7 +151,7 @@ impl VercelSandboxBackend {
 #[async_trait]
 impl ManagedSandboxBackend for VercelSandboxBackend {
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
-        reject_host_mounts(&request)?;
+        reject_unsupported_mounts(&request)?;
         let spec_hash = sandbox_spec_hash(&request.spec);
         let sandbox_name = vercel_sandbox_name(&request, &spec_hash);
         let response = match self.get_sandbox_session(&sandbox_name).await? {
@@ -627,14 +627,17 @@ fn stable_fnv1a_hex(input: &str) -> String {
     format!("{hash:016x}")
 }
 
-fn reject_host_mounts(request: &SandboxRequest) -> Result<()> {
-    if request.spec.mounts.is_empty() {
-        return Ok(());
+fn reject_unsupported_mounts(request: &SandboxRequest) -> Result<()> {
+    if !request.spec.mounts.is_empty() {
+        bail!(
+            "Vercel sandbox backend does not support host bind-mounts; \
+         remove conversation mounts or use a local sandbox provider"
+        );
     }
-    bail!(
-        "Vercel sandbox backend does not support host bind-mounts; \
-     remove conversation mounts or use a local sandbox provider"
-    )
+    if !request.spec.durable_file_systems.is_empty() {
+        bail!("Vercel sandbox backend does not support durable file systems");
+    }
+    Ok(())
 }
 
 fn duration_to_millis(duration: Duration) -> u64 {

--- a/crates/exoharness/src/server.rs
+++ b/crates/exoharness/src/server.rs
@@ -3,10 +3,16 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader, BufWriter};
 
-use crate::protocol::{ClientMessage, ConversationHandleInfo, Request, Response, ServerMessage};
+use crate::protocol::{
+    ClientMessage, ConversationHandleInfo, Request, Response, SandboxScope, ServerMessage,
+};
 use crate::{
-    AgentHandle, AgentId, ConversationHandle, ConversationId, ExoHarness, ListConversationsResult,
-    Result, SessionId, TurnHandle, TurnId, TurnRecord,
+    AgentHandle, AgentId, CancelSandboxProcessRequest, CloseSandboxProcessInputRequest,
+    ConversationHandle, ConversationId, CreateSandboxRequest, ExoHarness,
+    GetSandboxProcessEventsResult, ListConversationsResult, Result, SandboxId,
+    SandboxProcessEventQuery, SandboxProcessRecord, SandboxProcessStatus, SessionId, SnapshotId,
+    StartSandboxProcessRequest, StartSandboxRequest, TurnHandle, TurnId, TurnRecord,
+    WaitSandboxProcessRequest, WriteSandboxProcessInputRequest,
 };
 
 pub struct ExoHarnessServer {
@@ -131,66 +137,42 @@ impl ExoHarnessServer {
                     artifact: agent.write_artifact(request).await?,
                 })
             }
-            Request::AgentCreateSandbox { agent_id, request } => {
-                let agent = self.require_agent(&agent_id).await?;
-                Ok(Response::SandboxId {
-                    sandbox_id: agent.create_sandbox(request).await?,
-                })
-            }
-            Request::AgentSnapshotSandbox {
-                agent_id,
-                sandbox_id,
-            } => {
-                let agent = self.require_agent(&agent_id).await?;
-                Ok(Response::SnapshotId {
-                    snapshot_id: agent.snapshot_sandbox(sandbox_id).await?,
-                })
-            }
-            Request::AgentStartSandbox { agent_id, request } => {
-                let agent = self.require_agent(&agent_id).await?;
-                agent.start_sandbox(request).await?;
+            Request::CreateSandbox { scope, request } => Ok(Response::SandboxId {
+                sandbox_id: self.create_sandbox(scope, request).await?,
+            }),
+            Request::SnapshotSandbox { scope, sandbox_id } => Ok(Response::SnapshotId {
+                snapshot_id: self.snapshot_sandbox(scope, sandbox_id).await?,
+            }),
+            Request::StartSandbox { scope, request } => {
+                self.start_sandbox(scope, request).await?;
                 Ok(Response::Unit)
             }
-            Request::AgentStopSandbox {
-                agent_id,
-                sandbox_id,
-            } => {
-                let agent = self.require_agent(&agent_id).await?;
-                agent.stop_sandbox(sandbox_id).await?;
+            Request::StopSandbox { scope, sandbox_id } => {
+                self.stop_sandbox(scope, sandbox_id).await?;
                 Ok(Response::Unit)
             }
-            Request::AgentStartSandboxProcess { agent_id, request } => {
-                let agent = self.require_agent(&agent_id).await?;
-                Ok(Response::SandboxProcess {
-                    process: agent.start_sandbox_process(request).await?,
-                })
-            }
-            Request::AgentWriteSandboxProcessInput { agent_id, request } => {
-                let agent = self.require_agent(&agent_id).await?;
-                agent.write_sandbox_process_input(request).await?;
+            Request::StartSandboxProcess { scope, request } => Ok(Response::SandboxProcess {
+                process: self.start_sandbox_process(scope, request).await?,
+            }),
+            Request::WriteSandboxProcessInput { scope, request } => {
+                self.write_sandbox_process_input(scope, request).await?;
                 Ok(Response::Unit)
             }
-            Request::AgentCloseSandboxProcessInput { agent_id, request } => {
-                let agent = self.require_agent(&agent_id).await?;
-                agent.close_sandbox_process_input(request).await?;
+            Request::CloseSandboxProcessInput { scope, request } => {
+                self.close_sandbox_process_input(scope, request).await?;
                 Ok(Response::Unit)
             }
-            Request::AgentGetSandboxProcessEvents { agent_id, query } => {
-                let agent = self.require_agent(&agent_id).await?;
+            Request::GetSandboxProcessEvents { scope, query } => {
                 Ok(Response::SandboxProcessEvents {
-                    result: agent.get_sandbox_process_events(query).await?,
+                    result: self.get_sandbox_process_events(scope, query).await?,
                 })
             }
-            Request::AgentWaitSandboxProcess { agent_id, request } => {
-                let agent = self.require_agent(&agent_id).await?;
+            Request::WaitSandboxProcess { scope, request } => Ok(Response::SandboxProcessStatus {
+                status: self.wait_sandbox_process(scope, request).await?,
+            }),
+            Request::CancelSandboxProcess { scope, request } => {
                 Ok(Response::SandboxProcessStatus {
-                    status: agent.wait_sandbox_process(request).await?,
-                })
-            }
-            Request::AgentCancelSandboxProcess { agent_id, request } => {
-                let agent = self.require_agent(&agent_id).await?;
-                Ok(Response::SandboxProcessStatus {
-                    status: agent.cancel_sandbox_process(request).await?,
+                    status: self.cancel_sandbox_process(scope, request).await?,
                 })
             }
             Request::AgentListBindings { agent_id } => {
@@ -343,102 +325,6 @@ impl ExoHarnessServer {
                     artifact: conversation.write_artifact(request).await?,
                 })
             }
-            Request::ConversationCreateSandbox {
-                agent_id,
-                conversation_id,
-                request,
-            } => {
-                let conversation = self.require_conversation(agent_id, conversation_id).await?;
-                Ok(Response::SandboxId {
-                    sandbox_id: conversation.create_sandbox(request).await?,
-                })
-            }
-            Request::ConversationSnapshotSandbox {
-                agent_id,
-                conversation_id,
-                sandbox_id,
-            } => {
-                let conversation = self.require_conversation(agent_id, conversation_id).await?;
-                Ok(Response::SnapshotId {
-                    snapshot_id: conversation.snapshot_sandbox(sandbox_id).await?,
-                })
-            }
-            Request::ConversationStartSandbox {
-                agent_id,
-                conversation_id,
-                request,
-            } => {
-                let conversation = self.require_conversation(agent_id, conversation_id).await?;
-                conversation.start_sandbox(request).await?;
-                Ok(Response::Unit)
-            }
-            Request::ConversationStopSandbox {
-                agent_id,
-                conversation_id,
-                sandbox_id,
-            } => {
-                let conversation = self.require_conversation(agent_id, conversation_id).await?;
-                conversation.stop_sandbox(sandbox_id).await?;
-                Ok(Response::Unit)
-            }
-            Request::ConversationStartSandboxProcess {
-                agent_id,
-                conversation_id,
-                request,
-            } => {
-                let conversation = self.require_conversation(agent_id, conversation_id).await?;
-                Ok(Response::SandboxProcess {
-                    process: conversation.start_sandbox_process(request).await?,
-                })
-            }
-            Request::ConversationWriteSandboxProcessInput {
-                agent_id,
-                conversation_id,
-                request,
-            } => {
-                let conversation = self.require_conversation(agent_id, conversation_id).await?;
-                conversation.write_sandbox_process_input(request).await?;
-                Ok(Response::Unit)
-            }
-            Request::ConversationCloseSandboxProcessInput {
-                agent_id,
-                conversation_id,
-                request,
-            } => {
-                let conversation = self.require_conversation(agent_id, conversation_id).await?;
-                conversation.close_sandbox_process_input(request).await?;
-                Ok(Response::Unit)
-            }
-            Request::ConversationGetSandboxProcessEvents {
-                agent_id,
-                conversation_id,
-                query,
-            } => {
-                let conversation = self.require_conversation(agent_id, conversation_id).await?;
-                Ok(Response::SandboxProcessEvents {
-                    result: conversation.get_sandbox_process_events(query).await?,
-                })
-            }
-            Request::ConversationWaitSandboxProcess {
-                agent_id,
-                conversation_id,
-                request,
-            } => {
-                let conversation = self.require_conversation(agent_id, conversation_id).await?;
-                Ok(Response::SandboxProcessStatus {
-                    status: conversation.wait_sandbox_process(request).await?,
-                })
-            }
-            Request::ConversationCancelSandboxProcess {
-                agent_id,
-                conversation_id,
-                request,
-            } => {
-                let conversation = self.require_conversation(agent_id, conversation_id).await?;
-                Ok(Response::SandboxProcessStatus {
-                    status: conversation.cancel_sandbox_process(request).await?,
-                })
-            }
             Request::ConversationListBindings {
                 agent_id,
                 conversation_id,
@@ -525,33 +411,6 @@ impl ExoHarnessServer {
                     artifact: turn.write_artifact(request).await?,
                 })
             }
-            Request::TurnSnapshotSandbox {
-                agent_id,
-                conversation_id,
-                session_id,
-                turn_id,
-                sandbox_id,
-            } => {
-                let turn = self
-                    .require_turn(agent_id, conversation_id, session_id, turn_id)
-                    .await?;
-                Ok(Response::SnapshotId {
-                    snapshot_id: turn.snapshot_sandbox(sandbox_id).await?,
-                })
-            }
-            Request::TurnStartSandbox {
-                agent_id,
-                conversation_id,
-                session_id,
-                turn_id,
-                request,
-            } => {
-                let turn = self
-                    .require_turn(agent_id, conversation_id, session_id, turn_id)
-                    .await?;
-                turn.start_sandbox(request).await?;
-                Ok(Response::Unit)
-            }
             Request::TurnFinish {
                 agent_id,
                 conversation_id,
@@ -600,6 +459,284 @@ impl ExoHarnessServer {
         }
 
         Ok(())
+    }
+
+    async fn create_sandbox(
+        &self,
+        scope: SandboxScope,
+        request: CreateSandboxRequest,
+    ) -> Result<SandboxId> {
+        match scope {
+            SandboxScope::Agent { agent_id } => {
+                self.require_agent(&agent_id)
+                    .await?
+                    .create_sandbox(request)
+                    .await
+            }
+            SandboxScope::Conversation {
+                agent_id,
+                conversation_id,
+            } => {
+                self.require_conversation(agent_id, conversation_id)
+                    .await?
+                    .create_sandbox(request)
+                    .await
+            }
+            SandboxScope::Turn { .. } => {
+                Err(anyhow!("create_sandbox is not supported on a turn scope"))
+            }
+        }
+    }
+
+    async fn snapshot_sandbox(
+        &self,
+        scope: SandboxScope,
+        sandbox_id: SandboxId,
+    ) -> Result<SnapshotId> {
+        match scope {
+            SandboxScope::Agent { agent_id } => {
+                self.require_agent(&agent_id)
+                    .await?
+                    .snapshot_sandbox(sandbox_id)
+                    .await
+            }
+            SandboxScope::Conversation {
+                agent_id,
+                conversation_id,
+            } => {
+                self.require_conversation(agent_id, conversation_id)
+                    .await?
+                    .snapshot_sandbox(sandbox_id)
+                    .await
+            }
+            SandboxScope::Turn {
+                agent_id,
+                conversation_id,
+                session_id,
+                turn_id,
+            } => {
+                self.require_turn(agent_id, conversation_id, session_id, turn_id)
+                    .await?
+                    .snapshot_sandbox(sandbox_id)
+                    .await
+            }
+        }
+    }
+
+    async fn start_sandbox(&self, scope: SandboxScope, request: StartSandboxRequest) -> Result<()> {
+        match scope {
+            SandboxScope::Agent { agent_id } => {
+                self.require_agent(&agent_id)
+                    .await?
+                    .start_sandbox(request)
+                    .await
+            }
+            SandboxScope::Conversation {
+                agent_id,
+                conversation_id,
+            } => {
+                self.require_conversation(agent_id, conversation_id)
+                    .await?
+                    .start_sandbox(request)
+                    .await
+            }
+            SandboxScope::Turn {
+                agent_id,
+                conversation_id,
+                session_id,
+                turn_id,
+            } => {
+                self.require_turn(agent_id, conversation_id, session_id, turn_id)
+                    .await?
+                    .start_sandbox(request)
+                    .await
+            }
+        }
+    }
+
+    async fn stop_sandbox(&self, scope: SandboxScope, sandbox_id: SandboxId) -> Result<()> {
+        match scope {
+            SandboxScope::Agent { agent_id } => {
+                self.require_agent(&agent_id)
+                    .await?
+                    .stop_sandbox(sandbox_id)
+                    .await
+            }
+            SandboxScope::Conversation {
+                agent_id,
+                conversation_id,
+            } => {
+                self.require_conversation(agent_id, conversation_id)
+                    .await?
+                    .stop_sandbox(sandbox_id)
+                    .await
+            }
+            SandboxScope::Turn { .. } => {
+                Err(anyhow!("stop_sandbox is not supported on a turn scope"))
+            }
+        }
+    }
+
+    async fn start_sandbox_process(
+        &self,
+        scope: SandboxScope,
+        request: StartSandboxProcessRequest,
+    ) -> Result<SandboxProcessRecord> {
+        match scope {
+            SandboxScope::Agent { agent_id } => {
+                self.require_agent(&agent_id)
+                    .await?
+                    .start_sandbox_process(request)
+                    .await
+            }
+            SandboxScope::Conversation {
+                agent_id,
+                conversation_id,
+            } => {
+                self.require_conversation(agent_id, conversation_id)
+                    .await?
+                    .start_sandbox_process(request)
+                    .await
+            }
+            SandboxScope::Turn { .. } => Err(anyhow!(
+                "start_sandbox_process is not supported on a turn scope"
+            )),
+        }
+    }
+
+    async fn write_sandbox_process_input(
+        &self,
+        scope: SandboxScope,
+        request: WriteSandboxProcessInputRequest,
+    ) -> Result<()> {
+        match scope {
+            SandboxScope::Agent { agent_id } => {
+                self.require_agent(&agent_id)
+                    .await?
+                    .write_sandbox_process_input(request)
+                    .await
+            }
+            SandboxScope::Conversation {
+                agent_id,
+                conversation_id,
+            } => {
+                self.require_conversation(agent_id, conversation_id)
+                    .await?
+                    .write_sandbox_process_input(request)
+                    .await
+            }
+            SandboxScope::Turn { .. } => Err(anyhow!(
+                "write_sandbox_process_input is not supported on a turn scope"
+            )),
+        }
+    }
+
+    async fn close_sandbox_process_input(
+        &self,
+        scope: SandboxScope,
+        request: CloseSandboxProcessInputRequest,
+    ) -> Result<()> {
+        match scope {
+            SandboxScope::Agent { agent_id } => {
+                self.require_agent(&agent_id)
+                    .await?
+                    .close_sandbox_process_input(request)
+                    .await
+            }
+            SandboxScope::Conversation {
+                agent_id,
+                conversation_id,
+            } => {
+                self.require_conversation(agent_id, conversation_id)
+                    .await?
+                    .close_sandbox_process_input(request)
+                    .await
+            }
+            SandboxScope::Turn { .. } => Err(anyhow!(
+                "close_sandbox_process_input is not supported on a turn scope"
+            )),
+        }
+    }
+
+    async fn get_sandbox_process_events(
+        &self,
+        scope: SandboxScope,
+        query: SandboxProcessEventQuery,
+    ) -> Result<GetSandboxProcessEventsResult> {
+        match scope {
+            SandboxScope::Agent { agent_id } => {
+                self.require_agent(&agent_id)
+                    .await?
+                    .get_sandbox_process_events(query)
+                    .await
+            }
+            SandboxScope::Conversation {
+                agent_id,
+                conversation_id,
+            } => {
+                self.require_conversation(agent_id, conversation_id)
+                    .await?
+                    .get_sandbox_process_events(query)
+                    .await
+            }
+            SandboxScope::Turn { .. } => Err(anyhow!(
+                "get_sandbox_process_events is not supported on a turn scope"
+            )),
+        }
+    }
+
+    async fn wait_sandbox_process(
+        &self,
+        scope: SandboxScope,
+        request: WaitSandboxProcessRequest,
+    ) -> Result<SandboxProcessStatus> {
+        match scope {
+            SandboxScope::Agent { agent_id } => {
+                self.require_agent(&agent_id)
+                    .await?
+                    .wait_sandbox_process(request)
+                    .await
+            }
+            SandboxScope::Conversation {
+                agent_id,
+                conversation_id,
+            } => {
+                self.require_conversation(agent_id, conversation_id)
+                    .await?
+                    .wait_sandbox_process(request)
+                    .await
+            }
+            SandboxScope::Turn { .. } => Err(anyhow!(
+                "wait_sandbox_process is not supported on a turn scope"
+            )),
+        }
+    }
+
+    async fn cancel_sandbox_process(
+        &self,
+        scope: SandboxScope,
+        request: CancelSandboxProcessRequest,
+    ) -> Result<SandboxProcessStatus> {
+        match scope {
+            SandboxScope::Agent { agent_id } => {
+                self.require_agent(&agent_id)
+                    .await?
+                    .cancel_sandbox_process(request)
+                    .await
+            }
+            SandboxScope::Conversation {
+                agent_id,
+                conversation_id,
+            } => {
+                self.require_conversation(agent_id, conversation_id)
+                    .await?
+                    .cancel_sandbox_process(request)
+                    .await
+            }
+            SandboxScope::Turn { .. } => Err(anyhow!(
+                "cancel_sandbox_process is not supported on a turn scope"
+            )),
+        }
     }
 
     async fn require_agent(&self, agent_id: &AgentId) -> Result<Arc<dyn AgentHandle>> {

--- a/crates/exoharness/src/server.rs
+++ b/crates/exoharness/src/server.rs
@@ -131,6 +131,68 @@ impl ExoHarnessServer {
                     artifact: agent.write_artifact(request).await?,
                 })
             }
+            Request::AgentCreateSandbox { agent_id, request } => {
+                let agent = self.require_agent(&agent_id).await?;
+                Ok(Response::SandboxId {
+                    sandbox_id: agent.create_sandbox(request).await?,
+                })
+            }
+            Request::AgentSnapshotSandbox {
+                agent_id,
+                sandbox_id,
+            } => {
+                let agent = self.require_agent(&agent_id).await?;
+                Ok(Response::SnapshotId {
+                    snapshot_id: agent.snapshot_sandbox(sandbox_id).await?,
+                })
+            }
+            Request::AgentStartSandbox { agent_id, request } => {
+                let agent = self.require_agent(&agent_id).await?;
+                agent.start_sandbox(request).await?;
+                Ok(Response::Unit)
+            }
+            Request::AgentStopSandbox {
+                agent_id,
+                sandbox_id,
+            } => {
+                let agent = self.require_agent(&agent_id).await?;
+                agent.stop_sandbox(sandbox_id).await?;
+                Ok(Response::Unit)
+            }
+            Request::AgentStartSandboxProcess { agent_id, request } => {
+                let agent = self.require_agent(&agent_id).await?;
+                Ok(Response::SandboxProcess {
+                    process: agent.start_sandbox_process(request).await?,
+                })
+            }
+            Request::AgentWriteSandboxProcessInput { agent_id, request } => {
+                let agent = self.require_agent(&agent_id).await?;
+                agent.write_sandbox_process_input(request).await?;
+                Ok(Response::Unit)
+            }
+            Request::AgentCloseSandboxProcessInput { agent_id, request } => {
+                let agent = self.require_agent(&agent_id).await?;
+                agent.close_sandbox_process_input(request).await?;
+                Ok(Response::Unit)
+            }
+            Request::AgentGetSandboxProcessEvents { agent_id, query } => {
+                let agent = self.require_agent(&agent_id).await?;
+                Ok(Response::SandboxProcessEvents {
+                    result: agent.get_sandbox_process_events(query).await?,
+                })
+            }
+            Request::AgentWaitSandboxProcess { agent_id, request } => {
+                let agent = self.require_agent(&agent_id).await?;
+                Ok(Response::SandboxProcessStatus {
+                    status: agent.wait_sandbox_process(request).await?,
+                })
+            }
+            Request::AgentCancelSandboxProcess { agent_id, request } => {
+                let agent = self.require_agent(&agent_id).await?;
+                Ok(Response::SandboxProcessStatus {
+                    status: agent.cancel_sandbox_process(request).await?,
+                })
+            }
             Request::AgentListBindings { agent_id } => {
                 let agent = self.require_agent(&agent_id).await?;
                 Ok(Response::Bindings {

--- a/crates/exoharness/src/server.rs
+++ b/crates/exoharness/src/server.rs
@@ -463,6 +463,33 @@ impl ExoHarnessServer {
                     artifact: turn.write_artifact(request).await?,
                 })
             }
+            Request::TurnSnapshotSandbox {
+                agent_id,
+                conversation_id,
+                session_id,
+                turn_id,
+                sandbox_id,
+            } => {
+                let turn = self
+                    .require_turn(agent_id, conversation_id, session_id, turn_id)
+                    .await?;
+                Ok(Response::SnapshotId {
+                    snapshot_id: turn.snapshot_sandbox(sandbox_id).await?,
+                })
+            }
+            Request::TurnStartSandbox {
+                agent_id,
+                conversation_id,
+                session_id,
+                turn_id,
+                request,
+            } => {
+                let turn = self
+                    .require_turn(agent_id, conversation_id, session_id, turn_id)
+                    .await?;
+                turn.start_sandbox(request).await?;
+                Ok(Response::Unit)
+            }
             Request::TurnFinish {
                 agent_id,
                 conversation_id,

--- a/crates/exoharness/src/test_support.rs
+++ b/crates/exoharness/src/test_support.rs
@@ -24,7 +24,7 @@ pub(crate) fn local_test_config_with_daytona(root: impl Into<PathBuf>) -> BasicE
         sandbox_default: SandboxProvider::LocalProcess,
         sandbox_backends: vec![
             SandboxBackendChoice::LocalProcess,
-            SandboxBackendChoice::Daytona(DaytonaBackendSpec::with_conventional_secrets()),
+            SandboxBackendChoice::Daytona(DaytonaBackendSpec::default()),
         ],
     }
 }

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -369,6 +369,8 @@ pub enum EventData {
         image: String,
         default_workdir: String,
         file_system_mounts: Vec<FileSystemMount>,
+        #[serde(default)]
+        durable_file_systems: Vec<DurableFileSystem>,
         enable_networking: bool,
         idle_seconds: u64,
     },
@@ -495,6 +497,13 @@ pub struct FileSystemMount {
     pub internal: Option<bool>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct DurableFileSystem {
+    pub name: String,
+    pub mount_path: String,
+    pub mode: FileSystemMountMode,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CreateSandboxRequest {
     #[serde(default)]
@@ -503,6 +512,7 @@ pub struct CreateSandboxRequest {
     pub image: String,
     pub default_workdir: Option<String>,
     pub file_system_mounts: Option<Vec<FileSystemMount>>,
+    pub durable_file_systems: Option<Vec<DurableFileSystem>>,
     pub enable_networking: Option<bool>,
     pub idle_seconds: Option<u64>,
 }
@@ -833,6 +843,8 @@ pub enum SandboxProviderConfig {
         qualifier: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         endpoint_url: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        session_storage_mount_path: Option<String>,
         #[serde(default = "crate::sandbox_provider::default_aws_agentcore_image")]
         default_image: String,
     },

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -132,24 +132,8 @@ pub trait TurnHandle: Send + Sync {
 
     async fn add_events(&self, data: Vec<EventData>) -> Result<AddEventsResult>;
     async fn write_artifact(&self, request: WriteArtifactRequest) -> Result<ArtifactVersion>;
-    async fn snapshot_sandbox(
-        &self,
-        _conversation_id: ConversationId,
-        _id: SandboxId,
-    ) -> Result<SnapshotId> {
-        Err(anyhow::anyhow!(
-            "turn-scoped sandbox snapshots are not supported by this harness"
-        ))
-    }
-    async fn start_sandbox(
-        &self,
-        _conversation_id: ConversationId,
-        _request: StartSandboxRequest,
-    ) -> Result<()> {
-        Err(anyhow::anyhow!(
-            "turn-scoped sandbox start is not supported by this harness"
-        ))
-    }
+    async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId>;
+    async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()>;
     async fn finish(&self) -> Result<EventId>;
 }
 

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -260,7 +260,6 @@ pub struct GetEventsResult {
 pub struct AddEventsRequest {
     pub session_id: Option<SessionId>,
     pub turn_id: Option<TurnId>,
-    pub expected_head: Option<EventId>,
     pub data: Vec<EventData>,
 }
 

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -34,10 +34,14 @@ pub trait ExoHarness: Send + Sync {
 }
 
 #[async_trait]
-pub trait SandboxHandle: Send + Sync {
-    async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId>;
+pub trait SnapshotHandle: Send + Sync {
     async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId>;
     async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()>;
+}
+
+#[async_trait]
+pub trait SandboxHandle: SnapshotHandle {
+    async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId>;
     async fn stop_sandbox(&self, id: SandboxId) -> Result<()>;
     async fn start_sandbox_process(
         &self,
@@ -130,13 +134,11 @@ pub trait ConversationHandle: SandboxHandle {
 }
 
 #[async_trait]
-pub trait TurnHandle: Send + Sync {
+pub trait TurnHandle: SnapshotHandle {
     fn record(&self) -> &TurnRecord;
 
     async fn add_events(&self, data: Vec<EventData>) -> Result<AddEventsResult>;
     async fn write_artifact(&self, request: WriteArtifactRequest) -> Result<ArtifactVersion>;
-    async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId>;
-    async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()>;
     async fn finish(&self) -> Result<EventId>;
 }
 

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -521,6 +521,8 @@ pub struct CreateSandboxRequest {
 pub enum SandboxProvider {
     #[default]
     Daytona,
+    E2b,
+    Sprites,
     Vercel,
     #[serde(rename = "aws_agentcore", alias = "aws-agentcore")]
     AwsAgentCore,
@@ -541,6 +543,8 @@ impl SandboxProvider {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Daytona => "daytona",
+            Self::E2b => "e2b",
+            Self::Sprites => "sprites",
             Self::Vercel => "vercel",
             Self::AwsAgentCore => "aws-agentcore",
             Self::AppleContainer => "apple-container",
@@ -562,6 +566,8 @@ impl FromStr for SandboxProvider {
     fn from_str(value: &str) -> Result<Self> {
         match value.trim() {
             "daytona" => Ok(Self::Daytona),
+            "e2b" => Ok(Self::E2b),
+            "sprites" => Ok(Self::Sprites),
             "vercel" => Ok(Self::Vercel),
             "aws-agentcore" | "aws_agentcore" => Ok(Self::AwsAgentCore),
             "apple-container" | "apple_container" => Ok(Self::AppleContainer),
@@ -834,6 +840,27 @@ pub enum SandboxProviderConfig {
         #[serde(default = "crate::sandbox_provider::default_vercel_image")]
         default_image: String,
     },
+    E2b {
+        api_key_secret_id: SecretId,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        api_url: Option<String>,
+        #[serde(default = "default_e2b_template")]
+        default_image: String,
+    },
+    Sprites {
+        token_secret_id: SecretId,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        api_url: Option<String>,
+        /// Sprite HTTP URL auth mode: `sprite` (default) or `public`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        url_auth: Option<String>,
+        /// Organization slug when the token can access multiple orgs.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<String>,
+        /// Extra Sprites labels on create (exo resume labels are added automatically).
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        labels: Vec<String>,
+    },
     #[serde(rename = "aws_agentcore", alias = "aws-agentcore")]
     AwsAgentCore {
         runtime_arn: String,
@@ -849,23 +876,31 @@ pub enum SandboxProviderConfig {
     },
 }
 
+pub fn default_e2b_template() -> String {
+    "base".to_string()
+}
+
 impl SandboxProviderConfig {
     pub fn provider(&self) -> SandboxProvider {
         match self {
             Self::Daytona { .. } => SandboxProvider::Daytona,
+            Self::E2b { .. } => SandboxProvider::E2b,
+            Self::Sprites { .. } => SandboxProvider::Sprites,
             Self::Vercel { .. } => SandboxProvider::Vercel,
             Self::Docker { .. } => SandboxProvider::Docker,
             Self::AwsAgentCore { .. } => SandboxProvider::AwsAgentCore,
         }
     }
 
-    /// The binding's configured default base image.
-    pub fn default_image(&self) -> &str {
+    /// The binding's configured default base image / E2B template id.
+    pub fn default_image(&self) -> Option<&str> {
         match self {
             Self::Daytona { default_image, .. }
             | Self::Vercel { default_image, .. }
             | Self::Docker { default_image, .. }
-            | Self::AwsAgentCore { default_image, .. } => default_image,
+            | Self::E2b { default_image, .. }
+            | Self::AwsAgentCore { default_image, .. } => Some(default_image),
+            Self::Sprites { .. } => None,
         }
     }
 }

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -267,7 +267,6 @@ pub struct GetEventsResult {
 pub struct AddEventsRequest {
     pub session_id: Option<SessionId>,
     pub turn_id: Option<TurnId>,
-    pub expected_head: Option<EventId>,
     pub data: Vec<EventData>,
 }
 
@@ -376,6 +375,8 @@ pub enum EventData {
         image: String,
         default_workdir: String,
         file_system_mounts: Vec<FileSystemMount>,
+        #[serde(default)]
+        durable_file_systems: Vec<DurableFileSystem>,
         enable_networking: bool,
         idle_seconds: u64,
     },
@@ -502,6 +503,13 @@ pub struct FileSystemMount {
     pub internal: Option<bool>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct DurableFileSystem {
+    pub name: String,
+    pub mount_path: String,
+    pub mode: FileSystemMountMode,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct CreateSandboxRequest {
     #[serde(default)]
@@ -510,6 +518,7 @@ pub struct CreateSandboxRequest {
     pub image: String,
     pub default_workdir: Option<String>,
     pub file_system_mounts: Option<Vec<FileSystemMount>>,
+    pub durable_file_systems: Option<Vec<DurableFileSystem>>,
     pub enable_networking: Option<bool>,
     pub idle_seconds: Option<u64>,
 }
@@ -519,6 +528,8 @@ pub struct CreateSandboxRequest {
 pub enum SandboxProvider {
     #[default]
     Daytona,
+    E2b,
+    Sprites,
     Vercel,
     #[serde(rename = "aws_agentcore", alias = "aws-agentcore")]
     AwsAgentCore,
@@ -539,6 +550,8 @@ impl SandboxProvider {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Daytona => "daytona",
+            Self::E2b => "e2b",
+            Self::Sprites => "sprites",
             Self::Vercel => "vercel",
             Self::AwsAgentCore => "aws-agentcore",
             Self::AppleContainer => "apple-container",
@@ -560,6 +573,8 @@ impl FromStr for SandboxProvider {
     fn from_str(value: &str) -> Result<Self> {
         match value.trim() {
             "daytona" => Ok(Self::Daytona),
+            "e2b" => Ok(Self::E2b),
+            "sprites" => Ok(Self::Sprites),
             "vercel" => Ok(Self::Vercel),
             "aws-agentcore" | "aws_agentcore" => Ok(Self::AwsAgentCore),
             "apple-container" | "apple_container" => Ok(Self::AppleContainer),
@@ -832,6 +847,27 @@ pub enum SandboxProviderConfig {
         #[serde(default = "crate::sandbox_provider::default_vercel_image")]
         default_image: String,
     },
+    E2b {
+        api_key_secret_id: SecretId,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        api_url: Option<String>,
+        #[serde(default = "default_e2b_template")]
+        default_image: String,
+    },
+    Sprites {
+        token_secret_id: SecretId,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        api_url: Option<String>,
+        /// Sprite HTTP URL auth mode: `sprite` (default) or `public`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        url_auth: Option<String>,
+        /// Organization slug when the token can access multiple orgs.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        organization: Option<String>,
+        /// Extra Sprites labels on create (exo resume labels are added automatically).
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        labels: Vec<String>,
+    },
     #[serde(rename = "aws_agentcore", alias = "aws-agentcore")]
     AwsAgentCore {
         runtime_arn: String,
@@ -840,28 +876,38 @@ pub enum SandboxProviderConfig {
         qualifier: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         endpoint_url: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        session_storage_mount_path: Option<String>,
         #[serde(default = "crate::sandbox_provider::default_aws_agentcore_image")]
         default_image: String,
     },
+}
+
+pub fn default_e2b_template() -> String {
+    "base".to_string()
 }
 
 impl SandboxProviderConfig {
     pub fn provider(&self) -> SandboxProvider {
         match self {
             Self::Daytona { .. } => SandboxProvider::Daytona,
+            Self::E2b { .. } => SandboxProvider::E2b,
+            Self::Sprites { .. } => SandboxProvider::Sprites,
             Self::Vercel { .. } => SandboxProvider::Vercel,
             Self::Docker { .. } => SandboxProvider::Docker,
             Self::AwsAgentCore { .. } => SandboxProvider::AwsAgentCore,
         }
     }
 
-    /// The binding's configured default base image.
-    pub fn default_image(&self) -> &str {
+    /// The binding's configured default base image / E2B template id.
+    pub fn default_image(&self) -> Option<&str> {
         match self {
             Self::Daytona { default_image, .. }
             | Self::Vercel { default_image, .. }
             | Self::Docker { default_image, .. }
-            | Self::AwsAgentCore { default_image, .. } => default_image,
+            | Self::E2b { default_image, .. }
+            | Self::AwsAgentCore { default_image, .. } => Some(default_image),
+            Self::Sprites { .. } => None,
         }
     }
 }

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -34,58 +34,7 @@ pub trait ExoHarness: Send + Sync {
 }
 
 #[async_trait]
-pub trait AgentHandle: Send + Sync {
-    fn record(&self) -> &AgentRecord;
-
-    async fn list_conversations(
-        &self,
-        request: ListConversationsRequest,
-    ) -> Result<ListConversationsResult<Arc<dyn ConversationHandle>>>;
-    async fn get_conversation(
-        &self,
-        id: &ConversationId,
-    ) -> Result<Option<Arc<dyn ConversationHandle>>>;
-    async fn new_conversation(
-        &self,
-        request: NewConversationRequest,
-    ) -> Result<Arc<dyn ConversationHandle>>;
-    async fn delete_conversation(&self, id: &ConversationId) -> Result<bool>;
-
-    async fn list_bindings(&self) -> Result<Vec<BindingRecord>>;
-    async fn put_binding(&self, binding: Binding) -> Result<BindingId>;
-    async fn get_binding(&self, id: &BindingId) -> Result<Option<Binding>>;
-
-    async fn list_secrets(&self) -> Result<Vec<SecretMetadata>>;
-    async fn put_secret(&self, request: PutSecretRequest) -> Result<SecretId>;
-    async fn get_secret(&self, id: &SecretId) -> Result<Option<Secret>>;
-
-    async fn write_artifact(&self, request: WriteArtifactRequest) -> Result<ArtifactVersion>;
-    async fn read_artifact(&self, request: ReadArtifactRequest) -> Result<Option<Artifact>>;
-    async fn list_artifacts(&self) -> Result<Vec<ArtifactVersion>>;
-}
-
-#[async_trait]
-pub trait ConversationHandle: Send + Sync {
-    fn record(&self) -> &ConversationRecord;
-
-    async fn start_session(&self) -> Result<SessionId>;
-    async fn end_session(&self, id: SessionId) -> Result<()>;
-    async fn begin_turn(&self, request: BeginTurnRequest) -> Result<Arc<dyn TurnHandle>>;
-    /// Rebuilds the local TurnHandle facade for an already-created turn.
-    /// The durable identity is the agent, conversation, session, and turn ids;
-    /// this method only bundles those ids back into the trait object API.
-    async fn turn_handle(&self, record: TurnRecord) -> Result<Arc<dyn TurnHandle>>;
-
-    async fn get_events(&self, query: Option<EventQuery>) -> Result<GetEventsResult>;
-    async fn watch_events(&self, after_exclusive: Bound<EventId>) -> Result<EventStream>;
-    async fn get_event(&self, id: EventId) -> Result<Option<Event>>;
-    async fn add_events(&self, request: AddEventsRequest) -> Result<AddEventsResult>;
-    async fn fork(&self, request: ForkConversationRequest) -> Result<Arc<dyn ConversationHandle>>;
-
-    async fn write_artifact(&self, request: WriteArtifactRequest) -> Result<ArtifactVersion>;
-    async fn read_artifact(&self, request: ReadArtifactRequest) -> Result<Option<Artifact>>;
-    async fn list_artifacts(&self) -> Result<Vec<ArtifactVersion>>;
-
+pub trait SandboxHandle: Send + Sync {
     async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId>;
     async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId>;
     async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()>;
@@ -116,6 +65,60 @@ pub trait ConversationHandle: Send + Sync {
     ) -> Result<SandboxProcessStatus>;
     async fn run_in_sandbox(&self, request: RunInSandboxRequest)
     -> Result<Box<dyn SandboxProcess>>;
+}
+
+#[async_trait]
+pub trait AgentHandle: SandboxHandle {
+    fn record(&self) -> &AgentRecord;
+
+    async fn list_conversations(
+        &self,
+        request: ListConversationsRequest,
+    ) -> Result<ListConversationsResult<Arc<dyn ConversationHandle>>>;
+    async fn get_conversation(
+        &self,
+        id: &ConversationId,
+    ) -> Result<Option<Arc<dyn ConversationHandle>>>;
+    async fn new_conversation(
+        &self,
+        request: NewConversationRequest,
+    ) -> Result<Arc<dyn ConversationHandle>>;
+    async fn delete_conversation(&self, id: &ConversationId) -> Result<bool>;
+
+    async fn list_bindings(&self) -> Result<Vec<BindingRecord>>;
+    async fn put_binding(&self, binding: Binding) -> Result<BindingId>;
+    async fn get_binding(&self, id: &BindingId) -> Result<Option<Binding>>;
+
+    async fn list_secrets(&self) -> Result<Vec<SecretMetadata>>;
+    async fn put_secret(&self, request: PutSecretRequest) -> Result<SecretId>;
+    async fn get_secret(&self, id: &SecretId) -> Result<Option<Secret>>;
+
+    async fn write_artifact(&self, request: WriteArtifactRequest) -> Result<ArtifactVersion>;
+    async fn read_artifact(&self, request: ReadArtifactRequest) -> Result<Option<Artifact>>;
+    async fn list_artifacts(&self) -> Result<Vec<ArtifactVersion>>;
+}
+
+#[async_trait]
+pub trait ConversationHandle: SandboxHandle {
+    fn record(&self) -> &ConversationRecord;
+
+    async fn start_session(&self) -> Result<SessionId>;
+    async fn end_session(&self, id: SessionId) -> Result<()>;
+    async fn begin_turn(&self, request: BeginTurnRequest) -> Result<Arc<dyn TurnHandle>>;
+    /// Rebuilds the local TurnHandle facade for an already-created turn.
+    /// The durable identity is the agent, conversation, session, and turn ids;
+    /// this method only bundles those ids back into the trait object API.
+    async fn turn_handle(&self, record: TurnRecord) -> Result<Arc<dyn TurnHandle>>;
+
+    async fn get_events(&self, query: Option<EventQuery>) -> Result<GetEventsResult>;
+    async fn watch_events(&self, after_exclusive: Bound<EventId>) -> Result<EventStream>;
+    async fn get_event(&self, id: EventId) -> Result<Option<Event>>;
+    async fn add_events(&self, request: AddEventsRequest) -> Result<AddEventsResult>;
+    async fn fork(&self, request: ForkConversationRequest) -> Result<Arc<dyn ConversationHandle>>;
+
+    async fn write_artifact(&self, request: WriteArtifactRequest) -> Result<ArtifactVersion>;
+    async fn read_artifact(&self, request: ReadArtifactRequest) -> Result<Option<Artifact>>;
+    async fn list_artifacts(&self) -> Result<Vec<ArtifactVersion>>;
 
     async fn list_bindings(&self) -> Result<Vec<BindingRecord>>;
     async fn put_binding(&self, binding: Binding) -> Result<BindingId>;

--- a/examples/exoclaw/scripts/exoclaw-control
+++ b/examples/exoclaw/scripts/exoclaw-control
@@ -729,12 +729,12 @@ setup_local_profile() {
   echo "Wrote local profile prompt. The harness will load it from EXOCLAW_LOCAL_PROMPT_FILE."
 }
 
-# During fresh, all agents and conversations are deleted, so every sandbox
-# container left behind by earlier runs is obsolete. Remove exo sandbox
-# containers whose creating process is gone; containers whose owner is still
-# alive (e.g. another exo checkout's running stack) are left alone, as is
-# anything without exo sandbox labels.
-cleanup_orphaned_sandbox_containers() {
+# During fresh, all agents and conversations from this checkout are deleted, so
+# sandbox containers left behind by earlier runs of this checkout are obsolete.
+# Remove exo sandbox containers whose creating process is gone, plus any exo
+# sandbox container that has this repo mounted. Containers from other checkouts
+# with live owners are left alone, as is anything without exo sandbox labels.
+cleanup_stale_sandbox_containers() {
   if ! command -v docker >/dev/null 2>&1 || ! docker info >/dev/null 2>&1; then
     return
   fi
@@ -744,23 +744,34 @@ cleanup_orphaned_sandbox_containers() {
     [[ "$name" == exo-* ]] || continue
     key="$(docker inspect "$container" --format '{{index .Config.Labels "exo.sandbox.key"}}' 2>/dev/null)"
     [[ -n "$key" ]] || continue
-    owner="$(docker inspect "$container" --format '{{index .Config.Labels "exo.sandbox.owner-pid"}}' 2>/dev/null)"
-    if [[ -n "$owner" ]] && kill -0 "$owner" 2>/dev/null; then
+    owner="$(docker inspect "$container" --format '{{index .Config.Labels "exo.sandbox.owner-pid"}}' 2>/dev/null || true)"
+    if [[ -n "$owner" ]] && kill -0 "$owner" 2>/dev/null && ! container_mounts_current_checkout "$container"; then
       continue
     fi
-    echo "Removing orphaned sandbox container $name..."
+    echo "Removing stale sandbox container $name..."
     docker rm -f "$container" >/dev/null 2>&1 || true
     removed=$((removed + 1))
   done
   if [[ "$removed" -gt 0 ]]; then
-    echo "Removed $removed orphaned sandbox container(s)."
+    echo "Removed $removed stale sandbox container(s)."
   fi
+}
+
+container_mounts_current_checkout() {
+  local container="$1"
+  local source
+  while IFS= read -r source; do
+    if [[ "$source" == "$ROOT_DIR" ]]; then
+      return 0
+    fi
+  done < <(docker inspect "$container" --format '{{range .Mounts}}{{println .Source}}{{end}}' 2>/dev/null || true)
+  return 1
 }
 
 fresh_start() {
   build_exo
   delete_all_agents_and_conversations
-  cleanup_orphaned_sandbox_containers
+  cleanup_stale_sandbox_containers
   if [[ "$USE_SANDBOX" == true ]]; then
     PULL_SANDBOX=true
   fi

--- a/exoharness-arch.md
+++ b/exoharness-arch.md
@@ -37,10 +37,9 @@ handle types:
 
 The distinction between `ConversationHandle` and `TurnHandle` is important.
 Conversation-level writes append to the conversation head immediately. Turn-level
-writes are tied to the active turn and use the turn's expected head. If another
-writer advances the conversation while a turn is open, the turn becomes stale
-and further turn writes fail. Code that runs inside a turn should prefer
-`TurnHandle` for messages and artifacts.
+writes attach the active turn's session and turn ids to appended messages and
+artifacts. Code that runs inside a turn should prefer `TurnHandle` for messages
+and artifacts so the event log preserves turn ownership.
 
 ## Key Crates And Files
 
@@ -126,9 +125,9 @@ environment:
 - `list_bindings()`, `put_binding()`, `get_binding()`
 - `list_secrets()`, `put_secret()`, `get_secret()`
 
-Conversation-level `add_events()` accepts an optional `expected_head`. If set,
-the append fails unless the conversation head still matches. This is the
-optimistic concurrency primitive used throughout the system.
+Conversation-level `add_events()` is append-only. Callers that need to avoid
+overlapping agent runs should serialize through the executor-level `send()` APIs
+or another higher-level owner/lease.
 
 ### Turn: `TurnHandle`
 
@@ -139,16 +138,14 @@ A turn handle is the active-turn write surface:
 - `write_artifact(WriteArtifactRequest) -> ArtifactVersion`
 - `finish() -> EventId`
 
-The turn tracks the latest event it wrote. Each turn write checks that the
-conversation head is still the turn's latest event before appending more data.
+Turn writes append events tagged with the turn's session and turn ids.
 `finish()` writes `turn_ended` and marks the handle complete. Calling
-`finish()` again is idempotent and returns the existing latest event id.
+`finish()` again is idempotent and returns the existing finish event id.
 
 ## Records And IDs
 
 Most persisted records use UUIDv7 IDs. These IDs carry sortable timestamps,
-which makes event ordering straightforward and helps produce useful stale-turn
-error messages.
+which makes event ordering straightforward.
 
 Important records:
 
@@ -216,18 +213,6 @@ and finishes the turn. External systems such as adapters and scheduler wakeups
 usually call `send()` with a fresh session and then close the session after the
 wakeup completes.
 
-Stale turns happen when:
-
-1. A turn begins and records its expected conversation head.
-2. Some other writer appends to the same conversation outside that turn.
-3. The active turn tries to append a message, artifact, or `turn_ended`.
-
-The basic implementation reports this as:
-
-```text
-turn is stale and cannot be resumed: conversation head advanced outside this turn
-```
-
 For code running during a turn, use `context.exoharness.current.turn` instead of
 `context.exoharness.current.conversation` when appending messages or artifacts.
 For code outside a turn, serialize wakeups per conversation if multiple external
@@ -242,7 +227,7 @@ creates a new artifact id.
 Artifact APIs exist at agent and conversation scope. Conversation-level
 `write_artifact()` appends an `artifact_written` event to the conversation.
 Turn-level `write_artifact()` also appends an `artifact_written` event, but it
-does so through the active turn and preserves the turn's concurrency invariant.
+tags the event with the active turn's session and turn ids.
 
 TypeScript convenience methods:
 
@@ -345,9 +330,9 @@ The protocol request variants mirror the core handles:
   `conversation_write_artifact`, conversation bindings, conversation secrets.
 - Turn: `turn_add_events`, `turn_write_artifact`, `turn_finish`.
 
-The protocol server stores active turns in an in-memory handle table. TypeScript
-code receives a numeric `handle_id` for the active turn. Subsequent turn
-requests refer to that handle id. `turn_finish` removes the handle.
+The protocol addresses turns by durable ids. TypeScript code receives the active
+turn's agent, conversation, session, and turn ids, and subsequent turn requests
+send those ids back to the host.
 
 ## Executor Harness Facade
 
@@ -579,7 +564,8 @@ When a task is due, the scheduler runtime:
 
 The wakeup uses `HarnessConversation::send()`, so the task result becomes a
 normal agent turn. A per-conversation wakeup lock serializes these external
-wakeups to avoid stale-turn conflicts.
+wakeups so two scheduler/adapter triggers do not run the same conversation at
+once.
 
 ## Adapter Integration
 
@@ -599,9 +585,9 @@ Adapter runtime flow:
 8. The worker loop drains outbound messages and sends them externally.
 
 Inbound and outbound adapter state is intentionally stored in `AdapterStore`
-rather than as conversation artifacts during an active turn. This prevents an
-external adapter write from advancing the conversation head while a turn is
-using its `TurnHandle`.
+rather than as conversation artifacts. Adapter events can arrive while an agent
+turn is running, and storing them outside the conversation log avoids unrelated
+history churn.
 
 Like the scheduler, adapter wakeups use the per-conversation wakeup lock before
 calling `HarnessConversation::send()`.
@@ -636,9 +622,8 @@ Important properties:
 - Sandboxes are tracked in metadata plus an in-memory running-sandbox table.
 
 Because some coordination is in-memory, multiple independent processes writing
-to the same harness root should be treated carefully. The API has optimistic
-head checks, but the basic backend is primarily designed for a coordinated local
-runtime.
+to the same harness root should be treated carefully. The basic backend is
+primarily designed for a coordinated local runtime.
 
 ## Concurrency Rules
 
@@ -650,8 +635,6 @@ Use these rules when adding new subcomponents:
   `send()` API rather than appending assistant messages directly.
 - If multiple external sources can wake the same conversation, serialize those
   wakeups.
-- If code appends conversation events directly, set `expected_head` when it
-  depends on a stable head.
 - Do not write conversation artifacts from adapter or scheduler plumbing while a
   wakeup turn is active.
 - Keep durable subsystem queues in their subsystem stores when the data is not
@@ -767,9 +750,8 @@ adapter worker
 
 - The basic backend's event subscribers and running sandbox table are
   in-memory, so they are not a distributed coordination layer.
-- Turn handles are process-local protocol handles in the TypeScript bridge.
-  They cannot be persisted and resumed by another runner process.
-- Direct conversation writes during a turn can make that turn stale.
+- TypeScript turn requests carry durable turn ids, but there is no separate
+  turn lease token. Coordinate concurrent writers at the executor/wakeup layer.
 - Tool results are compacted for model history, so callers should follow
   artifact references for full output.
 - TypeScript runner protocol messages are line-delimited JSON. Anything written

--- a/typescript/harness/index.ts
+++ b/typescript/harness/index.ts
@@ -197,7 +197,6 @@ export interface GetEventsResult {
 export interface AddEventsRequest {
   sessionId?: string | null;
   turnId?: string | null;
-  expectedHead?: string | null;
   data: EventData[];
 }
 

--- a/typescript/harness/runner.ts
+++ b/typescript/harness/runner.ts
@@ -315,7 +315,6 @@ type RawExoRequest =
       request: {
         session_id?: string | null;
         turn_id?: string | null;
-        expected_head?: string | null;
         data: EventData[];
       };
     }
@@ -1045,13 +1044,11 @@ function toRawEventQuery(query?: EventQuery): RawEventQuery | null {
 function toRawAddEventsRequest(request: AddEventsRequest): {
   session_id?: string | null;
   turn_id?: string | null;
-  expected_head?: string | null;
   data: EventData[];
 } {
   return {
     session_id: request.sessionId ?? null,
     turn_id: request.turnId ?? null,
-    expected_head: request.expectedHead ?? null,
     data: request.data,
   };
 }


### PR DESCRIPTION
* Remove default implementation + implement in HTTP
* Do not let the turn handle's sandbox methods specify a conversation id, since they're scoped to turns
* Remove conversation id from conversation handle's sandbox methods