### PR TITLE
discord adapter: split outbound messages at the 2000-character limit

### DIFF
--- a/examples/exo/adapters/discord/discord.test.ts
+++ b/examples/exo/adapters/discord/discord.test.ts
@@ -6,6 +6,7 @@ import {
   describeCloseCode,
   errorMessage,
   inboundAttachments,
+  splitDiscordContent,
   startConnectionWatchdog,
 } from "./discord";
 
@@ -230,5 +231,36 @@ describe("startConnectionWatchdog", () => {
     expect(exit).not.toHaveBeenCalled();
     expect(emit).not.toHaveBeenCalled();
     stop();
+  });
+});
+
+describe("splitDiscordContent", () => {
+  it("keeps short messages intact", () => {
+    expect(splitDiscordContent("hello")).toEqual(["hello"]);
+  });
+
+  it("splits long messages at newline boundaries when possible", () => {
+    const chunks = splitDiscordContent(
+      `${"a".repeat(1_500)}\n${"b".repeat(1_000)}`,
+    );
+    expect(chunks).toHaveLength(2);
+    expect(chunks.join("")).toBe(`${"a".repeat(1_500)}\n${"b".repeat(1_000)}`);
+    expect(chunks.every((chunk) => chunk.length <= 2_000)).toBe(true);
+  });
+
+  it("hard-splits an unbroken string without losing content", () => {
+    const input = "x".repeat(4_501);
+    const chunks = splitDiscordContent(input);
+    expect(chunks.map((chunk) => chunk.length)).toEqual([2_000, 2_000, 501]);
+    expect(chunks.join("")).toBe(input);
+  });
+});
+
+describe("splitDiscordContent boundary handling", () => {
+  it("never emits a chunk over the configured limit", () => {
+    const input = `${"a".repeat(2_000)}\nnext`;
+    const chunks = splitDiscordContent(input);
+    expect(chunks.every((chunk) => chunk.length <= 2_000)).toBe(true);
+    expect(chunks.join("")).toBe(input);
   });
 });

--- a/examples/exo/adapters/discord/discord.ts
+++ b/examples/exo/adapters/discord/discord.ts
@@ -6,6 +6,32 @@ export type DiscordAttachmentLike = {
   name?: string | null;
 };
 
+const DISCORD_CONTENT_LIMIT = 2_000;
+
+export function splitDiscordContent(
+  text: string,
+  limit = DISCORD_CONTENT_LIMIT,
+): string[] {
+  if (text.length <= limit) {
+    return [text];
+  }
+
+  const chunks: string[] = [];
+  let remaining = text;
+  while (remaining.length > limit) {
+    const window = remaining.slice(0, limit);
+    const newline = window.lastIndexOf("\n");
+    const space = window.lastIndexOf(" ");
+    const splitAt = newline > 0 ? newline + 1 : space > 0 ? space + 1 : limit;
+    chunks.push(remaining.slice(0, splitAt));
+    remaining = remaining.slice(splitAt);
+  }
+  if (remaining.length > 0) {
+    chunks.push(remaining);
+  }
+  return chunks;
+}
+
 export function attachmentKindForContentType(
   contentType: string | null | undefined,
 ): AdapterAttachment["kind"] {

--- a/examples/exo/adapters/discord/worker.ts
+++ b/examples/exo/adapters/discord/worker.ts
@@ -21,6 +21,7 @@ import {
 import {
   createResilienceHandlers,
   inboundAttachments,
+  splitDiscordContent,
   startConnectionWatchdog,
 } from "./discord";
 import type { DiscordVoice as DiscordVoiceInstance } from "./voice";
@@ -177,10 +178,14 @@ try {
           attachmentCount: command.attachments.length,
         },
       });
-      await sendDiscordMessage(target, {
-        content: command.text,
-        files: await discordAttachmentFiles(command.attachments),
-      });
+      const files = await discordAttachmentFiles(command.attachments);
+      const contentChunks = splitDiscordContent(command.text);
+      for (const [index, content] of contentChunks.entries()) {
+        await sendDiscordMessage(target, {
+          content,
+          files: index === 0 ? files : [],
+        });
+      }
       // If this target has an active voice session, also speak the reply. The
       // text send above doubles as the inspectable transcript of the voice turn.
       if (voice) {


### PR DESCRIPTION
## Problem

Discord rejects messages longer than 2,000 characters, so long agent replies failed to send through the Discord adapter.

## Fix

- New `splitDiscordContent` helper chunks outbound content at the 2,000-character limit, preferring newline boundaries, then spaces, then a hard split — content is never lost or reordered.
- The worker sends the chunks sequentially, with attachments going out on the first chunk.

## Tests

New unit tests cover: short messages pass through untouched, newline-boundary splitting, hard-splitting unbroken strings, and never exceeding the limit at exact-boundary inputs. Full suite (119 tests), lint, and typecheck pass.

Note: this was a fix implement by Exo itself as it was running! 