### PR TITLE
Add Exoclaw durable memory tools

### DIFF
--- a/examples/exoclaw/docs/SELF-CONTROL.md
+++ b/examples/exoclaw/docs/SELF-CONTROL.md
@@ -77,6 +77,18 @@ Two properties matter for rollback:
 
 Gap: host events currently cover the adapter runner only. The scheduler runner and the control REPL do not yet write start/drain/crash events into the log, and there is no agent-level (cross-conversation) event stream — host events are fanned out to each adapter-attached conversation.
 
+### Agent-writable memory (the `remember` tool)
+
+Everything above is memory the agent reads; until recently it had no way to write a durable fact about the user or itself. Conversation history is replayed in full each turn, but it dies at the conversation boundary, and the local profile (`.exo/exoclaw-profile.md`) is human-curated.
+
+The memory tool closes that gap with a small artifact-backed store:
+
+- **Storage.** One JSON artifact at `memory/exoclaw-memory.json` on the agent handle, so it persists across every conversation for this agent.
+- **Write path.** `remember(text)` appends `{ id, text, createdAt }`; `forget(id)` removes one entry. A fixed cap drops the oldest entries if the store grows too large.
+- **Read path.** Prompt assembly reads the latest memory artifact and adds a developer message listing saved facts with ids, so the model can use them and delete stale ones.
+
+This is deliberately not embedding-based retrieval. For a small set of short facts, always injecting the whole store is simpler and easier to audit. If the memory set grows beyond what should fit in every prompt, the storage layer can stay the same while the read path evolves toward query-time recall.
+
 ## 3. Component Observability: Logs and Telemetry
 
 Exoclaw should be able to inspect each of its components when debugging or evolving them, before escalating to restarts.

--- a/examples/exoclaw/harness.ts
+++ b/examples/exoclaw/harness.ts
@@ -17,6 +17,7 @@ import { registerSchedulerTools } from "./scheduler-tools";
 import { registerSandboxTools } from "./sandbox-tools";
 import { registerGuardianTools } from "./guardian-tools";
 import { registerIntrospectionTools } from "./introspection-tools";
+import { memoryInstruction, registerMemoryTools } from "./memory-tools";
 import {
   basicHarnessInstructions,
   defaultBuiltInToolNames,
@@ -51,6 +52,7 @@ async function registerExoclawTools(
   registerFalTools(tools);
   registerSandboxTools(tools);
   registerGuardianTools(tools);
+  registerMemoryTools(tools);
   for (const modulePath of context.agentConfig.typescript?.toolModulePaths ??
     []) {
     await registerLibraryToolModulePath(tools, context, modulePath);
@@ -64,7 +66,7 @@ function builtInToolNames(context: TurnContext): BuiltInToolName[] {
   return defaultBuiltInToolNames(context);
 }
 
-function exoclawInstructions(context: TurnContext): Message[] {
+async function exoclawInstructions(context: TurnContext): Promise<Message[]> {
   const repoPath = process.env.EXOCLAW_REPO ?? DEFAULT_EXOCLAW_REPO;
   const selfMapPath = process.env.EXOCLAW_SELF_MAP ?? DEFAULT_EXOCLAW_SELF_MAP;
   const instructions: Message[] = [
@@ -76,7 +78,7 @@ function exoclawInstructions(context: TurnContext): Message[] {
     {
       role: "developer",
       content:
-        'This is the Exoclaw long-running agent harness. You can schedule recurring sandbox work with schedule_sandbox_task, inspect active tasks with list_scheduled_tasks, cancel tasks with cancel_scheduled_task, and permanently delete tasks with delete_scheduled_task. You can inspect sandbox filesystem snapshots with list_sandbox_snapshots, capture a checkpoint with snapshot_sandbox, and rewind to a previous checkpoint with rewind_sandbox. You can use guardian_action for host-side self-maintenance such as checking service status, building Exoclaw, viewing logs, and restarting the scheduler or adapter runners while preserving .exo state. guardian_action restart actions are deferred briefly so the current turn can finish before services stop; guardian builds also ask the control REPL wrapper to refresh its child process without closing the user\'s terminal. After requesting one, report that it was scheduled and use status/logs after services come back. You can also create long-running external adapters with create_adapter, inspect them with list_adapters, disable/delete them, and send explicit outbound replies with send_adapter_message. Use cancel_scheduled_task or disable_adapter when history should be preserved; use delete_scheduled_task or delete_adapter when the user asks to remove something entirely. Conversations default to sandboxScope: "agent", so shell commands use this agent\'s shared sandbox unless the conversation was configured with sandboxScope: "conversation". Scheduled tasks default to sandboxMode: "agent". Use sandboxMode: "conversation" when the task should run in this conversation\'s sandbox, and sandboxMode: "task_fresh" when the task should have a separate fresh sandbox that is reused across that task\'s runs. IRC, WhatsApp, Signal, and Discord adapters wake this conversation when their trigger policy matches; do not auto-send model text to external services. Call send_adapter_message only for intentional external replies, using the target value from the inbound wakeup when one is provided. For Discord, the target is a channel id unless the adapter has a defaultChannelId. If an adapter message asks you to schedule future work and the future result should appear externally, include the adapterId and target in the scheduled task reportPrompt so the scheduler wakeup can call send_adapter_message.',
+        'This is the Exoclaw long-running agent harness. You can schedule recurring sandbox work with schedule_sandbox_task, inspect active tasks with list_scheduled_tasks, cancel tasks with cancel_scheduled_task, and permanently delete tasks with delete_scheduled_task. You can inspect sandbox filesystem snapshots with list_sandbox_snapshots, capture a checkpoint with snapshot_sandbox, and rewind to a previous checkpoint with rewind_sandbox. You can use guardian_action for host-side self-maintenance such as checking service status, building Exoclaw, viewing logs, and restarting the scheduler or adapter runners while preserving .exo state. guardian_action restart actions are deferred briefly so the current turn can finish before services stop; guardian builds also ask the control REPL wrapper to refresh its child process without closing the user\'s terminal. After requesting one, report that it was scheduled and use status/logs after services come back. You can also create long-running external adapters with create_adapter, inspect them with list_adapters, disable/delete them, and send explicit outbound replies with send_adapter_message. Use cancel_scheduled_task or disable_adapter when history should be preserved; use delete_scheduled_task or delete_adapter when the user asks to remove something entirely. Conversations default to sandboxScope: "agent", so shell commands use this agent\'s shared sandbox unless the conversation was configured with sandboxScope: "conversation". Scheduled tasks default to sandboxMode: "agent". Use sandboxMode: "conversation" when the task should run in this conversation\'s sandbox, and sandboxMode: "task_fresh" when the task should have a separate fresh sandbox that is reused across that task\'s runs. IRC, WhatsApp, Signal, and Discord adapters wake this conversation when their trigger policy matches; do not auto-send model text to external services. Call send_adapter_message only for intentional external replies, using the target value from the inbound wakeup when one is provided. For Discord, the target is a channel id unless the adapter has a defaultChannelId. If an adapter message asks you to schedule future work and the future result should appear externally, include the adapterId and target in the scheduled task reportPrompt so the scheduler wakeup can call send_adapter_message. When the user shares a durable preference or fact about themselves ("remember that ..."), save it with the remember tool; remove stale entries with forget. Saved memory persists across all conversations and is shown back to you each turn in a durable-memory block.',
     },
     {
       role: "developer",
@@ -94,6 +96,10 @@ function exoclawInstructions(context: TurnContext): Message[] {
       role: "developer",
       content: localPrompt,
     });
+  }
+  const memory = await memoryInstruction(context);
+  if (memory !== null) {
+    instructions.push(memory);
   }
   return instructions;
 }

--- a/examples/exoclaw/memory-tools.test.ts
+++ b/examples/exoclaw/memory-tools.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from "vitest";
+
+import type { ArtifactVersion, JsonObject, TurnContext } from "@exo/harness";
+
+import { createMemoryToolInstances, memoryInstruction } from "./memory-tools";
+
+// Minimal in-memory stand-in for an artifact-backed handle (agent or
+// conversation). Each writeArtifactJson appends a new version at the same path,
+// matching how the real store versions artifacts.
+class FakeHandle {
+  private versions: {
+    artifactId: string;
+    path: string;
+    version: number;
+    value: unknown;
+  }[] = [];
+  private seq = 0;
+
+  async listArtifacts(): Promise<ArtifactVersion[]> {
+    return this.versions.map(({ artifactId, path, version }) => ({
+      artifactId,
+      path,
+      version,
+      createdAt: "1970-01-01T00:00:00Z",
+      sizeBytes: 0,
+    }));
+  }
+
+  async readArtifactJson<T>({
+    artifactId,
+    version,
+  }: {
+    artifactId: string;
+    version?: number;
+  }): Promise<T | null> {
+    const selected = this.versions.find(
+      (item) =>
+        item.artifactId === artifactId &&
+        (version === undefined || item.version === version),
+    );
+    return selected ? (selected.value as T) : null;
+  }
+
+  async writeArtifactJson({
+    path,
+    value,
+  }: {
+    path: string;
+    value: unknown;
+  }): Promise<ArtifactVersion> {
+    this.seq += 1;
+    const version = this.seq;
+    const artifactId = `${path}@${version}`;
+    this.versions.push({ artifactId, path, version, value });
+    return {
+      artifactId,
+      path,
+      version,
+      createdAt: "1970-01-01T00:00:00Z",
+      sizeBytes: 0,
+    };
+  }
+}
+
+function makeContext(): { context: TurnContext; agent: FakeHandle } {
+  const agent = new FakeHandle();
+  const context = {
+    exoharness: { current: { agent } },
+  } as unknown as TurnContext;
+  return { context, agent };
+}
+
+const toolsByName = Object.fromEntries(
+  createMemoryToolInstances().map((tool) => [tool.definition.name, tool]),
+);
+
+function call(name: string, args: JsonObject, context: TurnContext) {
+  return toolsByName[name].handler.execute(args, { context });
+}
+
+describe("memory tools", () => {
+  it("remembers a fact and injects it into the prompt", async () => {
+    const { context } = makeContext();
+    const result = (await call(
+      "remember",
+      { text: "favorite coffee is a flat white" },
+      context,
+    )) as { ok: boolean; id: string };
+
+    expect(result.ok).toBe(true);
+
+    const message = await memoryInstruction(context);
+    expect(message).not.toBeNull();
+    const content = String(message?.content);
+    expect(content).toContain("favorite coffee is a flat white");
+    expect(content).toContain(result.id);
+  });
+
+  it("appends across calls (read-modify-write, not overwrite)", async () => {
+    const { context } = makeContext();
+    await call("remember", { text: "fact one" }, context);
+    const second = (await call("remember", { text: "fact two" }, context)) as {
+      total: number;
+    };
+
+    expect(second.total).toBe(2);
+    const content = String((await memoryInstruction(context))?.content);
+    expect(content).toContain("fact one");
+    expect(content).toContain("fact two");
+  });
+
+  it("forgets a fact by id", async () => {
+    const { context } = makeContext();
+    const saved = (await call(
+      "remember",
+      { text: "temporary fact" },
+      context,
+    )) as { id: string };
+
+    const forgotten = (await call("forget", { id: saved.id }, context)) as {
+      ok: boolean;
+      removed: number;
+    };
+    expect(forgotten.ok).toBe(true);
+    expect(forgotten.removed).toBe(1);
+
+    expect(await memoryInstruction(context)).toBeNull();
+  });
+
+  it("rejects empty and oversized text", async () => {
+    const { context } = makeContext();
+    const empty = (await call("remember", { text: "   " }, context)) as {
+      ok: boolean;
+    };
+    expect(empty.ok).toBe(false);
+
+    const huge = (await call(
+      "remember",
+      { text: "x".repeat(1000) },
+      context,
+    )) as { ok: boolean };
+    expect(huge.ok).toBe(false);
+  });
+
+  it("returns null when nothing is remembered", async () => {
+    const { context } = makeContext();
+    expect(await memoryInstruction(context)).toBeNull();
+  });
+
+  it("makes the write path (remember) reject on a corrupt store", async () => {
+    const { context, agent } = makeContext();
+    // A payload that exists but does not match the schema.
+    await agent.writeArtifactJson({
+      path: "memory/exoclaw-memory.json",
+      value: { entries: "not-an-array" },
+    });
+    await expect(call("remember", { text: "x" }, context)).rejects.toThrow(
+      /corrupt memory artifact/,
+    );
+  });
+
+  it("degrades the read path on a corrupt store instead of throwing", async () => {
+    const { context, agent } = makeContext();
+    await agent.writeArtifactJson({
+      path: "memory/exoclaw-memory.json",
+      value: { entries: "not-an-array" },
+    });
+    // Prompt assembly must not throw — it returns a degraded note instead.
+    const message = await memoryInstruction(context);
+    expect(message).not.toBeNull();
+    expect(String(message?.content)).toMatch(/unavailable|corrupt/i);
+  });
+});

--- a/examples/exoclaw/memory-tools.ts
+++ b/examples/exoclaw/memory-tools.ts
@@ -1,0 +1,262 @@
+import { randomUUID } from "node:crypto";
+
+import type {
+  Agent,
+  ArtifactVersion,
+  HarnessToolRegistry,
+  JsonObject,
+  JsonValue,
+  Message,
+  ToolInstance,
+  ToolResult,
+  TurnContext,
+} from "@exo/harness";
+
+// Durable agent-writable memory: a single global store that persists across
+// every conversation for this agent. Stored as a JSON artifact on the agent
+// handle, mirroring how config/executor.json is persisted. See
+// examples/exoclaw/docs/SELF-CONTROL.md section 2 for the design.
+const MEMORY_ARTIFACT_PATH = "memory/exoclaw-memory.json";
+// Soft caps so always-injecting memory cannot grow the prompt without bound.
+const MAX_ENTRIES = 200;
+const MAX_TEXT_CHARS = 600;
+
+interface MemoryEntry {
+  id: string;
+  text: string;
+  createdAt: string;
+}
+
+interface MemoryStore {
+  entries: MemoryEntry[];
+}
+
+// The artifact subset both Agent and the test fake provide.
+type MemoryHandle = Pick<
+  Agent,
+  "listArtifacts" | "readArtifactJson" | "writeArtifactJson"
+>;
+
+function memoryHandle(context: TurnContext): MemoryHandle {
+  return context.exoharness.current.agent;
+}
+
+// Reads and validates the store. Throws on a corrupt artifact (invalid JSON or
+// failing the schema) so the write path refuses to bury it; the read/inject
+// path catches this in memoryInstruction. A missing artifact is not corrupt —
+// it is a legitimately empty store.
+async function readMemory(handle: MemoryHandle): Promise<MemoryStore> {
+  let raw: unknown;
+  try {
+    raw = await readLatestMemoryArtifact(handle);
+  } catch (cause) {
+    // readArtifactJson parses the stored bytes; it throws if they are not
+    // valid JSON. Treat that the same as a schema failure below.
+    throw new Error(
+      `corrupt memory artifact ${MEMORY_ARTIFACT_PATH}: not valid JSON`,
+      { cause },
+    );
+  }
+  if (raw === null) {
+    return { entries: [] };
+  }
+  if (!isMemoryStore(raw)) {
+    throw new Error(
+      `corrupt memory artifact ${MEMORY_ARTIFACT_PATH}: invalid memory store shape`,
+    );
+  }
+  return raw;
+}
+
+// TODO(storage-rework): remember/forget are read-modify-write with no
+// compare-and-swap. Agent-scoped memory is shared across conversations, so two
+// channels running turns concurrently can both read version N and both write
+// N+1, losing one update. Fix alongside the artifact versioning rework — either
+// an optimistic write that rejects when the latest version moved, or an
+// append-entry store op instead of rewriting the whole store.
+async function writeMemory(
+  handle: MemoryHandle,
+  store: MemoryStore,
+): Promise<void> {
+  await handle.writeArtifactJson({
+    path: MEMORY_ARTIFACT_PATH,
+    value: store as unknown as JsonValue,
+  });
+}
+
+function rememberTool(): ToolInstance {
+  return {
+    source: "built_in",
+    definition: {
+      name: "remember",
+      description:
+        "Save a durable fact so you still have it in future turns and conversations. Use this when the user shares a lasting preference or fact about themselves, or when you want to persist something about yourself. The fact is injected into your context every turn. Phrase it as a standalone statement.",
+      parameters: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          text: {
+            type: "string",
+            description:
+              'The fact to remember, phrased to stand on its own (e.g. "User\'s favorite coffee is a flat white").',
+          },
+        },
+        required: ["text"],
+      },
+    },
+    handler: {
+      async execute(args: JsonObject, execution): Promise<ToolResult> {
+        const text = typeof args.text === "string" ? args.text.trim() : "";
+        if (text.length === 0) {
+          return { ok: false, error: "text is required" };
+        }
+        if (text.length > MAX_TEXT_CHARS) {
+          return {
+            ok: false,
+            error: `text exceeds ${MAX_TEXT_CHARS} characters; summarize it first`,
+          };
+        }
+        const handle = memoryHandle(execution.context);
+        const store = await readMemory(handle);
+        const entry: MemoryEntry = {
+          id: `mem_${randomUUID().slice(0, 8)}`,
+          text,
+          createdAt: new Date().toISOString(),
+        };
+        store.entries.push(entry);
+        let dropped = 0;
+        if (store.entries.length > MAX_ENTRIES) {
+          dropped = store.entries.length - MAX_ENTRIES;
+          store.entries = store.entries.slice(-MAX_ENTRIES);
+        }
+        await writeMemory(handle, store);
+        return { ok: true, id: entry.id, total: store.entries.length, dropped };
+      },
+    },
+  };
+}
+
+function forgetTool(): ToolInstance {
+  return {
+    source: "built_in",
+    definition: {
+      name: "forget",
+      description:
+        "Remove a previously saved memory by its id. Memory ids are shown in brackets in the durable-memory block in your context.",
+      parameters: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          id: {
+            type: "string",
+            description: "The memory id to remove, e.g. mem_1a2b3c4d.",
+          },
+        },
+        required: ["id"],
+      },
+    },
+    handler: {
+      async execute(args: JsonObject, execution): Promise<ToolResult> {
+        const id = typeof args.id === "string" ? args.id.trim() : "";
+        if (id.length === 0) {
+          return { ok: false, error: "id is required" };
+        }
+        const handle = memoryHandle(execution.context);
+        const store = await readMemory(handle);
+        const before = store.entries.length;
+        store.entries = store.entries.filter((entry) => entry.id !== id);
+        const removed = before - store.entries.length;
+        if (removed > 0) {
+          await writeMemory(handle, store);
+        }
+        return { ok: removed > 0, id, removed };
+      },
+    },
+  };
+}
+
+export function createMemoryToolInstances(): ToolInstance[] {
+  return [rememberTool(), forgetTool()];
+}
+
+export function registerMemoryTools(registry: HarnessToolRegistry): void {
+  for (const tool of createMemoryToolInstances()) {
+    registry.register(tool);
+  }
+}
+
+// Build the developer message that injects saved memory into the prompt.
+// Returns null when nothing has been remembered yet.
+export async function memoryInstruction(
+  context: TurnContext,
+): Promise<Message | null> {
+  let store: MemoryStore;
+  try {
+    store = await readMemory(memoryHandle(context));
+  } catch (error) {
+    // Prompt assembly runs every model round, so a corrupt store must not brick
+    // the agent in every conversation. Degrade the read: log loudly and tell the
+    // model memory is unavailable rather than silently pretending it is empty.
+    // The write path (remember/forget) still throws, so nothing overwrites the
+    // corrupt artifact while it is broken.
+    const detail = error instanceof Error ? error.message : String(error);
+    console.error(`memory unavailable during prompt assembly: ${detail}`);
+    return {
+      role: "developer",
+      content:
+        "Your durable memory could not be read this turn (the stored memory artifact appears corrupt). Do not assume it is empty; if the user asks about saved facts, tell them memory is temporarily unavailable.",
+    };
+  }
+  if (store.entries.length === 0) {
+    return null;
+  }
+  const lines = store.entries.map((entry) => `- [${entry.id}] ${entry.text}`);
+  return {
+    role: "developer",
+    content: `Durable memory you saved earlier with the remember tool. Treat these as authoritative context. Add new facts with remember and drop stale ones with forget(id).\n\n${lines.join("\n")}`,
+  };
+}
+
+async function readLatestMemoryArtifact(
+  handle: MemoryHandle,
+): Promise<unknown | null> {
+  const latest = latestArtifactVersion(
+    await handle.listArtifacts(),
+    MEMORY_ARTIFACT_PATH,
+  );
+  if (latest === null) {
+    return null;
+  }
+  return handle.readArtifactJson({
+    artifactId: latest.artifactId,
+    version: latest.version,
+  });
+}
+
+function latestArtifactVersion(
+  artifacts: ArtifactVersion[],
+  path: string,
+): ArtifactVersion | null {
+  return (
+    artifacts
+      .filter((artifact) => artifact.path === path)
+      .sort((a, b) => b.version - a.version)[0] ?? null
+  );
+}
+
+function isMemoryStore(value: unknown): value is MemoryStore {
+  if (!isRecord(value) || !Array.isArray(value.entries)) {
+    return false;
+  }
+  return value.entries.every(
+    (entry) =>
+      isRecord(entry) &&
+      typeof entry.id === "string" &&
+      typeof entry.text === "string" &&
+      typeof entry.createdAt === "string",
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/examples/typescript/turn-loop.ts
+++ b/examples/typescript/turn-loop.ts
@@ -24,7 +24,7 @@ import { ensureTable } from "@exo/model-runtime/cost";
 import { resolveLlmBinding } from "./shared";
 
 export interface ResponsesTurnLoopOptions {
-  instructions?: (context: TurnContext) => Message[];
+  instructions?: (context: TurnContext) => Message[] | Promise<Message[]>;
   registerTools?: (
     tools: HarnessToolRegistry,
     context: TurnContext,
@@ -117,7 +117,9 @@ async function runResponsesTurnLoop(
     }
     const messages = await materializePromptMessages(
       conversation,
-      options.instructions?.(context) ?? basicHarnessInstructions(context),
+      options.instructions
+        ? await options.instructions(context)
+        : basicHarnessInstructions(context),
     );
     const request: NativeResponsesRequest = {
       model,


### PR DESCRIPTION
## Summary
- Add `remember` and `forget` tools backed by an agent artifact at `memory/exoclaw-memory.json`.
- Inject saved memory into Exoclaw's developer instructions each turn, while tolerating corrupt memory reads without bricking prompt assembly.
- Document the agent-writable memory model in `SELF-CONTROL.md`.

## Test plan
- `pnpm check`


Made with [Cursor](https://cursor.com)