### PR TITLE
docs: explain CLI and ExoChat interaction after /exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,20 +87,20 @@ not printed before. Please print them here.
 
 ## Basic Agent Interaction
 
-For the basic setup of Exo, there are two methods of interacting, on the command
-line where you ran the setup script (or exo.sh). And through a browser using
+For the basic setup of Exo, there are two methods of interacting: on the command
+line where you ran the setup script (or `exo.sh`), and through a browser using
 exo-chat.
 
-Exo agents are intended to be long running. For example, if you `/exit` from the
-command line you can still interace with it via exo-chat. And if you do exit,
-you can always connect back to the cli chat using `./exo.sh`.
+Exo agents are intended to be long-running. For example, if you `/exit` from the
+command line you can still interact with it via exo-chat. And if you do exit,
+you can always connect back to the CLI chat using `./exo.sh`.
 
 Exo-chat is a minimal, web-based chat where you can talk to your agent from
 anywhere on the internet. However, Exo also supports standard chat applications
 like IRC, Discord, WhatsApp, Signal, or Slack. To configure them, just ask your
 agent to do so.
 
-If you ever forget or loose you exo-chat URL, you can just ask Exo for it from
+If you ever forget or lose your exo-chat URL, you can just ask Exo for it from
 the command line.
 
 ## Operating Exo

--- a/README.md
+++ b/README.md
@@ -85,6 +85,24 @@ schedule a task to run every minute that grabs news headlines from the BBC RSS f
 not printed before. Please print them here.
 ```
 
+## Basic Agent Interaction
+
+For the basic setup of Exo, there are two methods of interacting, on the command
+line where you ran the setup script (or exo.sh). And through a browser using
+exo-chat.
+
+Exo agents are intended to be long running. For example, if you `/exit` from the
+command line you can still interace with it via exo-chat. And if you do exit,
+you can always connect back to the cli chat using `./exo.sh`.
+
+Exo-chat is a minimal, web-based chat where you can talk to your agent from
+anywhere on the internet. However, Exo also supports standard chat applications
+like IRC, Discord, WhatsApp, Signal, or Slack. To configure them, just ask your
+agent to do so.
+
+If you ever forget or loose you exo-chat URL, you can just ask Exo for it from
+the command line.
+
 ## Operating Exo
 
 `setup.sh` is only for the first-time install. After that, `./exo.sh` in the

--- a/setup.sh
+++ b/setup.sh
@@ -841,6 +841,10 @@ print_success_banner() {
 EOF
   echo "Exo is installed and your agent is ready."
   echo
+  echo "Your agent is long-running: once started, it stays up after you /exit the"
+  echo "chat, and it serves an ExoChat URL you can open from any browser, anywhere."
+  echo "If you ever lose that URL, ask your agent for it from the CLI chat."
+  echo
   echo "Start chatting:"
   if [[ "$launch_dir" != "$dir" ]]; then
     echo "  cd $dir"


### PR DESCRIPTION
## Summary
- Add a **Basic Agent Interaction** section covering CLI vs ExoChat after setup
- Clarify that `/exit` leaves the REPL but the agent keeps running, and `./exo.sh` reconnects
- Note that other chat adapters can be configured by asking the agent, and that the ExoChat URL can be recovered from the CLI

## Test plan
- [ ] Skim the new README section for clarity and typos
- [ ] Confirm it sits cleanly between Quick Start and Operating Exo

Made with [Cursor](https://cursor.com)