### PR TITLE
WIP: executor — pool TypeScript runner processes per harness module

### DIFF
--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -38,3 +38,4 @@ libc = "0.2"
 [dev-dependencies]
 futures.workspace = true
 tempfile = "3.23.0"
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -26,6 +26,7 @@ mod local_sandbox;
 mod rlm;
 #[cfg(test)]
 mod rlm_tests;
+mod runner_pool;
 mod scheduler_runtime;
 mod scheduler_store;
 mod scheduler_types;
@@ -33,6 +34,8 @@ mod shared;
 #[cfg(test)]
 mod test_support;
 mod typescript;
+#[cfg(test)]
+mod typescript_e2e_tests;
 
 pub use adapter::AdapterStore;
 pub use adapter::{

--- a/crates/executor/src/runner_pool.rs
+++ b/crates/executor/src/runner_pool.rs
@@ -1,0 +1,259 @@
+use std::ops::{Deref, DerefMut};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use exoharness::Result;
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::task::AbortHandle;
+
+/// Bounded pool of runner processes for one harness module.
+///
+/// Checkout is exclusive by ownership: `acquire` hands the runner itself to
+/// the caller, so no per-runner lock exists. `checkin` returns it warm;
+/// dropping a [`PooledRunner`] without checking in discards the runner
+/// instead — the safe default for a runner whose turn failed. Idle runners
+/// expire after `idle_ttl`, so a quiescent pool drains to zero; dropping the
+/// pool reaps them immediately (the expiry timers hold only a `Weak`).
+pub(crate) struct RunnerPool<R> {
+    permits: Arc<Semaphore>,
+    idle: Mutex<Vec<Idle<R>>>,
+    idle_ttl: Duration,
+    next_token: AtomicU64,
+}
+
+struct Idle<R> {
+    runner: R,
+    token: u64,
+    expiry: AbortHandle,
+}
+
+impl<R: Send + 'static> RunnerPool<R> {
+    pub(crate) fn new(max_size: usize, idle_ttl: Duration) -> Arc<Self> {
+        Arc::new(Self {
+            permits: Arc::new(Semaphore::new(max_size.max(1))),
+            idle: Mutex::new(Vec::new()),
+            idle_ttl,
+            next_token: AtomicU64::new(0),
+        })
+    }
+
+    /// Waits for capacity (FIFO), then reuses the most recently used idle
+    /// runner or spawns a fresh one. Spawn failures release the capacity and
+    /// are never cached.
+    pub(crate) async fn acquire(
+        self: &Arc<Self>,
+        spawn: impl FnOnce() -> Result<R>,
+    ) -> Result<PooledRunner<R>> {
+        let permit = Arc::clone(&self.permits)
+            .acquire_owned()
+            .await
+            .expect("runner pool semaphore is never closed");
+        // Bind the pop to a statement so the idle guard drops before the
+        // (blocking) spawn in the miss path.
+        let reused = self.idle.lock().expect("runner pool idle lock").pop();
+        let runner = match reused {
+            Some(idle) => {
+                idle.expiry.abort();
+                idle.runner
+            }
+            None => spawn()?,
+        };
+        Ok(PooledRunner {
+            runner: Some(runner),
+            pool: Arc::clone(self),
+            _permit: permit,
+        })
+    }
+
+    fn checkin(self: &Arc<Self>, runner: R) {
+        let token = self.next_token.fetch_add(1, Ordering::Relaxed);
+        let idle_ttl = self.idle_ttl;
+        let weak = Arc::downgrade(self);
+
+        // Hold the idle lock across spawn + push so the timer (Weak-held, so
+        // it never keeps the pool alive) can't run its removal before the
+        // entry exists. Checkout aborts the timer; a firing timer that lost
+        // the race to a checkout finds its token gone and no-ops.
+        let mut idle = self.idle.lock().expect("runner pool idle lock");
+        let expiry = tokio::spawn(async move {
+            tokio::time::sleep(idle_ttl).await;
+            let Some(pool) = weak.upgrade() else { return };
+            let mut idle = pool.idle.lock().expect("runner pool idle lock");
+            if let Some(index) = idle.iter().position(|entry| entry.token == token) {
+                idle.remove(index);
+            }
+        })
+        .abort_handle();
+        idle.push(Idle {
+            runner,
+            token,
+            expiry,
+        });
+    }
+}
+
+pub(crate) struct PooledRunner<R: Send + 'static> {
+    runner: Option<R>,
+    pool: Arc<RunnerPool<R>>,
+    _permit: OwnedSemaphorePermit,
+}
+
+impl<R: Send + 'static> PooledRunner<R> {
+    /// Return the runner to the pool warm. Dropping without calling this
+    /// discards the runner.
+    pub(crate) fn checkin(mut self) {
+        let runner = self.runner.take().expect("runner present until checkin");
+        self.pool.checkin(runner);
+    }
+}
+
+impl<R: Send + 'static> Deref for PooledRunner<R> {
+    type Target = R;
+
+    fn deref(&self) -> &R {
+        self.runner.as_ref().expect("runner present until checkin")
+    }
+}
+
+impl<R: Send + 'static> DerefMut for PooledRunner<R> {
+    fn deref_mut(&mut self) -> &mut R {
+        self.runner.as_mut().expect("runner present until checkin")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicUsize;
+
+    use super::*;
+
+    const TTL: Duration = Duration::from_secs(300);
+
+    fn counting_spawn(spawns: &Arc<AtomicUsize>) -> impl FnOnce() -> Result<usize> + use<> {
+        let spawns = Arc::clone(spawns);
+        move || Ok(spawns.fetch_add(1, Ordering::SeqCst) + 1)
+    }
+
+    #[tokio::test]
+    async fn reuses_idle_runners_lifo() {
+        let pool = RunnerPool::new(4, TTL);
+        let spawns = Arc::new(AtomicUsize::new(0));
+
+        let first = pool.acquire(counting_spawn(&spawns)).await.unwrap();
+        let second = pool.acquire(counting_spawn(&spawns)).await.unwrap();
+        first.checkin();
+        second.checkin();
+
+        let reused = pool.acquire(counting_spawn(&spawns)).await.unwrap();
+        assert_eq!(*reused, 2, "most recently checked in comes back first");
+        let older = pool.acquire(counting_spawn(&spawns)).await.unwrap();
+        assert_eq!(*older, 1);
+        assert_eq!(
+            spawns.load(Ordering::SeqCst),
+            2,
+            "no spawn while idle runners exist"
+        );
+    }
+
+    #[tokio::test]
+    async fn drop_discards_and_frees_capacity() {
+        let pool = RunnerPool::new(1, TTL);
+        let spawns = Arc::new(AtomicUsize::new(0));
+
+        drop(pool.acquire(counting_spawn(&spawns)).await.unwrap());
+
+        let next = pool.acquire(counting_spawn(&spawns)).await.unwrap();
+        assert_eq!(*next, 2, "discarded runner is not reused");
+        assert_eq!(spawns.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn saturated_acquire_waits_for_checkin() {
+        let pool = RunnerPool::new(1, TTL);
+        let spawns = Arc::new(AtomicUsize::new(0));
+
+        let held = pool.acquire(counting_spawn(&spawns)).await.unwrap();
+        let waiter = tokio::spawn({
+            let pool = Arc::clone(&pool);
+            let spawn = counting_spawn(&spawns);
+            async move { *pool.acquire(spawn).await.unwrap() }
+        });
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        assert!(!waiter.is_finished(), "acquire must block at capacity");
+
+        held.checkin();
+        assert_eq!(
+            waiter.await.unwrap(),
+            1,
+            "waiter reuses the checked-in runner"
+        );
+        assert_eq!(spawns.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn dropping_pool_is_not_pinned_by_idle_timers() {
+        let pool = RunnerPool::new(1, TTL);
+        let spawns = Arc::new(AtomicUsize::new(0));
+        pool.acquire(counting_spawn(&spawns))
+            .await
+            .unwrap()
+            .checkin();
+
+        let weak = Arc::downgrade(&pool);
+        drop(pool);
+        assert!(
+            weak.upgrade().is_none(),
+            "idle expiry timer must hold a Weak, not keep the pool (and its runners) alive",
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn idle_runner_expires_after_ttl() {
+        let pool = RunnerPool::new(1, TTL);
+        let spawns = Arc::new(AtomicUsize::new(0));
+
+        pool.acquire(counting_spawn(&spawns))
+            .await
+            .unwrap()
+            .checkin();
+        tokio::time::sleep(TTL + Duration::from_secs(1)).await;
+
+        let next = pool.acquire(counting_spawn(&spawns)).await.unwrap();
+        assert_eq!(*next, 2, "expired runner is gone; a fresh one is spawned");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn checkout_invalidates_pending_expiry() {
+        let pool = RunnerPool::new(1, TTL);
+        let spawns = Arc::new(AtomicUsize::new(0));
+
+        pool.acquire(counting_spawn(&spawns))
+            .await
+            .unwrap()
+            .checkin();
+        tokio::time::sleep(TTL / 2).await;
+
+        // Cycle the runner: the first check-in's timer must now be a no-op.
+        pool.acquire(counting_spawn(&spawns))
+            .await
+            .unwrap()
+            .checkin();
+        tokio::time::sleep(TTL / 2 + Duration::from_secs(1)).await;
+
+        let survivor = pool.acquire(counting_spawn(&spawns)).await.unwrap();
+        assert_eq!(
+            *survivor, 1,
+            "re-checked-in runner survives the stale timer"
+        );
+        survivor.checkin();
+
+        tokio::time::sleep(TTL + Duration::from_secs(1)).await;
+        let fresh = pool.acquire(counting_spawn(&spawns)).await.unwrap();
+        assert_eq!(
+            *fresh, 2,
+            "runner expires a full TTL after its last check-in"
+        );
+    }
+}

--- a/crates/executor/src/typescript.rs
+++ b/crates/executor/src/typescript.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::process::{ExitStatus, Stdio};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
 use anyhow::{Context as AnyhowContext, anyhow, bail};
@@ -24,25 +24,44 @@ use lingua::UniversalStreamChunk;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, BufWriter, Lines};
 use tokio::process::{Child, ChildStdout, Command};
-use tokio::sync::{Mutex, mpsc};
+use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
 use crate::execution_tracing::TurnExecutionTrace;
 use crate::harness_executor::{ExecutorHarnessRuntime, ExecutorStreamMode, HarnessExecutor};
 use crate::harness_facade::{SharedHarness, SharedHarnessBacked};
 use crate::harness_tool::{BasicToolRuntime, ExoclawToolRuntime, ensure_shell_sandbox};
+use crate::runner_pool::RunnerPool;
 use crate::shared::try_send_stream_event;
 use crate::{
     AgentConfig, BraintrustRuntimeConfig, ConversationConfig, ExecutionStreamEvent, SendRequest,
     ToolRuntime,
 };
 
+/// Max runner processes per harness module. Overridable via `EXO_TS_RUNNER_POOL`.
+const DEFAULT_RUNNER_POOL_SIZE: usize = 4;
+/// Upper bound on the env override — a guard against a typo spawning thousands
+/// of Node processes, not a tuned limit.
+const MAX_RUNNER_POOL_SIZE: usize = 256;
+/// Idle runners are reaped after this long; a quiescent pool drains to zero.
+const RUNNER_IDLE_TTL: Duration = Duration::from_secs(300);
+
+fn runner_pool_size_from_env() -> usize {
+    std::env::var("EXO_TS_RUNNER_POOL")
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .filter(|&size| size > 0)
+        .map(|size: usize| size.min(MAX_RUNNER_POOL_SIZE))
+        .unwrap_or(DEFAULT_RUNNER_POOL_SIZE)
+}
+
 pub struct TypeScriptExecutor<T> {
     root: Arc<dyn ExoHarness>,
     workspace_root: PathBuf,
     env: Arc<HashMap<String, String>>,
     tools: Arc<T>,
-    runners: Arc<Mutex<HashMap<String, Arc<Mutex<TypeScriptRunnerProcess>>>>>,
+    pool_size: usize,
+    runners: Arc<StdMutex<HashMap<String, Arc<RunnerPool<TypeScriptRunnerProcess>>>>>,
 }
 
 impl<T> TypeScriptExecutor<T> {
@@ -51,13 +70,15 @@ impl<T> TypeScriptExecutor<T> {
         workspace_root: PathBuf,
         env: HashMap<String, String>,
         tools: Arc<T>,
+        pool_size: usize,
     ) -> Self {
         Self {
             root,
             workspace_root,
             env: Arc::new(env),
             tools,
-            runners: Arc::new(Mutex::new(HashMap::new())),
+            pool_size,
+            runners: Arc::new(StdMutex::new(HashMap::new())),
         }
     }
 }
@@ -69,6 +90,7 @@ impl<T> Clone for TypeScriptExecutor<T> {
             workspace_root: self.workspace_root.clone(),
             env: Arc::clone(&self.env),
             tools: Arc::clone(&self.tools),
+            pool_size: self.pool_size,
             runners: Arc::clone(&self.runners),
         }
     }
@@ -117,28 +139,36 @@ where
             bail!("typescript harness module does not exist: {module_path}");
         }
 
-        let runner = self.runner(&module_path).await?;
-        let result = {
-            let mut runner = runner.lock().await;
-            runner
-                .execute_turn(
-                    self,
-                    TypeScriptTurn {
-                        agent,
-                        conversation,
-                        turn,
-                        agent_config,
-                        conversation_config,
-                        prepared,
-                        stream_mode,
-                        turn_trace,
-                    },
+        let pool = self.pool(&module_path);
+        let mut runner = pool
+            .acquire(|| {
+                TypeScriptRunnerProcess::start(
+                    &self.workspace_root,
+                    self.env.as_ref(),
+                    &module_path,
                 )
-                .await
-        };
+            })
+            .await?;
+        let result = runner
+            .execute_turn(
+                self,
+                TypeScriptTurn {
+                    agent,
+                    conversation,
+                    turn,
+                    agent_config,
+                    conversation_config,
+                    prepared,
+                    stream_mode,
+                    turn_trace,
+                },
+            )
+            .await;
 
-        if result.is_err() {
-            self.remove_runner(&module_path, &runner).await;
+        // A failed turn implies a dead runner (the guest exits on error), so
+        // only a clean turn returns its process to the pool.
+        if result.is_ok() {
+            runner.checkin();
         }
 
         result
@@ -149,28 +179,13 @@ impl<T> TypeScriptExecutor<T>
 where
     T: ToolRuntime + 'static,
 {
-    async fn runner(&self, module_path: &str) -> Result<Arc<Mutex<TypeScriptRunnerProcess>>> {
-        let mut runners = self.runners.lock().await;
-        if let Some(runner) = runners.get(module_path) {
-            return Ok(Arc::clone(runner));
-        }
-
-        let runner = Arc::new(Mutex::new(TypeScriptRunnerProcess::start(
-            &self.workspace_root,
-            self.env.as_ref(),
-            module_path,
-        )?));
-        runners.insert(module_path.to_string(), Arc::clone(&runner));
-        Ok(runner)
-    }
-
-    async fn remove_runner(&self, module_path: &str, runner: &Arc<Mutex<TypeScriptRunnerProcess>>) {
-        let mut runners = self.runners.lock().await;
-        if let Some(current) = runners.get(module_path)
-            && Arc::ptr_eq(current, runner)
-        {
-            runners.remove(module_path);
-        }
+    fn pool(&self, module_path: &str) -> Arc<RunnerPool<TypeScriptRunnerProcess>> {
+        let mut runners = self.runners.lock().expect("runner pool map lock");
+        Arc::clone(
+            runners
+                .entry(module_path.to_string())
+                .or_insert_with(|| RunnerPool::new(self.pool_size, RUNNER_IDLE_TTL)),
+        )
     }
 
     async fn execute_runtime_request(
@@ -803,6 +818,7 @@ impl<T> TypeScriptHarness<T> {
                 workspace_root,
                 HashMap::new(),
                 tools,
+                runner_pool_size_from_env(),
             ),
             None,
         );
@@ -822,7 +838,13 @@ impl TypeScriptHarness<BasicToolRuntime> {
             .context("failed to resolve current directory for TypeScript harness")?;
         let tools = Arc::new(BasicToolRuntime);
         let runtime = ExecutorHarnessRuntime::new(
-            TypeScriptExecutor::new(Arc::clone(&exoharness), workspace_root, env, tools),
+            TypeScriptExecutor::new(
+                Arc::clone(&exoharness),
+                workspace_root,
+                env,
+                tools,
+                runner_pool_size_from_env(),
+            ),
             runtime_config,
         );
         Ok(Self {
@@ -861,7 +883,13 @@ impl TypeScriptHarness<ExoclawToolRuntime> {
             adapter_worker_root,
         ));
         let runtime = ExecutorHarnessRuntime::new(
-            TypeScriptExecutor::new(Arc::clone(&exoharness), workspace_root, env, tools),
+            TypeScriptExecutor::new(
+                Arc::clone(&exoharness),
+                workspace_root,
+                env,
+                tools,
+                runner_pool_size_from_env(),
+            ),
             runtime_config,
         );
         Ok(Self {
@@ -1223,7 +1251,6 @@ fn format_error_chain(error: &anyhow::Error, context: std::fmt::Arguments<'_>) -
 #[cfg(test)]
 mod tests {
     use std::collections::VecDeque;
-    use std::sync::Mutex as StdMutex;
 
     use super::*;
 

--- a/crates/executor/src/typescript_e2e_tests.rs
+++ b/crates/executor/src/typescript_e2e_tests.rs
@@ -1,0 +1,156 @@
+//! End-to-end runner-pool test driving real Node runner processes.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use exoharness::{ExoHarness, SandboxProvider};
+use lingua::Message;
+use lingua::universal::UserContent;
+use tempfile::TempDir;
+
+use crate::harness_tool::BasicToolRuntime;
+use crate::test_support::local_test_config;
+use crate::{
+    AgentHarnessKind, BasicExoHarness, CreateAgentRequest, CreateConversationRequest, Harness,
+    SendRequest, TypeScriptHarness, TypeScriptHarnessConfig,
+};
+
+/// One probe line per runTurn phase: `<pid> <start|end> <epoch_ms>`.
+fn probe_harness_module(probe_path: &str, sleep_ms: u64) -> String {
+    format!(
+        r#"import {{ appendFileSync }} from "node:fs";
+
+const PROBE = {probe_path:?};
+
+export default {{
+  async runTurn() {{
+    appendFileSync(PROBE, `${{process.pid}} start ${{Date.now()}}\n`);
+    await new Promise((resolve) => setTimeout(resolve, {sleep_ms}));
+    appendFileSync(PROBE, `${{process.pid}} end ${{Date.now()}}\n`);
+  }},
+}};
+"#
+    )
+}
+
+fn parse_probe(contents: &str) -> Vec<(u64, String, u64)> {
+    contents
+        .lines()
+        .map(|line| {
+            let mut parts = line.split_whitespace();
+            (
+                parts.next().expect("pid").parse().expect("pid u64"),
+                parts.next().expect("phase").to_string(),
+                parts.next().expect("timestamp").parse().expect("ms u64"),
+            )
+        })
+        .collect()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "spawns real Node runner processes (needs node + tsx); run with --ignored"]
+async fn concurrent_turns_on_one_module_use_pooled_runners() {
+    let dir = TempDir::new().expect("tempdir");
+    let probe_path = dir.path().join("probe.log");
+    let module_path = dir.path().join("pool-probe.ts");
+    std::fs::write(
+        &module_path,
+        probe_harness_module(probe_path.to_str().expect("utf8 path"), 3000),
+    )
+    .expect("write harness module");
+
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("repo root");
+    let exoharness: Arc<dyn ExoHarness> = Arc::new(
+        BasicExoHarness::new(local_test_config(dir.path().join("store")))
+            .await
+            .expect("exoharness"),
+    );
+    let harness = TypeScriptHarness::new(exoharness, workspace_root, Arc::new(BasicToolRuntime));
+
+    let agent = harness
+        .create_agent(CreateAgentRequest {
+            slug: "pool-probe".to_string(),
+            name: None,
+            harness: AgentHarnessKind::TypeScript,
+            typescript: Some(TypeScriptHarnessConfig {
+                module_path: module_path.to_str().expect("utf8 path").to_string(),
+                tool_module_paths: Vec::new(),
+            }),
+            enable_agent_tool_creation: false,
+            sandbox_image: None,
+            sandbox_provider: SandboxProvider::LocalProcess,
+            enable_networking: false,
+            model: "unused".to_string(),
+            max_output_tokens: None,
+            max_tool_round_trips: None,
+            braintrust: None,
+        })
+        .await
+        .expect("create agent");
+
+    let mut conversations = Vec::new();
+    for index in 0..4 {
+        conversations.push(
+            agent
+                .create_conversation(CreateConversationRequest {
+                    slug: Some(format!("probe-{index}")),
+                    ..Default::default()
+                })
+                .await
+                .expect("create conversation"),
+        );
+    }
+
+    let send = |conversation: Arc<dyn crate::HarnessConversation>| async move {
+        conversation
+            .send(SendRequest {
+                input: vec![Message::User {
+                    content: UserContent::String("go".to_string()),
+                }],
+                session_id: None,
+            })
+            .await
+            .expect("send");
+    };
+
+    tokio::time::timeout(
+        Duration::from_secs(60),
+        futures::future::join_all(conversations.iter().cloned().map(send)),
+    )
+    .await
+    .expect("concurrent sends timed out");
+
+    let records = parse_probe(&std::fs::read_to_string(&probe_path).expect("probe file"));
+    let starts: Vec<_> = records.iter().filter(|r| r.1 == "start").collect();
+    let ends: Vec<_> = records.iter().filter(|r| r.1 == "end").collect();
+    assert_eq!(starts.len(), 4);
+    assert_eq!(ends.len(), 4);
+
+    let pids: std::collections::HashSet<u64> = starts.iter().map(|r| r.0).collect();
+    assert_eq!(
+        pids.len(),
+        4,
+        "4 concurrent turns must use 4 runner processes"
+    );
+
+    let last_start = starts.iter().map(|r| r.2).max().expect("starts");
+    let first_end = ends.iter().map(|r| r.2).min().expect("ends");
+    assert!(
+        last_start < first_end,
+        "all 4 turns must overlap: last start {last_start} >= first end {first_end}"
+    );
+
+    // A follow-up turn must reuse a warm runner instead of spawning a fifth.
+    tokio::time::timeout(Duration::from_secs(60), send(Arc::clone(&conversations[0])))
+        .await
+        .expect("reuse send timed out");
+    let records = parse_probe(&std::fs::read_to_string(&probe_path).expect("probe file"));
+    let reuse_pid = records.last().expect("reuse record").0;
+    assert!(
+        pids.contains(&reuse_pid),
+        "follow-up turn must reuse a pooled runner, got fresh pid {reuse_pid}"
+    );
+}

--- a/docs/ts-runner-pool-design.md
+++ b/docs/ts-runner-pool-design.md
@@ -1,0 +1,198 @@
+# TypeScript runner pool — design & semantics
+
+Status: draft for review. Semantics only; implementation follows after sign-off.
+
+## Problem
+
+`TypeScriptExecutor` keeps exactly one Node runner process per harness
+`module_path` and holds its mutex for the **entire turn**, model latency
+included (`crates/executor/src/typescript.rs:120-138`). All turns for the same
+module therefore execute strictly serially, even across unrelated
+conversations and unrelated agents — the runner map is keyed by module path
+alone, so every agent configured with the same harness module shares the one
+serial process. The agent-scale eval measured this as the dominant throughput
+ceiling and worked around it with K module-path symlinks round-robin'd by the
+driver — which multiplies the map key instead of fixing the executor, and
+round-robin assignment lets one slow turn idle its whole slot while other
+slots queue.
+
+The serialization is not accidental: the host↔guest stdio protocol has no
+turn correlation (`Init`/`Done`/`Error`/`StreamEvent` carry no turn id), so at
+most one turn may be in flight per process. This design keeps that protocol
+invariant and adds concurrency by **pooling processes**, not by multiplexing
+turns within a process (that is a separate, later change — see Evolution).
+
+## Goals
+
+- N concurrent turns for the same harness module within one exo process.
+- Free assignment: a turn takes _any_ idle runner; a slow turn never blocks a
+  turn that an idle runner could serve.
+- Failure isolation: one failed turn costs one process, nothing else.
+- Pool quiesces when idle (bursty daemons like exoclaw must not pin
+  N Node processes forever).
+- Minimal machinery: the simplest design that has the right semantics,
+  wherever that puts the changes. (As drafted it needs no protocol, guest, or
+  exoharness change — the diff lands in `crates/executor/src/typescript.rs` —
+  but that's a consequence, not a constraint; if a change elsewhere makes
+  this cleaner, we take it.)
+
+## Non-goals
+
+- Multiplexing turns over one process (option A / exec-id protocol).
+- Cross-process or cross-machine work distribution (PR #113's coordinator +
+  a future `claim_ready` worker fleet).
+- Scheduling policy, priorities, or per-turn timeouts. Callers wait FIFO;
+  pacing belongs to the layers above (conversation leases, drivers).
+- Pre-spawning / warm-up.
+
+## Design
+
+Replace the per-module `Arc<Mutex<TypeScriptRunnerProcess>>` with a
+per-module `RunnerPool`:
+
+```
+runners: Mutex<HashMap<module_path, Arc<RunnerPool>>>
+
+RunnerPool {
+    permits: Semaphore(max_size),        // concurrency budget
+    idle:    Mutex<Vec<IdleRunner>>,     // LIFO stack of warm processes
+}
+IdleRunner { process: TypeScriptRunnerProcess, since: Instant }
+```
+
+The per-runner mutex disappears entirely: checkout transfers **ownership** of
+the process to the turn (`&mut` by move), which is the exclusivity guarantee.
+The pool replaces the lock rather than wrapping it.
+
+### Turn lifecycle
+
+```
+execute_turn(module_path, turn)
+  │
+  ├─ pool = get-or-create RunnerPool for module_path
+  ├─ permit = pool.permits.acquire().await          // FIFO wait if saturated
+  ├─ runner = pool.idle.pop()                       // LIFO; prune expired
+  │           else TypeScriptRunnerProcess::start() // lazy spawn
+  ├─ runner.execute_turn(turn).await                // unchanged internals
+  │
+  ├─ Ok  ⇒ pool.idle.push(runner, now)              // check-in, warm
+  └─ Err ⇒ drop(runner)                             // kill_on_drop reaps it
+            (permit released on drop either way)
+```
+
+### Semantics (invariants)
+
+1. **Bounded concurrency.** At most `max_size` runner processes per module
+   path; at most one in-flight turn per process. Concurrency for a module is
+   exactly `min(in-flight turns, max_size)`.
+2. **Free assignment, no affinity.** Any idle runner of the module serves any
+   turn. Consecutive turns of one conversation may land on different
+   processes.
+3. **LIFO reuse.** Checkout pops the most-recently-used runner. Load
+   concentrates on few warm processes; the rest age out. Scale-down falls out
+   of reuse order instead of needing a balancer.
+4. **Lazy scale-up.** A process is spawned only when a turn arrives, no idle
+   runner exists, and the permit budget allows. Spawn cost (node + tsx +
+   module import, sub-second) is paid at the concurrency high-water mark
+   only.
+5. **TTL scale-down.** An idle runner unused for `IDLE_TTL` (5 min) is
+   dropped. A quiescent pool shrinks to zero processes. (Behavior change vs.
+   today, where the single runner lives forever; first turn after a long
+   idle pays one spawn.)
+6. **Failure isolation.** A turn error discards its process and only its
+   process; sibling runners and queued waiters are untouched. This matches
+   guest behavior — `runner.ts` exits on a failed `runTurn`, so "turn failed"
+   and "process dead" are already the same event. Spawn failures are returned
+   to the caller and never cached (a broken module fails each attempt fast,
+   as today).
+7. **No ordering.** The pool provides no serialization or ordering
+   guarantees whatsoever. Per-conversation FIFO/exclusivity live above, in
+   the conversation send lock today and PR #113's coordinator leases after.
+   Nothing may rely on the executor for mutual exclusion. (Nothing does
+   today — the module mutex is an artifact, not a contract — but this makes
+   it explicit.)
+8. **FIFO waiting, no timeout.** When saturated, callers queue on the
+   semaphore in arrival order. No checkout timeout at this layer: waiting on
+   a saturated pool is today's mutex wait, K-wide; introducing a new failure
+   mode here buys nothing.
+
+### Harness-author contract (made explicit)
+
+A harness module must not rely on process-local state (module-level globals,
+in-memory caches) surviving across turns. Cross-turn state belongs in the
+substrate (events, artifacts). This was always the de-facto contract — the
+single runner process already dies on any error and the eval's symlink pool
+already violated stickiness — but the pool makes it load-bearing. To be
+documented in the TS harness docs alongside this change.
+
+**Verified pool-safe:** sandbox-process reuse (`reuse_key`) resolves through
+the conversation event log + substrate process status
+(`typescript.rs:666-715`), not through runner memory. A turn on runner 2
+reuses a sandbox process created via runner 1; the runner-local
+`sandbox_processes` map only routes stdin/events for processes started during
+the current checkout, and a re-established pump resumes from the recorded
+cursor. Reaping an idle runner therefore orphans nothing: sandbox processes
+live in the sandbox, their event pumps die with the process's channel and are
+rebuilt on next use — identical to what runner death already does today.
+
+### Idle expiry
+
+No global reaper. Check-in arms a one-shot expiry: pushing a runner onto the
+free-list assigns it a unique check-in token and spawns a task that sleeps
+`IDLE_TTL`, then removes the free-list entry **with that token, if still
+present** — i.e. only if the runner sat idle the whole time. If the runner
+was checked out (and possibly re-checked-in) meanwhile, the token is gone and
+the timer no-ops; the newer check-in armed its own timer. Dropping the
+removed runner reaps the process (`kill_on_drop` SIGKILLs a quiescent Node
+process — the host has never sent the protocol's `Shutdown` message and an
+idle runner has nothing to flush, so graceful shutdown is not worth the
+machinery).
+
+Properties: a fully idle pool drains to zero with no periodic machinery and
+no task whose lifecycle must be managed — every timer either acts once or
+no-ops, and at most `max_size` timers per module sleep at any moment. Pool
+map entries themselves are kept (bounded by distinct module paths).
+
+## Configuration
+
+Two knobs, one exposed:
+
+| knob       | value                                   | rationale                                                                                                                                                                                                                      |
+| ---------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `max_size` | env `EXO_TS_RUNNER_POOL`, default **4** | Default must be >1 or the fix is opt-in and the measured serialization persists out of the box. 4 ≈ 200-400 MB worst-case per module, only under sustained concurrency, reclaimed by TTL. Eval drivers set 16 on big machines. |
+| `IDLE_TTL` | const, **300 s**                        | Long enough to ride out gaps between bursts; spawn is sub-second so the cost of expiring too eagerly is small anyway. Not worth an env var until proven otherwise.                                                             |
+
+Plumbing: `TypeScriptExecutor::new` gains the pool size (read from env in the
+`from_*` constructors), so tests can pin it.
+
+## Interaction with PR #113 and evolution path
+
+- **#113 (turn coordination)** changes _who calls_ `execute_turn`
+  (enqueue/claim/lease above the executor); this pool changes _what happens
+  inside_ it. Orthogonal; either can land first. Together: leases hand out up
+  to K conversations, and K turns on the same module actually overlap instead
+  of re-serializing at the runner mutex.
+- **Option A (turn multiplexing)** later changes invariant 1's "one turn per
+  process" to "≤ M turns per process" by adding exec-id correlation to the
+  protocol. The pool structure survives intact — permits count turn slots
+  instead of processes — and A shrinks the memory cost of a given
+  concurrency level rather than replacing the pool. A should wait for #113's
+  redelivery + resume, since a multiplexed process death aborts M turns.
+- **Eval cleanup:** `--runner-pool` symlink machinery in
+  `evaluation/agent-scale/driver` becomes obsolete (drive size via
+  `EXO_TS_RUNNER_POOL` instead); delete the `.harness.poolN.ts` artifacts.
+
+## Testing
+
+- Unit (pool semantics, fake spawner): checkout beyond `max_size` blocks;
+  LIFO reuse; error discards exactly one process; TTL prunes; waiter wakes on
+  check-in.
+- Integration: N concurrent `send`s on one module measurably overlap
+  (wall-clock ≪ N × turn time with a slow mock model); sandbox `reuse_key`
+  works across two different runners of one pool.
+
+## Resolved review decisions
+
+1. Default `max_size` = 4. Confirmed.
+2. `IDLE_TTL` = 300 s const (was 60 s in draft; too short for a default).
+3. No global reaper — per-check-in one-shot expiry (see Idle expiry above).


### PR DESCRIPTION
**Draft / WIP** — opening for early review of the approach.

## Problem
`TypeScriptExecutor` kept one Node runner process per `module_path` and held its mutex for the **whole turn** (model latency included), serializing every turn that shares a harness module — across all conversations *and* agents. The agent-scale eval measured this as the dominant throughput ceiling and worked around it with K module-path symlinks round-robin'd by the driver (multiplies the map key rather than fixing the executor; round-robin also idles a slow turn's slot).

## Change
Replace the per-runner mutex with a per-module `RunnerPool`: a semaphore budget over a LIFO free-list of warm runners.

- **Checkout by ownership** — `acquire` hands the runner to the turn; the mutex is gone. A clean turn checks it back in warm; a failed turn drops it (the guest already exits on error, so "turn failed" == "process dead").
- **Free assignment, LIFO reuse** — any idle runner serves any turn; load concentrates on hot processes, the rest age out.
- **Lazy spawn, TTL drain** — spawn only when a turn arrives and no idle runner exists; idle runners expire after `RUNNER_IDLE_TTL` (5 min) via a one-shot per-check-in timer holding a `Weak` to the pool, so dropping the executor reaps them immediately and a quiescent pool drains to zero.
- **Size** via `EXO_TS_RUNNER_POOL` (default 4, clamped to 256).
- No protocol / guest (`runner.ts`) / exoharness changes.

Design + semantics: `docs/ts-runner-pool-design.md`.

## Not in scope (deliberate)
- Multiplexing turns over one process (exec-id protocol) — later, and wants PR #113's redelivery first.
- Cross-process work distribution — PR #113's coordinator.
- Ordering/exclusion — stays above the executor (conversation send lock today, #113 leases after); the pool guarantees none.

## Tests
- 6 unit tests (fake spawner, paused clock): LIFO reuse, drop-discards-and-frees-capacity, saturated-acquire-blocks-then-reuses, TTL expiry, checkout-invalidates-stale-timer, Weak-not-pinned-on-drop.
- Ignored end-to-end test driving real Node runners (`--ignored`): 4 concurrent turns on one module → 4 distinct runner PIDs, overlapping, + warm reuse.

## Measured (agent-scale, synthetic mock model, single box)
- vs old serialized executor: **~6× throughput, ~5× lower p50 latency** (batch, 8-way).
- vs the symlink workaround at equal 8-way: **+19% throughput, −23% p50**, ~equal peak memory.
- Under light/bursty load: **~40% lower mean memory** (lazy spawn + reuse vs 8 pinned runners).

## Open / follow-ups
- Per-module `runners` map entry is never removed (minor; module set normally fixed).
- No global ceiling across modules (only per-module `pinned` + env clamp).

🤖 Draft generated with assistance from Claude.