### PR TITLE
scripts: bump default model to gpt-5.6-terra

### DIFF
--- a/exo.sh
+++ b/exo.sh
@@ -16,7 +16,7 @@ fi
 EXO_BIN="${EXO_BIN:-$ROOT_DIR/target/debug/exo}"
 SCHEDULER_BIN="${EXO_SCHEDULER_BIN:-$ROOT_DIR/target/debug/exo-scheduler-runner}"
 ENV_FILE="${EXO_ENV_FILE:-$ROOT_DIR/.env}"
-MODEL="${EXO_MODEL:-gpt-5.4}"
+MODEL="${EXO_MODEL:-gpt-5.6-terra}"
 AGENT="${EXO_AGENT:-exo-agent}"
 AGENT_NAME="${EXO_AGENT_NAME:-Exo Agent}"
 CONVERSATION="${EXO_CONVERSATION:-dev}"
@@ -98,7 +98,7 @@ Subcommands:
                    image) without starting anything
 
 Options:
-  --model <model>              Model binding name (default: gpt-5.4)
+  --model <model>              Model binding name (default: gpt-5.6-terra)
   --upstream-model <model>     Upstream model id for register-model (default: --model)
   --secret-name <name>         Secret name for register-model (e.g. openai)
   --secret-env <env-var>       Environment variable holding the API key for register-model

--- a/setup.sh
+++ b/setup.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 REPO_URL="${EXO_REPO_URL:-https://github.com/exoharness/exo.git}"
 REPO_REF="${EXO_REPO_REF:-main}"
 INSTALL_DIR="${EXO_INSTALL_DIR:-$PWD}"
-MODEL_NAME="${EXO_MODEL:-gpt-5.4}"
+MODEL_NAME="${EXO_MODEL:-gpt-5.6-terra}"
 UPSTREAM_MODEL="${EXO_UPSTREAM_MODEL:-}"
 MODEL_PROVIDER="${EXO_MODEL_PROVIDER:-}"
 AGENT_NAME="${EXO_AGENT_NAME:-Exo}"


### PR DESCRIPTION
Bumps the default `EXO_MODEL` in `setup.sh` and `exo.sh` (plus the usage text) from `gpt-5.4` to `gpt-5.6-terra`.

(best model would be 5.6-sol but it's twice as expensive)