### PR TITLE
Restore --networking flag on conversation create/update

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -681,6 +681,8 @@ struct ConversationSandboxRuntimeArgs {
     sandbox_provider: Option<SandboxProviderArg>,
     #[arg(long)]
     shell_program: Option<String>,
+    #[arg(long, value_enum)]
+    networking: Option<EnabledDisabled>,
 }
 
 impl ConversationSandboxRuntimeArgs {
@@ -713,6 +715,8 @@ struct ConversationSandboxRuntimeUpdateArgs {
     clear_sandbox_image: bool,
     #[arg(long)]
     clear_sandbox_provider: bool,
+    #[arg(long)]
+    clear_networking: bool,
 }
 
 impl ConversationSandboxRuntimeUpdateArgs {
@@ -725,6 +729,9 @@ impl ConversationSandboxRuntimeUpdateArgs {
         }
         if self.clear_sandbox_provider && self.runtime.sandbox_provider.is_some() {
             bail!("provide either --clear-sandbox-provider or --sandbox-provider, not both");
+        }
+        if self.clear_networking && self.runtime.networking.is_some() {
+            bail!("provide either --clear-networking or --networking, not both");
         }
         self.runtime.validate()?;
 
@@ -750,6 +757,14 @@ impl ConversationSandboxRuntimeUpdateArgs {
             changed = true;
         } else if let Some(sandbox_provider) = self.runtime.sandbox_provider {
             config.sandbox_provider = Some(SandboxProvider::from(sandbox_provider));
+            changed = true;
+        }
+
+        if self.clear_networking {
+            config.enable_networking = None;
+            changed = true;
+        } else if let Some(networking) = self.runtime.networking {
+            config.enable_networking = Some(networking.enabled());
             changed = true;
         }
 
@@ -1334,6 +1349,7 @@ async fn main() -> Result<()> {
                             .sandbox_provider
                             .map(SandboxProvider::from),
                         shell_program: sandbox_runtime.shell_program,
+                        enable_networking: sandbox_runtime.networking.map(EnabledDisabled::enabled),
                     })
                     .await?;
                 if let Some(sandbox_scope) = sandbox_scope {

--- a/crates/executor/src/conversation_sandbox.rs
+++ b/crates/executor/src/conversation_sandbox.rs
@@ -149,7 +149,9 @@ pub(crate) fn conversation_sandbox_spec(
             .unwrap_or_else(|| "/".to_string()),
         file_system_mounts: normalize_mounts(&config.mounts),
         durable_file_systems: config.durable_file_systems.clone(),
-        enable_networking: agent_config.enable_networking,
+        enable_networking: config
+            .enable_networking
+            .unwrap_or(agent_config.enable_networking),
         idle_seconds: 300,
     }
 }

--- a/crates/executor/src/executor_types.rs
+++ b/crates/executor/src/executor_types.rs
@@ -72,6 +72,8 @@ pub struct ConversationConfig {
     pub durable_file_systems: Vec<DurableFileSystem>,
     #[serde(default)]
     pub sandbox_scope: Option<SandboxScope>,
+    #[serde(default)]
+    pub enable_networking: Option<bool>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -109,6 +111,7 @@ impl Default for ConversationConfig {
             mounts: Vec::new(),
             durable_file_systems: Vec::new(),
             sandbox_scope: None,
+            enable_networking: None,
         }
     }
 }

--- a/crates/executor/src/harness_facade.rs
+++ b/crates/executor/src/harness_facade.rs
@@ -249,6 +249,7 @@ where
             mounts: default_conversation_config.mounts,
             durable_file_systems: default_conversation_config.durable_file_systems,
             sandbox_scope: default_conversation_config.sandbox_scope,
+            enable_networking: request.enable_networking,
         };
         self.runtime
             .put_conversation_config(conversation.as_ref(), conversation_config)

--- a/crates/executor/src/harness_tool.rs
+++ b/crates/executor/src/harness_tool.rs
@@ -902,7 +902,9 @@ pub(crate) async fn ensure_shell_sandbox(
     // Empty means "unspecified"; the harness fills the provider's default.
     let requested_image = config.effective_sandbox_image(agent_config);
     let desired_image = requested_image.map(str::to_string).unwrap_or_default();
-    let desired_enable_networking = agent_config.enable_networking;
+    let desired_enable_networking = config
+        .enable_networking
+        .unwrap_or(agent_config.enable_networking);
 
     if let Some(sandbox) = latest_shell_sandbox(conversation, desired_provider).await? {
         // When no image was requested, the stored sandbox holds the provider's

--- a/crates/executor/src/harness_types.rs
+++ b/crates/executor/src/harness_types.rs
@@ -81,4 +81,5 @@ pub struct CreateConversationRequest {
     pub sandbox_image: Option<String>,
     pub sandbox_provider: Option<SandboxProvider>,
     pub shell_program: Option<String>,
+    pub enable_networking: Option<bool>,
 }

--- a/examples/typescript/opencode-harness.ts
+++ b/examples/typescript/opencode-harness.ts
@@ -573,6 +573,11 @@ function opencodeSandboxEnv(
   }
   if (modelBinding.apiKey) {
     env.OPENCODE_API_KEY = modelBinding.apiKey;
+    const provider =
+      modelBinding.model.split("/")[0]?.toUpperCase().replace(/-/g, "_") ?? "";
+    if (provider) {
+      env[`${provider}_API_KEY`] = modelBinding.apiKey;
+    }
   }
   return env;
 }

--- a/scripts/agent-harness-e2e.ts
+++ b/scripts/agent-harness-e2e.ts
@@ -254,7 +254,15 @@ function runHistoryReplayCheck(
   writeFileSync(join(workspace, "tool-marker.txt"), `${toolMarker}\n`);
 
   const conversation = `history-${harness.key}-${runId}`;
-  runExo(["conversation", "create", agent.slug, "--slug", conversation]);
+  runExo([
+    "conversation",
+    "create",
+    agent.slug,
+    "--slug",
+    conversation,
+    "--networking",
+    "enabled",
+  ]);
   runExo([
     "conversation",
     "mount",
@@ -264,14 +272,6 @@ function runHistoryReplayCheck(
     workspace,
     "/workspace",
     "--rw",
-  ]);
-  runExo([
-    "conversation",
-    "update",
-    agent.slug,
-    conversation,
-    "--networking",
-    "enabled",
   ]);
 
   const codeWord = `${harness.key}-blue-lantern-${runId}`;
@@ -361,7 +361,15 @@ function runFilesystemSandboxCheck(
   writeFileSync(join(outside, "secret.txt"), `${outsideMarker}\n`);
 
   const conversation = `sandbox-${harness.key}-${runId}`;
-  runExo(["conversation", "create", agent.slug, "--slug", conversation]);
+  runExo([
+    "conversation",
+    "create",
+    agent.slug,
+    "--slug",
+    conversation,
+    "--networking",
+    "enabled",
+  ]);
   runExo([
     "conversation",
     "mount",
@@ -371,14 +379,6 @@ function runFilesystemSandboxCheck(
     workspace,
     "/workspace",
     "--rw",
-  ]);
-  runExo([
-    "conversation",
-    "update",
-    agent.slug,
-    conversation,
-    "--networking",
-    "enabled",
   ]);
 
   const outsideSecret = join(outside, "secret.txt");
@@ -454,7 +454,15 @@ function runNetworkDisabledCheck(
     join(tmpdir(), `exo-${harness.key}-network-workspace-`),
   );
   const conversation = `network-${harness.key}-${runId}`;
-  runExo(["conversation", "create", agent.slug, "--slug", conversation]);
+  runExo([
+    "conversation",
+    "create",
+    agent.slug,
+    "--slug",
+    conversation,
+    "--networking",
+    "disabled",
+  ]);
   runExo([
     "conversation",
     "mount",
@@ -464,14 +472,6 @@ function runNetworkDisabledCheck(
     workspace,
     "/workspace",
     "--rw",
-  ]);
-  runExo([
-    "conversation",
-    "update",
-    agent.slug,
-    conversation,
-    "--networking",
-    "disabled",
   ]);
 
   let failedText: string | null = null;


### PR DESCRIPTION
The --networking flag was accidentally dropped from conversation-level CLI commands when sandbox settings were refactored into ConversationSandboxRuntimeArgs (commit 3f206d6, PR #25). The flag remained on agent create/update, and the underlying enable_networking field stayed in the exoharness API, but conversation create/update lost their CLI surface for controlling it.

This restores --networking on both conversation create and conversation update by:
- Adding networking to ConversationSandboxRuntimeArgs
- Adding --clear-networking to ConversationSandboxRuntimeUpdateArgs
- Adding enable_networking: Option<bool> to ConversationConfig and CreateConversationRequest
- Wiring the conversation-level override through conversation_sandbox and harness_tool so it falls back to the agent default when unset

Also updates agent-harness-e2e.ts to pass --networking at conversation create time (instead of a separate conversation update call) so the sandbox is created with the correct networking policy from the start.

Finally, injects provider-specific API key env vars (e.g. FIREWORKS_API_KEY) into the opencode sandbox env alongside OPENCODE_API_KEY, so the opencode server can resolve non-default providers.