### PR TITLE
Opt-in capture of model reasoning summaries in the conversation trace

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -448,6 +448,10 @@ enum AgentCommands {
         max_output_tokens: Option<i64>,
         #[arg(long)]
         max_tool_round_trips: Option<u32>,
+        /// Request and store model reasoning summaries in the conversation
+        /// trace (disabled by default).
+        #[arg(long, value_enum)]
+        capture_reasoning: Option<EnabledDisabled>,
         #[arg(long)]
         braintrust_org: Option<String>,
         #[arg(long)]
@@ -487,6 +491,10 @@ enum AgentCommands {
         max_tool_round_trips: Option<u32>,
         #[arg(long)]
         clear_max_tool_round_trips: bool,
+        /// Request and store model reasoning summaries in the conversation
+        /// trace (disabled by default).
+        #[arg(long, value_enum)]
+        capture_reasoning: Option<EnabledDisabled>,
         #[arg(long)]
         clear_braintrust: bool,
         #[arg(long)]
@@ -879,6 +887,7 @@ async fn main() -> Result<()> {
                             model,
                             max_output_tokens: None,
                             max_tool_round_trips: None,
+                            capture_reasoning: false,
                             braintrust: None,
                         })
                         .await?
@@ -923,6 +932,7 @@ async fn main() -> Result<()> {
                 model,
                 max_output_tokens,
                 max_tool_round_trips,
+                capture_reasoning,
                 braintrust_org,
                 braintrust_project,
                 braintrust_project_id,
@@ -972,6 +982,9 @@ async fn main() -> Result<()> {
                         model,
                         max_output_tokens,
                         max_tool_round_trips,
+                        capture_reasoning: capture_reasoning
+                            .map(EnabledDisabled::enabled)
+                            .unwrap_or(false),
                         braintrust: build_braintrust_tracing_config(
                             braintrust_org,
                             braintrust_project,
@@ -1002,6 +1015,7 @@ async fn main() -> Result<()> {
                 clear_max_output_tokens,
                 max_tool_round_trips,
                 clear_max_tool_round_trips,
+                capture_reasoning,
                 clear_braintrust,
                 braintrust_org,
                 braintrust_project,
@@ -1180,6 +1194,13 @@ async fn main() -> Result<()> {
                     config.max_tool_round_trips = Some(max_tool_round_trips);
                     changed = true;
                 }
+                if let Some(capture_reasoning) = capture_reasoning {
+                    let capture_reasoning = capture_reasoning.enabled();
+                    if config.capture_reasoning != capture_reasoning {
+                        config.capture_reasoning = capture_reasoning;
+                        changed = true;
+                    }
+                }
 
                 if clear_braintrust {
                     config.braintrust = None;
@@ -1270,6 +1291,14 @@ async fn main() -> Result<()> {
                         .max_tool_round_trips
                         .map(|value| value.to_string())
                         .unwrap_or_else(|| "none".to_string())
+                );
+                println!(
+                    "capture_reasoning: {}",
+                    if config.capture_reasoning {
+                        "enabled"
+                    } else {
+                        "disabled"
+                    }
                 );
                 println!(
                     "braintrust: {}",

--- a/crates/executor/src/adapter/tools.rs
+++ b/crates/executor/src/adapter/tools.rs
@@ -1449,6 +1449,7 @@ mod tests {
             model: "test-model".to_string(),
             max_output_tokens: None,
             max_tool_round_trips: None,
+            capture_reasoning: false,
             braintrust: None,
         }
     }

--- a/crates/executor/src/basic_tests.rs
+++ b/crates/executor/src/basic_tests.rs
@@ -1294,6 +1294,7 @@ fn default_agent_config() -> AgentConfig {
         model: "test-model".to_string(),
         max_output_tokens: None,
         max_tool_round_trips: Some(4),
+        capture_reasoning: false,
         braintrust: None,
     }
 }

--- a/crates/executor/src/executor_types.rs
+++ b/crates/executor/src/executor_types.rs
@@ -34,6 +34,11 @@ pub struct AgentConfig {
     pub model: String,
     pub max_output_tokens: Option<i64>,
     pub max_tool_round_trips: Option<u32>,
+    /// Ask the model provider for reasoning summaries and store them in the
+    /// conversation trace. Off by default: reasoning is never requested or
+    /// stored unless explicitly enabled.
+    #[serde(default)]
+    pub capture_reasoning: bool,
     pub braintrust: Option<BraintrustTracingConfig>,
 }
 

--- a/crates/executor/src/harness_basic_tests.rs
+++ b/crates/executor/src/harness_basic_tests.rs
@@ -50,6 +50,7 @@ async fn creates_agents_and_conversations_with_persisted_config() {
             model: "gpt-5.4".to_string(),
             max_output_tokens: Some(512),
             max_tool_round_trips: Some(3),
+            capture_reasoning: false,
             braintrust: None,
         })
         .await
@@ -135,6 +136,7 @@ async fn send_persists_messages_through_harness() {
             model: "gpt-5.4".to_string(),
             max_output_tokens: None,
             max_tool_round_trips: Some(2),
+            capture_reasoning: false,
             braintrust: None,
         })
         .await
@@ -255,6 +257,7 @@ async fn usage_record_is_persisted_with_computed_cost() {
             model: "claude-sonnet-4-6".to_string(),
             max_output_tokens: None,
             max_tool_round_trips: Some(2),
+            capture_reasoning: false,
             braintrust: None,
         })
         .await
@@ -401,6 +404,7 @@ async fn usage_record_with_anthropic_cache_hits() {
             model: "claude-sonnet-4-6".to_string(),
             max_output_tokens: None,
             max_tool_round_trips: Some(2),
+            capture_reasoning: false,
             braintrust: None,
         })
         .await
@@ -522,6 +526,7 @@ async fn usage_record_with_openai_inclusive_accounting() {
             model: "gpt-4o-mini".to_string(),
             max_output_tokens: None,
             max_tool_round_trips: Some(2),
+            capture_reasoning: false,
             braintrust: None,
         })
         .await
@@ -603,6 +608,7 @@ async fn close_session_appends_session_ended_event() {
             model: "gpt-5.4".to_string(),
             max_output_tokens: None,
             max_tool_round_trips: Some(2),
+            capture_reasoning: false,
             braintrust: None,
         })
         .await
@@ -692,6 +698,7 @@ async fn updating_agent_config_refreshes_executor_cache() {
             model: "gpt-5.4".to_string(),
             max_output_tokens: None,
             max_tool_round_trips: Some(2),
+            capture_reasoning: false,
             braintrust: None,
         })
         .await
@@ -782,6 +789,7 @@ async fn send_executes_shell_tool_when_enabled() {
             model: "gpt-5.4".to_string(),
             max_output_tokens: None,
             max_tool_round_trips: Some(2),
+            capture_reasoning: false,
             braintrust: None,
         })
         .await
@@ -876,6 +884,7 @@ async fn harness_exposes_raw_exoharness_handles() {
             model: "gpt-5.4".to_string(),
             max_output_tokens: None,
             max_tool_round_trips: None,
+            capture_reasoning: false,
             braintrust: None,
         })
         .await
@@ -998,6 +1007,7 @@ async fn updating_mounts_recreates_conversation_sandbox() {
             model: "gpt-5.4".to_string(),
             max_output_tokens: None,
             max_tool_round_trips: Some(1),
+            capture_reasoning: false,
             braintrust: None,
         })
         .await
@@ -1110,6 +1120,7 @@ async fn updating_sandbox_image_recreates_shell_sandbox_without_shell_program() 
             model: "gpt-5.4".to_string(),
             max_output_tokens: None,
             max_tool_round_trips: Some(1),
+            capture_reasoning: false,
             braintrust: None,
         })
         .await
@@ -1234,6 +1245,7 @@ async fn conversation_model_override_changes_effective_model() {
             model: "gpt-5.4".to_string(),
             max_output_tokens: Some(512),
             max_tool_round_trips: Some(2),
+            capture_reasoning: false,
             braintrust: None,
         })
         .await

--- a/crates/executor/src/harness_facade.rs
+++ b/crates/executor/src/harness_facade.rs
@@ -132,6 +132,7 @@ where
             model: request.model,
             max_output_tokens: request.max_output_tokens,
             max_tool_round_trips: request.max_tool_round_trips,
+            capture_reasoning: request.capture_reasoning,
             braintrust: request.braintrust,
         };
         let agent = self

--- a/crates/executor/src/harness_types.rs
+++ b/crates/executor/src/harness_types.rs
@@ -71,6 +71,7 @@ pub struct CreateAgentRequest {
     pub model: String,
     pub max_output_tokens: Option<i64>,
     pub max_tool_round_trips: Option<u32>,
+    pub capture_reasoning: bool,
     pub braintrust: Option<BraintrustTracingConfig>,
 }
 

--- a/crates/executor/src/rlm_tests.rs
+++ b/crates/executor/src/rlm_tests.rs
@@ -78,6 +78,7 @@ async fn rlm_send_executes_repl_steps_and_persists_final_answer() {
             model: "gpt-5.4".to_string(),
             max_output_tokens: Some(512),
             max_tool_round_trips: Some(4),
+            capture_reasoning: false,
             braintrust: None,
         })
         .await
@@ -222,6 +223,7 @@ async fn rlm_subquery_variable_can_store_final_answer() {
             model: "gpt-5.4".to_string(),
             max_output_tokens: Some(512),
             max_tool_round_trips: Some(6),
+            capture_reasoning: false,
             braintrust: None,
         })
         .await
@@ -292,6 +294,7 @@ async fn rlm_send_stream_suppresses_internal_control_text() {
             model: "gpt-5.4".to_string(),
             max_output_tokens: Some(512),
             max_tool_round_trips: None,
+            capture_reasoning: false,
             braintrust: None,
         })
         .await
@@ -407,6 +410,7 @@ globalThis.answer = String(\n\
             model: "gpt-5.4".to_string(),
             max_output_tokens: Some(512),
             max_tool_round_trips: None,
+            capture_reasoning: false,
             braintrust: None,
         })
         .await
@@ -482,6 +486,7 @@ async fn rlm_can_finish_by_setting_final_in_repl() {
             model: "gpt-5.4".to_string(),
             max_output_tokens: Some(512),
             max_tool_round_trips: None,
+            capture_reasoning: false,
             braintrust: None,
         })
         .await

--- a/examples/typescript/turn-loop.ts
+++ b/examples/typescript/turn-loop.ts
@@ -127,6 +127,7 @@ async function runResponsesTurnLoop(
       tools: tools.definitions(),
       maxOutputTokens: context.agentConfig.maxOutputTokens,
       metadata: turnMetadata(context),
+      captureReasoning: context.agentConfig.captureReasoning,
     };
 
     const response = context.streaming

--- a/typescript/harness/index.ts
+++ b/typescript/harness/index.ts
@@ -39,6 +39,9 @@ export interface AgentConfig {
   model: string;
   maxOutputTokens?: number | null;
   maxToolRoundTrips?: number | null;
+  // Request and store model reasoning summaries in the conversation trace.
+  // Off by default: reasoning is never requested unless explicitly enabled.
+  captureReasoning: boolean;
   braintrust?: unknown;
 }
 

--- a/typescript/harness/runner.ts
+++ b/typescript/harness/runner.ts
@@ -55,6 +55,7 @@ interface RawAgentConfig {
   model: string;
   max_output_tokens?: number | null;
   max_tool_round_trips?: number | null;
+  capture_reasoning?: boolean;
   braintrust?: unknown;
 }
 
@@ -839,6 +840,7 @@ function toAgentConfig(raw: RawAgentConfig): AgentConfig {
     model: raw.model,
     maxOutputTokens: raw.max_output_tokens ?? null,
     maxToolRoundTrips: raw.max_tool_round_trips ?? null,
+    captureReasoning: raw.capture_reasoning ?? false,
     braintrust: raw.braintrust,
   };
 }

--- a/typescript/model-runtime/responses.test.ts
+++ b/typescript/model-runtime/responses.test.ts
@@ -3,6 +3,8 @@ import type { Response } from "openai/resources/responses/responses";
 
 import {
   AnthropicRuntime,
+  buildNonStreamingBody,
+  buildStreamingBody,
   ChatCompletionsRuntime,
   isAnthropicModel,
   isOpenRouterBinding,
@@ -78,6 +80,16 @@ describe("model runtime dispatch", () => {
         baseUrl: "https://openrouter.ai/api/v1",
       }),
     ).toBeInstanceOf(ChatCompletionsRuntime);
+  });
+});
+
+describe("reasoning summaries", () => {
+  it("requests reasoning summaries on both streaming and non-streaming bodies", () => {
+    const request = { model: "gpt-5.4", messages: [] };
+    expect(buildStreamingBody(request).reasoning).toEqual({ summary: "auto" });
+    expect(buildNonStreamingBody(request).reasoning).toEqual({
+      summary: "auto",
+    });
   });
 });
 

--- a/typescript/model-runtime/responses.test.ts
+++ b/typescript/model-runtime/responses.test.ts
@@ -84,8 +84,14 @@ describe("model runtime dispatch", () => {
 });
 
 describe("reasoning summaries", () => {
-  it("requests reasoning summaries on both streaming and non-streaming bodies", () => {
+  it("does not request reasoning summaries by default", () => {
     const request = { model: "gpt-5.4", messages: [] };
+    expect(buildStreamingBody(request).reasoning).toBeUndefined();
+    expect(buildNonStreamingBody(request).reasoning).toBeUndefined();
+  });
+
+  it("requests reasoning summaries when captureReasoning is enabled", () => {
+    const request = { model: "gpt-5.4", messages: [], captureReasoning: true };
     expect(buildStreamingBody(request).reasoning).toEqual({ summary: "auto" });
     expect(buildNonStreamingBody(request).reasoning).toEqual({
       summary: "auto",

--- a/typescript/model-runtime/responses.ts
+++ b/typescript/model-runtime/responses.ts
@@ -792,7 +792,7 @@ async function traceRootExecutorTurn(
   );
 }
 
-function buildNonStreamingBody(
+export function buildNonStreamingBody(
   request: NativeResponsesRequest,
 ): ResponseCreateParamsNonStreaming {
   return {
@@ -803,12 +803,13 @@ function buildNonStreamingBody(
       toolDefinitionsToResponsesTools(request.tools ?? []),
     max_output_tokens: request.maxOutputTokens ?? null,
     metadata: request.metadata ?? null,
+    reasoning: { summary: "auto" },
     stream: false,
     store: false,
   };
 }
 
-function buildStreamingBody(
+export function buildStreamingBody(
   request: NativeResponsesRequest,
 ): ResponseCreateParamsStreaming {
   return {
@@ -819,6 +820,7 @@ function buildStreamingBody(
       toolDefinitionsToResponsesTools(request.tools ?? []),
     max_output_tokens: request.maxOutputTokens ?? null,
     metadata: request.metadata ?? null,
+    reasoning: { summary: "auto" },
     stream: true,
     store: false,
   };

--- a/typescript/model-runtime/responses.ts
+++ b/typescript/model-runtime/responses.ts
@@ -77,6 +77,10 @@ export interface NativeResponsesRequest {
   responseTools?: Tool[];
   maxOutputTokens?: number | null;
   metadata?: Record<string, string>;
+  // Request reasoning summaries from providers that support them so the
+  // model's thinking is captured in the trace. Default false: omitted from
+  // the request body entirely.
+  captureReasoning?: boolean;
 }
 
 export interface NativeStreamHandlers {
@@ -803,7 +807,7 @@ export function buildNonStreamingBody(
       toolDefinitionsToResponsesTools(request.tools ?? []),
     max_output_tokens: request.maxOutputTokens ?? null,
     metadata: request.metadata ?? null,
-    reasoning: { summary: "auto" },
+    reasoning: reasoningParam(request),
     stream: false,
     store: false,
   };
@@ -820,10 +824,25 @@ export function buildStreamingBody(
       toolDefinitionsToResponsesTools(request.tools ?? []),
     max_output_tokens: request.maxOutputTokens ?? null,
     metadata: request.metadata ?? null,
-    reasoning: { summary: "auto" },
+    reasoning: reasoningParam(request),
     stream: true,
     store: false,
   };
+}
+
+// Reasoning summaries are opt-in (agent config captureReasoning): the model's
+// thinking is only requested — and therefore only stored in the conversation
+// trace — when the agent explicitly asked for it. `auto` lets the provider
+// pick summary verbosity; effort stays at the model default either way.
+// Caveat: capture only stores reasoning that actually happens. Models whose
+// default effort is none (observed live on gpt-5.4) produce zero reasoning
+// tokens and therefore no summaries; models that reason by default (e.g.
+// gpt-5-codex, o3-pro) return summaries with summary-only requests. The
+// provider also skips the summary entirely for very short reasoning bursts.
+function reasoningParam(
+  request: NativeResponsesRequest,
+): { summary: "auto" } | undefined {
+  return request.captureReasoning ? { summary: "auto" } : undefined;
 }
 
 function buildChatNonStreamingBody(


### PR DESCRIPTION
## Problem

The Responses runtime never asked the OpenAI Responses API for reasoning summaries, so the model's thinking was discarded — reasoning items in the event store were empty placeholders (`{type:"reasoning", text:""}`). Conversation data is valuable (it captures learnings and can feed RL later), so we want the option to persist it.

## Design: off by default, opt-in per agent

Storing reasoning is now an explicit agent-level choice:

- **Default: off.** Reasoning summaries are never requested from the provider and never stored.
- **Opt-in:** `exo agent create/update <agent> --capture-reasoning enabled` (visible in `agent show`).
- Plumbing: `AgentConfig.capture_reasoning` (Rust, `#[serde(default)]` — existing stored configs load unchanged) → TS harness runner → turn loop → Responses request builders, which add `reasoning: { summary: "auto" }` only when enabled.
- Context assembly still strips reasoning items on replay, so this affects only what's stored, never what future calls see.
- Effort is untouched: capture never changes model behavior, only whether the summary of reasoning-that-happened is persisted.

## Verified live (rebased on main, gpt-5-codex + gpt-5.4)

| Scenario | Result |
|---|---|
| Default off, reasoning model (gpt-5-codex, 3,008 reasoning tokens) | stored reasoning item stays empty |
| `--capture-reasoning enabled`, same model, hard prompt (1,600 reasoning tokens) | **431-char reasoning summary persisted** in the event store |
| Existing agents created before this change | load fine, show `capture_reasoning: disabled` |

Caveat found during live testing: capture only stores reasoning that actually happens. gpt-5.4 defaults to reasoning effort **none** (0 reasoning tokens even on hard prompts — confirmed via direct API probe: same prompt yields 4,651 reasoning tokens with `effort: "medium"`), so on such models the flag captures nothing unless effort is raised; gpt-5-codex and o3-pro reason by default and return summaries. The provider also skips summaries for very short reasoning bursts. Documented in `reasoningParam`.

Unit tests cover both defaults (no `reasoning` param) and enabled (`summary: "auto"`) on both body builders. Full suite: 103 TS + 219 Rust tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)