### PR TITLE
Re-land agent memory (#62) onto exoclaw-self-control

### DIFF
--- a/crates/executor/src/agent_sandbox.rs
+++ b/crates/executor/src/agent_sandbox.rs
@@ -1,6 +1,6 @@
 use exoharness::{
-    AgentHandle, Artifact, ArtifactVersion, ConversationHandle, CreateSandboxRequest,
-    ReadArtifactRequest, Result, SandboxProvider, Uuid7, WriteArtifactRequest,
+    AgentHandle, ConversationHandle, CreateSandboxRequest, ReadArtifactRequest, Result,
+    SandboxProvider, Uuid7, WriteArtifactRequest,
 };
 use serde::{Deserialize, Serialize};
 
@@ -127,7 +127,10 @@ pub(crate) async fn current_agent_sandbox(
 }
 
 async fn load_agent_sandbox_record(agent: &dyn AgentHandle) -> Result<Option<AgentSandboxRecord>> {
-    let Some(artifact) = latest_agent_artifact(agent, AGENT_SANDBOX_ARTIFACT_PATH).await? else {
+    let Some(artifact) = agent
+        .read_artifact(ReadArtifactRequest::path(AGENT_SANDBOX_ARTIFACT_PATH))
+        .await?
+    else {
         return Ok(None);
     };
     Ok(Some(serde_json::from_slice(&artifact.contents)?))
@@ -144,25 +147,6 @@ async fn store_agent_sandbox_record(
         })
         .await?;
     Ok(())
-}
-
-async fn latest_agent_artifact(agent: &dyn AgentHandle, path: &str) -> Result<Option<Artifact>> {
-    let Some(version) = latest_artifact_version(agent.list_artifacts().await?, path) else {
-        return Ok(None);
-    };
-    agent
-        .read_artifact(ReadArtifactRequest {
-            artifact_id: version.artifact_id,
-            version: Some(version.version),
-        })
-        .await
-}
-
-fn latest_artifact_version(artifacts: Vec<ArtifactVersion>, path: &str) -> Option<ArtifactVersion> {
-    artifacts
-        .into_iter()
-        .filter(|artifact| artifact.path == path)
-        .max_by_key(|artifact| artifact.version)
 }
 
 fn new_agent_sandbox_name() -> String {

--- a/crates/executor/src/harness_config.rs
+++ b/crates/executor/src/harness_config.rs
@@ -1,7 +1,6 @@
 use anyhow::anyhow;
 use exoharness::{
-    AgentHandle, Artifact, ArtifactVersion, ConversationHandle, ReadArtifactRequest, Result,
-    WriteArtifactRequest,
+    AgentHandle, ConversationHandle, ReadArtifactRequest, Result, WriteArtifactRequest,
 };
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -71,7 +70,7 @@ async fn read_json_artifact_from_agent<T: DeserializeOwned>(
     agent: &dyn AgentHandle,
     path: &str,
 ) -> Result<Option<T>> {
-    let Some(artifact) = latest_artifact_from_agent(agent, path).await? else {
+    let Some(artifact) = agent.read_artifact(ReadArtifactRequest::path(path)).await? else {
         return Ok(None);
     };
     Ok(Some(serde_json::from_slice(&artifact.contents)?))
@@ -81,47 +80,11 @@ async fn read_json_artifact_from_conversation<T: DeserializeOwned>(
     conversation: &dyn ConversationHandle,
     path: &str,
 ) -> Result<Option<T>> {
-    let Some(artifact) = latest_artifact_from_conversation(conversation, path).await? else {
+    let Some(artifact) = conversation
+        .read_artifact(ReadArtifactRequest::path(path))
+        .await?
+    else {
         return Ok(None);
     };
     Ok(Some(serde_json::from_slice(&artifact.contents)?))
-}
-
-async fn latest_artifact_from_agent(
-    agent: &dyn AgentHandle,
-    path: &str,
-) -> Result<Option<Artifact>> {
-    let latest_version = latest_artifact_version(agent.list_artifacts().await?, path);
-    let Some(latest_version) = latest_version else {
-        return Ok(None);
-    };
-    agent
-        .read_artifact(ReadArtifactRequest {
-            artifact_id: latest_version.artifact_id,
-            version: Some(latest_version.version),
-        })
-        .await
-}
-
-async fn latest_artifact_from_conversation(
-    conversation: &dyn ConversationHandle,
-    path: &str,
-) -> Result<Option<Artifact>> {
-    let latest_version = latest_artifact_version(conversation.list_artifacts().await?, path);
-    let Some(latest_version) = latest_version else {
-        return Ok(None);
-    };
-    conversation
-        .read_artifact(ReadArtifactRequest {
-            artifact_id: latest_version.artifact_id,
-            version: Some(latest_version.version),
-        })
-        .await
-}
-
-fn latest_artifact_version(artifacts: Vec<ArtifactVersion>, path: &str) -> Option<ArtifactVersion> {
-    artifacts
-        .into_iter()
-        .filter(|artifact| artifact.path == path)
-        .max_by_key(|artifact| artifact.version)
 }

--- a/crates/executor/src/harness_tool.rs
+++ b/crates/executor/src/harness_tool.rs
@@ -19,10 +19,10 @@ use crate::{AgentConfig, ConversationConfig, ToolRuntime};
 use crate::{SandboxScope, effective_sandbox_scope};
 use async_trait::async_trait;
 use exoharness::{
-    AgentHandle, Artifact, ArtifactVersion, ConversationHandle, CreateSandboxRequest, EventData,
-    EventKind, EventQuery, EventQueryDirection, FileSystemMount, FileSystemMountMode,
-    ReadArtifactRequest, Result, RunInSandboxRequest, SandboxProcess, SandboxProvider, SnapshotId,
-    StartSandboxRequest, ToolRequest, ToolResult, TurnHandle, WriteArtifactRequest,
+    AgentHandle, ConversationHandle, CreateSandboxRequest, EventData, EventKind, EventQuery,
+    EventQueryDirection, FileSystemMount, FileSystemMountMode, ReadArtifactRequest, Result,
+    RunInSandboxRequest, SandboxProcess, SandboxProvider, SnapshotId, StartSandboxRequest,
+    ToolRequest, ToolResult, TurnHandle, WriteArtifactRequest,
 };
 use futures::io::AsyncReadExt;
 use serde::{Deserialize, Serialize};
@@ -762,8 +762,11 @@ fn upsert_current_sandbox_snapshot(
 async fn load_sandbox_snapshot_registry(
     agent: &dyn AgentHandle,
 ) -> Result<SandboxSnapshotRegistry> {
-    let Some(artifact) =
-        latest_agent_artifact(agent, SANDBOX_SNAPSHOT_REGISTRY_ARTIFACT_PATH).await?
+    let Some(artifact) = agent
+        .read_artifact(ReadArtifactRequest::path(
+            SANDBOX_SNAPSHOT_REGISTRY_ARTIFACT_PATH,
+        ))
+        .await?
     else {
         return Ok(SandboxSnapshotRegistry::default());
     };
@@ -781,25 +784,6 @@ async fn store_sandbox_snapshot_registry(
         })
         .await?;
     Ok(())
-}
-
-async fn latest_agent_artifact(agent: &dyn AgentHandle, path: &str) -> Result<Option<Artifact>> {
-    let Some(version) = latest_artifact_version(agent.list_artifacts().await?, path) else {
-        return Ok(None);
-    };
-    agent
-        .read_artifact(ReadArtifactRequest {
-            artifact_id: version.artifact_id,
-            version: Some(version.version),
-        })
-        .await
-}
-
-fn latest_artifact_version(artifacts: Vec<ArtifactVersion>, path: &str) -> Option<ArtifactVersion> {
-    artifacts
-        .into_iter()
-        .filter(|artifact| artifact.path == path)
-        .max_by_key(|artifact| artifact.version)
 }
 
 fn parse_snapshot_id(value: &str) -> Result<SnapshotId> {

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -31,7 +31,7 @@ use crate::secrets::{
 };
 use crate::storage::BasicObjectStore;
 use crate::{
-    AddEventsRequest, AddEventsResult, AgentHandle, AgentId, AgentRecord, Artifact,
+    AddEventsRequest, AddEventsResult, AgentHandle, AgentId, AgentRecord, Artifact, ArtifactRef,
     ArtifactVersion, BeginTurnRequest, Binding, BindingId, BindingRecord, BindingType,
     BoxAsyncRead, BoxAsyncWrite, CancelSandboxProcessRequest, CloseSandboxProcessInputRequest,
     ConversationHandle, ConversationId, ConversationRecord, CreateSandboxRequest, Event, EventData,
@@ -947,7 +947,10 @@ impl AgentHandle for BasicAgentHandle {
             load_artifact_versions(&self.harness.inner.storage, &self.artifacts_dir()).await?;
         let selected = versions
             .into_iter()
-            .filter(|artifact| artifact.artifact_id == request.artifact_id)
+            .filter(|artifact| match &request.artifact {
+                ArtifactRef::Id(id) => artifact.artifact_id == *id,
+                ArtifactRef::Path(path) => &artifact.path == path,
+            })
             .filter(|artifact| {
                 request
                     .version
@@ -1594,7 +1597,10 @@ impl ConversationHandle for BasicConversationHandle {
             load_artifact_versions(&self.harness.inner.storage, &self.artifacts_dir()).await?;
         let selected = versions
             .into_iter()
-            .filter(|artifact| artifact.artifact_id == request.artifact_id)
+            .filter(|artifact| match &request.artifact {
+                ArtifactRef::Id(id) => artifact.artifact_id == *id,
+                ArtifactRef::Path(path) => &artifact.path == path,
+            })
             .filter(|artifact| {
                 request
                     .version

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -465,6 +465,132 @@ async fn artifacts_are_versioned_by_path() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn read_artifact_by_path_returns_latest_version() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let harness = BasicExoHarness::new(local_test_config(tempdir.path()))
+        .await
+        .expect("harness should initialize");
+    let agent = harness
+        .new_agent(NewAgentRequest {
+            slug: "agent".to_string(),
+            name: "Agent".to_string(),
+        })
+        .await
+        .expect("agent");
+
+    // No artifact yet at this path.
+    assert!(
+        agent
+            .read_artifact(crate::ReadArtifactRequest::path("memory/store.json"))
+            .await
+            .expect("read by path")
+            .is_none()
+    );
+
+    for contents in ["v1", "v2", "v3"] {
+        agent
+            .write_artifact(crate::WriteArtifactRequest {
+                path: "memory/store.json".to_string(),
+                contents: contents.as_bytes().to_vec(),
+            })
+            .await
+            .expect("write artifact");
+    }
+    // A decoy at a different path must not be selected.
+    agent
+        .write_artifact(crate::WriteArtifactRequest {
+            path: "config/other.json".to_string(),
+            contents: b"decoy".to_vec(),
+        })
+        .await
+        .expect("write decoy");
+
+    // Reading by path returns the highest version.
+    let latest = agent
+        .read_artifact(crate::ReadArtifactRequest::path("memory/store.json"))
+        .await
+        .expect("read by path")
+        .expect("some artifact");
+    assert_eq!(latest.version.version, 3);
+    assert_eq!(latest.version.path, "memory/store.json");
+    assert_eq!(latest.contents, b"v3");
+
+    // A pinned version is still honored when reading by path.
+    let pinned = agent
+        .read_artifact(crate::ReadArtifactRequest {
+            artifact: crate::ArtifactRef::Path("memory/store.json".to_string()),
+            version: Some(1),
+        })
+        .await
+        .expect("read pinned by path")
+        .expect("v1 exists");
+    assert_eq!(pinned.contents, b"v1");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn server_dispatches_read_artifact_by_path() {
+    use crate::protocol::{Request, Response};
+    use crate::server::ExoHarnessServer;
+
+    let tempdir = TempDir::new().expect("tempdir");
+    let harness = std::sync::Arc::new(
+        BasicExoHarness::new(local_test_config(tempdir.path()))
+            .await
+            .expect("harness should initialize"),
+    );
+    let agent = harness
+        .new_agent(NewAgentRequest {
+            slug: "agent".to_string(),
+            name: "Agent".to_string(),
+        })
+        .await
+        .expect("agent");
+    let agent_id = agent.record().id;
+
+    for contents in ["v1", "v2"] {
+        agent
+            .write_artifact(crate::WriteArtifactRequest {
+                path: "memory/store.json".to_string(),
+                contents: contents.as_bytes().to_vec(),
+            })
+            .await
+            .expect("write artifact");
+    }
+
+    let server = ExoHarnessServer::new(harness.clone());
+
+    // A path-keyed read returns the latest version through the protocol dispatch.
+    match server
+        .handle_request(Request::AgentReadArtifact {
+            agent_id,
+            request: crate::ReadArtifactRequest::path("memory/store.json"),
+        })
+        .await
+        .expect("dispatch read by path")
+    {
+        Response::Artifact { artifact } => {
+            let artifact = artifact.expect("some artifact");
+            assert_eq!(artifact.version.version, 2);
+            assert_eq!(artifact.contents, b"v2");
+        }
+        other => panic!("expected Response::Artifact, got {}", other.kind()),
+    }
+
+    // A missing path yields an empty artifact response, not an error.
+    match server
+        .handle_request(Request::AgentReadArtifact {
+            agent_id,
+            request: crate::ReadArtifactRequest::path("memory/missing.json"),
+        })
+        .await
+        .expect("dispatch read by missing path")
+    {
+        Response::Artifact { artifact } => assert!(artifact.is_none()),
+        other => panic!("expected Response::Artifact, got {}", other.kind()),
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn artifacts_store_metadata_and_raw_contents_separately() {
     let tempdir = TempDir::new().expect("tempdir");
     let harness = BasicExoHarness::new(local_test_config(tempdir.path()))
@@ -548,7 +674,7 @@ async fn legacy_json_artifacts_are_still_readable() {
 
     let loaded = agent
         .read_artifact(crate::ReadArtifactRequest {
-            artifact_id,
+            artifact: crate::ArtifactRef::Id(artifact_id),
             version: Some(1),
         })
         .await

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -60,6 +60,10 @@ pub trait AgentHandle: Send + Sync {
     async fn get_secret(&self, id: &SecretId) -> Result<Option<Secret>>;
 
     async fn write_artifact(&self, request: WriteArtifactRequest) -> Result<ArtifactVersion>;
+    /// Reads an artifact selected by id or path (see `ReadArtifactRequest`).
+    /// Implementations should resolve this in a single I/O where possible
+    /// (e.g. a backing query); callers asking by path get the latest version
+    /// unless one is pinned.
     async fn read_artifact(&self, request: ReadArtifactRequest) -> Result<Option<Artifact>>;
     async fn list_artifacts(&self) -> Result<Vec<ArtifactVersion>>;
 }
@@ -83,6 +87,7 @@ pub trait ConversationHandle: Send + Sync {
     async fn fork(&self, request: ForkConversationRequest) -> Result<Arc<dyn ConversationHandle>>;
 
     async fn write_artifact(&self, request: WriteArtifactRequest) -> Result<ArtifactVersion>;
+    /// Reads an artifact selected by id or path (see `ReadArtifactRequest`).
     async fn read_artifact(&self, request: ReadArtifactRequest) -> Result<Option<Artifact>>;
     async fn list_artifacts(&self) -> Result<Vec<ArtifactVersion>>;
 
@@ -493,8 +498,37 @@ pub struct WriteArtifactRequest {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ReadArtifactRequest {
-    pub artifact_id: ArtifactId,
+    /// Which artifact to read — by id, or by path (latest version unless
+    /// `version` pins one). Keeping this a single request lets a backend
+    /// resolve either form in one I/O instead of a list-then-filter.
+    pub artifact: ArtifactRef,
     pub version: Option<u64>,
+}
+
+impl ReadArtifactRequest {
+    /// Read (the latest version of) the artifact with this id.
+    pub fn id(artifact_id: ArtifactId) -> Self {
+        Self {
+            artifact: ArtifactRef::Id(artifact_id),
+            version: None,
+        }
+    }
+
+    /// Read the latest version of the artifact at this path.
+    pub fn path(path: impl Into<String>) -> Self {
+        Self {
+            artifact: ArtifactRef::Path(path.into()),
+            version: None,
+        }
+    }
+}
+
+/// Selects an artifact either by its stable id or by its path.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ArtifactRef {
+    Id(ArtifactId),
+    Path(String),
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]

--- a/examples/exoclaw/docs/SELF-CONTROL.md
+++ b/examples/exoclaw/docs/SELF-CONTROL.md
@@ -77,6 +77,22 @@ Two properties matter for rollback:
 
 Gap: host events currently cover the adapter runner only. The scheduler runner and the control REPL do not yet write start/drain/crash events into the log, and there is no agent-level (cross-conversation) event stream — host events are fanned out to each adapter-attached conversation.
 
+### Agent-writable memory (the `remember` tool)
+
+Everything above is memory the agent _reads_; until recently it had no way to _write_ a durable fact about the user or itself. Conversation history is replayed in full each turn, but it dies at the conversation boundary, and the local profile (`.exo/exoclaw-profile.md`) is human-curated — the agent cannot edit it. So "remember that my favorite coffee is X" had nowhere to go: it survived the current conversation by replay and was lost everywhere else.
+
+The memory tool closes that gap with the smallest mechanism that works, built entirely on the existing artifact store. The first cut is deliberately a single **global** store — no scoping — because that covers the motivating case ("remember my favorite coffee") and scope is easy to add later if a thread-local need appears.
+
+- **Storage.** One JSON artifact at `memory/exoclaw-memory.json` on the agent handle, so it persists across every conversation for this agent — exactly how `config/executor.json` is persisted. This is where durable user/identity facts live ("favorite coffee is X", "lives in Berkeley", "prefers terse replies").
+- **Write path — `remember(text)` tool.** Read-modify-write: load the current store, append an entry `{ id, text, createdAt }`, write a new artifact version. `forget(id)` removes one. A soft cap drops the oldest entries past a fixed ceiling so a runaway agent cannot grow the prompt without bound. The write is mechanical and lossless on purpose — no model call in the durable-write path.
+- **Read path — prompt injection.** At prompt-assembly time the harness reads the store and prepends a `developer` message listing the saved facts (with their ids, so the model can `forget` stale ones). This sits next to the identity prompt and local profile, so memory enters context the same way instructions do.
+
+How `forget` resolves a fuzzy request: the injected block carries the entry **ids**, so when the user says "forget the color thing" the main model — which already has the list in context — maps that to the matching id and calls `forget(id)`. The intelligence is the agent's; the tool only deletes by exact id.
+
+This is deliberately _not_ embedding-based retrieval. For a handful of short facts you inject all of them every turn — no vector store, no similarity search, no extra container. Embeddings only earn their place when the memory set outgrows what fits sensibly in every prompt; at that point the read path swaps always-inject for a query-time `recall` over an index, and the storage layer stays exactly where it is. The tool lives in the TypeScript harness (`examples/exoclaw/memory-tools.ts`) because both the artifact read/write API and prompt assembly are TS-side; no trusted-substrate change is required, since the substrate already provides durable, access-controlled artifacts.
+
+Limits of the prototype and the natural next increments (not blockers): always-inject means every saved fact costs prompt tokens each turn; there is no semantic dedup (saving the same fact twice yields two entries); the agent decides what to save (no automatic extraction from conversation); and there is no scoping yet (everything is global). A periodic, _async_ LLM consolidation pass — read the store, dedup/merge contradictions, write a new version while keeping the prior one for rollback — is the right place to add model-mediated cleanup, kept off the synchronous write path.
+
 ## 3. Component Observability: Logs and Telemetry
 
 Exoclaw should be able to inspect each of its components when debugging or evolving them, before escalating to restarts.

--- a/examples/exoclaw/harness.ts
+++ b/examples/exoclaw/harness.ts
@@ -17,6 +17,7 @@ import { registerSchedulerTools } from "./scheduler-tools";
 import { registerSandboxTools } from "./sandbox-tools";
 import { registerGuardianTools } from "./guardian-tools";
 import { registerIntrospectionTools } from "./introspection-tools";
+import { memoryInstruction, registerMemoryTools } from "./memory-tools";
 import {
   basicHarnessInstructions,
   defaultBuiltInToolNames,
@@ -51,6 +52,7 @@ async function registerExoclawTools(
   registerFalTools(tools);
   registerSandboxTools(tools);
   registerGuardianTools(tools);
+  registerMemoryTools(tools);
   for (const modulePath of context.agentConfig.typescript?.toolModulePaths ??
     []) {
     await registerLibraryToolModulePath(tools, context, modulePath);
@@ -64,7 +66,7 @@ function builtInToolNames(context: TurnContext): BuiltInToolName[] {
   return defaultBuiltInToolNames(context);
 }
 
-function exoclawInstructions(context: TurnContext): Message[] {
+async function exoclawInstructions(context: TurnContext): Promise<Message[]> {
   const repoPath = process.env.EXOCLAW_REPO ?? DEFAULT_EXOCLAW_REPO;
   const selfMapPath = process.env.EXOCLAW_SELF_MAP ?? DEFAULT_EXOCLAW_SELF_MAP;
   const instructions: Message[] = [
@@ -76,7 +78,7 @@ function exoclawInstructions(context: TurnContext): Message[] {
     {
       role: "developer",
       content:
-        'This is the Exoclaw long-running agent harness. You can schedule recurring sandbox work with schedule_sandbox_task, inspect active tasks with list_scheduled_tasks, cancel tasks with cancel_scheduled_task, and permanently delete tasks with delete_scheduled_task. You can inspect sandbox filesystem snapshots with list_sandbox_snapshots, capture a checkpoint with snapshot_sandbox, and rewind to a previous checkpoint with rewind_sandbox. You can use guardian_action for host-side self-maintenance such as checking service status, building Exoclaw, viewing logs, and restarting the scheduler or adapter runners while preserving .exo state. guardian_action restart actions are deferred briefly so the current turn can finish before services stop; guardian builds also ask the control REPL wrapper to refresh its child process without closing the user\'s terminal. After requesting one, report that it was scheduled and use status/logs after services come back. You can also create long-running external adapters with create_adapter, inspect them with list_adapters, disable/delete them, and send explicit outbound replies with send_adapter_message. Use cancel_scheduled_task or disable_adapter when history should be preserved; use delete_scheduled_task or delete_adapter when the user asks to remove something entirely. Conversations default to sandboxScope: "agent", so shell commands use this agent\'s shared sandbox unless the conversation was configured with sandboxScope: "conversation". Scheduled tasks default to sandboxMode: "agent". Use sandboxMode: "conversation" when the task should run in this conversation\'s sandbox, and sandboxMode: "task_fresh" when the task should have a separate fresh sandbox that is reused across that task\'s runs. IRC, WhatsApp, Signal, and Discord adapters wake this conversation when their trigger policy matches; do not auto-send model text to external services. Call send_adapter_message only for intentional external replies, using the target value from the inbound wakeup when one is provided. For Discord, the target is a channel id unless the adapter has a defaultChannelId. If an adapter message asks you to schedule future work and the future result should appear externally, include the adapterId and target in the scheduled task reportPrompt so the scheduler wakeup can call send_adapter_message.',
+        'This is the Exoclaw long-running agent harness. You can schedule recurring sandbox work with schedule_sandbox_task, inspect active tasks with list_scheduled_tasks, cancel tasks with cancel_scheduled_task, and permanently delete tasks with delete_scheduled_task. You can inspect sandbox filesystem snapshots with list_sandbox_snapshots, capture a checkpoint with snapshot_sandbox, and rewind to a previous checkpoint with rewind_sandbox. You can use guardian_action for host-side self-maintenance such as checking service status, building Exoclaw, viewing logs, and restarting the scheduler or adapter runners while preserving .exo state. guardian_action restart actions are deferred briefly so the current turn can finish before services stop; guardian builds also ask the control REPL wrapper to refresh its child process without closing the user\'s terminal. After requesting one, report that it was scheduled and use status/logs after services come back. You can also create long-running external adapters with create_adapter, inspect them with list_adapters, disable/delete them, and send explicit outbound replies with send_adapter_message. Use cancel_scheduled_task or disable_adapter when history should be preserved; use delete_scheduled_task or delete_adapter when the user asks to remove something entirely. Conversations default to sandboxScope: "agent", so shell commands use this agent\'s shared sandbox unless the conversation was configured with sandboxScope: "conversation". Scheduled tasks default to sandboxMode: "agent". Use sandboxMode: "conversation" when the task should run in this conversation\'s sandbox, and sandboxMode: "task_fresh" when the task should have a separate fresh sandbox that is reused across that task\'s runs. IRC, WhatsApp, Signal, and Discord adapters wake this conversation when their trigger policy matches; do not auto-send model text to external services. Call send_adapter_message only for intentional external replies, using the target value from the inbound wakeup when one is provided. For Discord, the target is a channel id unless the adapter has a defaultChannelId. If an adapter message asks you to schedule future work and the future result should appear externally, include the adapterId and target in the scheduled task reportPrompt so the scheduler wakeup can call send_adapter_message. When the user shares a durable preference or fact about themselves ("remember that ..."), save it with the remember tool; remove stale entries with forget. Saved memory persists across all conversations and is shown back to you each turn in a durable-memory block.',
     },
     {
       role: "developer",
@@ -94,6 +96,10 @@ function exoclawInstructions(context: TurnContext): Message[] {
       role: "developer",
       content: localPrompt,
     });
+  }
+  const memory = await memoryInstruction(context);
+  if (memory !== null) {
+    instructions.push(memory);
   }
   return instructions;
 }

--- a/examples/exoclaw/memory-tools.test.ts
+++ b/examples/exoclaw/memory-tools.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+
+import type { ArtifactVersion, JsonObject, TurnContext } from "@exo/harness";
+
+import { createMemoryToolInstances, memoryInstruction } from "./memory-tools";
+
+// Minimal in-memory stand-in for an artifact-backed handle (agent or
+// conversation). Each writeArtifactJson appends a new version at the same path,
+// matching how the real store versions artifacts.
+class FakeHandle {
+  private versions: {
+    artifactId: string;
+    path: string;
+    version: number;
+    value: unknown;
+  }[] = [];
+  private seq = 0;
+
+  async readArtifactJson<T>({ path }: { path: string }): Promise<T | null> {
+    const latest = this.versions
+      .filter((v) => v.path === path)
+      .sort((a, b) => b.version - a.version)[0];
+    return latest ? (latest.value as T) : null;
+  }
+
+  async writeArtifactJson({
+    path,
+    value,
+  }: {
+    path: string;
+    value: unknown;
+  }): Promise<ArtifactVersion> {
+    this.seq += 1;
+    const version = this.seq;
+    const artifactId = `${path}@${version}`;
+    this.versions.push({ artifactId, path, version, value });
+    return {
+      artifactId,
+      path,
+      version,
+      createdAt: "1970-01-01T00:00:00Z",
+      sizeBytes: 0,
+    };
+  }
+}
+
+function makeContext(): { context: TurnContext; agent: FakeHandle } {
+  const agent = new FakeHandle();
+  const context = {
+    exoharness: { current: { agent } },
+  } as unknown as TurnContext;
+  return { context, agent };
+}
+
+const toolsByName = Object.fromEntries(
+  createMemoryToolInstances().map((tool) => [tool.definition.name, tool]),
+);
+
+function call(name: string, args: JsonObject, context: TurnContext) {
+  return toolsByName[name].handler.execute(args, { context });
+}
+
+describe("memory tools", () => {
+  it("remembers a fact and injects it into the prompt", async () => {
+    const { context } = makeContext();
+    const result = (await call(
+      "remember",
+      { text: "favorite coffee is a flat white" },
+      context,
+    )) as { ok: boolean; id: string };
+
+    expect(result.ok).toBe(true);
+
+    const message = await memoryInstruction(context);
+    expect(message).not.toBeNull();
+    const content = String(message?.content);
+    expect(content).toContain("favorite coffee is a flat white");
+    expect(content).toContain(result.id);
+  });
+
+  it("appends across calls (read-modify-write, not overwrite)", async () => {
+    const { context } = makeContext();
+    await call("remember", { text: "fact one" }, context);
+    const second = (await call("remember", { text: "fact two" }, context)) as {
+      total: number;
+    };
+
+    expect(second.total).toBe(2);
+    const content = String((await memoryInstruction(context))?.content);
+    expect(content).toContain("fact one");
+    expect(content).toContain("fact two");
+  });
+
+  it("forgets a fact by id", async () => {
+    const { context } = makeContext();
+    const saved = (await call(
+      "remember",
+      { text: "temporary fact" },
+      context,
+    )) as { id: string };
+
+    const forgotten = (await call("forget", { id: saved.id }, context)) as {
+      ok: boolean;
+      removed: number;
+    };
+    expect(forgotten.ok).toBe(true);
+    expect(forgotten.removed).toBe(1);
+
+    expect(await memoryInstruction(context)).toBeNull();
+  });
+
+  it("rejects empty and oversized text", async () => {
+    const { context } = makeContext();
+    const empty = (await call("remember", { text: "   " }, context)) as {
+      ok: boolean;
+    };
+    expect(empty.ok).toBe(false);
+
+    const huge = (await call(
+      "remember",
+      { text: "x".repeat(1000) },
+      context,
+    )) as { ok: boolean };
+    expect(huge.ok).toBe(false);
+  });
+
+  it("returns null when nothing is remembered", async () => {
+    const { context } = makeContext();
+    expect(await memoryInstruction(context)).toBeNull();
+  });
+
+  it("makes the write path (remember) reject on a corrupt store", async () => {
+    const { context, agent } = makeContext();
+    // A payload that exists but does not match the schema.
+    await agent.writeArtifactJson({
+      path: "memory/exoclaw-memory.json",
+      value: { entries: "not-an-array" },
+    });
+    await expect(call("remember", { text: "x" }, context)).rejects.toThrow(
+      /corrupt memory artifact/,
+    );
+  });
+
+  it("degrades the read path on a corrupt store instead of throwing", async () => {
+    const { context, agent } = makeContext();
+    await agent.writeArtifactJson({
+      path: "memory/exoclaw-memory.json",
+      value: { entries: "not-an-array" },
+    });
+    // Prompt assembly must not throw — it returns a degraded note instead.
+    const message = await memoryInstruction(context);
+    expect(message).not.toBeNull();
+    expect(String(message?.content)).toMatch(/unavailable|corrupt/i);
+  });
+});

--- a/examples/exoclaw/memory-tools.ts
+++ b/examples/exoclaw/memory-tools.ts
@@ -1,0 +1,222 @@
+import { randomUUID } from "node:crypto";
+
+import { z } from "zod";
+
+import type {
+  Agent,
+  HarnessToolRegistry,
+  JsonObject,
+  JsonValue,
+  Message,
+  ToolInstance,
+  ToolResult,
+  TurnContext,
+} from "@exo/harness";
+
+// Durable agent-writable memory: a single global store that persists across
+// every conversation for this agent. Stored as a JSON artifact on the agent
+// handle, mirroring how config/executor.json is persisted. See
+// examples/exoclaw/docs/SELF-CONTROL.md section 2 for the design.
+const MEMORY_ARTIFACT_PATH = "memory/exoclaw-memory.json";
+// Soft caps so always-injecting memory cannot grow the prompt without bound.
+const MAX_ENTRIES = 200;
+const MAX_TEXT_CHARS = 600;
+
+const MemoryEntrySchema = z.object({
+  id: z.string(),
+  text: z.string(),
+  createdAt: z.string(),
+});
+
+const MemoryStoreSchema = z.object({
+  entries: z.array(MemoryEntrySchema),
+});
+
+type MemoryEntry = z.infer<typeof MemoryEntrySchema>;
+type MemoryStore = z.infer<typeof MemoryStoreSchema>;
+
+// The artifact subset both Agent and the test fake provide. Reading by path
+// (rather than listing every artifact and filtering here) lets exoharness
+// resolve the latest version in a single I/O.
+type MemoryHandle = Pick<Agent, "readArtifactJson" | "writeArtifactJson">;
+
+function memoryHandle(context: TurnContext): MemoryHandle {
+  return context.exoharness.current.agent;
+}
+
+// Reads and validates the store. Throws on a corrupt artifact (invalid JSON or
+// failing the schema) so the write path refuses to bury it; the read/inject
+// path catches this in memoryInstruction. A missing artifact is not corrupt —
+// it is a legitimately empty store.
+async function readMemory(handle: MemoryHandle): Promise<MemoryStore> {
+  let raw: unknown;
+  try {
+    raw = await handle.readArtifactJson({ path: MEMORY_ARTIFACT_PATH });
+  } catch (cause) {
+    // readArtifactJson parses the stored bytes; it throws if they are not
+    // valid JSON. Treat that the same as a schema failure below.
+    throw new Error(
+      `corrupt memory artifact ${MEMORY_ARTIFACT_PATH}: not valid JSON`,
+      { cause },
+    );
+  }
+  if (raw === null) {
+    return { entries: [] };
+  }
+  const parsed = MemoryStoreSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new Error(
+      `corrupt memory artifact ${MEMORY_ARTIFACT_PATH}: ${parsed.error.message}`,
+    );
+  }
+  return parsed.data;
+}
+
+// TODO(storage-rework): remember/forget are read-modify-write with no
+// compare-and-swap. Agent-scoped memory is shared across conversations, so two
+// channels running turns concurrently can both read version N and both write
+// N+1, losing one update. Fix alongside the artifact versioning rework — either
+// an optimistic write that rejects when the latest version moved, or an
+// append-entry store op instead of rewriting the whole store.
+async function writeMemory(
+  handle: MemoryHandle,
+  store: MemoryStore,
+): Promise<void> {
+  await handle.writeArtifactJson({
+    path: MEMORY_ARTIFACT_PATH,
+    value: store as unknown as JsonValue,
+  });
+}
+
+function rememberTool(): ToolInstance {
+  return {
+    source: "built_in",
+    definition: {
+      name: "remember",
+      description:
+        "Save a durable fact so you still have it in future turns and conversations. Use this when the user shares a lasting preference or fact about themselves, or when you want to persist something about yourself. The fact is injected into your context every turn. Phrase it as a standalone statement.",
+      parameters: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          text: {
+            type: "string",
+            description:
+              'The fact to remember, phrased to stand on its own (e.g. "User\'s favorite coffee is a flat white").',
+          },
+        },
+        required: ["text"],
+      },
+    },
+    handler: {
+      async execute(args: JsonObject, execution): Promise<ToolResult> {
+        const text = typeof args.text === "string" ? args.text.trim() : "";
+        if (text.length === 0) {
+          return { ok: false, error: "text is required" };
+        }
+        if (text.length > MAX_TEXT_CHARS) {
+          return {
+            ok: false,
+            error: `text exceeds ${MAX_TEXT_CHARS} characters; summarize it first`,
+          };
+        }
+        const handle = memoryHandle(execution.context);
+        const store = await readMemory(handle);
+        const entry: MemoryEntry = {
+          id: `mem_${randomUUID().slice(0, 8)}`,
+          text,
+          createdAt: new Date().toISOString(),
+        };
+        store.entries.push(entry);
+        let dropped = 0;
+        if (store.entries.length > MAX_ENTRIES) {
+          dropped = store.entries.length - MAX_ENTRIES;
+          store.entries = store.entries.slice(-MAX_ENTRIES);
+        }
+        await writeMemory(handle, store);
+        return { ok: true, id: entry.id, total: store.entries.length, dropped };
+      },
+    },
+  };
+}
+
+function forgetTool(): ToolInstance {
+  return {
+    source: "built_in",
+    definition: {
+      name: "forget",
+      description:
+        "Remove a previously saved memory by its id. Memory ids are shown in brackets in the durable-memory block in your context.",
+      parameters: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          id: {
+            type: "string",
+            description: "The memory id to remove, e.g. mem_1a2b3c4d.",
+          },
+        },
+        required: ["id"],
+      },
+    },
+    handler: {
+      async execute(args: JsonObject, execution): Promise<ToolResult> {
+        const id = typeof args.id === "string" ? args.id.trim() : "";
+        if (id.length === 0) {
+          return { ok: false, error: "id is required" };
+        }
+        const handle = memoryHandle(execution.context);
+        const store = await readMemory(handle);
+        const before = store.entries.length;
+        store.entries = store.entries.filter((entry) => entry.id !== id);
+        const removed = before - store.entries.length;
+        if (removed > 0) {
+          await writeMemory(handle, store);
+        }
+        return { ok: removed > 0, id, removed };
+      },
+    },
+  };
+}
+
+export function createMemoryToolInstances(): ToolInstance[] {
+  return [rememberTool(), forgetTool()];
+}
+
+export function registerMemoryTools(registry: HarnessToolRegistry): void {
+  for (const tool of createMemoryToolInstances()) {
+    registry.register(tool);
+  }
+}
+
+// Build the developer message that injects saved memory into the prompt.
+// Returns null when nothing has been remembered yet.
+export async function memoryInstruction(
+  context: TurnContext,
+): Promise<Message | null> {
+  let store: MemoryStore;
+  try {
+    store = await readMemory(memoryHandle(context));
+  } catch (error) {
+    // Prompt assembly runs every model round, so a corrupt store must not brick
+    // the agent in every conversation. Degrade the read: log loudly and tell the
+    // model memory is unavailable rather than silently pretending it is empty.
+    // The write path (remember/forget) still throws, so nothing overwrites the
+    // corrupt artifact while it is broken.
+    const detail = error instanceof Error ? error.message : String(error);
+    console.error(`memory unavailable during prompt assembly: ${detail}`);
+    return {
+      role: "developer",
+      content:
+        "Your durable memory could not be read this turn (the stored memory artifact appears corrupt). Do not assume it is empty; if the user asks about saved facts, tell them memory is temporarily unavailable.",
+    };
+  }
+  if (store.entries.length === 0) {
+    return null;
+  }
+  const lines = store.entries.map((entry) => `- [${entry.id}] ${entry.text}`);
+  return {
+    role: "developer",
+    content: `Durable memory you saved earlier with the remember tool. Treat these as authoritative context. Add new facts with remember and drop stale ones with forget(id).\n\n${lines.join("\n")}`,
+  };
+}

--- a/examples/typescript/turn-loop.ts
+++ b/examples/typescript/turn-loop.ts
@@ -24,7 +24,7 @@ import { ensureTable } from "@exo/model-runtime/cost";
 import { resolveLlmBinding } from "./shared";
 
 export interface ResponsesTurnLoopOptions {
-  instructions?: (context: TurnContext) => Message[];
+  instructions?: (context: TurnContext) => Message[] | Promise<Message[]>;
   registerTools?: (
     tools: HarnessToolRegistry,
     context: TurnContext,
@@ -115,9 +115,12 @@ async function runResponsesTurnLoop(
     if (options.registerTools) {
       await options.registerTools(tools, context);
     }
+    const instructions = options.instructions
+      ? await options.instructions(context)
+      : basicHarnessInstructions(context);
     const messages = await materializePromptMessages(
       conversation,
-      options.instructions?.(context) ?? basicHarnessInstructions(context),
+      instructions,
     );
     const request: NativeResponsesRequest = {
       model,

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "opusscript": "^0.1.1",
     "prism-media": "^1.3.5",
     "qrcode-terminal": "^0.12.0",
-    "sodium-native": "^5.1.0"
+    "sodium-native": "^5.1.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "25.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,10 @@ importers:
     dependencies:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.2.126
-        version: 0.2.126(zod@4.3.6)
+        version: 0.2.126(zod@4.4.3)
       '@braintrust/lingua':
         specifier: ^0.1.0
-        version: 0.1.0(@anthropic-ai/sdk@0.81.0(zod@4.3.6))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))
+        version: 0.1.0(@anthropic-ai/sdk@0.81.0(zod@4.4.3))(openai@6.33.0(ws@8.21.0)(zod@4.4.3))
       '@braintrust/lingua-wasm':
         specifier: ^0.1.0
         version: 0.1.0
@@ -28,13 +28,13 @@ importers:
         version: 7.0.0-rc13(sharp@0.34.5)
       braintrust:
         specifier: 3.7.0
-        version: 3.7.0(zod@4.3.6)
+        version: 3.7.0(zod@4.4.3)
       discord.js:
         specifier: ^14.26.4
         version: 14.26.4
       openai:
         specifier: 6.33.0
-        version: 6.33.0(ws@8.21.0)(zod@4.3.6)
+        version: 6.33.0(ws@8.21.0)(zod@4.4.3)
       opusscript:
         specifier: ^0.1.1
         version: 0.1.1
@@ -47,6 +47,9 @@ importers:
       sodium-native:
         specifier: ^5.1.0
         version: 5.1.0(bare-events@2.9.1)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: 25.5.0
@@ -2809,8 +2812,8 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.3.6:
-    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -2842,11 +2845,11 @@ snapshots:
   '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.126':
     optional: true
 
-  '@anthropic-ai/claude-agent-sdk@0.2.126(zod@4.3.6)':
+  '@anthropic-ai/claude-agent-sdk@0.2.126(zod@4.4.3)':
     dependencies:
-      '@anthropic-ai/sdk': 0.81.0(zod@4.3.6)
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
-      zod: 4.3.6
+      '@anthropic-ai/sdk': 0.81.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      zod: 4.4.3
     optionalDependencies:
       '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.2.126
       '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.2.126
@@ -2860,11 +2863,11 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
-  '@anthropic-ai/sdk@0.81.0(zod@4.3.6)':
+  '@anthropic-ai/sdk@0.81.0(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
   '@apm-js-collab/code-transformer@0.9.0': {}
 
@@ -2874,11 +2877,11 @@ snapshots:
 
   '@braintrust/lingua-wasm@0.1.0': {}
 
-  '@braintrust/lingua@0.1.0(@anthropic-ai/sdk@0.81.0(zod@4.3.6))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))':
+  '@braintrust/lingua@0.1.0(@anthropic-ai/sdk@0.81.0(zod@4.4.3))(openai@6.33.0(ws@8.21.0)(zod@4.4.3))':
     dependencies:
-      '@anthropic-ai/sdk': 0.81.0(zod@4.3.6)
+      '@anthropic-ai/sdk': 0.81.0(zod@4.4.3)
       '@braintrust/lingua-wasm': 0.1.0
-      openai: 6.33.0(ws@8.21.0)(zod@4.3.6)
+      openai: 6.33.0(ws@8.21.0)(zod@4.4.3)
 
   '@bufbuild/protobuf@1.10.0': {}
 
@@ -3253,7 +3256,7 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 1.19.14(hono@4.12.16)
       ajv: 8.18.0
@@ -3270,8 +3273,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -3902,7 +3905,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  braintrust@3.7.0(zod@4.3.6):
+  braintrust@3.7.0(zod@4.4.3):
     dependencies:
       '@ai-sdk/provider': 1.1.3
       '@apm-js-collab/code-transformer': 0.9.0
@@ -3931,8 +3934,8 @@ snapshots:
       termi-link: 1.1.0
       unplugin: 2.3.11
       uuid: 9.0.1
-      zod: 4.3.6
-      zod-to-json-schema: 3.25.2(zod@4.3.6)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-web-identity'
       - supports-color
@@ -4777,10 +4780,10 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  openai@6.33.0(ws@8.21.0)(zod@4.3.6):
+  openai@6.33.0(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
       ws: 8.21.0
-      zod: 4.3.6
+      zod: 4.4.3
 
   opusscript@0.1.1: {}
 
@@ -5510,10 +5513,10 @@ snapshots:
 
   yallist@4.0.0: {}
 
-  zod-to-json-schema@3.25.2(zod@4.3.6):
+  zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.3
 
   zod@3.25.76: {}
 
-  zod@4.3.6: {}
+  zod@4.4.3: {}

--- a/typescript/harness/index.ts
+++ b/typescript/harness/index.ts
@@ -235,6 +235,14 @@ export interface HistoryMessage {
   content: string;
 }
 
+/**
+ * Selects an artifact to read: by id, or by path (latest version unless a
+ * `version` is pinned). exoharness resolves either form server-side.
+ */
+export type ReadArtifactArgs =
+  | { artifactId: string; version?: number }
+  | { path: string; version?: number };
+
 export interface Agent {
   readonly record: AgentRecord;
   listConversations(): Promise<Conversation[]>;
@@ -242,18 +250,9 @@ export interface Agent {
   newConversation(request?: NewConversationRequest): Promise<Conversation>;
   deleteConversation(id: string): Promise<boolean>;
   listArtifacts(): Promise<ArtifactVersion[]>;
-  readArtifact(args: {
-    artifactId: string;
-    version?: number;
-  }): Promise<Artifact | null>;
-  readArtifactText(args: {
-    artifactId: string;
-    version?: number;
-  }): Promise<string | null>;
-  readArtifactJson<T>(args: {
-    artifactId: string;
-    version?: number;
-  }): Promise<T | null>;
+  readArtifact(args: ReadArtifactArgs): Promise<Artifact | null>;
+  readArtifactText(args: ReadArtifactArgs): Promise<string | null>;
+  readArtifactJson<T>(args: ReadArtifactArgs): Promise<T | null>;
   writeArtifact(args: {
     path: string;
     contents: Uint8Array | string;
@@ -300,18 +299,9 @@ export interface Conversation {
   addEvents(request: AddEventsRequest): Promise<AddEventsResult>;
   fork(request?: ForkConversationRequest): Promise<Conversation>;
   listArtifacts(): Promise<ArtifactVersion[]>;
-  readArtifact(args: {
-    artifactId: string;
-    version?: number;
-  }): Promise<Artifact | null>;
-  readArtifactText(args: {
-    artifactId: string;
-    version?: number;
-  }): Promise<string | null>;
-  readArtifactJson<T>(args: {
-    artifactId: string;
-    version?: number;
-  }): Promise<T | null>;
+  readArtifact(args: ReadArtifactArgs): Promise<Artifact | null>;
+  readArtifactText(args: ReadArtifactArgs): Promise<string | null>;
+  readArtifactJson<T>(args: ReadArtifactArgs): Promise<T | null>;
   writeArtifact(args: {
     path: string;
     contents: Uint8Array | string;

--- a/typescript/harness/runner.ts
+++ b/typescript/harness/runner.ts
@@ -28,6 +28,7 @@ import {
   type Message,
   type NewConversationRequest,
   type PendingToolCall,
+  type ReadArtifactArgs,
   type SandboxProcess,
   type SandboxProcessStartRequest,
   type SendRequest,
@@ -267,7 +268,10 @@ type RawExoRequest =
   | {
       type: "agent_read_artifact";
       agent_id: string;
-      request: { artifact_id: string; version?: number };
+      request: {
+        artifact: { id: string } | { path: string };
+        version?: number;
+      };
     }
   | {
       type: "agent_write_artifact";
@@ -338,7 +342,10 @@ type RawExoRequest =
       type: "conversation_read_artifact";
       agent_id: string;
       conversation_id: string;
-      request: { artifact_id: string; version?: number };
+      request: {
+        artifact: { id: string } | { path: string };
+        version?: number;
+      };
     }
   | {
       type: "conversation_write_artifact";
@@ -986,6 +993,12 @@ function decodeArtifactText(artifact: Artifact | null): string | null {
   return new TextDecoder().decode(artifact.contents);
 }
 
+function artifactRef(
+  args: ReadArtifactArgs,
+): { id: string } | { path: string } {
+  return "path" in args ? { path: args.path } : { id: args.artifactId };
+}
+
 function decodeArtifactJson<T>(artifact: Artifact | null): T | null {
   const text = decodeArtifactText(artifact);
   if (text === null) {
@@ -1153,10 +1166,7 @@ function createAgent(client: ProtocolClient, raw: RawAgentRecord): Agent {
       const payload = await client.requestExo({
         type: "agent_read_artifact",
         agent_id: record.id,
-        request: {
-          artifact_id: args.artifactId,
-          version: args.version,
-        },
+        request: { artifact: artifactRef(args), version: args.version },
       });
       if (payload.type !== "artifact") {
         throw new Error(`expected artifact payload, got ${payload.type}`);
@@ -1168,10 +1178,7 @@ function createAgent(client: ProtocolClient, raw: RawAgentRecord): Agent {
       return decodeArtifactText(await agent.readArtifact(args));
     },
 
-    async readArtifactJson<T>(args: {
-      artifactId: string;
-      version?: number;
-    }): Promise<T | null> {
+    async readArtifactJson<T>(args: ReadArtifactArgs): Promise<T | null> {
       return decodeArtifactJson<T>(await agent.readArtifact(args));
     },
 
@@ -1447,10 +1454,7 @@ function createConversation(
         type: "conversation_read_artifact",
         agent_id: raw.agent_id,
         conversation_id: record.id,
-        request: {
-          artifact_id: args.artifactId,
-          version: args.version,
-        },
+        request: { artifact: artifactRef(args), version: args.version },
       });
       if (payload.type !== "artifact") {
         throw new Error(`expected artifact payload, got ${payload.type}`);
@@ -1462,10 +1466,7 @@ function createConversation(
       return decodeArtifactText(await conversation.readArtifact(args));
     },
 
-    async readArtifactJson<T>(args: {
-      artifactId: string;
-      version?: number;
-    }): Promise<T | null> {
+    async readArtifactJson<T>(args: ReadArtifactArgs): Promise<T | null> {
       return decodeArtifactJson<T>(await conversation.readArtifact(args));
     },
 


### PR DESCRIPTION
Re-lands the approved + merged work from #62.

#62 was accidentally based on `pr-target-scoped-conversations` (the branch behind #57) and merged into it on 2026-06-17 — but #57 had already squash-merged up into `exoclaw-self-control` on 2026-06-14, so the memory work never propagated to the dev tip (#64). This PR carries that exact code (squash commit 7de9550) onto `exoclaw-self-control`.

- Diff = the agent-memory feature only (remember/forget, zod validation, read-artifact-by-path rework). No re-introduction of the already-merged target-scoped commits.
- Cherry-pick applied with zero conflicts; builds green, TS 81 tests + exoharness artifact tests pass on this base.

Review history and discussion live on #62 (approved by 61cygni and ankrgyl).