### PR TITLE
Add OpenRouter support; trace all runtimes via braintrust wrap* helpers

### DIFF
--- a/crates/executor/src/basic.rs
+++ b/crates/executor/src/basic.rs
@@ -537,19 +537,23 @@ fn build_usage_record(
         None => (None, None, None, None, None),
     };
 
-    let cost_usd = if has_usage && !model.is_empty() {
-        pricing.compute_cost_usd(
-            &model,
-            TokenCounts {
-                prompt: prompt_tokens,
-                completion: completion_tokens,
-                prompt_cached: prompt_cached_tokens,
-                prompt_cache_creation: prompt_cache_creation_tokens,
-            },
-        )
-    } else {
-        None
-    };
+    // Prefer the provider-reported cost (e.g. OpenRouter's `usage.cost`); fall
+    // back to the local price-table estimate when the provider doesn't send one.
+    let cost_usd = response.provider_cost_usd.or_else(|| {
+        if has_usage && !model.is_empty() {
+            pricing.compute_cost_usd(
+                &model,
+                TokenCounts {
+                    prompt: prompt_tokens,
+                    completion: completion_tokens,
+                    prompt_cached: prompt_cached_tokens,
+                    prompt_cache_creation: prompt_cache_creation_tokens,
+                },
+            )
+        } else {
+            None
+        }
+    });
 
     Some(Box::new(UsageRecord {
         model,

--- a/crates/executor/src/basic_tests.rs
+++ b/crates/executor/src/basic_tests.rs
@@ -45,6 +45,7 @@ async fn send_appends_user_and_assistant_messages() {
         .expect("conversation should exist");
     let executor = BasicExecutor::new(
         Arc::new(FakeModelClient::new(vec![ModelResponse {
+            provider_cost_usd: None,
             response_id: None,
             messages: vec![assistant_message("pong")],
             tool_calls: vec![],
@@ -130,6 +131,7 @@ async fn send_executes_tool_round_trip() {
     let tool_call_id = "call-1".to_string();
     let model = Arc::new(FakeModelClient::new(vec![
         ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![],
             tool_calls: vec![PendingToolCall {
@@ -145,6 +147,7 @@ async fn send_executes_tool_round_trip() {
             duration: None,
         },
         ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("done")],
             tool_calls: vec![],
@@ -249,6 +252,7 @@ async fn send_records_tool_result_when_tool_execution_fails() {
     let tool_call_id = "call-1".to_string();
     let model = Arc::new(FakeModelClient::new(vec![
         ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![],
             tool_calls: vec![PendingToolCall {
@@ -264,6 +268,7 @@ async fn send_records_tool_result_when_tool_execution_fails() {
             duration: None,
         },
         ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("recovered")],
             tool_calls: vec![],
@@ -369,6 +374,7 @@ async fn send_stream_emits_chunks_and_persists_final_response() {
                 UniversalStreamChunk::finish(0, "stop"),
             ],
             final_response: ModelResponse {
+                provider_cost_usd: None,
                 response_id: Some(Uuid7::now()),
                 messages: vec![assistant_message("hello")],
                 tool_calls: vec![],

--- a/crates/executor/src/executor_types.rs
+++ b/crates/executor/src/executor_types.rs
@@ -198,6 +198,10 @@ pub struct ModelResponse {
     /// Wall-clock duration from request start to end of response.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub duration: Option<Duration>,
+    /// Authoritative cost in USD reported by the provider (e.g. OpenRouter's
+    /// `usage.cost`), if any. Preferred over the price-table estimate when set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_cost_usd: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/executor/src/harness_basic_tests.rs
+++ b/crates/executor/src/harness_basic_tests.rs
@@ -109,6 +109,7 @@ async fn send_persists_messages_through_harness() {
     let harness = BasicHarness::new(
         exoharness,
         Arc::new(FakeModelClient::new(vec![ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("pong")],
             tool_calls: Vec::new(),
@@ -202,6 +203,7 @@ async fn usage_record_is_persisted_with_computed_cost() {
     let harness = BasicHarness::with_pricing_table(
         Arc::clone(&exoharness),
         Arc::new(FakeModelClient::new(vec![ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("pong")],
             tool_calls: Vec::new(),
@@ -347,6 +349,7 @@ async fn usage_record_with_anthropic_cache_hits() {
     let harness = BasicHarness::with_pricing_table(
         Arc::clone(&exoharness),
         Arc::new(FakeModelClient::new(vec![ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("pong")],
             tool_calls: Vec::new(),
@@ -465,6 +468,7 @@ async fn usage_record_with_openai_inclusive_accounting() {
     let harness = BasicHarness::with_pricing_table(
         Arc::clone(&exoharness),
         Arc::new(FakeModelClient::new(vec![ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("pong")],
             tool_calls: Vec::new(),
@@ -573,6 +577,7 @@ async fn close_session_appends_session_ended_event() {
     let harness = BasicHarness::new(
         Arc::clone(&exoharness),
         Arc::new(FakeModelClient::new(vec![ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("pong")],
             tool_calls: Vec::new(),
@@ -651,6 +656,7 @@ async fn updating_agent_config_refreshes_executor_cache() {
     );
     let model = Arc::new(FakeModelClient::new(vec![
         ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("pong-1")],
             tool_calls: Vec::new(),
@@ -660,6 +666,7 @@ async fn updating_agent_config_refreshes_executor_cache() {
             duration: None,
         },
         ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("pong-2")],
             tool_calls: Vec::new(),
@@ -733,6 +740,7 @@ async fn send_executes_shell_tool_when_enabled() {
     );
     let model = Arc::new(FakeModelClient::new(vec![
         ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: Vec::new(),
             tool_calls: vec![PendingToolCall {
@@ -748,6 +756,7 @@ async fn send_executes_shell_tool_when_enabled() {
             duration: None,
         },
         ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("done")],
             tool_calls: Vec::new(),
@@ -921,6 +930,7 @@ async fn updating_mounts_recreates_conversation_sandbox() {
     );
     let model = Arc::new(FakeModelClient::new(vec![
         ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: Vec::new(),
             tool_calls: vec![PendingToolCall {
@@ -936,6 +946,7 @@ async fn updating_mounts_recreates_conversation_sandbox() {
             duration: None,
         },
         ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("done-1")],
             tool_calls: Vec::new(),
@@ -945,6 +956,7 @@ async fn updating_mounts_recreates_conversation_sandbox() {
             duration: None,
         },
         ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: Vec::new(),
             tool_calls: vec![PendingToolCall {
@@ -960,6 +972,7 @@ async fn updating_mounts_recreates_conversation_sandbox() {
             duration: None,
         },
         ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("done-2")],
             tool_calls: Vec::new(),
@@ -1175,6 +1188,7 @@ async fn conversation_model_override_changes_effective_model() {
     );
     let model = Arc::new(FakeModelClient::new(vec![
         ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("first")],
             tool_calls: Vec::new(),
@@ -1184,6 +1198,7 @@ async fn conversation_model_override_changes_effective_model() {
             duration: None,
         },
         ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("second")],
             tool_calls: Vec::new(),
@@ -1193,6 +1208,7 @@ async fn conversation_model_override_changes_effective_model() {
             duration: None,
         },
         ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("third")],
             tool_calls: Vec::new(),

--- a/crates/executor/src/harness_runtime.rs
+++ b/crates/executor/src/harness_runtime.rs
@@ -108,9 +108,53 @@ fn resolve_runtime_config(
 ) -> Result<ResolvedRuntimeConfig> {
     if is_anthropic_model(&request.model) {
         resolve_anthropic_config(request, env)
+    } else if is_openrouter_request(request) {
+        resolve_openrouter_config(request, env)
     } else {
         resolve_openai_config(request, env)
     }
+}
+
+/// OpenRouter is an OpenAI-compatible aggregator selected by its base URL (it
+/// has no Responses API, so it can't be detected by model name the way native
+/// Anthropic is). A binding pointed at `openrouter.ai` routes through the
+/// OpenAI provider in Chat Completions mode.
+fn is_openrouter_request(request: &ModelRequest) -> bool {
+    request
+        .base_url
+        .as_deref()
+        .is_some_and(|url| url.contains("openrouter.ai"))
+}
+
+fn resolve_openrouter_config(
+    request: &ModelRequest,
+    env: &HashMap<String, String>,
+) -> Result<ResolvedRuntimeConfig> {
+    let key = request
+        .api_key
+        .clone()
+        .or_else(|| optional_env(env, "OPENROUTER_API_KEY"))
+        .ok_or_else(|| anyhow::anyhow!("model request is missing an API key"))?;
+    let endpoint = request
+        .base_url
+        .clone()
+        .map(|raw| Url::parse(&raw))
+        .transpose()?;
+    Ok(ResolvedRuntimeConfig {
+        provider_alias: "openrouter".to_string(),
+        // OpenRouter speaks the OpenAI Chat Completions wire format, so reuse
+        // the OpenAI provider but force Chat Completions (not Responses).
+        provider_kind: "openai".to_string(),
+        format: ProviderFormat::ChatCompletions,
+        endpoint,
+        endpoint_template: None,
+        metadata: HashMap::new(),
+        auth: AuthConfig::ApiKey {
+            key,
+            header: Some("authorization".to_string()),
+            prefix: Some("Bearer".to_string()),
+        },
+    })
 }
 
 /// Anthropic model bindings route to the native Messages API. We detect them by
@@ -368,6 +412,26 @@ mod tests {
 
         assert_eq!(config.provider_kind, "openai");
         assert_eq!(config.format, ProviderFormat::Responses);
+    }
+
+    #[test]
+    fn openrouter_bindings_use_openai_chat_completions() {
+        let mut request = model_request();
+        request.model = "openai/gpt-4o-mini".to_string();
+        request.api_key = Some("sk-or-test".to_string());
+        request.base_url = Some("https://openrouter.ai/api/v1".to_string());
+
+        let config = resolve_runtime_config(&request, &HashMap::new()).unwrap();
+
+        assert_eq!(config.provider_alias, "openrouter");
+        assert_eq!(config.provider_kind, "openai");
+        assert_eq!(config.format, ProviderFormat::ChatCompletions);
+        assert!(matches!(
+            config.auth,
+            AuthConfig::ApiKey { ref header, ref prefix, .. }
+                if header.as_deref() == Some("authorization")
+                    && prefix.as_deref() == Some("Bearer")
+        ));
     }
 
     #[test]

--- a/crates/executor/src/harness_runtime.rs
+++ b/crates/executor/src/harness_runtime.rs
@@ -23,7 +23,16 @@ use lingua::universal::{
 use lingua::{Message, ProviderFormat};
 use reqwest::Url;
 
-type UniversalChunkStream = Pin<Box<dyn Stream<Item = Result<UniversalStreamChunk>> + Send>>;
+type RawChunkStream = Pin<
+    Box<
+        dyn Stream<
+                Item = std::result::Result<
+                    braintrust_llm_router::StreamChunk,
+                    braintrust_llm_router::Error,
+                >,
+            > + Send,
+    >,
+>;
 
 #[derive(Debug, Default, Clone)]
 pub struct RouterModelClient {
@@ -47,8 +56,11 @@ impl ModelClient for RouterModelClient {
         let route = resolve_provider_route(&router, &request.model, format)?;
         let (prepared, _router_metadata) = router.create_request(payload, format, &route).await?;
         let body = router.complete(prepared, &ClientHeaders::new()).await?;
+        let provider_cost_usd = extract_provider_cost(&body);
         let response = lingua::response_to_universal(body)?;
-        normalize_model_response(response)
+        let mut model_response = normalize_model_response(response)?;
+        model_response.provider_cost_usd = provider_cost_usd;
+        Ok(model_response)
     }
 
     async fn complete_stream(&self, request: ModelRequest) -> Result<Box<dyn ModelResponseStream>> {
@@ -65,29 +77,52 @@ impl ModelClient for RouterModelClient {
             .complete_stream(prepared, &ClientHeaders::new(), None)
             .await?;
         Ok(Box::new(RouterModelResponseStream {
-            stream: map_universal_stream(raw_stream, format),
+            raw: Box::pin(raw_stream),
+            format,
             accumulator: UniversalResponseAccumulator::default(),
+            provider_cost_usd: None,
         }))
     }
 }
 
 struct RouterModelResponseStream {
-    stream: UniversalChunkStream,
+    raw: RawChunkStream,
+    format: ProviderFormat,
     accumulator: UniversalResponseAccumulator,
+    provider_cost_usd: Option<f64>,
 }
 
 #[async_trait]
 impl ModelResponseStream for RouterModelResponseStream {
     async fn next_chunk(&mut self) -> Result<Option<UniversalStreamChunk>> {
-        let Some(chunk) = self.stream.next().await.transpose()? else {
-            return Ok(None);
-        };
-        self.accumulator.push(&chunk);
-        Ok(Some(chunk))
+        // Map raw provider chunks to universal chunks inline (rather than via a
+        // pre-mapped stream) so we can also read the provider-reported cost off
+        // the raw bytes — it rides in `usage.cost` on the final chunk and isn't
+        // preserved by lingua's UniversalUsage.
+        loop {
+            let Some(raw) = self.raw.next().await.transpose()? else {
+                return Ok(None);
+            };
+            if let Some(cost) = extract_provider_cost(&raw.data) {
+                self.provider_cost_usd = Some(cost);
+            }
+            match lingua::parse_stream_event(raw.data, self.format, self.format) {
+                Ok(parsed) => {
+                    if let Some(chunk) = parsed.universal {
+                        self.accumulator.push(&chunk);
+                        return Ok(Some(chunk));
+                    }
+                    // Non-content event (e.g. a usage-only final chunk): keep reading.
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
     }
 
     async fn finish(self: Box<Self>) -> Result<ModelResponse> {
-        normalize_model_response(self.accumulator.finalize())
+        let mut response = normalize_model_response(self.accumulator.finalize())?;
+        response.provider_cost_usd = self.provider_cost_usd;
+        Ok(response)
     }
 }
 
@@ -435,6 +470,16 @@ mod tests {
     }
 
     #[test]
+    fn extracts_provider_reported_cost_from_usage() {
+        let body = br#"{"usage":{"prompt_tokens":16,"completion_tokens":6,"cost":0.000006}}"#;
+        assert_eq!(extract_provider_cost(body), Some(0.000006));
+
+        // No cost field (OpenAI/Anthropic) -> None, and cheaply skipped.
+        let no_cost = br#"{"usage":{"prompt_tokens":16,"completion_tokens":6}}"#;
+        assert_eq!(extract_provider_cost(no_cost), None);
+    }
+
+    #[test]
     fn chat_completions_stream_request_includes_lingua_usage_stream_option() {
         let request = build_universal_request(&model_request(), true).unwrap();
         let serialized = serialize_request(ProviderFormat::ChatCompletions, &request).unwrap();
@@ -527,25 +572,18 @@ fn serialize_request(format: ProviderFormat, request: &UniversalRequest) -> Resu
     Ok(Bytes::from(lingua_json::to_vec(&payload)?))
 }
 
-fn map_universal_stream<S>(raw_stream: S, format: ProviderFormat) -> UniversalChunkStream
-where
-    S: Stream<
-            Item = std::result::Result<
-                braintrust_llm_router::StreamChunk,
-                braintrust_llm_router::Error,
-            >,
-        > + Send
-        + 'static,
-{
-    Box::pin(raw_stream.filter_map(move |item| async move {
-        match item {
-            Ok(chunk) => match lingua::parse_stream_event(chunk.data, format, format) {
-                Ok(parsed) => parsed.universal.map(Ok),
-                Err(error) => Some(Err(error.into())),
-            },
-            Err(error) => Some(Err(error.into())),
-        }
-    }))
+/// Some providers (e.g. OpenRouter) report the authoritative dollar cost of a
+/// request in `usage.cost`. lingua's `UniversalUsage` doesn't carry that field,
+/// so we read it straight off the raw response/stream JSON. Returns `None` when
+/// absent (the common case — OpenAI and Anthropic don't send it).
+fn extract_provider_cost(data: &[u8]) -> Option<f64> {
+    // Cheap guard so we don't JSON-parse every streamed content chunk; only the
+    // final usage chunk carries a cost field.
+    if !data.windows(6).any(|window| window == b"\"cost\"") {
+        return None;
+    }
+    let value: lingua_json::Value = lingua_json::from_slice(data).ok()?;
+    value.get("usage")?.get("cost")?.as_f64()
 }
 
 fn normalize_model_response(response: UniversalResponse) -> Result<ModelResponse> {
@@ -553,6 +591,7 @@ fn normalize_model_response(response: UniversalResponse) -> Result<ModelResponse
     let tool_calls = extract_tool_calls(&response.messages)?;
 
     Ok(ModelResponse {
+        provider_cost_usd: None,
         response_id,
         messages: response.messages,
         tool_calls,

--- a/crates/executor/src/rlm_tests.rs
+++ b/crates/executor/src/rlm_tests.rs
@@ -30,6 +30,7 @@ async fn rlm_send_executes_repl_steps_and_persists_final_answer() {
     ) as Arc<dyn ExoHarness>;
     let model = Arc::new(FakeModelClient::new(vec![
         ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("Inspecting the transcript.")],
             tool_calls: vec![PendingToolCall {
@@ -51,6 +52,7 @@ async fn rlm_send_executes_repl_steps_and_persists_final_answer() {
             duration: None,
         },
         ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("FINAL(done)")],
             tool_calls: Vec::new(),
@@ -136,6 +138,7 @@ async fn rlm_subquery_variable_can_store_final_answer() {
     ) as Arc<dyn ExoHarness>;
     let model = Arc::new(FakeModelClient::new(vec![
         ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("Preparing a smaller prompt.")],
             tool_calls: vec![PendingToolCall {
@@ -154,6 +157,7 @@ async fn rlm_subquery_variable_can_store_final_answer() {
             duration: None,
         },
         ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("Delegating the arithmetic.")],
             tool_calls: vec![PendingToolCall {
@@ -182,6 +186,7 @@ async fn rlm_subquery_variable_can_store_final_answer() {
             duration: None,
         },
         ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("4")],
             tool_calls: Vec::new(),
@@ -191,6 +196,7 @@ async fn rlm_subquery_variable_can_store_final_answer() {
             duration: None,
         },
         ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("FINAL_VAR(final_answer)")],
             tool_calls: Vec::new(),
@@ -260,6 +266,7 @@ async fn rlm_send_stream_suppresses_internal_control_text() {
             UniversalStreamChunk::finish(0, "stop"),
         ],
         final_response: ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("FINAL(2)")],
             tool_calls: Vec::new(),
@@ -332,6 +339,7 @@ async fn rlm_exposes_history_via_get_messages() {
     ) as Arc<dyn ExoHarness>;
     let model = Arc::new(FakeModelClient::new(vec![
         ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("FINAL(recorded)")],
             tool_calls: Vec::new(),
@@ -341,6 +349,7 @@ async fn rlm_exposes_history_via_get_messages() {
             duration: None,
         },
         ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("Checking prior user content.")],
             tool_calls: vec![PendingToolCall {
@@ -372,6 +381,7 @@ globalThis.answer = String(\n\
             duration: None,
         },
         ModelResponse {
+            provider_cost_usd: None,
             response_id: Some(Uuid7::now()),
             messages: vec![assistant_message("FINAL_VAR(answer)")],
             tool_calls: Vec::new(),
@@ -438,6 +448,7 @@ async fn rlm_can_finish_by_setting_final_in_repl() {
             .expect("basic exoharness should initialize"),
     ) as Arc<dyn ExoHarness>;
     let model = Arc::new(FakeModelClient::new(vec![ModelResponse {
+        provider_cost_usd: None,
         response_id: Some(Uuid7::now()),
         messages: vec![assistant_message("Setting Final in the REPL.")],
         tool_calls: vec![PendingToolCall {

--- a/typescript/model-runtime/responses.test.ts
+++ b/typescript/model-runtime/responses.test.ts
@@ -5,6 +5,7 @@ import {
   AnthropicRuntime,
   ChatCompletionsRuntime,
   isAnthropicModel,
+  isOpenRouterBinding,
   modelRequiresResponsesApi,
   responseToLinguaEvents,
   responseToolCalls,
@@ -62,6 +63,21 @@ describe("model runtime dispatch", () => {
         apiKey: "key",
       }),
     ).toBeInstanceOf(AnthropicRuntime);
+  });
+
+  it("routes OpenRouter bindings through chat completions by base URL", () => {
+    expect(
+      isOpenRouterBinding({ baseUrl: "https://openrouter.ai/api/v1" }),
+    ).toBe(true);
+    expect(isOpenRouterBinding({ baseUrl: null })).toBe(false);
+    // A Responses-looking model name over OpenRouter still uses chat completions.
+    expect(
+      runtimeFromModelBinding(undefined, {
+        model: "openai/gpt-5-pro",
+        apiKey: "key",
+        baseUrl: "https://openrouter.ai/api/v1",
+      }),
+    ).toBeInstanceOf(ChatCompletionsRuntime);
   });
 });
 

--- a/typescript/model-runtime/responses.ts
+++ b/typescript/model-runtime/responses.ts
@@ -5,6 +5,7 @@ import {
   initLogger,
   traced,
   wrapAnthropic,
+  wrapOpenAI,
   type Span,
   type StartSpanArgs,
 } from "braintrust";
@@ -133,12 +134,18 @@ export class ResponsesRuntime implements ResponsesRuntimeLike {
 
   constructor(options: ResponsesRuntimeOptions = {}) {
     ensureBraintrustLogger(options.braintrust ?? null);
-    this.client = new OpenAI({
-      apiKey: options.apiKey,
-      baseURL: options.baseURL,
-      organization: options.organization,
-      project: options.project,
-    });
+    // wrapOpenAI auto-instruments chat.completions/responses calls with a
+    // braintrust LLM span. Also covers the OpenRouter path (same OpenAI client,
+    // just a different base URL) — braintrust's wrapOpenRouter is for their
+    // native SDK, not the OpenAI SDK, so it doesn't apply here.
+    this.client = wrapOpenAI(
+      new OpenAI({
+        apiKey: options.apiKey,
+        baseURL: options.baseURL,
+        organization: options.organization,
+        project: options.project,
+      }),
+    );
   }
 
   static fromEnvironment(agentConfig?: AgentConfig): ResponsesRuntime {
@@ -233,50 +240,13 @@ export class ResponsesRuntime implements ResponsesRuntimeLike {
     request: NativeResponsesRequest,
     options: NativeLlmTraceOptions,
   ): Promise<NativeLlmResult> {
-    const toolNames = (request.tools ?? []).map((tool) => tool.name);
-    const run = async (span: Span): Promise<NativeLlmResult> => {
-      try {
-        const result = options.streamed
-          ? await this.completeStreamRaw(
-              buildStreamingBody(request),
-              options.handlers,
-            )
-          : {
-              response: await this.completeRaw(buildNonStreamingBody(request)),
-              ttftMs: null,
-            };
-
-        span.log({
-          output: llmOutputTraceValue(result.response),
-          metadata: {
-            response_id: result.response.id,
-          },
-          metrics: responseUsageMetrics(result.response, result.ttftMs),
-        });
-        return result;
-      } catch (error) {
-        span.log({ error: errorMessage(error) });
-        throw error;
-      }
+    if (options.streamed) {
+      return this.completeStreamRaw(buildStreamingBody(request), options.handlers);
+    }
+    return {
+      response: await this.completeRaw(buildNonStreamingBody(request)),
+      ttftMs: null,
     };
-    const spanArgs = {
-      name: `responses:${request.model}`,
-      type: "llm" as const,
-      event: {
-        input: llmInputTraceValue(request),
-        metadata: {
-          round_index: options.roundIndex,
-          runtime: "responses",
-          model: request.model,
-          max_output_tokens: request.maxOutputTokens ?? null,
-          tool_count: toolNames.length,
-          tools: toolNames,
-          streamed: options.streamed,
-        },
-      },
-    };
-
-    return tracedUnderParent(options.parent, run, spanArgs);
   }
 
   private async completeRaw(
@@ -372,12 +342,18 @@ export class ChatCompletionsRuntime implements ResponsesRuntimeLike {
 
   constructor(options: ResponsesRuntimeOptions = {}) {
     ensureBraintrustLogger(options.braintrust ?? null);
-    this.client = new OpenAI({
-      apiKey: options.apiKey,
-      baseURL: options.baseURL,
-      organization: options.organization,
-      project: options.project,
-    });
+    // wrapOpenAI auto-instruments chat.completions/responses calls with a
+    // braintrust LLM span. Also covers the OpenRouter path (same OpenAI client,
+    // just a different base URL) — braintrust's wrapOpenRouter is for their
+    // native SDK, not the OpenAI SDK, so it doesn't apply here.
+    this.client = wrapOpenAI(
+      new OpenAI({
+        apiKey: options.apiKey,
+        baseURL: options.baseURL,
+        organization: options.organization,
+        project: options.project,
+      }),
+    );
   }
 
   static fromModelBinding(
@@ -462,50 +438,18 @@ export class ChatCompletionsRuntime implements ResponsesRuntimeLike {
     request: NativeResponsesRequest,
     options: NativeLlmTraceOptions,
   ): Promise<NativeLlmResult> {
-    const toolNames = (request.tools ?? []).map((tool) => tool.name);
-    const run = async (span: Span): Promise<NativeLlmResult> => {
-      try {
-        const result = options.streamed
-          ? await this.completeStreamRaw(
-              buildChatStreamingBody(request),
-              options.handlers,
-            )
-          : {
-              response: chatCompletionToResponse(
-                await this.completeRaw(buildChatNonStreamingBody(request)),
-              ),
-              ttftMs: null,
-            };
-
-        span.log({
-          output: llmOutputTraceValue(result.response),
-          metadata: {
-            response_id: result.response.id,
-          },
-          metrics: responseUsageMetrics(result.response, result.ttftMs),
-        });
-        return result;
-      } catch (error) {
-        span.log({ error: errorMessage(error) });
-        throw error;
-      }
+    if (options.streamed) {
+      return this.completeStreamRaw(
+        buildChatStreamingBody(request),
+        options.handlers,
+      );
+    }
+    return {
+      response: chatCompletionToResponse(
+        await this.completeRaw(buildChatNonStreamingBody(request)),
+      ),
+      ttftMs: null,
     };
-    return tracedUnderParent(options.parent, run, {
-      name: `chat:${request.model}`,
-      type: "llm",
-      event: {
-        input: llmInputTraceValue(request),
-        metadata: {
-          round_index: options.roundIndex,
-          runtime: "chat_completions",
-          model: request.model,
-          max_output_tokens: request.maxOutputTokens ?? null,
-          tool_count: toolNames.length,
-          tools: toolNames,
-          streamed: options.streamed,
-        },
-      },
-    });
   }
 
   private async completeRaw(
@@ -1396,38 +1340,6 @@ function braintrustOptionsFromAgentConfig(
   }
 
   return options;
-}
-
-function llmInputTraceValue(request: NativeResponsesRequest): unknown {
-  return request.messages ?? request.input ?? null;
-}
-
-function llmOutputTraceValue(response: Response): Record<string, unknown> {
-  return {
-    messages: responseMessages(response),
-    tool_calls: responseToolCalls(response),
-    status: response.status,
-  };
-}
-
-function responseUsageMetrics(
-  response: Response,
-  ttftMs: number | null,
-): Record<string, number> {
-  const metrics: Record<string, number> = {};
-  const usage = response.usage;
-  if (usage) {
-    metrics.prompt_tokens = usage.input_tokens;
-    metrics.completion_tokens = usage.output_tokens;
-    metrics.tokens = usage.total_tokens;
-    metrics.prompt_cached_tokens = usage.input_tokens_details.cached_tokens;
-    metrics.completion_reasoning_tokens =
-      usage.output_tokens_details.reasoning_tokens;
-  }
-  if (ttftMs !== null) {
-    metrics.time_to_first_token = ttftMs / 1000;
-  }
-  return metrics;
 }
 
 function toolResultTraceOutput(events: EventData[]): unknown {

--- a/typescript/model-runtime/responses.ts
+++ b/typescript/model-runtime/responses.ts
@@ -332,6 +332,11 @@ export function runtimeFromModelBinding(
   if (isAnthropicModel(model)) {
     return AnthropicRuntime.fromModelBinding(agentConfig, binding);
   }
+  // OpenRouter is OpenAI-compatible but Chat Completions only (no Responses
+  // API), so force the chat path regardless of how the model name looks.
+  if (isOpenRouterBinding(binding)) {
+    return ChatCompletionsRuntime.fromModelBinding(agentConfig, binding);
+  }
   return modelRequiresResponsesApi(model)
     ? ResponsesRuntime.fromModelBinding(agentConfig, binding)
     : ChatCompletionsRuntime.fromModelBinding(agentConfig, binding);
@@ -342,6 +347,12 @@ export function runtimeFromModelBinding(
 // ids carry provider prefixes and intentionally don't match here.
 export function isAnthropicModel(model: string): boolean {
   return model.toLowerCase().startsWith("claude");
+}
+
+// OpenRouter is selected by its base URL (it aggregates many vendors, so the
+// model name isn't a reliable signal), mirroring the Rust runtime.
+export function isOpenRouterBinding(binding: ResponsesModelBinding): boolean {
+  return (binding.baseUrl ?? "").includes("openrouter.ai");
 }
 
 export function modelRequiresResponsesApi(model: string): boolean {

--- a/typescript/model-runtime/responses.ts
+++ b/typescript/model-runtime/responses.ts
@@ -234,7 +234,10 @@ export class ResponsesRuntime implements ResponsesRuntimeLike {
     options: NativeLlmTraceOptions,
   ): Promise<Response> {
     if (options.streamed) {
-      return this.completeStreamRaw(buildStreamingBody(request), options.handlers);
+      return this.completeStreamRaw(
+        buildStreamingBody(request),
+        options.handlers,
+      );
     }
     return this.completeRaw(buildNonStreamingBody(request));
   }
@@ -572,9 +575,7 @@ export class AnthropicRuntime implements ResponsesRuntimeLike {
     if (options.streamed) {
       return this.completeStreamRaw(body, options.handlers);
     }
-    return anthropicMessageToResponse(
-      await this.client.messages.create(body),
-    );
+    return anthropicMessageToResponse(await this.client.messages.create(body));
   }
 
   private async completeStreamRaw(

--- a/typescript/model-runtime/responses.ts
+++ b/typescript/model-runtime/responses.ts
@@ -119,11 +119,6 @@ export interface ResponsesRuntimeLike {
   ): Promise<EventData[]>;
 }
 
-interface NativeLlmResult {
-  response: Response;
-  ttftMs: number | null;
-}
-
 interface NativeLlmTraceOptions extends NativeTraceOptions {
   streamed: boolean;
   handlers?: NativeStreamHandlers;
@@ -182,11 +177,10 @@ export class ResponsesRuntime implements ResponsesRuntimeLike {
     request: NativeResponsesRequest,
     options: NativeTraceOptions = {},
   ): Promise<Response> {
-    const { response } = await this.runLlmRequest(request, {
+    return this.runLlmRequest(request, {
       ...options,
       streamed: false,
     });
-    return response;
   }
 
   async completeStream(
@@ -194,12 +188,11 @@ export class ResponsesRuntime implements ResponsesRuntimeLike {
     handlers: NativeStreamHandlers = {},
     options: NativeTraceOptions = {},
   ): Promise<Response> {
-    const { response } = await this.runLlmRequest(request, {
+    return this.runLlmRequest(request, {
       ...options,
       streamed: true,
       handlers,
     });
-    return response;
   }
 
   async traceToolCall(
@@ -239,14 +232,11 @@ export class ResponsesRuntime implements ResponsesRuntimeLike {
   private async runLlmRequest(
     request: NativeResponsesRequest,
     options: NativeLlmTraceOptions,
-  ): Promise<NativeLlmResult> {
+  ): Promise<Response> {
     if (options.streamed) {
       return this.completeStreamRaw(buildStreamingBody(request), options.handlers);
     }
-    return {
-      response: await this.completeRaw(buildNonStreamingBody(request)),
-      ttftMs: null,
-    };
+    return this.completeRaw(buildNonStreamingBody(request));
   }
 
   private async completeRaw(
@@ -258,7 +248,7 @@ export class ResponsesRuntime implements ResponsesRuntimeLike {
   private async completeStreamRaw(
     body: ResponseCreateParamsStreaming,
     handlers: NativeStreamHandlers = {},
-  ): Promise<NativeLlmResult> {
+  ): Promise<Response> {
     const startedAt = performance.now();
     let sawFirstChunk = false;
     let ttftMs: number | null = null;
@@ -287,10 +277,7 @@ export class ResponsesRuntime implements ResponsesRuntimeLike {
     if (!finalResponse) {
       throw new Error("Responses API stream ended without completion");
     }
-    return {
-      response: finalResponse,
-      ttftMs,
-    };
+    return finalResponse;
   }
 }
 
@@ -380,11 +367,10 @@ export class ChatCompletionsRuntime implements ResponsesRuntimeLike {
     request: NativeResponsesRequest,
     options: NativeTraceOptions = {},
   ): Promise<Response> {
-    const { response } = await this.runLlmRequest(request, {
+    return this.runLlmRequest(request, {
       ...options,
       streamed: false,
     });
-    return response;
   }
 
   async completeStream(
@@ -392,12 +378,11 @@ export class ChatCompletionsRuntime implements ResponsesRuntimeLike {
     handlers: NativeStreamHandlers = {},
     options: NativeTraceOptions = {},
   ): Promise<Response> {
-    const { response } = await this.runLlmRequest(request, {
+    return this.runLlmRequest(request, {
       ...options,
       streamed: true,
       handlers,
     });
-    return response;
   }
 
   async traceToolCall(
@@ -437,19 +422,16 @@ export class ChatCompletionsRuntime implements ResponsesRuntimeLike {
   private async runLlmRequest(
     request: NativeResponsesRequest,
     options: NativeLlmTraceOptions,
-  ): Promise<NativeLlmResult> {
+  ): Promise<Response> {
     if (options.streamed) {
       return this.completeStreamRaw(
         buildChatStreamingBody(request),
         options.handlers,
       );
     }
-    return {
-      response: chatCompletionToResponse(
-        await this.completeRaw(buildChatNonStreamingBody(request)),
-      ),
-      ttftMs: null,
-    };
+    return chatCompletionToResponse(
+      await this.completeRaw(buildChatNonStreamingBody(request)),
+    );
   }
 
   private async completeRaw(
@@ -461,7 +443,7 @@ export class ChatCompletionsRuntime implements ResponsesRuntimeLike {
   private async completeStreamRaw(
     body: ChatCompletionCreateParamsStreaming,
     handlers: NativeStreamHandlers = {},
-  ): Promise<NativeLlmResult> {
+  ): Promise<Response> {
     const startedAt = performance.now();
     let sawFirstChunk = false;
     let ttftMs: number | null = null;
@@ -481,10 +463,7 @@ export class ChatCompletionsRuntime implements ResponsesRuntimeLike {
       }
     }
 
-    return {
-      response: accumulator.finalize(),
-      ttftMs,
-    };
+    return accumulator.finalize();
   }
 }
 
@@ -533,11 +512,10 @@ export class AnthropicRuntime implements ResponsesRuntimeLike {
     request: NativeResponsesRequest,
     options: NativeTraceOptions = {},
   ): Promise<Response> {
-    const { response } = await this.runLlmRequest(request, {
+    return this.runLlmRequest(request, {
       ...options,
       streamed: false,
     });
-    return response;
   }
 
   async completeStream(
@@ -545,12 +523,11 @@ export class AnthropicRuntime implements ResponsesRuntimeLike {
     handlers: NativeStreamHandlers = {},
     options: NativeTraceOptions = {},
   ): Promise<Response> {
-    const { response } = await this.runLlmRequest(request, {
+    return this.runLlmRequest(request, {
       ...options,
       streamed: true,
       handlers,
     });
-    return response;
   }
 
   async traceToolCall(
@@ -590,23 +567,20 @@ export class AnthropicRuntime implements ResponsesRuntimeLike {
   private async runLlmRequest(
     request: NativeResponsesRequest,
     options: NativeLlmTraceOptions,
-  ): Promise<NativeLlmResult> {
+  ): Promise<Response> {
     const body = buildAnthropicBody(request);
     if (options.streamed) {
       return this.completeStreamRaw(body, options.handlers);
     }
-    return {
-      response: anthropicMessageToResponse(
-        await this.client.messages.create(body),
-      ),
-      ttftMs: null,
-    };
+    return anthropicMessageToResponse(
+      await this.client.messages.create(body),
+    );
   }
 
   private async completeStreamRaw(
     body: Anthropic.MessageCreateParamsNonStreaming,
     handlers: NativeStreamHandlers = {},
-  ): Promise<NativeLlmResult> {
+  ): Promise<Response> {
     const startedAt = performance.now();
     let sawFirstChunk = false;
     let ttftMs: number | null = null;
@@ -626,10 +600,7 @@ export class AnthropicRuntime implements ResponsesRuntimeLike {
       }
     }
 
-    return {
-      response: anthropicMessageToResponse(await stream.finalMessage()),
-      ttftMs,
-    };
+    return anthropicMessageToResponse(await stream.finalMessage());
   }
 }
 


### PR DESCRIPTION
Builds on #81 (native Anthropic support). Three things:

### 1. OpenRouter provider support (both runtimes)
OpenRouter is OpenAI-compatible but Chat Completions only (no Responses API), so it's selected by **base URL** rather than model name (its ids are vendor-prefixed, e.g. `openai/gpt-4o-mini`).
- **Rust** (`harness_runtime.rs`): `resolve_runtime_config` adds an `is_openrouter_request` branch (base URL contains `openrouter.ai`) → OpenAI provider in `ChatCompletions` format, Bearer auth, `OPENROUTER_API_KEY` fallback.
- **TypeScript** (`responses.ts`): `runtimeFromModelBinding` routes OpenRouter bindings to `ChatCompletionsRuntime` regardless of model name.

Register:
```
exo secret set openrouter --env OPENROUTER_API_KEY
exo model register or --model "openai/gpt-4o-mini" --secret openrouter --base-url https://openrouter.ai/api/v1
```

### 2. Provider-reported cost
OpenRouter returns the authoritative request cost in `usage.cost`, but the LiteLLM price table is keyed by bare model ids and misses the vendor-prefixed ones. Added `ModelResponse.provider_cost_usd`: a generic provider-reported cost that `build_usage_record` prefers over the price-table estimate, populated from `usage.cost` on both the non-streaming and streaming paths. OpenAI/Anthropic don't send the field, so they keep using the table.

### 3. Tracing via braintrust wrap* helpers
Following PR #81 review feedback (use `wrapAnthropic`), migrated **all three** runtimes to the braintrust wrappers (`wrapOpenAI` + `wrapAnthropic`) and deleted the hand-rolled LLM spans plus the now-dead `llmInputTraceValue`/`llmOutputTraceValue`/`responseUsageMetrics`/`NativeLlmResult` scaffolding. Tracing is now uniform across runtimes and captures the native wire call instead of the normalized `Response`.

Note on `wrapOpenRouter`: it instruments OpenRouter's *native SDK* (`chat.send`/`callModel`), not the OpenAI SDK we use for the OpenRouter path, so `wrapOpenAI` is the correct wrapper there.

### Verification
Live end-to-end on all four paths (chat + streaming + multi-round tool calls): OpenAI chat (gpt-4o-mini), OpenAI Responses (gpt-5.4-nano), OpenRouter, Anthropic. Cost confirmed flowing from the provider on OpenRouter; Anthropic still computes from the table. `cargo test`, `pnpm typecheck`, `vitest`, and lint all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)