### PR TITLE
tests: skip by-slug index in snapshot round-trip dir walk

### DIFF
--- a/crates/cli/tests/snapshot_round_trip.rs
+++ b/crates/cli/tests/snapshot_round_trip.rs
@@ -255,18 +255,21 @@ fn preflight() -> bool {
     true
 }
 
-/// Read a directory expected to contain exactly one entry and return that
-/// entry's path. Used to walk into the per-agent / per-conversation directories
-/// without hardcoding the test-generated UUIDs.
+/// Read a directory expected to contain exactly one record entry and return
+/// that entry's path. Used to walk into the per-agent / per-conversation
+/// directories without hardcoding the test-generated UUIDs. Skips `by-slug`,
+/// the slug-uniqueness index the harness keeps next to the agent record
+/// directories.
 fn find_single_subdir(parent: &std::path::Path) -> std::path::PathBuf {
     let mut entries: Vec<_> = std::fs::read_dir(parent)
         .unwrap_or_else(|error| panic!("read_dir({}) failed: {error:#}", parent.display()))
         .filter_map(Result::ok)
+        .filter(|entry| entry.file_name() != "by-slug")
         .collect();
     assert_eq!(
         entries.len(),
         1,
-        "expected exactly one entry under {}, found {}",
+        "expected exactly one record entry under {}, found {}",
         parent.display(),
         entries.len()
     );


### PR DESCRIPTION
The slug-uniqueness index (#118) added agents/by-slug/, breaking
find_single_subdir's exactly-one-entry assertion in the docker
integration matrix cells.
