### PR TITLE
Default missing tool results to null

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@
 
 </div>
 
-Exo is a systems approach to recursive self improvement. In short, it's a 
-complete AI agent harness (supporting tools, tasks, integrations, etc. 
-similar to OpenClaw, Pi or Hermes), with the crucial difference that it 
-has full visibility into both its code and runtime logs. This allows Exo 
-to incrementally improve every aspect of itself, clone itself, and even 
+Exo is a systems approach to recursive self improvement. In short, it's a
+complete AI agent harness (supporting tools, tasks, integrations, etc.
+similar to OpenClaw, Pi or Hermes), with the crucial difference that it
+has full visibility into both its code and runtime logs. This allows Exo
+to incrementally improve every aspect of itself, clone itself, and even
 manage a lineage of clones.
 
-While most agents can do some form of self improvement, such as updating 
-memory or creating skills, Exo is fully recursive in that it can clone or 
-operate on any aspect of itself, from prompts, to memory, tooling, or even 
-basic harness policy itself. It's architected so that this evolution can 
+While most agents can do some form of self improvement, such as updating
+memory or creating skills, Exo is fully recursive in that it can clone or
+operate on any aspect of itself, from prompts, to memory, tooling, or even
+basic harness policy itself. It's architected so that this evolution can
 be done incrementally
 and (mostly) safely. The only thing it can't muck with is an event log which
 provides a canonical history of what it's tried to prevent getting stuck in
@@ -67,7 +67,7 @@ _Note that Exo requires git and Docker. The setup script offers to install
 them if missing, and installs pinned node, pnpm, and rust toolchains
 automatically via [mise](https://mise.jdx.dev)._
 
-It'll build Exo (may take a few minutes), then ask for the API key and your name 
+It'll build Exo (may take a few minutes), then ask for the API key and your name
 and your agent's name, and give you the command to start Exo (./exo.sh).
 
 ## Basic Agent Interaction

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -354,6 +354,7 @@ pub enum EventData {
     },
     ToolResult {
         tool_call_id: ToolCallId,
+        #[serde(default)]
         result: ToolResult,
     },
     LinguaStreamChunk {
@@ -986,6 +987,19 @@ mod tests {
         match event {
             EventData::Messages { usage, .. } => assert!(usage.is_none()),
             _ => panic!("expected Messages variant"),
+        }
+    }
+
+    #[test]
+    fn tool_result_event_deserializes_without_result_field() {
+        let json = serde_json::json!({
+            "type": "tool_result",
+            "tool_call_id": "call-1",
+        });
+        let event: EventData = serde_json::from_value(json).expect("legacy event should parse");
+        match event {
+            EventData::ToolResult { result, .. } => assert!(result.is_null()),
+            _ => panic!("expected ToolResult variant"),
         }
     }
 

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -996,7 +996,8 @@ mod tests {
             "type": "tool_result",
             "tool_call_id": "call-1",
         });
-        let event: EventData = serde_json::from_value(json).expect("legacy event should parse");
+        let event: EventData =
+            serde_json::from_value(json).expect("tool result without result field should parse");
         match event {
             EventData::ToolResult { result, .. } => assert!(result.is_null()),
             _ => panic!("expected ToolResult variant"),


### PR DESCRIPTION
## Context

`EventData` currently rejects tool-result events that omit the `result` field. Treating the field as nullable allows these events to deserialize while preserving strict handling for the rest of the event shape.

## Description

Default a missing `ToolResult.result` field to JSON `null` during Serde deserialization. Present tool results are unchanged.

## Testing

`cargo test -p exoharness tool_result_event_deserializes_without_result_field`
