### PR TITLE
exoclaw: don't let a failing listArtifacts break prompt assembly

### DIFF
--- a/examples/exoclaw/todo-tools.test.ts
+++ b/examples/exoclaw/todo-tools.test.ts
@@ -186,4 +186,12 @@ describe("todo tools", () => {
     });
     expect(await todoInstruction(context)).toBeNull();
   });
+
+  it("treats a failing listArtifacts as empty instead of throwing", async () => {
+    const { context, conversation } = makeContext();
+    conversation.listArtifacts = async () => {
+      throw new Error("transient rpc failure");
+    };
+    expect(await todoInstruction(context)).toBeNull();
+  });
 });

--- a/examples/exoclaw/todo-tools.ts
+++ b/examples/exoclaw/todo-tools.ts
@@ -45,22 +45,23 @@ function todoHandle(context: TurnContext): TodoHandle {
 }
 
 async function readTodos(handle: TodoHandle): Promise<Todo[]> {
-  const latest = (await handle.listArtifacts())
-    .filter((artifact) => artifact.path === TODO_ARTIFACT_PATH)
-    .sort((a, b) => b.version - a.version)[0];
-  if (latest === undefined) {
-    return [];
-  }
   let raw: unknown;
   try {
+    const latest = (await handle.listArtifacts())
+      .filter((artifact) => artifact.path === TODO_ARTIFACT_PATH)
+      .sort((a, b) => b.version - a.version)[0];
+    if (latest === undefined) {
+      return [];
+    }
     raw = await handle.readArtifactJson({
       artifactId: latest.artifactId,
       version: latest.version,
     });
   } catch {
-    // A corrupt list is not worth bricking prompt assembly over; unlike
-    // memory it is fully regenerable, so treat it as empty and let the next
-    // todowrite overwrite it.
+    // A corrupt or unreadable list (including a transient listArtifacts
+    // failure) is not worth bricking prompt assembly over; unlike memory it
+    // is fully regenerable, so treat it as empty and let the next todowrite
+    // overwrite it.
     return [];
   }
   return isTodoList(raw) ? raw : [];


### PR DESCRIPTION
## What

Fixes #111. `readTodos` awaited `handle.listArtifacts()` outside its try/catch, so a transient RPC error from the list call threw out of `todoInstruction` and broke prompt assembly for that turn — while the sibling memory path degrades to empty on the same failure.

## Fix

Move the `listArtifacts()` call (and version selection) inside the existing try, per the issue's suggestion. The catch's rationale already applies: the todo list is fully regenerable by the next `todowrite`, so an unreadable list degrades to empty instead of bricking the turn.

## Tests

Added a regression test: a rejecting `listArtifacts` now yields a null todo instruction instead of throwing. `vitest` 7/7, lint/format/typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)