### PR TITLE
harness: prevent agent tool name collisions from bricking startup

### DIFF
--- a/typescript/harness/built-in-tools.ts
+++ b/typescript/harness/built-in-tools.ts
@@ -9,7 +9,11 @@ import type {
   TurnContext,
 } from "./index";
 import type { HarnessToolRegistry, ToolInstance } from "./tools";
-import { DEFAULT_AGENT_TOOL_DIRECTORY, loadAgentTool } from "./tool-modules";
+import {
+  DEFAULT_AGENT_TOOL_DIRECTORY,
+  findAgentToolNameConflict,
+  loadAgentTool,
+} from "./tool-modules";
 
 export type BuiltInToolName =
   | "shell"
@@ -265,6 +269,18 @@ async function installAgentTool(
   }
   if (!tool) {
     throw new Error("agent tool validation did not return a tool");
+  }
+
+  const conflictingModulePath = await findAgentToolNameConflict(
+    tool.definition.name,
+    name,
+    toolsDirectory,
+  );
+  if (conflictingModulePath) {
+    const conflictingModuleName = path.basename(conflictingModulePath, ".ts");
+    throw new Error(
+      `tool ${tool.definition.name} is already installed by module ${conflictingModuleName}; reinstall using name ${conflictingModuleName} to replace it, or uninstall_agent_tool it first`,
+    );
   }
 
   await fs.writeFile(sourcePath, moduleSource, "utf8");

--- a/typescript/harness/index.test.ts
+++ b/typescript/harness/index.test.ts
@@ -624,6 +624,97 @@ describe("agent tool loading", () => {
     }
   });
 
+  it("rejects installing an agent tool whose tool name belongs to another module", async () => {
+    const previousCwd = process.cwd();
+    const tempdir = await fs.mkdtemp(path.join(os.tmpdir(), "exo-agent-tool-"));
+    process.chdir(tempdir);
+    try {
+      const context = fakeTurnContext();
+      const registry = createToolRegistry(context);
+      registerBuiltInTools(registry, context, ["install_agent_tool"]);
+
+      // Two different module files whose source defines the same tool name,
+      // reverse_text: only the first install may claim that tool name.
+      const moduleSource = reverseTextToolSource();
+      await registry.executePending([
+        installAgentToolCall("install_1", "reverse-text", moduleSource),
+      ]);
+      const events = await registry.executePending([
+        installAgentToolCall("install_2", "reverse-text-v2", moduleSource),
+      ]);
+
+      expect(events).toEqual([
+        wrappedToolResultEvent(
+          "install_2",
+          "install_agent_tool",
+          "built_in",
+          2,
+          {
+            ok: false,
+            error:
+              "tool reverse_text is already installed by module reverse-text; " +
+              "reinstall using name reverse-text to replace it, or uninstall_agent_tool it first",
+          },
+        ),
+      ]);
+      await expect(
+        fs.access(".exo/agent-tools/reverse-text-v2.ts"),
+      ).rejects.toThrow();
+    } finally {
+      process.chdir(previousCwd);
+      await fs.rm(tempdir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips broken and duplicate agent tool modules instead of failing startup", async () => {
+    const previousCwd = process.cwd();
+    const tempdir = await fs.mkdtemp(path.join(os.tmpdir(), "exo-agent-tool-"));
+    process.chdir(tempdir);
+    try {
+      const toolsDirectory = ".exo/agent-tools";
+      await fs.mkdir(toolsDirectory, { recursive: true });
+      await fs.writeFile(
+        path.join(toolsDirectory, "a-broken.ts"),
+        "this is not valid typescript {{{\n",
+        "utf8",
+      );
+      await fs.writeFile(
+        path.join(toolsDirectory, "b-reverse-text.ts"),
+        reverseTextToolSource(),
+        "utf8",
+      );
+      await fs.writeFile(
+        path.join(toolsDirectory, "c-duplicate-reverse-text.ts"),
+        reverseTextToolSource(),
+        "utf8",
+      );
+
+      const context = fakeTurnContext();
+      const registry = createToolRegistry(context);
+      await registerAgentToolsFromDirectoryIfExists(registry, context);
+
+      expect(registry.get("reverse_text")?.source).toBe("agent");
+      await expect(
+        registry.executePending([
+          {
+            toolCallId: "call_1",
+            request: {
+              functionName: "reverse_text",
+              arguments: { text: "hello" },
+            },
+          },
+        ]),
+      ).resolves.toEqual([
+        wrappedToolResultEvent("call_1", "reverse_text", "agent", 1, {
+          text: "olleh",
+        }),
+      ]);
+    } finally {
+      process.chdir(previousCwd);
+      await fs.rm(tempdir, { recursive: true, force: true });
+    }
+  });
+
   it("rejects agent tool modules without a default Tool export", async () => {
     const registry = createToolRegistry(fakeTurnContext());
 
@@ -707,6 +798,24 @@ function fakeTool(
 function ircToolModulePath(): string {
   return new URL("../../examples/typescript/tools/irc.ts", import.meta.url)
     .href;
+}
+
+function installAgentToolCall(
+  toolCallId: string,
+  moduleName: string,
+  moduleSource: string,
+) {
+  return {
+    toolCallId,
+    request: {
+      functionName: "install_agent_tool",
+      arguments: {
+        name: moduleName,
+        moduleSource,
+        initialization: {},
+      },
+    },
+  };
 }
 
 function reverseTextToolSource(): string {

--- a/typescript/harness/tool-modules.ts
+++ b/typescript/harness/tool-modules.ts
@@ -100,26 +100,63 @@ export async function registerAgentToolsFromDirectoryIfExists(
   context: TurnContext,
   toolsDirectory = DEFAULT_AGENT_TOOL_DIRECTORY,
 ): Promise<void> {
+  // A broken agent-written module (duplicate tool name, failed import, ...)
+  // must not prevent the harness from starting: the agent cannot repair its
+  // own tools if it can never boot. Skip the module and keep going.
+  // Future TODO: consider self-repairing by removing the broken module.
+  for (const modulePath of await agentToolModulePaths(toolsDirectory)) {
+    try {
+      await registerAgentToolModulePath(registry, context, modulePath);
+    } catch (error) {
+      console.error(
+        `skipping agent tool module ${modulePath}: ${errorMessage(error)}`,
+      );
+    }
+  }
+}
+
+export async function findAgentToolNameConflict(
+  toolName: string,
+  moduleName: string,
+  toolsDirectory = DEFAULT_AGENT_TOOL_DIRECTORY,
+): Promise<string | null> {
+  const ownModulePath = path.resolve(toolsDirectory, `${moduleName}.ts`);
+  for (const modulePath of await agentToolModulePaths(toolsDirectory)) {
+    if (modulePath === ownModulePath) {
+      continue;
+    }
+    let entries: ToolModuleEntry[];
+    try {
+      entries = normalizeToolModuleExport(
+        await loadToolModule(modulePath, "agent"),
+        "agent",
+      );
+    } catch {
+      continue;
+    }
+    if (entries.some((entry) => entry.tool.definition.name === toolName)) {
+      return modulePath;
+    }
+  }
+  return null;
+}
+
+async function agentToolModulePaths(toolsDirectory: string): Promise<string[]> {
   let entries: Dirent[];
   try {
     entries = await fs.readdir(toolsDirectory, { withFileTypes: true });
   } catch (error) {
     if (isNotFoundError(error)) {
-      return;
+      return [];
     }
     throw error;
   }
-
-  const modulePaths = entries
+  return entries
     .filter((entry) => entry.isFile())
     .map((entry) => entry.name)
     .filter((name) => name.endsWith(".ts") && !name.endsWith(".source.ts"))
     .sort()
     .map((name) => path.resolve(toolsDirectory, name));
-
-  for (const modulePath of modulePaths) {
-    await registerAgentToolModulePath(registry, context, modulePath);
-  }
 }
 
 export async function loadToolModule(
@@ -258,6 +295,10 @@ function isToolModule(value: unknown): value is ToolModule {
 
 function isRecord(value: unknown): value is JsonObject {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function isNotFoundError(error: unknown): boolean {


### PR DESCRIPTION
Fixing a bug I came across in some local use: it installed two different tool modules (`youtube-uploader` and `youtube-upload-manager`) that both defined a tool named `youtube_upload_video`. Each tool was valid in isolation by the tool registry crashed because of the conflict. Could not fix itself. 

Fixed in two places:
1. made install_agent_tool check for naming collisions before proceeeding
2. made the system resilient to tool crashes. 

added some tests.