### PR TITLE
exochat: fix page-level scroll; messages pane is the scroll container

### DIFF
--- a/website/src/chat.css
+++ b/website/src/chat.css
@@ -147,7 +147,10 @@ svg {
 .chat-shell {
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;
-  min-height: 100svh;
+  /* Fixed height (not min-height): the middle row must be the scroll
+     container, so the shell itself can never outgrow the viewport. */
+  height: 100svh;
+  overflow: hidden;
   background: var(--background);
 }
 


### PR DESCRIPTION
Long conversations grew the page (`.chat-shell` used `min-height`), so the topbar/composer scrolled away and the message viewport never scrolled. Fixed height + overflow hidden makes the middle grid row constrain the scroller.

Verified in headless Chromium with 60 injected messages: pre-fix the page grows to 6695px with the composer offscreen; post-fix the page stays viewport-sized, messages scroll in their own pane, topbar and composer stay pinned.

Cherry-picked from #120 for immediate deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)