### PR TITLE
feat(executor): pluggable WorkSource trait for the scheduler claim loop

### DIFF
--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -23,6 +23,7 @@ mod harness_runtime;
 mod harness_tool;
 mod harness_types;
 mod local_sandbox;
+mod mesh_work_source;
 mod rlm;
 #[cfg(test)]
 mod rlm_tests;
@@ -33,6 +34,7 @@ mod shared;
 #[cfg(test)]
 mod test_support;
 mod typescript;
+mod work_source;
 
 pub use adapter::AdapterStore;
 pub use adapter::{
@@ -67,12 +69,18 @@ pub use harness_types::{
     CreateAgentRequest, CreateConversationRequest, Harness, HarnessAgent, HarnessConversation,
 };
 pub use local_sandbox::LocalSandboxExoHarness;
+pub use mesh_work_source::{
+    CliMeshClient, MeshBoardConfig, MeshBoardItem, MeshBoardSource, MeshClient,
+};
 pub use rlm::RlmHarness;
-pub use scheduler_runtime::{SchedulerRunOptions, run_due_tasks, run_task};
+pub use scheduler_runtime::{
+    SchedulerRunOptions, run_due_tasks, run_due_tasks_from_sources, run_task,
+};
 pub use scheduler_store::SchedulerStore;
 pub use scheduler_types::{
     DEFAULT_MAX_OUTPUT_BYTES, NewScheduledTask, ScheduledTaskRecord, ScheduledTaskRunRecord, now_ms,
 };
 pub use typescript::TypeScriptHarness;
+pub use work_source::{ClaimedWork, CompletionHook, StoreWorkSource, WorkOutcome, WorkSource};
 
 pub(crate) use basic::BasicExecutor;

--- a/crates/executor/src/mesh_work_source.rs
+++ b/crates/executor/src/mesh_work_source.rs
@@ -1,0 +1,481 @@
+//! A [`WorkSource`] that drains a meshi board as an optional source of work.
+//!
+//! ## How this honors meshi's contract
+//!
+//! meshi's one invariant is: **it coordinates, it never schedules, assigns,
+//! merges, or deploys.** This source respects that completely:
+//!
+//! * It only **reads** the board's *open* items (`meshi board --json`). It never
+//!   asks meshi to schedule or push work to exo; exo's own claim loop pulls.
+//! * It **claims** via meshi's own atomic grab (`meshi self grab <id>`). The
+//!   grab is meshi-owned and race-safe: if another runtime already grabbed the
+//!   item, meshi reports `already_grabbed` and this source simply skips it.
+//!   exo never overrides meshi's ownership decision.
+//! * On completion it **acknowledges** back through meshi's own
+//!   `meshi self complete <id>` so the coordination loop closes — again, exo
+//!   reporting an outcome to meshi, not meshi driving exo.
+//!
+//! meshi therefore stays entirely *outside* exo as an optional source the
+//! scheduler drains. The whole source is gated behind config and is off by
+//! default.
+
+use std::path::PathBuf;
+use std::process::Stdio;
+
+use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
+use serde::Deserialize;
+use tokio::process::Command;
+
+use crate::scheduler_types::{NewScheduledTask, ScheduledTaskRecord, now_ms};
+use crate::work_source::{ClaimedWork, CompletionHook, WorkOutcome, WorkSource};
+
+/// Configuration for a [`MeshBoardSource`]. Construct one only when meshi work
+/// draining is explicitly enabled; the scheduler treats the absence of a source
+/// as "meshi disabled".
+#[derive(Debug, Clone)]
+pub struct MeshBoardConfig {
+    /// Path to the `meshi` CLI binary.
+    pub meshi_bin: PathBuf,
+    /// Board scope to drain (`--workstream`). `None` drains the default board.
+    pub workstream: Option<String>,
+    /// The exo agent that runs work claimed from the board.
+    pub agent_id: String,
+    /// The exo conversation that owns the run + its wakeup.
+    pub conversation_id: String,
+    /// Command template run for each grabbed item. The board item id is appended
+    /// as the final argument, so the runner receives the item to act on.
+    pub command_template: Vec<String>,
+    /// Report-prompt handed to the scheduler's wakeup for each item.
+    pub report_prompt: String,
+}
+
+impl MeshBoardConfig {
+    fn validate(&self) -> Result<()> {
+        if self.command_template.is_empty() {
+            bail!("mesh board command_template must not be empty");
+        }
+        if self.agent_id.trim().is_empty() {
+            bail!("mesh board agent_id must not be empty");
+        }
+        if self.conversation_id.trim().is_empty() {
+            bail!("mesh board conversation_id must not be empty");
+        }
+        Ok(())
+    }
+}
+
+/// One open item read from `meshi board --json`. Fields mirror what meshi
+/// exposes in a board listing; unknown fields are ignored.
+#[derive(Debug, Clone, Deserialize)]
+pub struct MeshBoardItem {
+    pub id: String,
+    #[serde(default)]
+    pub subject: Option<String>,
+    #[serde(default)]
+    pub requested_action: Option<String>,
+    #[serde(default)]
+    pub body_preview: Option<String>,
+}
+
+/// The `meshi board --json` envelope.
+#[derive(Debug, Clone, Deserialize)]
+struct MeshBoardListing {
+    #[serde(default)]
+    items: Vec<MeshBoardItem>,
+}
+
+/// The `meshi self grab <id>` result. meshi owns the grab atomically; we only
+/// read the outcome.
+#[derive(Debug, Clone, Deserialize)]
+struct MeshGrabResult {
+    #[serde(default)]
+    action: Option<String>,
+}
+
+impl MeshGrabResult {
+    /// Whether this runtime won the grab. Any non-`grabbed` action (notably
+    /// `already_grabbed`) means another runtime owns the item and exo skips it.
+    fn won(&self) -> bool {
+        self.action.as_deref() == Some("grabbed")
+    }
+}
+
+/// Abstracts the meshi CLI so the source can be unit-tested without a live mesh.
+/// The real implementation shells out to `meshi`; tests use an in-memory mock.
+#[async_trait]
+pub trait MeshClient: Send + Sync {
+    /// `meshi board [--workstream <ws>] --json` -> raw stdout JSON.
+    async fn board_json(&self, workstream: Option<&str>) -> Result<String>;
+    /// `meshi self grab <id>` -> raw stdout JSON.
+    async fn grab_json(&self, item_id: &str) -> Result<String>;
+    /// `meshi self complete <id> --result <result>` -> ignored stdout.
+    async fn complete(&self, item_id: &str, result: &str) -> Result<()>;
+}
+
+/// The production [`MeshClient`]: shells out to the `meshi` binary.
+pub struct CliMeshClient {
+    meshi_bin: PathBuf,
+}
+
+impl CliMeshClient {
+    pub fn new(meshi_bin: PathBuf) -> Self {
+        Self { meshi_bin }
+    }
+
+    async fn run(&self, args: &[&str]) -> Result<String> {
+        let output = Command::new(&self.meshi_bin)
+            .args(args)
+            .stdin(Stdio::null())
+            .output()
+            .await
+            .with_context(|| format!("failed to invoke meshi: {}", self.meshi_bin.display()))?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!(
+                "meshi {} exited with {}: {}",
+                args.join(" "),
+                output.status,
+                stderr.trim()
+            );
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    }
+}
+
+#[async_trait]
+impl MeshClient for CliMeshClient {
+    async fn board_json(&self, workstream: Option<&str>) -> Result<String> {
+        let mut args = vec!["board"];
+        if let Some(ws) = workstream {
+            args.push("--workstream");
+            args.push(ws);
+        }
+        args.push("--json");
+        self.run(&args).await
+    }
+
+    async fn grab_json(&self, item_id: &str) -> Result<String> {
+        // `meshi self grab <id>` is the atomic, meshi-owned claim.
+        self.run(&["self", "grab", item_id]).await
+    }
+
+    async fn complete(&self, item_id: &str, result: &str) -> Result<()> {
+        self.run(&["self", "complete", item_id, "--result", result])
+            .await
+            .map(|_| ())
+    }
+}
+
+/// Drains a meshi board as an optional exo work source.
+pub struct MeshBoardSource {
+    name: String,
+    config: MeshBoardConfig,
+    client: Box<dyn MeshClient>,
+}
+
+impl MeshBoardSource {
+    /// Build a source backed by the real meshi CLI.
+    pub fn from_config(config: MeshBoardConfig) -> Result<Self> {
+        config.validate()?;
+        let client = Box::new(CliMeshClient::new(config.meshi_bin.clone()));
+        Ok(Self::with_client(config, client))
+    }
+
+    /// Build a source with an injected [`MeshClient`] (used in tests).
+    pub fn with_client(config: MeshBoardConfig, client: Box<dyn MeshClient>) -> Self {
+        Self {
+            name: "meshi-board".to_string(),
+            config,
+            client,
+        }
+    }
+
+    /// Map an open board item to a schedulable exo task. The command template
+    /// gets the item id appended so the runner knows which item it owns.
+    fn item_to_task(&self, item: &MeshBoardItem, now_ms: u64) -> Result<ScheduledTaskRecord> {
+        let mut command = self.config.command_template.clone();
+        command.push(item.id.clone());
+
+        let report_prompt = compose_report_prompt(&self.config.report_prompt, item);
+
+        // `@every` is required by the scheduler's schedule parser. A meshi item
+        // is a single unit of work, not a recurring schedule; the lease + the
+        // source's "open" filter prevent re-runs, so the interval is inert.
+        ScheduledTaskRecord::new(
+            NewScheduledTask {
+                agent_id: self.config.agent_id.clone(),
+                conversation_id: self.config.conversation_id.clone(),
+                name: mesh_task_name(&item.id),
+                schedule: "@every 1h".to_string(),
+                sandbox_mode: None,
+                setup_command: None,
+                command,
+                report_prompt,
+                max_output_bytes: None,
+            },
+            now_ms,
+        )
+    }
+}
+
+/// Sanitize a board item id into a scheduler-legal task name (alnum, `-`, `_`).
+fn mesh_task_name(item_id: &str) -> String {
+    let sanitized: String = item_id
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    format!("mesh-{sanitized}")
+}
+
+fn compose_report_prompt(base: &str, item: &MeshBoardItem) -> String {
+    let mut prompt = base.to_string();
+    if let Some(subject) = &item.subject {
+        prompt.push_str(&format!("\n\nBoard item: {subject}"));
+    }
+    if let Some(action) = &item.requested_action {
+        prompt.push_str(&format!("\nRequested action: {action}"));
+    }
+    if let Some(body) = &item.body_preview {
+        prompt.push_str(&format!("\nDetails: {body}"));
+    }
+    prompt
+}
+
+#[async_trait]
+impl WorkSource for MeshBoardSource {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    async fn claim_due(
+        &self,
+        _now_ms: u64,
+        limit: usize,
+        _lease_ms: u64,
+    ) -> Result<Vec<ClaimedWork>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let board_raw = self
+            .client
+            .board_json(self.config.workstream.as_deref())
+            .await?;
+        let listing: MeshBoardListing = serde_json::from_str(&board_raw)
+            .with_context(|| format!("failed to parse meshi board listing: {board_raw}"))?;
+
+        let mut claimed = Vec::new();
+        for item in listing.items {
+            if claimed.len() >= limit {
+                break;
+            }
+            // meshi owns the grab. We only act on items we win; `already_grabbed`
+            // (another runtime owns it) is skipped — exo never overrides meshi.
+            let grab_raw = self.client.grab_json(&item.id).await?;
+            let grab: MeshGrabResult = serde_json::from_str(&grab_raw)
+                .with_context(|| format!("failed to parse meshi grab result: {grab_raw}"))?;
+            if !grab.won() {
+                continue;
+            }
+
+            let task = self
+                .item_to_task(&item, now_ms())
+                .with_context(|| format!("failed to map meshi item {} to a task", item.id))?;
+
+            claimed.push(ClaimedWork {
+                source: self.name.clone(),
+                task,
+                on_complete: Some(self.completion_hook(item.id.clone())),
+            });
+        }
+        Ok(claimed)
+    }
+}
+
+impl MeshBoardSource {
+    /// Build the completion hook that acknowledges the grabbed item back to
+    /// meshi via `meshi self complete`. This is exo reporting an outcome to the
+    /// coordination layer, not meshi scheduling exo.
+    fn completion_hook(&self, item_id: String) -> CompletionHook {
+        // The CLI client is cheap to reconstruct from config; rebuild one for
+        // the hook so it owns its dependencies (the hook outlives the claim).
+        let client = CliMeshClient::new(self.config.meshi_bin.clone());
+        Box::new(move |outcome: WorkOutcome| {
+            Box::pin(async move {
+                let result = match outcome {
+                    WorkOutcome::Completed { exit_code } => format!(
+                        "exo ran the work; exit_code={}",
+                        exit_code
+                            .map(|c| c.to_string())
+                            .unwrap_or_else(|| "unknown".to_string())
+                    ),
+                    WorkOutcome::Errored => "exo failed to run the work".to_string(),
+                };
+                client.complete(&item_id, &result).await
+            })
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+
+    /// In-memory mock of the meshi CLI so we never require a live mesh.
+    struct MockMeshClient {
+        board: String,
+        grabbed: Mutex<Vec<String>>,
+        completed: Mutex<Vec<(String, String)>>,
+        /// item ids meshi reports as `already_grabbed`.
+        already_grabbed: Vec<String>,
+    }
+
+    impl MockMeshClient {
+        fn new(board: &str) -> Self {
+            Self {
+                board: board.to_string(),
+                grabbed: Mutex::new(Vec::new()),
+                completed: Mutex::new(Vec::new()),
+                already_grabbed: Vec::new(),
+            }
+        }
+
+        fn with_already_grabbed(mut self, ids: Vec<String>) -> Self {
+            self.already_grabbed = ids;
+            self
+        }
+    }
+
+    #[async_trait]
+    impl MeshClient for MockMeshClient {
+        async fn board_json(&self, _workstream: Option<&str>) -> Result<String> {
+            Ok(self.board.clone())
+        }
+
+        async fn grab_json(&self, item_id: &str) -> Result<String> {
+            if self.already_grabbed.iter().any(|id| id == item_id) {
+                return Ok(r#"{"ok":true,"action":"already_grabbed"}"#.to_string());
+            }
+            self.grabbed.lock().unwrap().push(item_id.to_string());
+            Ok(r#"{"ok":true,"action":"grabbed"}"#.to_string())
+        }
+
+        async fn complete(&self, item_id: &str, result: &str) -> Result<()> {
+            self.completed
+                .lock()
+                .unwrap()
+                .push((item_id.to_string(), result.to_string()));
+            Ok(())
+        }
+    }
+
+    fn test_config() -> MeshBoardConfig {
+        MeshBoardConfig {
+            meshi_bin: PathBuf::from("meshi"),
+            workstream: Some("review".to_string()),
+            agent_id: "agent".to_string(),
+            conversation_id: "conversation".to_string(),
+            command_template: vec!["dossbot".to_string(), "work".to_string()],
+            report_prompt: "Report on the board item.".to_string(),
+        }
+    }
+
+    #[test]
+    fn mesh_task_name_sanitizes() {
+        assert_eq!(mesh_task_name("msg-001"), "mesh-msg-001");
+        assert_eq!(mesh_task_name("a/b c"), "mesh-a-b-c");
+    }
+
+    #[test]
+    fn item_to_task_appends_id_and_validates() {
+        let source = MeshBoardSource::with_client(
+            test_config(),
+            Box::new(MockMeshClient::new(r#"{"items":[]}"#)),
+        );
+        let item = MeshBoardItem {
+            id: "msg-001".to_string(),
+            subject: Some("Review the SOW".to_string()),
+            requested_action: Some("SHIP or block".to_string()),
+            body_preview: Some("Details here".to_string()),
+        };
+        let task = source.item_to_task(&item, 1).unwrap();
+        assert_eq!(task.agent_id, "agent");
+        assert_eq!(task.conversation_id, "conversation");
+        assert_eq!(task.name, "mesh-msg-001");
+        // Command template + the item id appended.
+        assert_eq!(task.command, vec!["dossbot", "work", "msg-001"]);
+        assert!(task.report_prompt.contains("Review the SOW"));
+        assert!(task.report_prompt.contains("SHIP or block"));
+    }
+
+    #[tokio::test]
+    async fn claim_due_maps_open_items_to_tasks() {
+        let board = r#"{
+            "open": 2,
+            "items": [
+                {"id":"msg-001","subject":"Review A","requested_action":"ship","body_preview":"a"},
+                {"id":"msg-002","subject":"Review B","requested_action":"ship","body_preview":"b"}
+            ]
+        }"#;
+        let source =
+            MeshBoardSource::with_client(test_config(), Box::new(MockMeshClient::new(board)));
+        let claimed = source.claim_due(now_ms(), 10, 1000).await.unwrap();
+        assert_eq!(claimed.len(), 2);
+        assert_eq!(claimed[0].source, "meshi-board");
+        assert_eq!(claimed[0].task.command, vec!["dossbot", "work", "msg-001"]);
+        assert_eq!(claimed[1].task.command, vec!["dossbot", "work", "msg-002"]);
+        // Each carries a completion hook so the loop can ack meshi.
+        assert!(claimed[0].on_complete.is_some());
+    }
+
+    #[tokio::test]
+    async fn claim_due_skips_already_grabbed_items() {
+        let board = r#"{
+            "items": [
+                {"id":"msg-001"},
+                {"id":"msg-002"}
+            ]
+        }"#;
+        let client = MockMeshClient::new(board).with_already_grabbed(vec!["msg-001".to_string()]);
+        let source = MeshBoardSource::with_client(test_config(), Box::new(client));
+        let claimed = source.claim_due(now_ms(), 10, 1000).await.unwrap();
+        // msg-001 was grabbed by another runtime; exo honors meshi and skips it.
+        assert_eq!(claimed.len(), 1);
+        assert_eq!(claimed[0].task.command, vec!["dossbot", "work", "msg-002"]);
+    }
+
+    #[tokio::test]
+    async fn claim_due_respects_limit() {
+        let board = r#"{
+            "items": [
+                {"id":"msg-001"},
+                {"id":"msg-002"},
+                {"id":"msg-003"}
+            ]
+        }"#;
+        let source =
+            MeshBoardSource::with_client(test_config(), Box::new(MockMeshClient::new(board)));
+        let claimed = source.claim_due(now_ms(), 2, 1000).await.unwrap();
+        assert_eq!(claimed.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn claim_due_empty_board_yields_nothing() {
+        let source = MeshBoardSource::with_client(
+            test_config(),
+            Box::new(MockMeshClient::new(
+                r#"{"open":0,"oldest_age_seconds":0,"items":[]}"#,
+            )),
+        );
+        let claimed = source.claim_due(now_ms(), 10, 1000).await.unwrap();
+        assert!(claimed.is_empty());
+    }
+}

--- a/crates/executor/src/scheduler_runtime.rs
+++ b/crates/executor/src/scheduler_runtime.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use exoharness::{RunInSandboxRequest, SandboxProcess, WriteArtifactRequest};
 use futures::io::{AsyncRead, AsyncReadExt};
 use serde::Serialize;
@@ -13,6 +13,7 @@ use crate::scheduler_types::{
     DEFAULT_COMMAND_TIMEOUT_MS, DEFAULT_TASK_LEASE_MS, ScheduledTaskRecord, ScheduledTaskRunRecord,
     ScheduledTaskSandboxMode, now_ms,
 };
+use crate::work_source::{ClaimedWork, CompletionHook, StoreWorkSource, WorkOutcome, WorkSource};
 use crate::{Harness, Uuid7};
 
 #[derive(Debug, Clone, Copy)]
@@ -43,19 +44,98 @@ struct ScheduledTaskArtifact {
     error: Option<String>,
 }
 
+/// Run all tasks due in the store-backed source.
+///
+/// This is the original entry point and is preserved verbatim in behavior: it
+/// drains the single [`SchedulerStore`] source. It is now a thin wrapper over
+/// [`run_due_tasks_from_sources`] with one [`StoreWorkSource`].
 pub async fn run_due_tasks(
     harness: Arc<dyn Harness>,
     store: &SchedulerStore,
     options: SchedulerRunOptions,
 ) -> Result<Vec<ScheduledTaskRunRecord>> {
-    let due = store
-        .claim_due_tasks(now_ms(), options.limit, DEFAULT_TASK_LEASE_MS)
-        .await?;
+    let sources: Vec<Box<dyn WorkSource>> = vec![Box::new(StoreWorkSource::new(store.clone()))];
+    run_due_tasks_from_sources(harness, store, &sources, options).await
+}
+
+/// Run all due work drained from a list of [`WorkSource`]s.
+///
+/// Each source is asked to atomically claim up to `limit` units of due work
+/// (leased for [`DEFAULT_TASK_LEASE_MS`]); the claimed work is then run with the
+/// exact same claim/lease/run/record contract exo has always used. The
+/// `store` remains the system of record for the *run* (`put_run`/`put_task`),
+/// regardless of which source produced the work; a source may additionally
+/// observe completion via [`ClaimedWork::on_complete`].
+pub async fn run_due_tasks_from_sources(
+    harness: Arc<dyn Harness>,
+    store: &SchedulerStore,
+    sources: &[Box<dyn WorkSource>],
+    options: SchedulerRunOptions,
+) -> Result<Vec<ScheduledTaskRunRecord>> {
+    let claimed = claim_from_sources(sources, now_ms(), options.limit).await?;
     futures::future::try_join_all(
-        due.into_iter()
-            .map(|task| run_task(Arc::clone(&harness), store, task)),
+        claimed
+            .into_iter()
+            .map(|work| run_claimed_work(Arc::clone(&harness), store, work)),
     )
     .await
+}
+
+/// Drain claimed work from each source in order, sharing one `limit` budget
+/// across all sources. Returns at most `limit` units. Extracted so the
+/// trait-dispatch contract (ordering + budget) is unit-testable without a live
+/// sandbox/harness.
+async fn claim_from_sources(
+    sources: &[Box<dyn WorkSource>],
+    now: u64,
+    limit: usize,
+) -> Result<Vec<ClaimedWork>> {
+    let mut claimed: Vec<ClaimedWork> = Vec::new();
+    for source in sources {
+        let remaining = limit.saturating_sub(claimed.len());
+        if remaining == 0 {
+            break;
+        }
+        let from_source = source
+            .claim_due(now, remaining, DEFAULT_TASK_LEASE_MS)
+            .await
+            .with_context(|| format!("work source `{}` failed to claim", source.name()))?;
+        claimed.extend(from_source);
+    }
+    Ok(claimed)
+}
+
+/// Run one unit of claimed work and, if the source attached a completion hook,
+/// acknowledge the outcome back to the source.
+async fn run_claimed_work(
+    harness: Arc<dyn Harness>,
+    store: &SchedulerStore,
+    work: ClaimedWork,
+) -> Result<ScheduledTaskRunRecord> {
+    let ClaimedWork {
+        task, on_complete, ..
+    } = work;
+    let run = run_task(harness, store, task).await?;
+    notify_completion(&run, on_complete).await;
+    Ok(run)
+}
+
+/// Map a finished run to a [`WorkOutcome`] and fire the source's completion
+/// hook, if any. A hook failure is logged, never fatal — exo has already
+/// recorded the run; acknowledging the source is best-effort.
+async fn notify_completion(run: &ScheduledTaskRunRecord, on_complete: Option<CompletionHook>) {
+    let Some(hook) = on_complete else {
+        return;
+    };
+    let outcome = match &run.error {
+        Some(_) => WorkOutcome::Errored,
+        None => WorkOutcome::Completed {
+            exit_code: run.exit_code,
+        },
+    };
+    if let Err(error) = hook(outcome).await {
+        tracing::warn!(%error, run_id = %run.id, "work source completion hook failed");
+    }
 }
 
 pub async fn run_task(
@@ -511,8 +591,160 @@ fn preview(bytes: &[u8]) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
     use super::*;
+    use crate::scheduler_types::NewScheduledTask;
+    use crate::work_source::ClaimedWork;
     use futures::{future::FutureExt, io::Cursor};
+
+    fn mock_task(name: &str) -> ScheduledTaskRecord {
+        ScheduledTaskRecord::new(
+            NewScheduledTask {
+                agent_id: "agent".to_string(),
+                conversation_id: "conversation".to_string(),
+                name: name.to_string(),
+                schedule: "@every 1m".to_string(),
+                sandbox_mode: None,
+                setup_command: None,
+                command: vec!["true".to_string()],
+                report_prompt: "Report.".to_string(),
+                max_output_bytes: None,
+            },
+            1,
+        )
+        .unwrap()
+    }
+
+    /// A mock [`WorkSource`] that yields a fixed number of tasks per claim and
+    /// records how many units it was asked for, so we can assert the loop's
+    /// per-source budget arithmetic.
+    struct MockSource {
+        name: String,
+        tasks: Vec<ScheduledTaskRecord>,
+        last_limit: Arc<AtomicUsize>,
+    }
+
+    impl MockSource {
+        fn new(name: &str, count: usize) -> Self {
+            Self {
+                name: name.to_string(),
+                tasks: (0..count)
+                    .map(|i| mock_task(&format!("{name}-{i}")))
+                    .collect(),
+                last_limit: Arc::new(AtomicUsize::new(usize::MAX)),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl WorkSource for MockSource {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        async fn claim_due(
+            &self,
+            _now_ms: u64,
+            limit: usize,
+            _lease_ms: u64,
+        ) -> Result<Vec<ClaimedWork>> {
+            self.last_limit.store(limit, Ordering::SeqCst);
+            Ok(self
+                .tasks
+                .iter()
+                .take(limit)
+                .cloned()
+                .map(|task| ClaimedWork::from_store(self.name.clone(), task))
+                .collect())
+        }
+    }
+
+    #[tokio::test]
+    async fn claim_from_sources_drains_in_order_and_shares_budget() {
+        let first = MockSource::new("first", 3);
+        let second = MockSource::new("second", 5);
+        let second_limit = Arc::clone(&second.last_limit);
+        let sources: Vec<Box<dyn WorkSource>> = vec![Box::new(first), Box::new(second)];
+
+        let claimed = claim_from_sources(&sources, now_ms(), 5).await.unwrap();
+        // First source gives 3; second source is asked for the remaining 2.
+        assert_eq!(claimed.len(), 5);
+        assert_eq!(second_limit.load(Ordering::SeqCst), 2);
+        assert_eq!(claimed[0].source, "first");
+        assert_eq!(claimed[3].source, "second");
+    }
+
+    #[tokio::test]
+    async fn claim_from_sources_stops_when_budget_exhausted() {
+        let first = MockSource::new("first", 5);
+        let second = MockSource::new("second", 5);
+        let second_limit = Arc::clone(&second.last_limit);
+        let sources: Vec<Box<dyn WorkSource>> = vec![Box::new(first), Box::new(second)];
+
+        let claimed = claim_from_sources(&sources, now_ms(), 5).await.unwrap();
+        assert_eq!(claimed.len(), 5);
+        // Budget exhausted by the first source; the second is never asked.
+        assert_eq!(second_limit.load(Ordering::SeqCst), usize::MAX);
+    }
+
+    #[tokio::test]
+    async fn notify_completion_fires_hook_with_outcome() {
+        let fired = Arc::new(Mutex::new(None));
+        let captured = Arc::clone(&fired);
+        let hook: CompletionHook = Box::new(move |outcome| {
+            let captured = Arc::clone(&captured);
+            Box::pin(async move {
+                *captured.lock().unwrap() = Some(outcome);
+                Ok(())
+            })
+        });
+        let run = ScheduledTaskRunRecord {
+            id: "run".to_string(),
+            task_id: "task".to_string(),
+            started_at_ms: 0,
+            finished_at_ms: 1,
+            exit_code: Some(0),
+            stdout_bytes: 0,
+            stderr_bytes: 0,
+            truncated: false,
+            result_artifact_id: None,
+            error: None,
+        };
+        notify_completion(&run, Some(hook)).await;
+        assert_eq!(
+            *fired.lock().unwrap(),
+            Some(WorkOutcome::Completed { exit_code: Some(0) })
+        );
+    }
+
+    #[tokio::test]
+    async fn notify_completion_maps_error_outcome() {
+        let fired = Arc::new(Mutex::new(None));
+        let captured = Arc::clone(&fired);
+        let hook: CompletionHook = Box::new(move |outcome| {
+            let captured = Arc::clone(&captured);
+            Box::pin(async move {
+                *captured.lock().unwrap() = Some(outcome);
+                Ok(())
+            })
+        });
+        let run = ScheduledTaskRunRecord {
+            id: "run".to_string(),
+            task_id: "task".to_string(),
+            started_at_ms: 0,
+            finished_at_ms: 1,
+            exit_code: None,
+            stdout_bytes: 0,
+            stderr_bytes: 0,
+            truncated: false,
+            result_artifact_id: None,
+            error: Some("boom".to_string()),
+        };
+        notify_completion(&run, Some(hook)).await;
+        assert_eq!(*fired.lock().unwrap(), Some(WorkOutcome::Errored));
+    }
 
     struct HangingSandboxProcess;
 

--- a/crates/executor/src/work_source.rs
+++ b/crates/executor/src/work_source.rs
@@ -1,0 +1,203 @@
+//! Pluggable work sources for the scheduler claim loop.
+//!
+//! The scheduler's `run_due_tasks` loop historically claimed work from exactly
+//! one place: the file/db-backed [`SchedulerStore`]. A [`WorkSource`] abstracts
+//! "where due work comes from" so the loop can drain from a list of sources
+//! while keeping exo's existing claim / lease / run / record contract intact.
+//!
+//! The contract is deliberately narrow so it can land upstream:
+//!
+//! * A source is asked to **atomically claim** up to `limit` units of due work,
+//!   each leased for `lease_ms`, and returns them as [`ScheduledTaskRecord`]s
+//!   (the unit exo already knows how to run).
+//! * Recording the *result* of a run stays with the [`SchedulerStore`] exactly
+//!   as before. A source may optionally observe completion via
+//!   [`ClaimedWork::on_complete`] (e.g. to acknowledge an external queue), but
+//!   the store remains the system of record for the run itself.
+//!
+//! The existing store is exposed as [`StoreWorkSource`]; [`MeshBoardSource`]
+//! is one external impl (see [`crate::mesh_work_source`]).
+
+use std::fmt;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::scheduler_store::SchedulerStore;
+use crate::scheduler_types::ScheduledTaskRecord;
+
+/// Outcome of running a unit of claimed work, handed to
+/// [`ClaimedWork::on_complete`] so an external source can close its own loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkOutcome {
+    /// The command ran to completion (regardless of its exit code).
+    Completed { exit_code: Option<i32> },
+    /// The run errored before/while producing an exit code.
+    Errored,
+}
+
+/// A boxed, fallible completion hook. Sources that need to acknowledge work
+/// back to an external system (e.g. `meshi self complete`) attach one of these;
+/// the store-backed source attaches none.
+pub type CompletionHook =
+    Box<dyn FnOnce(WorkOutcome) -> futures::future::BoxFuture<'static, Result<()>> + Send>;
+
+/// One unit of work a [`WorkSource`] has atomically claimed and leased.
+///
+/// The [`ScheduledTaskRecord`] is the schedulable unit exo runs. `on_complete`,
+/// if present, is invoked by the scheduler after the run finishes so the source
+/// can acknowledge the external system that owns the underlying item.
+pub struct ClaimedWork {
+    /// Identifies the source that produced this work (for tracing/telemetry).
+    pub source: String,
+    /// The schedulable task exo will run.
+    pub task: ScheduledTaskRecord,
+    /// Optional hook invoked once the run finishes.
+    pub on_complete: Option<CompletionHook>,
+}
+
+impl ClaimedWork {
+    /// Wrap a record claimed from a source with no external completion hook
+    /// (the store-backed case: the store records the run itself).
+    pub fn from_store(source: impl Into<String>, task: ScheduledTaskRecord) -> Self {
+        Self {
+            source: source.into(),
+            task,
+            on_complete: None,
+        }
+    }
+}
+
+impl fmt::Debug for ClaimedWork {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ClaimedWork")
+            .field("source", &self.source)
+            .field("task_id", &self.task.id)
+            .field("has_completion_hook", &self.on_complete.is_some())
+            .finish()
+    }
+}
+
+/// Abstracts where the scheduler's due work comes from.
+///
+/// Implementations own the *claim*: returning a record means the source has
+/// taken responsibility for it (leased it, removed it from its own "open" set,
+/// etc.) so two concurrent drains never double-run the same unit. This mirrors
+/// [`SchedulerStore::claim_due_tasks`], which exo already relied on.
+#[async_trait]
+pub trait WorkSource: Send + Sync {
+    /// A stable identifier for the source (used in tracing).
+    fn name(&self) -> &str;
+
+    /// Atomically claim up to `limit` units of due work, each leased for
+    /// `lease_ms`. Implementations must not return more than `limit` units and
+    /// must not return the same unit to two concurrent callers.
+    async fn claim_due(&self, now_ms: u64, limit: usize, lease_ms: u64)
+    -> Result<Vec<ClaimedWork>>;
+}
+
+/// The default work source: the file/db-backed [`SchedulerStore`].
+///
+/// This is a thin adapter that preserves exo's existing semantics exactly —
+/// it delegates to [`SchedulerStore::claim_due_tasks`] and attaches no
+/// completion hook, because the store records runs through `put_run`/`put_task`
+/// in the scheduler as it always has.
+#[derive(Clone)]
+pub struct StoreWorkSource {
+    store: SchedulerStore,
+    name: String,
+}
+
+impl StoreWorkSource {
+    pub fn new(store: SchedulerStore) -> Self {
+        Self {
+            store,
+            name: "store".to_string(),
+        }
+    }
+
+    pub fn store(&self) -> &SchedulerStore {
+        &self.store
+    }
+}
+
+#[async_trait]
+impl WorkSource for StoreWorkSource {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    async fn claim_due(
+        &self,
+        now_ms: u64,
+        limit: usize,
+        lease_ms: u64,
+    ) -> Result<Vec<ClaimedWork>> {
+        let claimed = self.store.claim_due_tasks(now_ms, limit, lease_ms).await?;
+        Ok(claimed
+            .into_iter()
+            .map(|task| ClaimedWork::from_store("store", task))
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scheduler_types::NewScheduledTask;
+
+    fn sample_task(name: &str) -> ScheduledTaskRecord {
+        ScheduledTaskRecord::new(
+            NewScheduledTask {
+                agent_id: "agent".to_string(),
+                conversation_id: "conversation".to_string(),
+                name: name.to_string(),
+                schedule: "@every 1m".to_string(),
+                sandbox_mode: None,
+                setup_command: None,
+                command: vec!["true".to_string()],
+                report_prompt: "Report.".to_string(),
+                max_output_bytes: None,
+            },
+            1,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn from_store_has_no_completion_hook() {
+        let work = ClaimedWork::from_store("store", sample_task("check"));
+        assert_eq!(work.source, "store");
+        assert!(work.on_complete.is_none());
+    }
+
+    #[tokio::test]
+    async fn store_work_source_claims_and_leases() {
+        let tempdir = tempfile::TempDir::new().unwrap();
+        let store = SchedulerStore::new(tempdir.path());
+        let mut task = store
+            .create_task(NewScheduledTask {
+                agent_id: "agent".to_string(),
+                conversation_id: "conversation".to_string(),
+                name: "check".to_string(),
+                schedule: "@every 1m".to_string(),
+                sandbox_mode: None,
+                setup_command: None,
+                command: vec!["true".to_string()],
+                report_prompt: "Report.".to_string(),
+                max_output_bytes: None,
+            })
+            .await
+            .unwrap();
+        task.next_run_at_ms = 1;
+        store.put_task(&task).await.unwrap();
+
+        let source = StoreWorkSource::new(store);
+        let claimed = source.claim_due(2, 10, 100).await.unwrap();
+        assert_eq!(claimed.len(), 1);
+        assert_eq!(claimed[0].source, "store");
+        assert!(claimed[0].on_complete.is_none());
+        // Lease holds: a second claim before expiry yields nothing.
+        assert!(source.claim_due(3, 10, 100).await.unwrap().is_empty());
+    }
+}


### PR DESCRIPTION
## What

Generalizes the scheduler's claim loop so "where due work comes from" is pluggable. Today `scheduler_runtime::run_due_tasks` is hard-wired to one source: the file/db-backed `SchedulerStore`. This introduces a `WorkSource` trait, makes the store one impl, and lets the loop drain from a list of sources while preserving exo's existing claim / lease / run / record contract exactly.

## The seam

`run_due_tasks` -> `claim_from_sources` -> `store.claim_due_tasks(now, limit, lease)`. The atomic claim/lease was already the contract; this just abstracts the producer of claimed, leased units.

## API

```rust
#[async_trait]
pub trait WorkSource: Send + Sync {
    fn name(&self) -> &str;
    async fn claim_due(&self, now_ms: u64, limit: usize, lease_ms: u64)
        -> Result<Vec<ClaimedWork>>;
}
```

- `ClaimedWork` = a `ScheduledTaskRecord` (the unit exo already runs) + an optional `on_complete` hook so an external source can ack the system that owns the underlying item. The store-backed source attaches none; the store stays the system of record for the run.
- `StoreWorkSource` is the existing store behind the trait (delegates to `claim_due_tasks`).
- `run_due_tasks` is now a thin wrapper over the new `run_due_tasks_from_sources` with a single `StoreWorkSource`, so existing behavior and the one existing caller (the exoclaw scheduler-runner example) are unchanged.

Scheduler semantics are unchanged: a single shared `limit` budget across sources, same lease, same `put_run`/`put_task` recording, same wakeup.

## Why upstream

Pluggable work sources are a general capability (queues, external boards, other producers), independent of any one downstream impl. This PR is the trait + the store impl + the loop generalization. (A downstream `MeshBoardSource` impl that drains a coordination board is included as a worked example of an external source; reviewers can take or drop it.)

## Tests

12 new unit tests, all existing scheduler tests stay green (82 executor tests pass). Workspace clippy clean. Trait-dispatch coverage (source ordering, shared limit budget, completion-hook outcome mapping) is exercised with a mock source; no live external system needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)