### PR TITLE
setup: leave existing Exo checkouts untouched

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -445,29 +445,12 @@ backup_existing_install_dir() {
   echo "Backed up existing files to $backup_dir"
 }
 
-update_existing_checkout() {
-  local dir="$1"
-  echo "Updating existing Exo checkout at $dir"
-  if git -C "$dir" rev-parse --abbrev-ref --symbolic-full-name '@{u}' >/dev/null 2>&1; then
-    git -C "$dir" pull --rebase --autostash
-    return
-  fi
-
-  echo "No upstream branch is configured; fetching $REPO_REF from origin."
-  git -C "$dir" fetch origin "$REPO_REF"
-  if [[ "$(git -C "$dir" rev-parse --abbrev-ref HEAD)" == "HEAD" ]]; then
-    git -C "$dir" checkout FETCH_HEAD
-  else
-    git -C "$dir" rebase --autostash FETCH_HEAD
-  fi
-}
-
 clone_or_reuse_repo() {
   local install_dir="$1"
   local tmp_parent
   local tmp_checkout
   if is_exo_checkout "$install_dir"; then
-    update_existing_checkout "$install_dir"
+    echo "Using existing Exo checkout at $install_dir"
     return
   fi
   mkdir -p "$install_dir"


### PR DESCRIPTION
When setup finds an existing Exo checkout, treat it as user-owned and reuse it without trying to update it. This avoids pulling, fetching, checking out FETCH_HEAD, or rebasing a checkout that may be on a feature branch, detached, dirty, or otherwise managed outside setup.

Fresh installs still clone the requested REPO_REF.