### PR TITLE
Fix flaky adapter worker test: wait for complete JSON, not file existence

### DIFF
--- a/crates/executor/src/adapter/worker.rs
+++ b/crates/executor/src/adapter/worker.rs
@@ -444,7 +444,12 @@ mod tests {
         let path = path.as_ref().to_path_buf();
         tokio::time::timeout(Duration::from_secs(5), async {
             loop {
-                if let Ok(contents) = tokio::fs::read_to_string(&path).await {
+                // The worker creates the file before the content lands (shell
+                // `>` truncates first), so wait until the contents are a
+                // complete JSON document, not merely until the file exists.
+                if let Ok(contents) = tokio::fs::read_to_string(&path).await
+                    && serde_json::from_str::<serde_json::Value>(&contents).is_ok()
+                {
                     return contents;
                 }
                 tokio::time::sleep(Duration::from_millis(50)).await;


### PR DESCRIPTION
The `dispatches_outbound_commands_while_event_handler_is_busy` test writes `command.json` from the worker via shell `>` redirection, which creates/truncates the file before the content is written. `wait_for_file` returned on the first successful read, so a slow runner could read an empty or partially written file and fail the `send_message` assertion — as seen on CI ubuntu-latest for PR #103 (run 28833021195), while the same code passed locally and on macOS.

Fix: keep polling until the file contents parse as a complete JSON document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)