### PR TITLE
website: rename landing page to exoharness, move links to top

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -3,11 +3,11 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <title>exo</title>
+    <title>exoharness</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta
       name="description"
-      content="exo is a minimal system for building agents. It separates trusted state, resources, and security from agent-specific logic."
+      content="exoharness is a minimal architecture for building agents. It separates trusted state, resources, and security from agent-specific logic."
     />
 
     <style>
@@ -728,8 +728,8 @@
         font: inherit;
       }
 
-      .footer {
-        margin-top: 42px;
+      .linkbar {
+        margin-bottom: 18px;
         color: var(--muted);
       }
 
@@ -807,12 +807,34 @@
             height="36"
             style="vertical-align: -7px; margin-right: 10px"
           />
-          <span class="md"># </span>exo
+          <span class="md"># </span>exoharness
         </h1>
+        <nav class="linkbar" aria-label="Project links">
+          <span class="md">[</span
+          ><a href="https://github.com/exoharness/exo">github</a
+          ><span class="md">]</span>
+          <span class="md">(</span>https://github.com/exoharness/exo<span
+            class="md"
+            >)</span
+          >
+          <span class="md"> - [</span
+          ><a
+            href="https://github.com/exoharness/exo/blob/main/spec/exoharness.md"
+            >spec</a
+          ><span class="md">]</span>
+          <span class="md">(</span>./spec/exoharness.md<span class="md">)</span>
+          <span class="md"> - [</span><a href="/docs">docs</a
+          ><span class="md">]</span> <span class="md">(</span>./docs<span
+            class="md"
+            >)</span
+          >
+          <span class="md"> - </span>mit
+        </nav>
         <p class="lede">
-          exo is a minimal system for building agents. It separates trusted
-          infrastructure for state, resources, and security from agent-specific
-          logic that can evolve, stop, resume, and rewind across runs.
+          exoharness is a minimal architecture for building agents. It
+          separates trusted infrastructure for state, resources, and security
+          from agent-specific logic that can evolve, stop, resume, and rewind
+          across runs.
         </p>
         <p class="quote">
           <span class="md">&gt;</span>
@@ -1174,27 +1196,16 @@
         </p>
       </section>
 
-      <footer class="footer">
-        <span class="md">[</span
-        ><a href="https://github.com/exoharness/exo">github</a
-        ><span class="md">]</span>
-        <span class="md">(</span>https://github.com/exoharness/exo<span
-          class="md"
-          >)</span
-        >
-        <span class="md"> - [</span
-        ><a
-          href="https://github.com/exoharness/exo/blob/main/spec/exoharness.md"
-          >spec</a
-        ><span class="md">]</span>
-        <span class="md">(</span>./spec/exoharness.md<span class="md">)</span>
-        <span class="md"> - [</span><a href="/docs">docs</a
-        ><span class="md">]</span> <span class="md">(</span>./docs<span
-          class="md"
-          >)</span
-        >
-        <span class="md"> - </span>mit
-      </footer>
+      <section aria-labelledby="vs-exo">
+        <h2 id="vs-exo"><span class="md">## </span>exoharness vs exo</h2>
+        <p>
+          exoharness is the substrate; exo is a fully recursively
+          self-improving agent built on top of the exoharness. Because the
+          exoharness owns the durable state — the event log, secrets,
+          artifacts, and sandboxes — exo can rewrite its own executor, tools,
+          and prompts across runs without risking its history or identity.
+        </p>
+      </section>
     </main>
     <script>
       const profiles = {

--- a/website/index.html
+++ b/website/index.html
@@ -831,10 +831,10 @@
           <span class="md"> - </span>mit
         </nav>
         <p class="lede">
-          exoharness is a minimal architecture for building agents. It
-          separates trusted infrastructure for state, resources, and security
-          from agent-specific logic that can evolve, stop, resume, and rewind
-          across runs.
+          exoharness is a minimal architecture for building agents. It separates
+          trusted infrastructure for state, resources, and security from
+          agent-specific logic that can evolve, stop, resume, and rewind across
+          runs.
         </p>
         <p class="quote">
           <span class="md">&gt;</span>
@@ -1199,11 +1199,11 @@
       <section aria-labelledby="vs-exo">
         <h2 id="vs-exo"><span class="md">## </span>exoharness vs exo</h2>
         <p>
-          exoharness is the substrate; exo is a fully recursively
-          self-improving agent built on top of the exoharness. Because the
-          exoharness owns the durable state — the event log, secrets,
-          artifacts, and sandboxes — exo can rewrite its own executor, tools,
-          and prompts across runs without risking its history or identity.
+          exoharness is the substrate; exo is a fully recursively self-improving
+          agent built on top of the exoharness. Because the exoharness owns the
+          durable state — the event log, secrets, artifacts, and sandboxes — exo
+          can rewrite its own executor, tools, and prompts across runs without
+          risking its history or identity.
         </p>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- Title, heading, and lede on the landing page now say "exoharness is a minimal architecture for building agents" instead of "exo is a minimal system".
- The github/spec/docs links moved from the page footer to a linkbar directly under the heading.
- Added a closing "exoharness vs exo" section: exo is a fully recursively self-improving agent built on top of the exoharness.

Note: the currently deployed exoharness.ai still serves stale `github.com/ankrgyl/exo` links from an old build — the repo already points at `github.com/exoharness/exo`, so redeploying after this lands fixes that too.

## Testing
- `vite build` passes; verified the built page (title, heading, links, new section) via `vite preview`.
- Pre-commit hook ran lint, typecheck, and the vitest suite (121 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)