### PR TITLE
Add Anthropic provider support to both typescript and rust runtimes

### DIFF
--- a/crates/executor/src/harness_runtime.rs
+++ b/crates/executor/src/harness_runtime.rs
@@ -39,8 +39,8 @@ impl RouterModelClient {
 #[async_trait]
 impl ModelClient for RouterModelClient {
     async fn complete(&self, request: ModelRequest) -> Result<ModelResponse> {
-        let format = ProviderFormat::Responses;
         let config = resolve_runtime_config(&request, self.env.as_ref())?;
+        let format = config.format;
         let router = build_router(&request, format, &config)?;
         let universal_request = build_universal_request(&request, false)?;
         let payload = serialize_request(format, &universal_request)?;
@@ -52,8 +52,8 @@ impl ModelClient for RouterModelClient {
     }
 
     async fn complete_stream(&self, request: ModelRequest) -> Result<Box<dyn ModelResponseStream>> {
-        let format = ProviderFormat::Responses;
         let config = resolve_runtime_config(&request, self.env.as_ref())?;
+        let format = config.format;
         let router = build_router(&request, format, &config)?;
         let universal_request = build_universal_request(&request, true)?;
         let payload = serialize_request(format, &universal_request)?;
@@ -95,6 +95,7 @@ impl ModelResponseStream for RouterModelResponseStream {
 struct ResolvedRuntimeConfig {
     provider_alias: String,
     provider_kind: String,
+    format: ProviderFormat,
     endpoint: Option<Url>,
     endpoint_template: Option<String>,
     metadata: HashMap<String, lingua_json::Value>,
@@ -102,6 +103,57 @@ struct ResolvedRuntimeConfig {
 }
 
 fn resolve_runtime_config(
+    request: &ModelRequest,
+    env: &HashMap<String, String>,
+) -> Result<ResolvedRuntimeConfig> {
+    if is_anthropic_model(&request.model) {
+        resolve_anthropic_config(request, env)
+    } else {
+        resolve_openai_config(request, env)
+    }
+}
+
+/// Anthropic model bindings route to the native Messages API. We detect them by
+/// model name (`claude*`). Bedrock/Vertex Anthropic ids carry provider prefixes
+/// (e.g. `us.anthropic.claude-...`) so they do not match here and keep falling
+/// through to the OpenAI-compatible path.
+fn is_anthropic_model(model: &str) -> bool {
+    model.to_ascii_lowercase().starts_with("claude")
+}
+
+fn resolve_anthropic_config(
+    request: &ModelRequest,
+    env: &HashMap<String, String>,
+) -> Result<ResolvedRuntimeConfig> {
+    let key = request
+        .api_key
+        .clone()
+        .or_else(|| optional_env(env, "ANTHROPIC_API_KEY"))
+        .ok_or_else(|| anyhow::anyhow!("model request is missing an API key"))?;
+    // `None` lets the provider use its built-in default
+    // (`https://api.anthropic.com/v1/`).
+    let endpoint = request
+        .base_url
+        .clone()
+        .or_else(|| optional_env(env, "ANTHROPIC_BASE_URL"))
+        .map(|raw| Url::parse(&raw))
+        .transpose()?;
+    Ok(ResolvedRuntimeConfig {
+        provider_alias: "anthropic".to_string(),
+        provider_kind: "anthropic".to_string(),
+        format: ProviderFormat::Anthropic,
+        endpoint,
+        endpoint_template: None,
+        metadata: HashMap::new(),
+        auth: AuthConfig::ApiKey {
+            key,
+            header: Some("x-api-key".to_string()),
+            prefix: None,
+        },
+    })
+}
+
+fn resolve_openai_config(
     request: &ModelRequest,
     env: &HashMap<String, String>,
 ) -> Result<ResolvedRuntimeConfig> {
@@ -129,6 +181,7 @@ fn resolve_runtime_config(
     Ok(ResolvedRuntimeConfig {
         provider_alias: "openai".to_string(),
         provider_kind: "openai".to_string(),
+        format: ProviderFormat::Responses,
         endpoint,
         endpoint_template: None,
         metadata,
@@ -287,6 +340,34 @@ mod tests {
 
         assert_eq!(payload.stream, Some(true));
         assert!(payload.stream_options.is_none());
+    }
+
+    #[test]
+    fn anthropic_models_route_to_the_native_messages_api() {
+        let mut request = model_request();
+        request.model = "claude-sonnet-4-6".to_string();
+        request.api_key = Some("sk-ant-test".to_string());
+
+        let config = resolve_runtime_config(&request, &HashMap::new()).unwrap();
+
+        assert_eq!(config.provider_kind, "anthropic");
+        assert_eq!(config.format, ProviderFormat::Anthropic);
+        assert!(matches!(
+            config.auth,
+            AuthConfig::ApiKey { ref header, ref prefix, .. }
+                if header.as_deref() == Some("x-api-key") && prefix.is_none()
+        ));
+    }
+
+    #[test]
+    fn non_anthropic_models_keep_the_openai_responses_route() {
+        let mut request = model_request();
+        request.api_key = Some("sk-test".to_string());
+
+        let config = resolve_runtime_config(&request, &HashMap::new()).unwrap();
+
+        assert_eq!(config.provider_kind, "openai");
+        assert_eq!(config.format, ProviderFormat::Responses);
     }
 
     #[test]

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.126",
+    "@anthropic-ai/sdk": "^0.106.0",
     "@braintrust/lingua": "^0.1.0",
     "@braintrust/lingua-wasm": "^0.1.0",
     "@cursor/sdk": "^1.0.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,12 @@ importers:
       '@anthropic-ai/claude-agent-sdk':
         specifier: ^0.2.126
         version: 0.2.126(zod@4.3.6)
+      '@anthropic-ai/sdk':
+        specifier: ^0.106.0
+        version: 0.106.0(zod@4.3.6)
       '@braintrust/lingua':
         specifier: ^0.1.0
-        version: 0.1.0(@anthropic-ai/sdk@0.81.0(zod@4.3.6))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))
+        version: 0.1.0(@anthropic-ai/sdk@0.106.0(zod@4.3.6))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))
       '@braintrust/lingua-wasm':
         specifier: ^0.1.0
         version: 0.1.0
@@ -121,6 +124,15 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
+
+  '@anthropic-ai/sdk@0.106.0':
+    resolution: {integrity: sha512-ufwVvYNDBj2dzOGupBCTaNzBLxqcTnGOzI4z8Wouxlt+mT3J3HuOmatgCy1VmwCHOUueqZ41ERhm0O99OUcbWA==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@anthropic-ai/sdk@0.81.0':
     resolution: {integrity: sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==}
@@ -1080,6 +1092,9 @@ packages:
     resolution: {integrity: sha512-oBN+msHzPnm1M5DDx3wVD7iBwpNXFUtkh2MrAbUJu0OhKjliLChi28hq++mu1+qdMpAVQO5JKAvQQxYVbyneiw==}
     engines: {node: '>= 10'}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1676,6 +1691,9 @@ packages:
 
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
@@ -2500,6 +2518,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -2860,6 +2881,13 @@ snapshots:
       - '@cfworker/json-schema'
       - supports-color
 
+  '@anthropic-ai/sdk@0.106.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
+    optionalDependencies:
+      zod: 4.3.6
+
   '@anthropic-ai/sdk@0.81.0(zod@4.3.6)':
     dependencies:
       json-schema-to-ts: 3.1.1
@@ -2874,9 +2902,9 @@ snapshots:
 
   '@braintrust/lingua-wasm@0.1.0': {}
 
-  '@braintrust/lingua@0.1.0(@anthropic-ai/sdk@0.81.0(zod@4.3.6))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))':
+  '@braintrust/lingua@0.1.0(@anthropic-ai/sdk@0.106.0(zod@4.3.6))(openai@6.33.0(ws@8.21.0)(zod@4.3.6))':
     dependencies:
-      '@anthropic-ai/sdk': 0.81.0(zod@4.3.6)
+      '@anthropic-ai/sdk': 0.106.0(zod@4.3.6)
       '@braintrust/lingua-wasm': 0.1.0
       openai: 6.33.0(ws@8.21.0)(zod@4.3.6)
 
@@ -3565,6 +3593,8 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
+
+  '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -4281,6 +4311,8 @@ snapshots:
   fast-deep-equal@3.1.3: {}
 
   fast-fifo@1.3.2: {}
+
+  fast-sha256@1.3.0: {}
 
   fast-uri@3.1.0: {}
 
@@ -5248,6 +5280,11 @@ snapshots:
     optional: true
 
   stackback@0.0.2: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
 
   statuses@2.0.2: {}
 

--- a/typescript/model-runtime/responses.test.ts
+++ b/typescript/model-runtime/responses.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import type { Response } from "openai/resources/responses/responses";
 
 import {
+  AnthropicRuntime,
   ChatCompletionsRuntime,
+  isAnthropicModel,
   modelRequiresResponsesApi,
   responseToLinguaEvents,
   responseToolCalls,
@@ -48,6 +50,18 @@ describe("model runtime dispatch", () => {
         apiKey: "key",
       }),
     ).toBeInstanceOf(ResponsesRuntime);
+  });
+
+  it("dispatches claude models to the native Anthropic runtime", () => {
+    expect(isAnthropicModel("claude-sonnet-4-6")).toBe(true);
+    expect(isAnthropicModel("gpt-5.4")).toBe(false);
+    expect(isAnthropicModel("us.anthropic.claude-sonnet-4-6")).toBe(false);
+    expect(
+      runtimeFromModelBinding(undefined, {
+        model: "claude-sonnet-4-6",
+        apiKey: "key",
+      }),
+    ).toBeInstanceOf(AnthropicRuntime);
   });
 });
 

--- a/typescript/model-runtime/responses.ts
+++ b/typescript/model-runtime/responses.ts
@@ -1,4 +1,5 @@
 import OpenAI from "openai";
+import Anthropic from "@anthropic-ai/sdk";
 import {
   flush,
   initLogger,
@@ -7,6 +8,7 @@ import {
   type StartSpanArgs,
 } from "braintrust";
 import {
+  linguaToAnthropicMessages,
   linguaToResponsesMessages,
   responsesMessagesToLingua,
   type Message as LinguaMessage,
@@ -325,9 +327,20 @@ export function runtimeFromModelBinding(
   agentConfig: AgentConfig | undefined,
   binding: ResponsesModelBinding,
 ): ResponsesRuntimeLike {
-  return modelRequiresResponsesApi(binding.model ?? "")
+  const model = binding.model ?? "";
+  if (isAnthropicModel(model)) {
+    return AnthropicRuntime.fromModelBinding(agentConfig, binding);
+  }
+  return modelRequiresResponsesApi(model)
     ? ResponsesRuntime.fromModelBinding(agentConfig, binding)
     : ChatCompletionsRuntime.fromModelBinding(agentConfig, binding);
+}
+
+// Anthropic model bindings call the native Messages API. We detect them by
+// model name (`claude*`), mirroring the Rust runtime; Bedrock/Vertex Anthropic
+// ids carry provider prefixes and intentionally don't match here.
+export function isAnthropicModel(model: string): boolean {
+  return model.toLowerCase().startsWith("claude");
 }
 
 export function modelRequiresResponsesApi(model: string): boolean {
@@ -517,6 +530,279 @@ export class ChatCompletionsRuntime implements ResponsesRuntimeLike {
       ttftMs,
     };
   }
+}
+
+// Anthropic's Messages API requires `max_tokens`; the OpenAI side leaves it
+// optional. Use the binding's configured limit when present, otherwise a
+// conservative default.
+const DEFAULT_ANTHROPIC_MAX_TOKENS = 4096;
+
+// Mirrors ChatCompletionsRuntime: build a provider-native request, call the
+// provider SDK, then normalize the provider response into the OpenAI Responses
+// `Response` shape that the rest of the harness consumes.
+export class AnthropicRuntime implements ResponsesRuntimeLike {
+  private readonly client: Anthropic;
+
+  constructor(options: ResponsesRuntimeOptions = {}) {
+    ensureBraintrustLogger(options.braintrust ?? null);
+    this.client = new Anthropic({
+      apiKey: options.apiKey,
+      baseURL: options.baseURL,
+    });
+  }
+
+  static fromModelBinding(
+    agentConfig: AgentConfig | undefined,
+    binding: ResponsesModelBinding,
+  ): AnthropicRuntime {
+    return new AnthropicRuntime({
+      apiKey: binding.apiKey,
+      baseURL: binding.baseUrl ?? undefined,
+      braintrust: braintrustOptionsFromAgentConfig(agentConfig),
+    });
+  }
+
+  async runTurn(
+    context: TurnContext,
+    run: (turnParent: TraceParent) => Promise<string | null>,
+  ): Promise<void> {
+    await traceExecutorTurn(context, run);
+  }
+
+  async complete(
+    request: NativeResponsesRequest,
+    options: NativeTraceOptions = {},
+  ): Promise<Response> {
+    const { response } = await this.runLlmRequest(request, {
+      ...options,
+      streamed: false,
+    });
+    return response;
+  }
+
+  async completeStream(
+    request: NativeResponsesRequest,
+    handlers: NativeStreamHandlers = {},
+    options: NativeTraceOptions = {},
+  ): Promise<Response> {
+    const { response } = await this.runLlmRequest(request, {
+      ...options,
+      streamed: true,
+      handlers,
+    });
+    return response;
+  }
+
+  async traceToolCall(
+    turnParent: TraceParent,
+    context: TurnContext,
+    toolCall: PendingToolCall,
+    roundIndex: number,
+    execute: ToolCallExecutor = (toolCall) =>
+      context.executePendingTools([toolCall]),
+  ): Promise<EventData[]> {
+    return tracedUnderParent(
+      turnParent,
+      async (span) => {
+        try {
+          const events = await execute(toolCall);
+          span.log({ output: toolResultTraceOutput(events) });
+          return events;
+        } catch (error) {
+          span.log({ error: errorMessage(error) });
+          throw error;
+        }
+      },
+      {
+        name: toolCall.request.functionName,
+        type: "tool",
+        spanAttributes: { purpose: "tool_call" },
+        event: {
+          input: toolCall.request,
+          metadata: {
+            round_index: roundIndex,
+          },
+        },
+      },
+    );
+  }
+
+  private async runLlmRequest(
+    request: NativeResponsesRequest,
+    options: NativeLlmTraceOptions,
+  ): Promise<NativeLlmResult> {
+    const toolNames = (request.tools ?? []).map((tool) => tool.name);
+    const body = buildAnthropicBody(request);
+    const run = async (span: Span): Promise<NativeLlmResult> => {
+      try {
+        const result = options.streamed
+          ? await this.completeStreamRaw(body, options.handlers)
+          : {
+              response: anthropicMessageToResponse(
+                await this.client.messages.create(body),
+              ),
+              ttftMs: null,
+            };
+
+        span.log({
+          output: llmOutputTraceValue(result.response),
+          metadata: {
+            response_id: result.response.id,
+          },
+          metrics: responseUsageMetrics(result.response, result.ttftMs),
+        });
+        return result;
+      } catch (error) {
+        span.log({ error: errorMessage(error) });
+        throw error;
+      }
+    };
+    return tracedUnderParent(options.parent, run, {
+      name: `anthropic:${request.model}`,
+      type: "llm",
+      event: {
+        input: llmInputTraceValue(request),
+        metadata: {
+          round_index: options.roundIndex,
+          runtime: "anthropic",
+          model: request.model,
+          max_output_tokens: request.maxOutputTokens ?? null,
+          tool_count: toolNames.length,
+          tools: toolNames,
+          streamed: options.streamed,
+        },
+      },
+    });
+  }
+
+  private async completeStreamRaw(
+    body: Anthropic.MessageCreateParamsNonStreaming,
+    handlers: NativeStreamHandlers = {},
+  ): Promise<NativeLlmResult> {
+    const startedAt = performance.now();
+    let sawFirstChunk = false;
+    let ttftMs: number | null = null;
+    const stream = this.client.messages.stream(body);
+
+    for await (const event of stream) {
+      if (
+        event.type === "content_block_delta" &&
+        event.delta.type === "text_delta"
+      ) {
+        if (!sawFirstChunk) {
+          sawFirstChunk = true;
+          ttftMs = Math.max(0, Math.round(performance.now() - startedAt));
+          await handlers.onFirstChunk?.(ttftMs);
+        }
+        await handlers.onTextDelta?.(event.delta.text);
+      }
+    }
+
+    return {
+      response: anthropicMessageToResponse(await stream.finalMessage()),
+      ttftMs,
+    };
+  }
+}
+
+function buildAnthropicBody(
+  request: NativeResponsesRequest,
+): Anthropic.MessageCreateParamsNonStreaming {
+  const { system, messages } = splitAnthropicMessages(request.messages ?? []);
+  const tools = toolDefinitionsToAnthropicTools(request.tools ?? []);
+  return {
+    model: request.model,
+    max_tokens: request.maxOutputTokens ?? DEFAULT_ANTHROPIC_MAX_TOKENS,
+    system: system.length === 0 ? undefined : system,
+    messages,
+    tools: tools.length === 0 ? undefined : tools,
+  };
+}
+
+// Anthropic takes the system prompt as a top-level field, not a message role.
+// Pull system/developer turns out, then let lingua convert the rest — the same
+// `linguaTo<Provider>Messages` path the Responses runtime uses for its input.
+function splitAnthropicMessages(messages: Message[]): {
+  system: string;
+  messages: Anthropic.MessageParam[];
+} {
+  const systemParts: string[] = [];
+  const conversation: Message[] = [];
+  for (const message of messages) {
+    if (message.role === "system" || message.role === "developer") {
+      systemParts.push(messageContentText(message.content));
+    } else {
+      conversation.push(message);
+    }
+  }
+  return {
+    system: systemParts.join("\n\n"),
+    messages: linguaToAnthropicMessages(
+      conversation as LinguaMessage[],
+    ) as Anthropic.MessageParam[],
+  };
+}
+
+function toolDefinitionsToAnthropicTools(
+  tools: ToolDefinition[],
+): Anthropic.Tool[] {
+  return tools.map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    input_schema: tool.parameters as Anthropic.Tool.InputSchema,
+  }));
+}
+
+function anthropicMessageToResponse(message: Anthropic.Message): Response {
+  const output: unknown[] = [];
+  const text = message.content
+    .filter((block): block is Anthropic.TextBlock => block.type === "text")
+    .map((block) => block.text)
+    .join("");
+  if (text.length > 0) {
+    output.push(responseMessageOutput(`${message.id}_message`, text));
+  }
+  for (const block of message.content) {
+    if (block.type === "tool_use") {
+      output.push(
+        responseFunctionCallOutput({
+          id: block.id,
+          type: "function",
+          function: {
+            name: block.name,
+            arguments: JSON.stringify(block.input ?? {}),
+          },
+        } as ChatFunctionToolCall),
+      );
+    }
+  }
+  return {
+    id: message.id,
+    object: "response",
+    created_at: Math.floor(Date.now() / 1000),
+    status: "completed",
+    model: message.model,
+    output,
+    usage: anthropicUsageToResponseUsage(message.usage),
+  } as unknown as Response;
+}
+
+function anthropicUsageToResponseUsage(
+  usage: Anthropic.Usage | null | undefined,
+): unknown {
+  if (!usage) {
+    return null;
+  }
+  const input = usage.input_tokens ?? 0;
+  const output = usage.output_tokens ?? 0;
+  const cached = usage.cache_read_input_tokens ?? 0;
+  return {
+    input_tokens: input,
+    output_tokens: output,
+    total_tokens: input + output,
+    input_tokens_details: { cached_tokens: cached },
+    output_tokens_details: { reasoning_tokens: 0 },
+  };
 }
 
 export async function runResponsesTurn(

--- a/typescript/model-runtime/responses.ts
+++ b/typescript/model-runtime/responses.ts
@@ -4,6 +4,7 @@ import {
   flush,
   initLogger,
   traced,
+  wrapAnthropic,
   type Span,
   type StartSpanArgs,
 } from "braintrust";
@@ -545,10 +546,14 @@ export class AnthropicRuntime implements ResponsesRuntimeLike {
 
   constructor(options: ResponsesRuntimeOptions = {}) {
     ensureBraintrustLogger(options.braintrust ?? null);
-    this.client = new Anthropic({
-      apiKey: options.apiKey,
-      baseURL: options.baseURL,
-    });
+    // wrapAnthropic auto-instruments every messages.create/.stream call with a
+    // braintrust LLM span (input/output/usage), so we don't hand-roll spans.
+    this.client = wrapAnthropic(
+      new Anthropic({
+        apiKey: options.apiKey,
+        baseURL: options.baseURL,
+      }),
+    );
   }
 
   static fromModelBinding(
@@ -631,48 +636,16 @@ export class AnthropicRuntime implements ResponsesRuntimeLike {
     request: NativeResponsesRequest,
     options: NativeLlmTraceOptions,
   ): Promise<NativeLlmResult> {
-    const toolNames = (request.tools ?? []).map((tool) => tool.name);
     const body = buildAnthropicBody(request);
-    const run = async (span: Span): Promise<NativeLlmResult> => {
-      try {
-        const result = options.streamed
-          ? await this.completeStreamRaw(body, options.handlers)
-          : {
-              response: anthropicMessageToResponse(
-                await this.client.messages.create(body),
-              ),
-              ttftMs: null,
-            };
-
-        span.log({
-          output: llmOutputTraceValue(result.response),
-          metadata: {
-            response_id: result.response.id,
-          },
-          metrics: responseUsageMetrics(result.response, result.ttftMs),
-        });
-        return result;
-      } catch (error) {
-        span.log({ error: errorMessage(error) });
-        throw error;
-      }
+    if (options.streamed) {
+      return this.completeStreamRaw(body, options.handlers);
+    }
+    return {
+      response: anthropicMessageToResponse(
+        await this.client.messages.create(body),
+      ),
+      ttftMs: null,
     };
-    return tracedUnderParent(options.parent, run, {
-      name: `anthropic:${request.model}`,
-      type: "llm",
-      event: {
-        input: llmInputTraceValue(request),
-        metadata: {
-          round_index: options.roundIndex,
-          runtime: "anthropic",
-          model: request.model,
-          max_output_tokens: request.maxOutputTokens ?? null,
-          tool_count: toolNames.length,
-          tools: toolNames,
-          streamed: options.streamed,
-        },
-      },
-    });
   }
 
   private async completeStreamRaw(


### PR DESCRIPTION
Route `claude*` models to the native Anthropic API instead of shipping the key to OpenAI's endpoint.

Rust (`harness_runtime.rs`): `resolve_runtime_config` now branches by model name — claude* → Anthropic Messages API (provider/format `anthropic`, `x-api-key` auth, `ANTHROPIC_API_KEY` fallback, default endpoint), everything else unchanged on the OpenAI Responses path.

TypeScript (`responses.ts`): `runtimeFromModelBinding` routes claude* to a new `AnthropicRuntime` that mirrors `ChatCompletionsRuntime` — builds an Anthropic Messages request (system split out, messages via lingua `linguaToAnthropicMessages`, tools via `toolDefinitionsToAnthropicTools`), calls `@anthropic-ai/sdk`, and normalizes the response into the OpenAI Responses `Response` shape the harness consumes. Adds `@anthropic-ai/sdk` as a direct dependency.

Verified live (chat + multi-round shell tool calls) on both runtimes.