### PR TITLE
WIP: ExoChat: typing indicator + slimmer auto-growing composer

### DIFF
--- a/crates/executor/src/adapter/runtime.rs
+++ b/crates/executor/src/adapter/runtime.rs
@@ -420,6 +420,37 @@ pub async fn send_adapter_message_with_handles(
     Ok(())
 }
 
+/// In-memory side channel for typing signals: not durable on purpose — a
+/// stale "typing" after a restart would be a lie, and the outbox must stay
+/// reserved for real messages.
+#[derive(Clone)]
+struct TypingSignal {
+    queue: Arc<std::sync::Mutex<Vec<WorkerCommand>>>,
+    notify: Arc<Notify>,
+}
+
+impl TypingSignal {
+    fn push(&self, target: &str, state: &str) {
+        self.queue
+            .lock()
+            .expect("typing signal queue poisoned")
+            .push(WorkerCommand::Typing {
+                target: Some(target.to_string()),
+                state: state.to_string(),
+            });
+        self.notify.notify_one();
+    }
+
+    fn drain(&self) -> Vec<WorkerCommand> {
+        std::mem::take(&mut *self.queue.lock().expect("typing signal queue poisoned"))
+    }
+}
+
+// Adapters whose workers understand the typing command.
+fn adapter_supports_typing(config: &AdapterConfig) -> bool {
+    config.adapter_type == "exochat"
+}
+
 async fn run_adapter_loop(
     harness: Arc<dyn Harness>,
     store: &AdapterStore,
@@ -432,6 +463,12 @@ async fn run_adapter_loop(
     let config = adapter.config.clone();
     let secret_env = worker_secret_env(agent.exoharness_handle().as_ref(), &config).await?;
     let outbound_notifier = register_adapter_outbound_notifier(&adapter.id);
+    let typing = adapter_supports_typing(&config).then(|| TypingSignal {
+        queue: Arc::new(std::sync::Mutex::new(Vec::new())),
+        notify: Arc::clone(&outbound_notifier.notify),
+    });
+    let event_typing = typing.clone();
+    let outbound_typing = typing.clone();
     let event_store = store.clone();
     let event_adapter = adapter.clone();
     let event_agent = std::sync::Arc::clone(&agent);
@@ -452,6 +489,7 @@ async fn run_adapter_loop(
             let agent = std::sync::Arc::clone(&event_agent);
             let conversation = std::sync::Arc::clone(&event_conversation);
             let config = event_config.clone();
+            let typing = event_typing.clone();
             async move {
                 handle_worker_event(
                     &store,
@@ -460,6 +498,7 @@ async fn run_adapter_loop(
                     &adapter,
                     &config,
                     event,
+                    typing,
                 )
                 .await
             }
@@ -467,18 +506,23 @@ async fn run_adapter_loop(
         move || {
             let store = outbound_store.clone();
             let adapter_id = outbound_adapter_id.clone();
+            let typing = outbound_typing.clone();
             async move {
-                Ok(store
-                    .claim_outbound_messages(&adapter_id)
-                    .await?
-                    .into_iter()
-                    .map(|message| WorkerCommand::SendMessage {
-                        id: message.id,
-                        target: message.target,
-                        text: message.text,
-                        attachments: message.attachments,
-                    })
-                    .collect())
+                let mut commands: Vec<WorkerCommand> =
+                    typing.as_ref().map(TypingSignal::drain).unwrap_or_default();
+                commands.extend(
+                    store
+                        .claim_outbound_messages(&adapter_id)
+                        .await?
+                        .into_iter()
+                        .map(|message| WorkerCommand::SendMessage {
+                            id: message.id,
+                            target: message.target,
+                            text: message.text,
+                            attachments: message.attachments,
+                        }),
+                );
+                Ok(commands)
             }
         },
         move || {
@@ -552,6 +596,7 @@ async fn handle_worker_event(
     adapter: &AdapterRecord,
     config: &AdapterConfig,
     event: WorkerEvent,
+    typing: Option<TypingSignal>,
 ) -> Result<()> {
     match event {
         WorkerEvent::Connected { subject, metadata } => {
@@ -595,6 +640,7 @@ async fn handle_worker_event(
                 message_id,
                 metadata,
                 attachments,
+                typing,
             )
             .await
         }
@@ -748,6 +794,7 @@ async fn handle_worker_message(
     message_id: Option<String>,
     metadata: serde_json::Value,
     attachments: Vec<AdapterAttachment>,
+    typing: Option<TypingSignal>,
 ) -> Result<()> {
     if let Some(message_id) = &message_id
         && !store
@@ -800,7 +847,13 @@ async fn handle_worker_message(
         parts.extend(image_parts);
         UserContent::Array(parts)
     };
+    if let Some(typing) = &typing {
+        typing.push(&target, "started");
+    }
     let wakeup_result = send_conversation_wakeup_content(conversation, content).await;
+    if let Some(typing) = &typing {
+        typing.push(&target, "stopped");
+    }
     // A failed model turn must not tear down the worker: the external
     // connection is healthy and dropping it loses every queued message.
     // Record the failure and keep processing events.

--- a/crates/executor/src/adapter/worker.rs
+++ b/crates/executor/src/adapter/worker.rs
@@ -23,6 +23,13 @@ pub enum WorkerCommand {
         #[serde(default)]
         attachments: Vec<AdapterAttachment>,
     },
+    /// Best-effort presence signal (no ack): the agent started or finished a
+    /// wakeup turn for an inbound message from this adapter.
+    Typing {
+        #[serde(default)]
+        target: Option<String>,
+        state: String,
+    },
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/examples/exoclaw/adapters/agent-cli/worker.ts
+++ b/examples/exoclaw/adapters/agent-cli/worker.ts
@@ -128,6 +128,10 @@ for await (const line of input) {
   let commandId: string | null = null;
   try {
     const command = parseWorkerCommand(JSON.parse(line));
+    if (command.type !== "send_message") {
+      // Typing signals are exochat-only; ignore other command types.
+      continue;
+    }
     commandId = command.id;
     if (command.attachments.length > 0) {
       throw new Error("agent-cli does not support attachments");

--- a/examples/exoclaw/adapters/discord/worker.ts
+++ b/examples/exoclaw/adapters/discord/worker.ts
@@ -162,6 +162,10 @@ try {
     let commandId: string | null = null;
     try {
       const command = parseWorkerCommand(JSON.parse(line));
+      if (command.type !== "send_message") {
+        // Typing signals are exochat-only; ignore other command types.
+        continue;
+      }
       commandId = command.id;
       const target = command.target ?? defaultChannelId;
       if (!target) {

--- a/examples/exoclaw/adapters/exochat/worker.ts
+++ b/examples/exoclaw/adapters/exochat/worker.ts
@@ -63,6 +63,19 @@ for await (const line of input) {
   let commandId: string | null = null;
   try {
     const command = parseWorkerCommand(JSON.parse(line));
+    if (command.type === "typing") {
+      // Best-effort presence signal; never worth an error or a nack.
+      try {
+        await sendFrame({
+          type: "typing",
+          state: command.state,
+          createdAt: Date.now(),
+        });
+      } catch {
+        // Disconnected; the signal is stale by the time we reconnect.
+      }
+      continue;
+    }
     commandId = command.id;
     const target = command.target ?? session.channelId;
     if (target !== session.channelId) {

--- a/examples/exoclaw/adapters/irc/worker.ts
+++ b/examples/exoclaw/adapters/irc/worker.ts
@@ -148,6 +148,10 @@ for await (const line of input) {
   let commandId: string | null = null;
   try {
     const command = parseWorkerCommand(JSON.parse(line));
+    if (command.type !== "send_message") {
+      // Typing signals are exochat-only; ignore other command types.
+      continue;
+    }
     commandId = command.id;
     process.stderr.write(`[irc-adapter] sending message to ${channel}\n`);
     writeIrcCommand(`PRIVMSG ${channel} :${command.text}`);

--- a/examples/exoclaw/adapters/protocol.ts
+++ b/examples/exoclaw/adapters/protocol.ts
@@ -1,10 +1,16 @@
-export type WorkerOutboundCommand = {
-  type: "send_message";
-  id: string;
-  target?: string | null;
-  text: string;
-  attachments: AdapterAttachment[];
-};
+export type WorkerOutboundCommand =
+  | {
+      type: "send_message";
+      id: string;
+      target?: string | null;
+      text: string;
+      attachments: AdapterAttachment[];
+    }
+  | {
+      type: "typing";
+      target?: string | null;
+      state: "started" | "stopped";
+    };
 
 export type AdapterAttachment = {
   kind: "image" | "video" | "audio" | "document";
@@ -69,7 +75,20 @@ export function adapterConfig(): JsonObject {
 }
 
 export function parseWorkerCommand(value: unknown): WorkerOutboundCommand {
-  if (!isRecord(value) || value.type !== "send_message") {
+  if (!isRecord(value)) {
+    throw new Error("worker command must be an object");
+  }
+  if (value.type === "typing") {
+    if (value.state !== "started" && value.state !== "stopped") {
+      throw new Error("typing state must be 'started' or 'stopped'");
+    }
+    return {
+      type: "typing",
+      target: typeof value.target === "string" ? value.target : null,
+      state: value.state,
+    };
+  }
+  if (value.type !== "send_message") {
     throw new Error("worker command must be a send_message object");
   }
   if (typeof value.id !== "string" || value.id.length === 0) {

--- a/examples/exoclaw/adapters/signal/worker.ts
+++ b/examples/exoclaw/adapters/signal/worker.ts
@@ -103,6 +103,10 @@ for await (const line of input) {
   let commandId: string | null = null;
   try {
     const command = parseWorkerCommand(JSON.parse(line));
+    if (command.type !== "send_message") {
+      // Typing signals are exochat-only; ignore other command types.
+      continue;
+    }
     commandId = command.id;
     if (!command.target) {
       throw new Error(

--- a/examples/exoclaw/adapters/slack/worker.ts
+++ b/examples/exoclaw/adapters/slack/worker.ts
@@ -180,6 +180,10 @@ async function readCommands(): Promise<void> {
     let commandId: string | null = null;
     try {
       const command = parseWorkerCommand(JSON.parse(line));
+      if (command.type !== "send_message") {
+        // Typing signals are exochat-only; ignore other command types.
+        continue;
+      }
       commandId = command.id;
       if (command.attachments.length > 0) {
         throw new Error("Slack adapter supports text-only messages for now");

--- a/examples/exoclaw/adapters/whatsapp/worker.ts
+++ b/examples/exoclaw/adapters/whatsapp/worker.ts
@@ -145,6 +145,10 @@ for await (const line of input) {
   let commandId: string | null = null;
   try {
     const command = parseWorkerCommand(JSON.parse(line));
+    if (command.type !== "send_message") {
+      // Typing signals are exochat-only; ignore other command types.
+      continue;
+    }
     commandId = command.id;
     if (!command.target) {
       throw new Error("WhatsApp send_message requires a target chat id");

--- a/website/src/chat.css
+++ b/website/src/chat.css
@@ -363,18 +363,22 @@ h1 {
 
 .composer-surface {
   display: grid;
-  gap: 14px;
+  gap: 8px;
   width: min(100%, 920px);
   margin: 0 auto;
   border: 1px solid var(--border);
-  border-radius: 28px;
+  border-radius: 22px;
   background: var(--muted);
   box-shadow: none;
-  padding: 18px;
+  padding: 10px 14px;
 }
 
 .composer-input {
-  min-height: 54px;
+  /* One line by default; grows with content (field-sizing) up to a cap,
+     then scrolls. */
+  min-height: 24px;
+  max-height: 180px;
+  overflow-y: auto;
   border-color: transparent !important;
   border-radius: 0 !important;
   background: transparent !important;
@@ -409,8 +413,8 @@ h1 {
 }
 
 .composer-tool-button {
-  width: 40px;
-  height: 40px;
+  width: 34px;
+  height: 34px;
   border-color: color-mix(in oklab, var(--foreground) 14%, transparent);
   border-radius: 999px;
   background: transparent;
@@ -423,9 +427,56 @@ h1 {
 }
 
 .composer-send-button {
-  width: 40px;
-  height: 40px;
+  width: 34px;
+  height: 34px;
   border-radius: 999px;
+}
+
+.typing-indicator {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  width: max-content;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  background: var(--muted);
+}
+
+.typing-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--muted-foreground);
+  animation: typing-bounce 1.2s ease-in-out infinite;
+}
+
+.typing-dot:nth-child(2) {
+  animation-delay: 0.15s;
+}
+
+.typing-dot:nth-child(3) {
+  animation-delay: 0.3s;
+}
+
+@keyframes typing-bounce {
+  0%,
+  60%,
+  100% {
+    opacity: 0.35;
+    transform: translateY(0);
+  }
+  30% {
+    opacity: 1;
+    transform: translateY(-3px);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .typing-dot {
+    animation: none;
+    opacity: 0.6;
+  }
 }
 
 @media (max-width: 720px) {

--- a/website/src/chat.jsx
+++ b/website/src/chat.jsx
@@ -50,6 +50,19 @@ function ChatApp() {
     enabled: session.demo,
     label: session.demo ? "Preview" : "Waiting",
   });
+  const [peerTyping, setPeerTyping] = React.useState(false);
+  const typingTimerRef = React.useRef(null);
+  const setTyping = React.useCallback((active) => {
+    if (typingTimerRef.current) {
+      clearTimeout(typingTimerRef.current);
+      typingTimerRef.current = null;
+    }
+    setPeerTyping(active);
+    if (active) {
+      // Safety valve: a missed "stopped" signal must not spin forever.
+      typingTimerRef.current = setTimeout(() => setPeerTyping(false), 120_000);
+    }
+  }, []);
   const [status, setStatus] = React.useState({
     data: {
       label: "Crypto",
@@ -241,13 +254,24 @@ function ChatApp() {
 
       setStatusPart("peer", { tone: "warning", value: "waiting" });
       setComposer({ enabled: false, label: "Waiting" });
+      setTyping(false);
       if (remoteSeenRef.current) {
         addNotice("Peer left. Messages are not queued by the relay.");
       }
     }
 
     function renderFrame(frame, self) {
+      if (frame.type === "typing") {
+        if (!self) {
+          setTyping(frame.state === "started");
+        }
+        return;
+      }
+
       if (frame.type === "chat") {
+        if (!self) {
+          setTyping(false);
+        }
         addEvent({
           frame,
           kind: "message",
@@ -272,7 +296,7 @@ function ChatApp() {
         self,
       });
     }
-  }, [addEvent, addNotice, session, setStatusPart]);
+  }, [addEvent, addNotice, session, setStatusPart, setTyping]);
 
   const sendChat = React.useCallback(async () => {
     const text = input.trim();
@@ -398,6 +422,15 @@ function ChatApp() {
                   <ConversationEvent event={event} />
                 </MessageScrollerItem>
               ))}
+              {peerTyping ? (
+                <MessageScrollerItem
+                  key="typing-indicator"
+                  messageId="typing-indicator"
+                  scrollAnchor
+                >
+                  <TypingIndicator />
+                </MessageScrollerItem>
+              ) : null}
             </MessageScrollerContent>
           </MessageScrollerViewport>
           <MessageScrollerButton
@@ -465,6 +498,20 @@ function StatusBadge({ icon: Icon, status }) {
       <span>{status.label}</span>
       <strong>{status.value}</strong>
     </Badge>
+  );
+}
+
+function TypingIndicator() {
+  return (
+    <div
+      aria-label="exo is responding"
+      className="typing-indicator"
+      role="status"
+    >
+      <span className="typing-dot" />
+      <span className="typing-dot" />
+      <span className="typing-dot" />
+    </div>
   );
 }
 


### PR DESCRIPTION
- Typing indicator driven by a real signal: the adapter runner sends typing started/stopped around the wakeup turn, the exochat worker forwards it as an encrypted frame, and the web UI shows animated dots (120s safety timeout; cleared on reply or peer loss). Disconnected vs thinking stays distinguishable via the peer presence badge.
- Composer: one line tall by default, auto-grows to 180px, then scrolls; tighter padding and smaller buttons.

Verified: cargo + vitest suites green; composer behavior verified in headless Chromium (24px collapsed, 180px cap, scrollable past cap).