### PR TITLE
Move exo.sh to repo root, default to canonical template

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To use Exo as an agent, you'll need an OpenAI or OpenRouter API key. If you
 have that, simply do the following:
 
 ```
-curl -fsSL https://raw.githubusercontent.com/ankrgyl/exo/main/public/setup.sh -o setup.sh
+curl -fsSL https://raw.githubusercontent.com/ankrgyl/exo/main/setup.sh -o setup.sh
 bash setup.sh
 ```
 
@@ -68,6 +68,32 @@ Install python3 and curl in the sandbox. You don't need sudo, just use apt-get. 
 schedule a task to run every minute that grabs news headlines from the BBC RSS feed. Only print new headlines you've
 not printed before. Please print them here.
 ```
+
+## Operating Exo
+
+`setup.sh` is only for the first-time install. After that, `./exo.sh` in the
+repo root is the day-to-day control surface for your agent. Running it with no
+arguments starts (or reconnects to) the local agent so you can talk to it via
+the command line.
+
+```
+./exo.sh                # start the full stack (Docker sandbox, ExoChat) and open the CLI chat interface
+./exo.sh list           # list agents and conversations
+./exo.sh stop-all       # stop the scheduler and adapter runners; state is preserved
+./exo.sh fresh          # rebuild, delete all agents/conversations, start clean
+./exo.sh setup-profile  # update your local profile (name, preferences)
+./exo.sh --help         # all commands and options
+```
+
+The most common commands: use `stop-all` when you want to shut Exo down,
+plain `./exo.sh` to bring it back with all state intact, and `fresh` when you
+want to throw everything away and start over with a brand-new agent.
+
+By default `./exo.sh` uses the `canonical` template: a Docker sandbox, the repo
+mounted at `/workspace/exo`, and ExoChat for remote access. Pass
+`--template dev` for a developer variant that sets up IRC and Discord instead
+of ExoChat, or `--template minimal` for a bare REPL with no Docker defaults or
+adapter setup.
 
 ## Understanding Exo
 
@@ -120,7 +146,7 @@ There are a number of prompt files that Exo uses during runtime. You can edit th
   rules for the default Exo agent.
 - `.exo/exoclaw-profile.md`: local, git-ignored profile instructions such as
   your name and machine-specific preferences. Create or update it with
-  `scripts/exo.sh setup-profile`.
+  `./exo.sh setup-profile`.
 - `examples/exoclaw/harness.ts`: assembles the full prompt sent each turn,
   including dynamic instructions about tools, adapters, memory, sandbox behavior,
   and self-maintenance.

--- a/docs/exo-prompts.md
+++ b/docs/exo-prompts.md
@@ -218,13 +218,13 @@ Prefer concise operational answers.
 You can create it interactively with:
 
 ```bash
-scripts/exo.sh setup-profile
+./exo.sh setup-profile
 ```
 
 You can use a different local profile path with:
 
 - `EXOCLAW_LOCAL_PROMPT_FILE`
-- `scripts/exo.sh --local-prompt-file <path>`
+- `./exo.sh --local-prompt-file <path>`
 
 For committed Exoclaw behavior, use:
 
@@ -257,7 +257,7 @@ maintenance, Fal images, or sandbox scope.
 The Exoclaw launcher can send prompt files into the conversation before the REPL
 starts:
 
-- `scripts/exo.sh`
+- `./exo.sh`
 
 Important flags:
 
@@ -351,7 +351,7 @@ The model learns about sandbox behavior from harness instructions and tool
 descriptions. Exoclaw's developer prompt says that conversations default to the
 agent sandbox and explains when to use conversation or task sandboxes.
 
-`scripts/exo.sh` configures the important filesystem mounts:
+`./exo.sh` configures the important filesystem mounts:
 
 - this repository at `/workspace/exo`
 - the Fal image cache at `/fal`
@@ -360,7 +360,7 @@ agent sandbox and explains when to use conversation or task sandboxes.
 Relevant files:
 
 - `examples/exoclaw/harness.ts`
-- `scripts/exo.sh`
+- `./exo.sh`
 - `crates/executor/src/conversation_sandbox.rs`
 - `crates/executor/src/agent_sandbox.rs`
 

--- a/examples/exoclaw/README.md
+++ b/examples/exoclaw/README.md
@@ -22,7 +22,7 @@ cp .env.example .env   # then fill in OPENAI_API_KEY
 2. Tell Exoclaw who you are (optional but recommended):
 
 ```bash
-scripts/exo.sh setup-profile
+./exo.sh setup-profile
 ```
 
 This interactively asks for your name and any local instructions, and writes
@@ -33,7 +33,7 @@ reply. You can rerun this or edit the file directly at any time.
 3. Build and start everything with one command (run from the repo root):
 
 ```bash
-scripts/exo.sh fresh --canonical
+./exo.sh fresh
 ```
 
 This builds the `exo` binary, creates the agent and a `dev` conversation, pulls
@@ -42,10 +42,10 @@ scheduler and adapter runner, sets up the ExoChat adapter, prints a browser
 chat URL using the hosted control plane at `https://exoharness.ai`, and drops
 you into a REPL.
 
-For developer testing with IRC and Discord instead, use `canonical-dev`:
+For developer testing with IRC and Discord instead, use the `dev` template:
 
 ```bash
-scripts/exo.sh fresh --canonical-dev
+./exo.sh fresh --template dev
 ```
 
 4. Chat with Exoclaw in the REPL:
@@ -74,9 +74,9 @@ Notes:
 
 - `fresh` deletes existing agents, conversations, and adapters first. For
   day-to-day restarts that keep state, drop `fresh`:
-  `scripts/exo.sh canonical`
-- For a minimal start without adapter setup:
-  `scripts/exo.sh --pull-sandbox`
+  `./exo.sh`
+- For a minimal start without Docker defaults or adapter setup:
+  `./exo.sh --template minimal --pull-sandbox`
 
 ## Setting up Discord
 
@@ -99,14 +99,14 @@ path is:
 5. Create or confirm the adapter:
 
    ```bash
-   scripts/exo.sh --setup discord
+   ./exo.sh --setup discord
    ```
 
    If you are starting from scratch for adapter development, you can include
    Discord in the developer canonical setup:
 
    ```bash
-   scripts/exo.sh fresh --canonical-dev
+   ./exo.sh fresh --template dev
    ```
 
 6. Copy a Discord channel id for testing. In Discord, enable **User Settings** >
@@ -167,7 +167,7 @@ examples/exoclaw/scripts/exoclaw-service-guardian configure --sandbox-backend do
 ```
 
 The service guardian manages only the scheduler and adapter runners. Start or
-reconnect an interactive REPL with `scripts/exo.sh`.
+reconnect an interactive REPL with `./exo.sh`.
 
 Exoclaw can call the same host-side surface through the `guardian_action` tool.
 That tool exposes only allowlisted actions such as `status`, `build`,
@@ -176,7 +176,7 @@ Restart actions are handed off to a detached guardian process after a short
 delay so the current agent turn can finish before services stop. Detached
 restart output is written to `.exo/exoclaw-service-guardian-actions.log`.
 
-When `scripts/exo.sh --control` is running, it also acts
+When `./exo.sh --control` is running, it also acts
 as the foreground REPL supervisor. Guardian builds write
 `.exo/exo-control.restart`; the control wrapper sees that marker, restarts only
 the child `exo repl`, and keeps your terminal open.
@@ -192,7 +192,7 @@ it as an additional developer prompt when it exists, and `.exo` is ignored by
 git. To create it interactively:
 
 ```bash
-scripts/exo.sh setup-profile
+./exo.sh setup-profile
 ```
 
 The script asks for the user's name and any extra local instructions. To use a
@@ -251,33 +251,33 @@ Adapters are host-owned long-running runtimes for external applications. They
 are intentionally separate from scheduled sandbox commands: adapters own sockets,
 reconnect behavior, inbound message parsing, event history, and conversation
 wake-ups. Agents configure adapters with tools, and the local adapter runner
-started by `scripts/exo.sh` keeps them connected.
+started by `./exo.sh` keeps them connected.
 
 Exoclaw ships with ExoChat, IRC, WhatsApp, Signal, Discord, and agent-cli adapters
-(see `adapters/agent-cli/README.md` for the shell CLI). The canonical local
+(see `adapters/agent-cli/README.md` for the shell CLI). The default canonical
 setup turns on ExoChat:
 
 ```bash
-scripts/exo.sh canonical
+./exo.sh
 ```
 
 For developer testing with IRC and Discord, use:
 
 ```bash
-scripts/exo.sh canonical-dev
+./exo.sh --template dev
 ```
 
 To send every setup prompt before opening the REPL:
 
 ```bash
-scripts/exo.sh --setup-all
+./exo.sh --setup-all
 ```
 
 For a fresh control agent with a local profile prompt and all adapters:
 
 ```bash
 PATH="/opt/homebrew/opt/openjdk/bin:$PATH" \
-  scripts/exo.sh fresh \
+  ./exo.sh fresh \
   --agent exoclaw-agent \
   --agent-name "Exoclaw" \
   --conversation dev \
@@ -343,13 +343,13 @@ the cli. The following command will create a REPL with the agent and a
 persistent sandbox that will be durable across conversations
 
 ```bash
-scripts/exo.sh --pull-sandbox
+./exo.sh --pull-sandbox
 ```
 
 If you want a conversation to have its own sandbox, use `sandboxScope: "conversation"`:
 
 ```bash
-scripts/exo.sh --conversation isolated-dev --sandbox-scope conversation
+./exo.sh --conversation isolated-dev --sandbox-scope conversation
 exo --harness exoclaw conversation update exoclaw-agent isolated-dev --sandbox-scope conversation
 ```
 

--- a/examples/exoclaw/SELF.md
+++ b/examples/exoclaw/SELF.md
@@ -15,7 +15,7 @@ Use this map before changing Exoclaw itself.
 - `examples/exoclaw/prompts/me.md`: durable identity and operating rules.
 - `examples/exoclaw/guardian-tools.ts`: model-visible host maintenance tool.
 - `examples/exoclaw/scripts/exoclaw-service-guardian`: host-side build and service control.
-- `scripts/exo.sh`: local startup script for REPL, scheduler, adapters, sandbox, and repo mount.
+- `./exo.sh`: local startup script for REPL, scheduler, adapters, sandbox, and repo mount.
 - `examples/exoclaw/sandbox-tools.ts`: sandbox snapshot and rewind tool definitions.
 - `examples/exoclaw/introspection-tools.ts`: `list_adapter_events` and `list_conversation_events` introspection tools.
 - `examples/exoclaw/host-tools.ts`: `registerHostTool` helper that bridges TypeScript tool definitions to Rust execution.
@@ -44,11 +44,11 @@ Use this map before changing Exoclaw itself.
 From the repository root on the host:
 
 ```bash
-scripts/exo.sh canonical
+./exo.sh
 examples/exoclaw/scripts/exoclaw-service-guardian status
 examples/exoclaw/scripts/exoclaw-service-guardian build
 examples/exoclaw/scripts/exoclaw-service-guardian restart-all --build
-scripts/exo.sh --control
+./exo.sh --control
 ```
 
 Inside the Exoclaw sandbox, inspect the mounted code with:
@@ -122,7 +122,7 @@ inside the conversation before touching host services:
   to pick up a new build. Restart actions are deferred briefly so the current
   turn can finish before services stop; check status/logs after they come back.
 - In control mode, service guardian builds write `.exo/exo-control.restart`;
-  the `scripts/exo.sh --control` wrapper restarts only the child `exo repl` and
+  the `./exo.sh --control` wrapper restarts only the child `exo repl` and
   keeps the user's terminal open.
 - Service restarts drain gracefully: the guardian writes
   `.exo/exoclaw-adapters.restart` / `.exo/exoclaw-scheduler.restart`, the

--- a/examples/exoclaw/adapter-architecture.md
+++ b/examples/exoclaw/adapter-architecture.md
@@ -38,7 +38,7 @@ The implementation is split across a few small executor and CLI modules:
   used by Exoclaw.
 - `typescript/harness/adapter-tools.ts` exposes the model-facing Exoclaw tools.
 - `crates/cli/src/adapters.rs` provides `exo --harness exoclaw adapters ...`.
-- `scripts/exo.sh` starts the adapter runner next to the scheduler.
+- `./exo.sh` starts the adapter runner next to the scheduler.
 
 At a high level:
 
@@ -266,7 +266,7 @@ The adapter runner is started by:
 ./target/debug/exo --harness exoclaw adapters run --limit 50
 ```
 
-`scripts/exo.sh` starts this automatically unless `--no-adapters` is
+`./exo.sh` starts this automatically unless `--no-adapters` is
 provided. It also records a pid file at `.exo/exoclaw-adapters.pid`.
 
 The runtime periodically lists enabled adapters and starts one supervision task

--- a/examples/exoclaw/adapters/agent-cli/README.md
+++ b/examples/exoclaw/adapters/agent-cli/README.md
@@ -26,7 +26,7 @@ Put the client on your PATH:
 ln -s "$PWD/examples/exoclaw/scripts/exo-cli" ~/bin/exo-cli
 ```
 
-That is the only manual step. As long as the Exoclaw stack is running (`scripts/exo.sh canonical`), the first `exo-cli` invocation bootstraps everything else automatically: it adds the workspace mount (default `$HOME/projects` → `/agent-cli`, override with `EXOCLAW_AGENT_CLI_ROOT` / `EXOCLAW_AGENT_CLI_MOUNT`), sends the agent a message asking it to create the adapter, waits for the worker socket to appear, then delivers your prompt. Subsequent invocations skip straight to the socket.
+That is the only manual step. As long as the Exoclaw stack is running (`./exo.sh`), the first `exo-cli` invocation bootstraps everything else automatically: it adds the workspace mount (default `$HOME/projects` → `/agent-cli`, override with `EXOCLAW_AGENT_CLI_ROOT` / `EXOCLAW_AGENT_CLI_MOUNT`), sends the agent a message asking it to create the adapter, waits for the worker socket to appear, then delivers your prompt. Subsequent invocations skip straight to the socket.
 
 The adapter config the agent creates looks like:
 
@@ -46,7 +46,7 @@ The adapter config the agent creates looks like:
 You can also configure things explicitly at stack startup instead of relying on the bootstrap:
 
 ```bash
-scripts/exo.sh canonical \
+./exo.sh \
   --agent-cli-mount "$HOME/projects" \
   --setup agent-cli
 ```
@@ -59,7 +59,7 @@ scripts/exo.sh canonical \
 
 ## Quirks And Gotchas
 
-- The bootstrap requires the adapter runner to already be running; `exo-cli` cannot start the Exoclaw stack itself and will tell you to run `scripts/exo.sh canonical` if it is down.
+- The bootstrap requires the adapter runner to already be running; `exo-cli` cannot start the Exoclaw stack itself and will tell you to run `./exo.sh` if it is down.
 - The mount is part of the sandbox spec, not the adapter. The bootstrap adds it for you, but an already-running sandbox only picks it up when the sandbox is recreated.
 - `exo-cli` exits after the first reply. The conversation keeps its history, so a follow-up `exo-cli` invocation continues the same conversation context.
 - Replies can take as long as an agent turn. The client waits up to `EXO_AGENT_CLI_TIMEOUT_MS` (default 15 minutes).

--- a/examples/exoclaw/adapters/discord/README.md
+++ b/examples/exoclaw/adapters/discord/README.md
@@ -42,13 +42,13 @@ The setup prompt below expects the secret name to be `discord-bot-token`.
 Run the Exoclaw setup prompt:
 
 ```bash
-scripts/exo.sh --setup discord
+./exo.sh --setup discord
 ```
 
 If you are setting up a fresh local Exoclaw agent, use the same flags you normally use for your agent/conversation, for example:
 
 ```bash
-scripts/exo.sh \
+./exo.sh \
   --agent exospooky \
   --conversation dev \
   --setup discord

--- a/examples/exoclaw/adapters/exochat/README.md
+++ b/examples/exoclaw/adapters/exochat/README.md
@@ -6,10 +6,10 @@ so setup requires no phone number, bot token, or third-party workspace.
 
 ## Setup
 
-Use canonical setup:
+Use the default canonical setup:
 
 ```bash
-scripts/exo.sh fresh --canonical
+./exo.sh fresh
 ```
 
 The control script starts the adapter runner, watches `.exo/exoclaw-adapters.log`,
@@ -25,7 +25,7 @@ pnpm dlx wrangler dev --config website/wrangler.jsonc --port 8787
 Then start Exoclaw against it from the repo root:
 
 ```bash
-EXO_CHAT_BASE_URL=http://127.0.0.1:8787 scripts/exo.sh fresh --canonical
+EXO_CHAT_BASE_URL=http://127.0.0.1:8787 ./exo.sh fresh
 ```
 
 The setup prompt creates a library adapter similar to:

--- a/examples/exoclaw/adapters/irc/README.md
+++ b/examples/exoclaw/adapters/irc/README.md
@@ -24,7 +24,7 @@ For IRC plus Discord developer testing, run the developer canonical profile from
 the repo after setup:
 
 ```bash
-scripts/exo.sh fresh --canonical-dev
+./exo.sh fresh --template dev
 ```
 
 ## Adapter Setup
@@ -32,7 +32,7 @@ scripts/exo.sh fresh --canonical-dev
 Use the Exoclaw setup flow:
 
 ```bash
-scripts/exo.sh fresh --pull-sandbox --setup irc
+./exo.sh fresh --pull-sandbox --setup irc
 ```
 
 The setup prompt at `setup-prompt.md` asks Exoclaw to create a built-in adapter similar to:

--- a/examples/exoclaw/adapters/signal/README.md
+++ b/examples/exoclaw/adapters/signal/README.md
@@ -15,7 +15,7 @@ Incoming Signal messages become Exoclaw adapter message events. Outbound `send_a
 Install the JVM `signal-cli` distribution and Java, then make sure the `signal-cli` script and Java are available to the adapter worker. Run setup with:
 
 ```bash
-scripts/exo.sh fresh --pull-sandbox --setup signal
+./exo.sh fresh --pull-sandbox --setup signal
 ```
 
 The script watches `.exo/exoclaw-adapters.log`, prints the linked-device QR code if it appears, and pauses while you scan it from Signal: Settings > Linked devices > Link new device.
@@ -61,7 +61,7 @@ Java must be visible on `PATH` for the JVM script. On Homebrew macOS, prefix Exo
 
 ```bash
 PATH="/opt/homebrew/opt/openjdk/bin:$PATH" \
-scripts/exo.sh fresh --pull-sandbox --setup signal
+./exo.sh fresh --pull-sandbox --setup signal
 ```
 
 You can also add `/opt/homebrew/opt/openjdk/bin` to your shell profile.

--- a/examples/exoclaw/adapters/slack/README.md
+++ b/examples/exoclaw/adapters/slack/README.md
@@ -11,7 +11,7 @@ The MVP is text-only. The recommended setup wakes on `app_mention` events and Sl
 Start Exoclaw normally:
 
 ```bash
-scripts/exo.sh
+./exo.sh
 ```
 
 Then ask the agent:
@@ -25,7 +25,7 @@ The agent will walk you through creating the Slack app, storing secrets, creatin
 This startup shortcut is still available, but optional:
 
 ```bash
-scripts/exo.sh --setup slack
+./exo.sh --setup slack
 ```
 
 You do not need to run `pnpm slack:setup` for the chat-driven flow.
@@ -83,7 +83,7 @@ exo secret set slack-bot-token --value 'xoxb-...'
 During interactive setup, the agent creates the adapter after you confirm the Slack secrets are stored. You can also send the setup prompt while starting a fresh local Exoclaw agent:
 
 ```bash
-scripts/exo.sh \
+./exo.sh \
   --agent exospooky \
   --conversation dev \
   --setup slack

--- a/examples/exoclaw/adapters/whatsapp/README.md
+++ b/examples/exoclaw/adapters/whatsapp/README.md
@@ -13,7 +13,7 @@ When WhatsApp asks for pairing, the worker logs an ASCII QR code and emits a lif
 Use the Exoclaw setup flow:
 
 ```bash
-scripts/exo.sh fresh --pull-sandbox --setup whatsapp
+./exo.sh fresh --pull-sandbox --setup whatsapp
 ```
 
 The script watches `.exo/exoclaw-adapters.log`, prints the QR code if it appears, and pauses while you scan it. Scan from WhatsApp using the linked-device flow.

--- a/examples/exoclaw/docs/SELF-CONTROL.md
+++ b/examples/exoclaw/docs/SELF-CONTROL.md
@@ -32,14 +32,14 @@ This document defines the self-introspection and self-control capability areas w
 
 Exoclaw should always be able to inspect the code that defines its own behavior, change it, and restart itself on the new build.
 
-**Seeing its own code.** Local startup with `scripts/exo.sh` mounts the repository into the sandbox at `/workspace/exo` (configurable with `--self-repo-mount` or `EXOCLAW_REPO`). The shell tool therefore starts with a stable view of the source tree. `examples/exoclaw/SELF.md` is the checked-in self map — a compact navigation guide to prompts, harness assembly, adapters, scheduler, supervisors, and local state — and the harness tells Exoclaw its path each turn through `EXOCLAW_SELF_MAP`. The self map is intentionally navigational, not a full architecture document.
+**Seeing its own code.** Local startup with `./exo.sh` mounts the repository into the sandbox at `/workspace/exo` (configurable with `--self-repo-mount` or `EXOCLAW_REPO`). The shell tool therefore starts with a stable view of the source tree. `examples/exoclaw/SELF.md` is the checked-in self map — a compact navigation guide to prompts, harness assembly, adapters, scheduler, supervisors, and local state — and the harness tells Exoclaw its path each turn through `EXOCLAW_SELF_MAP`. The self map is intentionally navigational, not a full architecture document.
 
 **Editing its own code.** Edits happen through the shell tool against the repo mount. Git is the change history and the rollback mechanism for code: Exoclaw can diff, commit, and revert its own modifications (see area 8).
 
 **Building and rerunning itself.** Host-side actions happen outside the sandbox through two cooperating supervisors:
 
 - `examples/exoclaw/scripts/exoclaw-service-guardian` is the host service supervisor: it builds Exoclaw, shows service status, prints scheduler and adapter logs, and restarts the scheduler or adapter runners while preserving `.exo` state.
-- `scripts/exo.sh --control` is the terminal supervisor: it keeps the user's terminal open, streams service logs, runs the interactive `exo repl` as a child, and can restart only that child after a rebuild.
+- `./exo.sh --control` is the terminal supervisor: it keeps the user's terminal open, streams service logs, runs the interactive `exo repl` as a child, and can restart only that child after a rebuild.
 
 The model-visible `guardian_action` tool wraps the guardian script with a strict allowlist: `status`, `build`, `start_services`, `stop_services`, `restart_services`, `restart_adapters`, `restart_scheduler`, `restart_all`, and `logs`. It does not accept arbitrary shell commands. The `restart_*` actions are deferred briefly and handed to a detached guardian process so the current model turn can finish and report that the restart was scheduled. `restart_all` is the normal self-reboot path; `start_services`, `stop_services`, and `restart_services` are lower-level controls for the guardian-managed scheduler and adapter runner.
 
@@ -47,7 +47,7 @@ Service restarts drain instead of killing blindly: the guardian writes a restart
 
 Reboots are announced through the adapters: because restarts are deferred, the agent can post a "going down" message with `send_adapter_message` in the same turn that requests the restart. The guardian writes `.exo/exoclaw-reboot-notice.json`; the fresh adapter runner claims it and sends one wakeup per adapter conversation so the agent can announce its return. Announcements queue in the durable adapter outbox and deliver when the worker reconnects. Stale notices (older than 15 minutes) are discarded.
 
-The canonical local startup is `scripts/exo.sh canonical` (Docker provider/backend, repo self-map mount, guardian config, adapter setup prompts, control REPL). `fresh --canonical` gives the same shape from a clean agent/conversation state.
+The canonical local startup is plain `./exo.sh` (Docker provider/backend, repo self-map mount, guardian config, adapter setup prompts, control REPL — the default `--template canonical`). `./exo.sh fresh` gives the same shape from a clean agent/conversation state.
 
 ## 2. Durable Memory and Identity
 
@@ -173,7 +173,7 @@ What constitutes "Exoclaw" for cloning purposes (the area 2 inventory):
 
 Building blocks that already exist: conversation `fork` in the exoharness API, sandbox snapshots, the adapter records being plain JSON under `.exo`, and the canonical event log for the clone to know its own provenance (a `cloned_from` custom event would make lineage explicit).
 
-The likely path is an export/import pair: a guardian-level `export` action that produces a portable bundle (git ref + `.exo` state + secret manifest listing what must be re-provisioned + snapshot references), and a bootstrap path on the target (`scripts/exo.sh` already encapsulates most platform differences: Docker vs. apple-container, launch mechanics). Migration is then export, transfer, import, re-provision secrets, and re-bind adapter identities — with the old instance drained (area 1's markers) before the new one takes over the external identities.
+The likely path is an export/import pair: a guardian-level `export` action that produces a portable bundle (git ref + `.exo` state + secret manifest listing what must be re-provisioned + snapshot references), and a bootstrap path on the target (`./exo.sh` already encapsulates most platform differences: Docker vs. apple-container, launch mechanics). Migration is then export, transfer, import, re-provision secrets, and re-bind adapter identities — with the old instance drained (area 1's markers) before the new one takes over the external identities.
 
 ## 8. Self-Verification and Rollback
 

--- a/examples/exoclaw/harness.ts
+++ b/examples/exoclaw/harness.ts
@@ -94,7 +94,7 @@ async function exoclawInstructions(context: TurnContext): Promise<Message[]> {
     },
     {
       role: "developer",
-      content: `If the user asks to set up Slack, help them directly in this chat. Do not require them to run scripts/exo.sh --setup slack, scripts/exo.sh setup slack, or pnpm slack:setup; those are optional shortcuts/helpers. Follow this Slack setup guide:\n\n${SLACK_SETUP_PROMPT}`,
+      content: `If the user asks to set up Slack, help them directly in this chat. Do not require them to run ./exo.sh --setup slack, ./exo.sh setup slack, or pnpm slack:setup; those are optional shortcuts/helpers. Follow this Slack setup guide:\n\n${SLACK_SETUP_PROMPT}`,
     },
     {
       role: "developer",

--- a/examples/exoclaw/scripts/exo-cli
+++ b/examples/exoclaw/scripts/exo-cli
@@ -5,7 +5,7 @@
 # Fast path: the agent-cli adapter is already listening, so the prompt goes
 # straight to the agent. First run: this script bootstraps the adapter by
 # adding the workspace mount and asking the running agent to create it. The
-# only prerequisite is that the Exoclaw stack (scripts/exo.sh) is running.
+# only prerequisite is that the Exoclaw stack (./exo.sh) is running.
 set -euo pipefail
 
 SOURCE="${BASH_SOURCE[0]}"
@@ -47,8 +47,8 @@ adapter_runner_running() {
 bootstrap() {
   echo "exo-cli: agent-cli adapter not running; bootstrapping it now..." >&2
 
-  [[ -x "$EXO_BIN" ]] || die "exo binary not found at $EXO_BIN. Build it or start the stack: scripts/exo.sh canonical"
-  adapter_runner_running || die "the Exoclaw adapter runner is not running. Start the stack first: scripts/exo.sh canonical"
+  [[ -x "$EXO_BIN" ]] || die "exo binary not found at $EXO_BIN. Build it or start the stack: ./exo.sh"
+  adapter_runner_running || die "the Exoclaw adapter runner is not running. Start the stack first: ./exo.sh"
   [[ -d "$MOUNT_ROOT" ]] || die "workspace root does not exist: $MOUNT_ROOT (override with EXOCLAW_AGENT_CLI_ROOT)"
 
   echo "exo-cli: mounting $MOUNT_ROOT at $MOUNT_PATH in the agent sandbox..." >&2

--- a/exo.sh
+++ b/exo.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 EXO_BIN="${EXO_BIN:-$ROOT_DIR/target/debug/exo}"
 SCHEDULER_BIN="${EXOCLAW_SCHEDULER_BIN:-$ROOT_DIR/target/debug/exoclaw-scheduler-runner}"
@@ -34,8 +34,7 @@ ADAPTER_LIMIT="${EXO_ADAPTER_LIMIT:-50}"
 CONTROL=false
 SETUP_PROFILE=false
 SKIP_BUILD="${EXO_SKIP_BUILD:-false}"
-CANONICAL_SETUP=false
-CANONICAL_PROFILE="${EXO_CANONICAL_PROFILE:-user}"
+TEMPLATE="${EXO_TEMPLATE:-canonical}"
 SANDBOX_PROVIDER_EXPLICIT=false
 SANDBOX_BACKEND_EXPLICIT=false
 declare -a CONTROL_PIDS=()
@@ -45,37 +44,67 @@ if [[ -n "$SETUP_ADAPTER" ]]; then
   SETUP_ADAPTERS+=("$SETUP_ADAPTER")
 fi
 INITIAL_PROMPT_FILE="${EXO_INITIAL_PROMPT_FILE:-}"
+UPSTREAM_MODEL="${EXO_UPSTREAM_MODEL:-}"
+SECRET_NAME=""
+SECRET_ENV=""
+MODEL_BASE_URL=""
+USER_NAME="${EXO_USER_NAME:-}"
 export EXOCLAW_LOCAL_PROMPT_FILE="$LOCAL_PROMPT_FILE"
 
 usage() {
   cat <<'EOF'
 Usage:
-  scripts/exo.sh [options]
-  scripts/exo.sh list
-  scripts/exo.sh delall all
-  scripts/exo.sh fresh
-  scripts/exo.sh canonical
-  scripts/exo.sh canonical-dev
-  scripts/exo.sh stop-all
-  scripts/exo.sh setup-profile
-  scripts/exo.sh setup-sandbox
+  ./exo.sh [options]
+  ./exo.sh list
+  ./exo.sh delall all
+  ./exo.sh fresh
+  ./exo.sh stop-all
+  ./exo.sh build
+  ./exo.sh register-model
+  ./exo.sh write-profile
+  ./exo.sh setup-profile
+  ./exo.sh setup-sandbox
 
-Default behavior creates or reuses an Exoclaw agent and conversation, starts the
-local scheduler and adapter loops, then starts a REPL. It reads .env by default
-if present.
+Default behavior starts the canonical stack: it creates or reuses an Exoclaw
+agent and conversation with a Docker sandbox, repo self-map mount, ExoChat
+setup, guardian config, and control logs, starts the local scheduler and
+adapter loops, then starts a REPL. It reads .env by default if present.
+Choose a different template with --template.
+
+Subcommands:
+  list             List agents and conversations
+  delall all       Delete all agents and conversations
+  fresh            Rebuild, delete all state, and start a clean REPL
+  stop-all         Stop the scheduler and adapter runners, preserving .exo state
+  build            Install JS dependencies and build the exo CLI and scheduler
+  register-model   Store an API-key secret and register a model binding; uses
+                   --model, --upstream-model, --secret-name, --secret-env, and
+                   optionally --base-url
+  write-profile    Write the local profile prompt non-interactively; uses
+                   --user-name and --local-prompt-file
+  setup-profile    Prompt interactively and write the local profile prompt
+  setup-sandbox    Pull the sandbox image
 
 Options:
   --model <model>              Model binding name (default: gpt-5.4)
+  --upstream-model <model>     Upstream model id for register-model (default: --model)
+  --secret-name <name>         Secret name for register-model (e.g. openai)
+  --secret-env <env-var>       Environment variable holding the API key for register-model
+  --base-url <url>             Optional API base URL for register-model
+  --user-name <name>           User name for write-profile (default: none)
   --agent <slug>               Agent slug (default: exoclaw-agent)
   --conversation <slug>        Conversation slug (default: dev)
   --convo <slug>               Alias for --conversation
   --agent-name <name>          Agent display name (default: Exoclaw Agent)
   --conversation-name <name>   Conversation display name (default: Dev)
   --module <path>              Exoclaw TypeScript harness module
-  --canonical                  Docker sandbox, repo self-map mount, ExoChat setup,
-                               control logs, and guardian config
-  --canonical-dev              Docker sandbox, repo self-map mount, IRC+Discord setup,
-                               control logs, and guardian config
+  --template <name>            Launch template (default: canonical):
+                                 canonical  Docker sandbox, repo self-map mount, ExoChat
+                                            setup, control logs, and guardian config
+                                 dev        Same as canonical but with IRC+Discord
+                                            instead of ExoChat
+                                 minimal    No Docker defaults, adapter setup prompts,
+                                            control console, or guardian config
   --sandbox-image <image>      Sandbox image (default: ubuntu:24.04)
   --sandbox-provider <provider>
                                 Sandbox provider: daytona, apple-container, docker, or local-process
@@ -121,8 +150,8 @@ Environment overrides:
   EXO_BIN, EXO_START_SCHEDULER, EXO_START_ADAPTERS, EXOCLAW_REPO,
   EXOCLAW_AGENT_CLI_ROOT, EXOCLAW_AGENT_CLI_MOUNT,
   EXOCLAW_SCHEDULER_BIN, EXO_SCHEDULER_INTERVAL_SECONDS, EXO_ADAPTER_LIMIT,
-  EXO_SETUP_ADAPTER, EXO_INITIAL_PROMPT_FILE, EXO_CANONICAL_PROFILE,
-  EXO_SKIP_BUILD
+  EXO_SETUP_ADAPTER, EXO_INITIAL_PROMPT_FILE, EXO_TEMPLATE,
+  EXO_SKIP_BUILD, EXO_UPSTREAM_MODEL, EXO_USER_NAME
 EOF
 }
 
@@ -217,8 +246,8 @@ add_setup_adapter() {
   SETUP_ADAPTERS+=("$adapter")
 }
 
-apply_canonical_setup_defaults() {
-  if [[ "$CANONICAL_SETUP" != true ]]; then
+apply_template_defaults() {
+  if [[ "$TEMPLATE" == "minimal" ]]; then
     return
   fi
 
@@ -233,8 +262,8 @@ apply_canonical_setup_defaults() {
   if [[ "$SANDBOX_BACKEND_EXPLICIT" != true ]]; then
     SANDBOX_BACKEND="docker"
   fi
-  case "$CANONICAL_PROFILE" in
-    user)
+  case "$TEMPLATE" in
+    canonical)
       add_setup_adapter "exochat"
       ;;
     dev)
@@ -242,13 +271,13 @@ apply_canonical_setup_defaults() {
       add_setup_adapter "discord"
       ;;
     *)
-      die "EXO_CANONICAL_PROFILE must be user or dev"
+      die "--template must be canonical, dev, or minimal"
       ;;
   esac
 }
 
 configure_guardian_for_current_launch() {
-  if [[ "$CANONICAL_SETUP" != true ]]; then
+  if [[ "$TEMPLATE" == "minimal" ]]; then
     return
   fi
 
@@ -272,6 +301,43 @@ build_exoclaw_scheduler() {
   (cd "$ROOT_DIR" && CARGO_TARGET_DIR=target cargo build \
     --manifest-path examples/exoclaw/scheduler-runner/Cargo.toml \
     --ignore-rust-version)
+}
+
+build_all() {
+  echo "Installing JS dependencies..."
+  (cd "$ROOT_DIR" && pnpm install)
+  build_exo
+  build_exoclaw_scheduler
+}
+
+register_model() {
+  [[ -n "$SECRET_NAME" ]] || die "register-model requires --secret-name"
+  [[ -n "$SECRET_ENV" ]] || die "register-model requires --secret-env"
+  ensure_exo_bin
+  local upstream="${UPSTREAM_MODEL:-$MODEL}"
+  echo "Storing secret $SECRET_NAME from \$$SECRET_ENV..."
+  exo secret set "$SECRET_NAME" --env "$SECRET_ENV"
+  echo "Registering model $MODEL -> $upstream..."
+  local args=(model register "$MODEL" --model "$upstream" --secret "$SECRET_NAME")
+  if [[ -n "$MODEL_BASE_URL" ]]; then
+    args+=(--base-url "$MODEL_BASE_URL")
+  fi
+  exo "${args[@]}"
+}
+
+write_local_profile() {
+  mkdir -p "$(dirname "$LOCAL_PROMPT_FILE")"
+  {
+    echo "# Local Exo Profile"
+    echo
+    echo "This file is local to this machine and should not be committed."
+    if [[ -n "$USER_NAME" ]]; then
+      echo
+      echo "The user's name is $USER_NAME."
+    fi
+  } >"$LOCAL_PROMPT_FILE"
+  chmod 600 "$LOCAL_PROMPT_FILE"
+  echo "Wrote local Exo profile: $LOCAL_PROMPT_FILE"
 }
 
 scheduler_source_newer_than() {
@@ -1185,18 +1251,6 @@ while [[ $# -gt 0 ]]; do
       shift
       COMMAND="fresh"
       ;;
-    canonical)
-      shift
-      COMMAND="repl"
-      CANONICAL_SETUP=true
-      CANONICAL_PROFILE="user"
-      ;;
-    canonical-dev|dev|docker-dev)
-      shift
-      COMMAND="repl"
-      CANONICAL_SETUP=true
-      CANONICAL_PROFILE="dev"
-      ;;
     stop-all|stop)
       shift
       [[ $# -eq 0 ]] || die "stop-all does not accept additional arguments"
@@ -1210,9 +1264,46 @@ while [[ $# -gt 0 ]]; do
       shift
       COMMAND="setup-sandbox"
       ;;
+    build)
+      shift
+      [[ $# -eq 0 ]] || die "build does not accept additional arguments"
+      COMMAND="build"
+      ;;
+    register-model)
+      shift
+      COMMAND="register-model"
+      ;;
+    write-profile)
+      shift
+      COMMAND="write-profile"
+      ;;
     --model)
       MODEL="${2:-}"
       [[ -n "$MODEL" ]] || die "--model requires a value"
+      shift 2
+      ;;
+    --upstream-model)
+      UPSTREAM_MODEL="${2:-}"
+      [[ -n "$UPSTREAM_MODEL" ]] || die "--upstream-model requires a value"
+      shift 2
+      ;;
+    --secret-name)
+      SECRET_NAME="${2:-}"
+      [[ -n "$SECRET_NAME" ]] || die "--secret-name requires a value"
+      shift 2
+      ;;
+    --secret-env)
+      SECRET_ENV="${2:-}"
+      [[ -n "$SECRET_ENV" ]] || die "--secret-env requires a value"
+      shift 2
+      ;;
+    --base-url)
+      MODEL_BASE_URL="${2:-}"
+      [[ -n "$MODEL_BASE_URL" ]] || die "--base-url requires a value"
+      shift 2
+      ;;
+    --user-name)
+      USER_NAME="${2:-}"
       shift 2
       ;;
     --agent)
@@ -1263,14 +1354,20 @@ while [[ $# -gt 0 ]]; do
       SANDBOX_BACKEND_EXPLICIT=true
       shift 2
       ;;
-    --canonical)
-      CANONICAL_SETUP=true
-      CANONICAL_PROFILE="user"
-      shift
+    --template)
+      TEMPLATE="${2:-}"
+      case "$TEMPLATE" in
+        canonical|dev|minimal) ;;
+        *) die "--template must be canonical, dev, or minimal" ;;
+      esac
+      shift 2
       ;;
-    --canonical-dev)
-      CANONICAL_SETUP=true
-      CANONICAL_PROFILE="dev"
+    --template=*)
+      TEMPLATE="${1#--template=}"
+      case "$TEMPLATE" in
+        canonical|dev|minimal) ;;
+        *) die "--template must be canonical, dev, or minimal" ;;
+      esac
       shift
       ;;
     --self-repo-mount)
@@ -1397,7 +1494,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-apply_canonical_setup_defaults
+apply_template_defaults
 
 export EXOCLAW_LOCAL_PROMPT_FILE="$LOCAL_PROMPT_FILE"
 export EXOCLAW_REPO="$SELF_REPO_MOUNT_PATH"
@@ -1424,5 +1521,14 @@ case "$COMMAND" in
     ;;
   setup-sandbox)
     setup_sandbox
+    ;;
+  build)
+    build_all
+    ;;
+  register-model)
+    register_model
+    ;;
+  write-profile)
+    write_local_profile
     ;;
 esac

--- a/setup.sh
+++ b/setup.sh
@@ -204,7 +204,7 @@ missing_has() {
 
 is_exo_checkout() {
   local dir="$1"
-  [[ -d "$dir/.git" && -f "$dir/scripts/exo.sh" ]]
+  [[ -d "$dir/.git" && -f "$dir/exo.sh" ]]
 }
 
 prompt_yes_no() {
@@ -395,27 +395,6 @@ trust_mise_config() {
   mise trust "$config"
 }
 
-control_script_supports() {
-  local flag="$1"
-  scripts/exo.sh --help 2>/dev/null | grep -q -- "$flag"
-}
-
-write_local_profile() {
-  local file="$1"
-  local user_name="$2"
-  mkdir -p "$(dirname "$file")"
-  {
-    echo "# Local Exo Profile"
-    echo
-    echo "This file is local to this machine and should not be committed."
-    if [[ -n "$user_name" ]]; then
-      echo
-      echo "The user's name is $user_name."
-    fi
-  } >"$file"
-  chmod 600 "$file"
-}
-
 choose_install_dir() {
   if is_exo_checkout "$PWD"; then
     echo "Using current Exo checkout: $PWD" >&2
@@ -560,31 +539,20 @@ main() {
   info "Configure Exo"
   USER_NAME="$(prompt_text "Your name, or blank to skip" "$USER_NAME")"
   AGENT_NAME="$(prompt_text "Agent display name" "$AGENT_NAME")"
-  local profile_file="${EXOCLAW_LOCAL_PROMPT_FILE:-$install_dir/.exo/exoclaw-profile.md}"
-  write_local_profile "$profile_file" "$USER_NAME"
-  echo "Wrote local Exo profile: $profile_file"
+  ./exo.sh write-profile ${USER_NAME:+--user-name "$USER_NAME"}
 
-  info "Install dependencies"
-  pnpm install
-
-  info "Build exo"
-  CARGO_TARGET_DIR=target cargo build -p exo --ignore-rust-version
+  info "Build Exo"
+  ./exo.sh build
 
   info "Store secrets and register model"
-  ./target/debug/exo --env-file-if-exists "$env_file" \
-    secret set "$MODEL_PROVIDER" --env "$MODEL_API_KEY_ENV"
-  ./target/debug/exo --env-file-if-exists "$env_file" \
-    model register "$MODEL_NAME" --model "$UPSTREAM_MODEL" \
-    --secret "$MODEL_PROVIDER" ${MODEL_BASE_URL:+--base-url "$MODEL_BASE_URL"}
+  ./exo.sh register-model --model "$MODEL_NAME" \
+    --upstream-model "$UPSTREAM_MODEL" \
+    --secret-name "$MODEL_PROVIDER" --secret-env "$MODEL_API_KEY_ENV" \
+    ${MODEL_BASE_URL:+--base-url "$MODEL_BASE_URL"}
 
   info "Start canonical Exo"
-  local control_args=(fresh --canonical --agent-name "$AGENT_NAME")
-  if control_script_supports "--skip-build"; then
-    control_args=(fresh --canonical --skip-build --agent-name "$AGENT_NAME")
-  fi
   unset EXO_SETUP_ADAPTER
-  export EXO_CANONICAL_PROFILE=user
-  exec scripts/exo.sh "${control_args[@]}"
+  exec ./exo.sh fresh --skip-build --agent-name "$AGENT_NAME"
 }
 
 main "$@"

--- a/website/docs-src/getting-started/first-session.md
+++ b/website/docs-src/getting-started/first-session.md
@@ -46,7 +46,7 @@ agent to:
   operating rules of the default agent.
 - `.exo/exoclaw-profile.md` — your local, git-ignored profile (name,
   machine-specific preferences). Recreate it anytime with
-  `scripts/exo.sh setup-profile`.
+  `./exo.sh setup-profile`.
 - `examples/exoclaw/harness.ts` — assembles the full prompt each turn,
   including dynamic instructions about tools, adapters, memory, and
   self-maintenance.
@@ -56,14 +56,14 @@ them to take effect.
 
 ## Managing the agent
 
-`scripts/exo.sh` is the control surface for the canonical agent:
+`./exo.sh` is the control surface for the canonical agent:
 
 ```bash
-scripts/exo.sh              # create or reuse the agent, start services + REPL
-scripts/exo.sh list         # list agents and conversations
-scripts/exo.sh stop-all     # stop scheduler and adapter loops
-scripts/exo.sh fresh        # start over with a fresh agent
-scripts/exo.sh setup-profile
+./exo.sh              # create or reuse the agent, start services + REPL
+./exo.sh list         # list agents and conversations
+./exo.sh stop-all     # stop scheduler and adapter loops
+./exo.sh fresh        # start over with a fresh agent
+./exo.sh setup-profile
 ```
 
 Where to go from here: there's little else you *need* to learn — talk to the

--- a/website/docs-src/getting-started/index.md
+++ b/website/docs-src/getting-started/index.md
@@ -11,7 +11,7 @@ script, then learn what to do with it.
 1. [Installation](./installation) — run `setup.sh`; it handles keys,
    build, and launch.
 2. [Your First Session](./first-session) — test prompts, prompt
-   customization, and the `scripts/exo.sh` control surface.
+   customization, and the `./exo.sh` control surface.
 
 Building from primitives instead of using the canonical agent:
 


### PR DESCRIPTION
## Summary

- Move the control script from `scripts/exo.sh` to `exo.sh` at the repo root so it sits next to `setup.sh` as the primary day-to-day entry point; update all references across docs, adapter READMEs, the harness prompt, and `exo-cli`.
- Add `build`, `register-model`, and `write-profile` subcommands to `exo.sh` and slim `setup.sh` down to pure bootstrap (deps, clone, `.env` prompts) that delegates checkout operations to `./exo.sh`.
- Make the canonical stack the default launch: replace `canonical` / `canonical-dev` with a `--template <canonical|dev|minimal>` flag that defaults to `canonical`, so plain `./exo.sh` starts the full Docker + ExoChat stack. `dev` swaps in IRC+Discord; `minimal` preserves the old bare-REPL behavior.
- Add an "Operating Exo" section to the README covering everyday `./exo.sh` usage, and fix the quickstart curl URL to point at the root `setup.sh`.

## Test plan

- [x] `bash -n` on both scripts; `./exo.sh --help` renders new usage
- [x] `--template` validation rejects unknown values; both `--template dev` and `--template=dev` forms parse
- [x] `write-profile` writes the expected file; `register-model` enforces required flags
- [x] `pnpm check` (lint, typecheck, 323 tests) passes
- [ ] Fresh install via `bash setup.sh` in an empty directory reaches the REPL with ExoChat
- [ ] `./exo.sh --template dev` sets up IRC+Discord instead of ExoChat

Made with [Cursor](https://cursor.com)