### PR TITLE
tests: skip by-slug index in snapshot round-trip dir walk

### DIFF
--- a/crates/cli/tests/snapshot_round_trip.rs
+++ b/crates/cli/tests/snapshot_round_trip.rs
@@ -255,18 +255,21 @@ fn preflight() -> bool {
     true
 }
 
-/// Read a directory expected to contain exactly one entry and return that
-/// entry's path. Used to walk into the per-agent / per-conversation directories
-/// without hardcoding the test-generated UUIDs.
+/// Read a directory expected to contain exactly one record entry and return
+/// that entry's path. Used to walk into the per-agent / per-conversation
+/// directories without hardcoding the test-generated UUIDs. Skips `by-slug`,
+/// the slug-uniqueness index the harness keeps next to the agent record
+/// directories.
 fn find_single_subdir(parent: &std::path::Path) -> std::path::PathBuf {
     let mut entries: Vec<_> = std::fs::read_dir(parent)
         .unwrap_or_else(|error| panic!("read_dir({}) failed: {error:#}", parent.display()))
         .filter_map(Result::ok)
+        .filter(|entry| entry.file_name() != "by-slug")
         .collect();
     assert_eq!(
         entries.len(),
         1,
-        "expected exactly one entry under {}, found {}",
+        "expected exactly one record entry under {}, found {}",
         parent.display(),
         entries.len()
     );


### PR DESCRIPTION
## Problem
The docker cells of the Integration tests workflow fail on `filesystem_snapshot_and_rewind_round_trip` (see run 29067452982, linux + macos):

```
assertion `left == right` failed: expected exactly one entry under .../agents, found 2
```

#118 added a slug-uniqueness index at `agents/by-slug/`, so the agents dir now holds two entries (the agent's UUID dir + the index). The test's `find_single_subdir` helper asserts exactly one.

## Fix
Filter `by-slug` out of the dir walk before asserting single-entry.

## Verification
`cargo test -p exo --test snapshot_round_trip -- --ignored` passes locally against real docker (was failing with the same assertion before the fix).