### PR TITLE
Update repo URLs after org move: ankrgyl/exo -> exoharness/exo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 # exo
 
-[![CI](https://github.com/ankrgyl/exo/actions/workflows/ci.yml/badge.svg)](https://github.com/ankrgyl/exo/actions/workflows/ci.yml)
-[![Integration tests](https://github.com/ankrgyl/exo/actions/workflows/integration.yml/badge.svg)](https://github.com/ankrgyl/exo/actions/workflows/integration.yml)
+[![CI](https://github.com/exoharness/exo/actions/workflows/ci.yml/badge.svg)](https://github.com/exoharness/exo/actions/workflows/ci.yml)
+[![Integration tests](https://github.com/exoharness/exo/actions/workflows/integration.yml/badge.svg)](https://github.com/exoharness/exo/actions/workflows/integration.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/rust-stable-orange.svg?logo=rust)](Cargo.toml)
 [![TypeScript](https://img.shields.io/badge/typescript-5.x-3178c6.svg?logo=typescript&logoColor=white)](tsconfig.json)
@@ -55,7 +55,7 @@ To use Exo as an agent, you'll need an OpenAI or OpenRouter API key. If you
 have that, simply do the following:
 
 ```
-curl -fsSL https://raw.githubusercontent.com/ankrgyl/exo/main/setup.sh -o setup.sh
+curl -fsSL https://raw.githubusercontent.com/exoharness/exo/main/setup.sh -o setup.sh
 bash setup.sh
 ```
 

--- a/examples/exo/adapters/irc/README.md
+++ b/examples/exo/adapters/irc/README.md
@@ -16,7 +16,7 @@ default ExoChat control adapter:
 
 ```bash
 mkdir exo && cd exo
-curl -fsSL https://raw.githubusercontent.com/ankrgyl/exo/main/setup.sh -o setup.sh
+curl -fsSL https://raw.githubusercontent.com/exoharness/exo/main/setup.sh -o setup.sh
 bash setup.sh
 ```
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO_URL="${EXO_REPO_URL:-https://github.com/ankrgyl/exo.git}"
+REPO_URL="${EXO_REPO_URL:-https://github.com/exoharness/exo.git}"
 REPO_REF="${EXO_REPO_REF:-main}"
 INSTALL_DIR="${EXO_INSTALL_DIR:-$PWD}"
 MODEL_NAME="${EXO_MODEL:-gpt-5.4}"

--- a/website/docs-src/.vitepress/config.mts
+++ b/website/docs-src/.vitepress/config.mts
@@ -23,10 +23,10 @@ export default defineConfig({
     siteTitle: "exo",
     nav: [
       { text: "Home", link: "/" },
-      { text: "GitHub", link: "https://github.com/ankrgyl/exo" },
+      { text: "GitHub", link: "https://github.com/exoharness/exo" },
     ],
     search: { provider: "local" },
-    socialLinks: [{ icon: "github", link: "https://github.com/ankrgyl/exo" }],
+    socialLinks: [{ icon: "github", link: "https://github.com/exoharness/exo" }],
     sidebar: [
       { text: "Overview", link: "/" },
       {

--- a/website/docs-src/concepts/adapters.md
+++ b/website/docs-src/concepts/adapters.md
@@ -131,7 +131,7 @@ mount root for agent-cli.
 ::: info
   Each adapter has a full setup walkthrough (bot creation, permissions,
   linking, troubleshooting) in its README under
-  [`examples/exo/adapters/`](https://github.com/ankrgyl/exo/tree/main/examples/exo/adapters)
+  [`examples/exo/adapters/`](https://github.com/exoharness/exo/tree/main/examples/exo/adapters)
   — start there when setting one up for real.
 :::
 

--- a/website/docs-src/concepts/index.md
+++ b/website/docs-src/concepts/index.md
@@ -70,5 +70,5 @@ agent was never at risk.
   guardian, scheduler, memory, and the self-improvement loop.
 
 The canonical reference is
-[`spec/exoharness.md`](https://github.com/ankrgyl/exo/blob/main/spec/exoharness.md);
+[`spec/exoharness.md`](https://github.com/exoharness/exo/blob/main/spec/exoharness.md);
 these pages are a guided tour of the same material.

--- a/website/docs-src/getting-started/installation.md
+++ b/website/docs-src/getting-started/installation.md
@@ -20,7 +20,7 @@ You'll also need an **OpenAI API key**.
 ## Run the setup script
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ankrgyl/exo/main/setup.sh -o setup.sh
+curl -fsSL https://raw.githubusercontent.com/exoharness/exo/main/setup.sh -o setup.sh
 bash setup.sh
 ```
 
@@ -52,7 +52,7 @@ harness from scratch or script against the exoharness — install it from a
 checkout with cargo:
 
 ```bash
-git clone https://github.com/ankrgyl/exo
+git clone https://github.com/exoharness/exo
 cd exo
 cargo install --path crates/cli --locked
 exo --help

--- a/website/docs-src/tutorials/custom-coding-agent.md
+++ b/website/docs-src/tutorials/custom-coding-agent.md
@@ -12,7 +12,7 @@ hooks from the [Custom Agent Quickstart](./write-your-own-agent):
 `registerTools` and `instructions`.
 
 The finished file is
-[`examples/typescript/coding-agent-harness.ts`](https://github.com/ankrgyl/exo/blob/main/examples/typescript/coding-agent-harness.ts).
+[`examples/typescript/coding-agent-harness.ts`](https://github.com/exoharness/exo/blob/main/examples/typescript/coding-agent-harness.ts).
 
 ## The loop is already there
 

--- a/website/docs-src/tutorials/write-your-own-agent.md
+++ b/website/docs-src/tutorials/write-your-own-agent.md
@@ -17,7 +17,7 @@ need:
    the current number without calling a tool.
 
 The finished file lives at
-[`examples/typescript/sysmon-harness.ts`](https://github.com/ankrgyl/exo/blob/main/examples/typescript/sysmon-harness.ts).
+[`examples/typescript/sysmon-harness.ts`](https://github.com/exoharness/exo/blob/main/examples/typescript/sysmon-harness.ts).
 
 ## The harness contract
 
@@ -40,7 +40,7 @@ export default defineHarness({
 });
 ```
 
-That's [`examples/typescript/basic-harness.ts`](https://github.com/ankrgyl/exo/blob/main/examples/typescript/basic-harness.ts)
+That's [`examples/typescript/basic-harness.ts`](https://github.com/exoharness/exo/blob/main/examples/typescript/basic-harness.ts)
 verbatim. `runResponsesHarnessTurn` accepts two hooks, and they are the whole
 customization surface for this tutorial:
 
@@ -133,7 +133,7 @@ Notes:
 - `initializationParameters` / `initialize(args)` exist so a tool can be
   configured per-agent (an API prefix, a base URL) separately from per-call
   arguments — see
-  [`examples/typescript/tools/uppercase.ts`](https://github.com/ankrgyl/exo/blob/main/examples/typescript/tools/uppercase.ts)
+  [`examples/typescript/tools/uppercase.ts`](https://github.com/exoharness/exo/blob/main/examples/typescript/tools/uppercase.ts)
   for a configured example. Ours needs no configuration.
 - Harness code runs on the **host**, so `node:os` reports the host machine.
   For work that belongs in isolation, call the `shell` tool or
@@ -187,7 +187,7 @@ conversation history — see [Data Model](../concepts/data-model) if you
 want the details on why.)
 
 The same pattern scales to anything derivable: the canonical agent's harness
-([`examples/exo/harness.ts`](https://github.com/ankrgyl/exo/blob/main/examples/exo/harness.ts))
+([`examples/exo/harness.ts`](https://github.com/exoharness/exo/blob/main/examples/exo/harness.ts))
 uses it to splice in an identity prompt, a git-ignored local profile file,
 and the agent's persistent memory block each round.
 

--- a/website/index.html
+++ b/website/index.html
@@ -1092,7 +1092,7 @@
         </p>
         <p>
           For the exact model and terminology, read
-          <a href="https://github.com/ankrgyl/exo/blob/main/spec/exoharness.md"
+          <a href="https://github.com/exoharness/exo/blob/main/spec/exoharness.md"
             >spec/exoharness.md</a
           >.
         </p>
@@ -1175,13 +1175,13 @@
 
       <footer class="footer">
         <span class="md">[</span
-        ><a href="https://github.com/ankrgyl/exo">github</a
+        ><a href="https://github.com/exoharness/exo">github</a
         ><span class="md">]</span>
-        <span class="md">(</span>https://github.com/ankrgyl/exo<span class="md"
+        <span class="md">(</span>https://github.com/exoharness/exo<span class="md"
           >)</span
         >
         <span class="md"> - [</span
-        ><a href="https://github.com/ankrgyl/exo/blob/main/spec/exoharness.md"
+        ><a href="https://github.com/exoharness/exo/blob/main/spec/exoharness.md"
           >spec</a
         ><span class="md">]</span>
         <span class="md">(</span>./spec/exoharness.md<span class="md">)</span>

--- a/website/index.html
+++ b/website/index.html
@@ -1092,7 +1092,8 @@
         </p>
         <p>
           For the exact model and terminology, read
-          <a href="https://github.com/exoharness/exo/blob/main/spec/exoharness.md"
+          <a
+            href="https://github.com/exoharness/exo/blob/main/spec/exoharness.md"
             >spec/exoharness.md</a
           >.
         </p>
@@ -1177,11 +1178,13 @@
         <span class="md">[</span
         ><a href="https://github.com/exoharness/exo">github</a
         ><span class="md">]</span>
-        <span class="md">(</span>https://github.com/exoharness/exo<span class="md"
+        <span class="md">(</span>https://github.com/exoharness/exo<span
+          class="md"
           >)</span
         >
         <span class="md"> - [</span
-        ><a href="https://github.com/exoharness/exo/blob/main/spec/exoharness.md"
+        ><a
+          href="https://github.com/exoharness/exo/blob/main/spec/exoharness.md"
           >spec</a
         ><span class="md">]</span>
         <span class="md">(</span>./spec/exoharness.md<span class="md">)</span>


### PR DESCRIPTION
The repository moved to the exoharness org. Update all hardcoded references — README badges, setup.sh clone default, install docs (raw.githubusercontent.com links), website config, and tutorial links. GitHub redirects the old URLs for now, but the raw links in install instructions are the ones that would break first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)