### PR TITLE
Reject the reserved skill name 'index' to protect the catalog artifact

### DIFF
--- a/typescript/harness/skill-tools.test.ts
+++ b/typescript/harness/skill-tools.test.ts
@@ -243,6 +243,31 @@ describe("skill tools", () => {
     expect(noDescription.error).toMatch(/description/);
   });
 
+  it("rejects the reserved name index without touching the catalog", async () => {
+    const { context } = makeContext();
+    await call("install_skill", { skillMd: PDF_SKILL_MD }, context);
+    const result = (await call(
+      "install_skill",
+      {
+        skillMd:
+          "---\nname: index\ndescription: Shadows the catalog artifact.\n---\nbody",
+      },
+      context,
+    )) as { ok: boolean; error: string };
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/reserved/);
+
+    // The catalog must remain readable and unchanged.
+    const listed = (await call("list_skills", {}, context)) as {
+      ok: boolean;
+      skills: { name: string }[];
+    };
+    expect(listed.ok).toBe(true);
+    expect(listed.skills.map((skill) => skill.name)).toEqual([
+      "pdf-processing",
+    ]);
+  });
+
   it("rejects absolute and traversal file paths", async () => {
     const { context } = makeContext();
     for (const path of ["/etc/passwd", "../escape.txt", "a//b"]) {

--- a/typescript/harness/skill-tools.ts
+++ b/typescript/harness/skill-tools.ts
@@ -21,6 +21,9 @@ const SKILLS_INDEX_ARTIFACT_PATH = "skills/index.json";
 
 // agentskills.io spec: lowercase alphanumeric with single hyphens, 1-64 chars.
 const SKILL_NAME_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+// `index` would make skillArtifactPath collide with the catalog at
+// SKILLS_INDEX_ARTIFACT_PATH, shadowing the index and bricking the skill.
+const RESERVED_SKILL_NAMES = new Set(["index"]);
 const MAX_NAME_CHARS = 64;
 const MAX_DESCRIPTION_CHARS = 1024;
 // Soft caps so a single install cannot make the store unreasonably large.
@@ -149,6 +152,9 @@ function validateSkillName(name: string): string | null {
   }
   if (!SKILL_NAME_PATTERN.test(name)) {
     return "frontmatter name must be lowercase letters, digits, and single hyphens (e.g. pdf-processing)";
+  }
+  if (RESERVED_SKILL_NAMES.has(name)) {
+    return `${name} is a reserved skill name; choose a different name`;
   }
   return null;
 }


### PR DESCRIPTION
A skill named 'index' stored its content at skills/index.json, the same path as the skills catalog. The install shadowed the catalog (transiently corrupting reads mid-install) and the catalog shadowed the skill, so use_skill('index') always reported the content as corrupt.

Fixes #109