### PR TITLE
harness: empty-completion retry + duplicate-send guard for the turn loop

### DIFF
--- a/examples/typescript/turn-loop.loop.test.ts
+++ b/examples/typescript/turn-loop.loop.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi } from "vitest";
+import type { TurnContext } from "@exo/harness";
+
+// The loop pulls prompt messages, the tool registry, turn metadata, and response
+// parsing from these modules. Stub the heavy pieces so a fake runtime can drive
+// the loop and we can observe which tool calls actually execute.
+vi.mock("@exo/harness", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    materializePromptMessages: async () => [],
+    turnMetadata: () => ({}),
+    createToolRegistry: () => ({
+      register() {
+        return this;
+      },
+      definitions: () => [],
+      executePending: async () => [],
+      get: () => undefined,
+    }),
+  };
+});
+
+vi.mock("@exo/model-runtime/responses", async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    responseToLinguaEvents: (r: { __events?: unknown[] } | undefined) =>
+      r?.__events ?? [],
+    responseToolCalls: (r: { __toolCalls?: unknown[] } | undefined) =>
+      r?.__toolCalls ?? [],
+  };
+});
+
+// Imported after the mocks are registered (vi.mock is hoisted to the top).
+import { runResponsesTurnLoop } from "./turn-loop";
+
+function sendResponse(id: string) {
+  return {
+    __events: [],
+    __toolCalls: [
+      {
+        toolCallId: id,
+        request: { functionName: "send_adapter_message", arguments: {} },
+      },
+    ],
+  };
+}
+function shellResponse(id: string) {
+  return {
+    __events: [],
+    __toolCalls: [
+      { toolCallId: id, request: { functionName: "shell", arguments: {} } },
+    ],
+  };
+}
+function textResponse(content: string) {
+  return {
+    __events: [
+      { type: "messages", messages: [{ role: "assistant", content }] },
+    ],
+    __toolCalls: [],
+  };
+}
+
+// Drive the loop through a fixed response sequence; return the function names of
+// the tool calls that actually executed (skipped duplicates never reach here).
+async function runWith(sequence: unknown[]): Promise<string[]> {
+  let call = 0;
+  const executed: string[] = [];
+  const runtime = {
+    complete: async () => sequence[call++],
+    completeStream: async () => sequence[call++],
+    traceToolCall: async (
+      _parent: unknown,
+      _ctx: unknown,
+      toolCall: { toolCallId: string; request: { functionName: string } },
+    ) => {
+      executed.push(toolCall.request.functionName);
+      return [
+        {
+          type: "tool_result",
+          tool_call_id: toolCall.toolCallId,
+          result: { code: 0 },
+        },
+      ];
+    },
+  };
+  const context = {
+    streaming: false,
+    request: { input: [] },
+    agentConfig: {
+      maxToolRoundTrips: null,
+      maxOutputTokens: null,
+      instructions: [],
+      enableAgentToolCreation: false,
+      typescript: {},
+    },
+    exoharness: {
+      current: {
+        conversation: {},
+        turn: { addEvents: async () => ({ latestEventId: "e" }) },
+      },
+    },
+  } as unknown as TurnContext;
+
+  await runResponsesTurnLoop(
+    runtime as never,
+    context,
+    {} as never,
+    "test-model",
+    { registerTools: async () => {} },
+  );
+  return executed;
+}
+
+describe("runResponsesTurnLoop duplicate-send guard", () => {
+  it("skips a repeated send when nothing was done in between, and ends the turn", async () => {
+    // round 0 sends; round 1 sends again with no work between → duplicate
+    const executed = await runWith([sendResponse("s1"), sendResponse("s2")]);
+    const sends = executed.filter((f) => f === "send_adapter_message");
+    expect(sends).toHaveLength(1); // only the first reply goes out
+  });
+
+  it("allows a second send when real work happened in between", async () => {
+    // send (acknowledge) → shell (real work) → send (report) → done
+    const executed = await runWith([
+      sendResponse("s1"),
+      shellResponse("sh1"),
+      sendResponse("s2"),
+      textResponse("done"),
+    ]);
+    const sends = executed.filter((f) => f === "send_adapter_message");
+    expect(sends).toHaveLength(2); // acknowledge → work → report all go through
+    expect(executed).toContain("shell");
+  });
+});

--- a/examples/typescript/turn-loop.test.ts
+++ b/examples/typescript/turn-loop.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import type { EventData } from "@exo/harness";
+
+import { shouldRetryEmptyCompletion } from "./turn-loop";
+
+// shouldRetryEmptyCompletion only reads array lengths and counters, so tests
+// build a minimal event shape and cast to EventData.
+function textEvent(): EventData {
+  return { type: "messages", messages: [] } as unknown as EventData;
+}
+
+describe("shouldRetryEmptyCompletion", () => {
+  it("retries when the round produced no events and no tool calls", () => {
+    expect(shouldRetryEmptyCompletion([], [], 0, 2)).toBe(true);
+    expect(shouldRetryEmptyCompletion([], [], 1, 2)).toBe(true);
+  });
+
+  it("stops once the retry budget is spent", () => {
+    expect(shouldRetryEmptyCompletion([], [], 2, 2)).toBe(false);
+    expect(shouldRetryEmptyCompletion([], [], 3, 2)).toBe(false);
+  });
+
+  it("never retries when the budget is zero", () => {
+    expect(shouldRetryEmptyCompletion([], [], 0, 0)).toBe(false);
+  });
+
+  it("does not treat a round with text events as an empty completion", () => {
+    expect(shouldRetryEmptyCompletion([textEvent()], [], 0, 2)).toBe(false);
+  });
+
+  it("does not treat a round with tool calls as an empty completion", () => {
+    expect(shouldRetryEmptyCompletion([], [{}], 0, 2)).toBe(false);
+  });
+});

--- a/examples/typescript/turn-loop.ts
+++ b/examples/typescript/turn-loop.ts
@@ -89,7 +89,7 @@ export function agentToolCreationInstruction(): Message {
   };
 }
 
-async function runResponsesTurnLoop(
+export async function runResponsesTurnLoop(
   runtime: ResponsesRuntimeLike,
   context: TurnContext,
   turnParent: TraceParent,
@@ -99,6 +99,13 @@ async function runResponsesTurnLoop(
   const { conversation } = context.exoharness.current;
   const maxToolRoundTrips = context.agentConfig.maxToolRoundTrips;
   let latestEventId: string | null = null;
+  let emptyRetries = 0;
+  const MAX_EMPTY_RETRIES = 2;
+  // Duplicate-send guard: weak models can loop on send_adapter_message, blasting
+  // the user with near-identical variants of the same reply. Track whether a
+  // reply has already gone out with no real work since — a second send with
+  // nothing done in between is a duplicate and is skipped.
+  let repliedSinceWork = false;
 
   for (let round = 0; ; round += 1) {
     if (
@@ -159,10 +166,39 @@ async function runResponsesTurnLoop(
       if (hasSyntheticToolResult) {
         continue;
       }
+      // Empty completion: nothing at all this round — no text, no tool call.
+      // Weak models and busy endpoints do this intermittently; it is not a real
+      // end of turn, so retry a bounded number of times rather than silently
+      // ending (which for an adapter turn means the user got no reply at all).
+      if (
+        shouldRetryEmptyCompletion(
+          events,
+          toolCalls,
+          emptyRetries,
+          MAX_EMPTY_RETRIES,
+        )
+      ) {
+        emptyRetries += 1;
+        round -= 1; // a retry must not consume the tool-round-trip budget
+        continue;
+      }
       return latestEventId;
     }
+    emptyRetries = 0; // a productive round clears the empty-retry counter
 
+    let sends = 0;
+    let sendsSkipped = 0;
     for (const toolCall of toolCalls) {
+      const isSend = toolCall.request.functionName === "send_adapter_message";
+      if (isSend) {
+        sends += 1;
+        if (repliedSinceWork) {
+          // Already replied this turn with no work since — skip the duplicate
+          // instead of blasting the user with another variant of the reply.
+          sendsSkipped += 1;
+          continue;
+        }
+      }
       const toolResultEvents = await runtime.traceToolCall(
         turnParent,
         context,
@@ -173,6 +209,14 @@ async function runResponsesTurnLoop(
       if (toolResultEvents.length > 0) {
         latestEventId = await appendTurnEvents(context, toolResultEvents);
       }
+      // A send marks "already replied"; any real tool resets it, so a genuine
+      // acknowledge → do work → report-result sequence stays allowed.
+      repliedSinceWork = isSend;
+    }
+    // Every send this round was a duplicate — the model is just repeating its
+    // reply, so end the turn instead of looping into further repeats.
+    if (sends > 0 && sends === sendsSkipped) {
+      return latestEventId;
     }
   }
 }
@@ -182,4 +226,20 @@ async function appendTurnEvents(
   data: EventData[],
 ): Promise<string> {
   return (await context.exoharness.current.turn.addEvents(data)).latestEventId;
+}
+
+// An empty completion is a round that produced nothing at all — no text, no
+// tool call. Weak models and busy endpoints do this intermittently; it is not a
+// real end of turn, so the loop retries a bounded number of times.
+export function shouldRetryEmptyCompletion(
+  events: readonly EventData[],
+  toolCalls: readonly unknown[],
+  emptyRetries: number,
+  maxEmptyRetries: number,
+): boolean {
+  return (
+    toolCalls.length === 0 &&
+    events.length === 0 &&
+    emptyRetries < maxEmptyRetries
+  );
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
       "@exo/model-runtime/responses": fileURLToPath(
         new URL("./typescript/model-runtime/responses.ts", import.meta.url),
       ),
+      "@exo/model-runtime/cost": fileURLToPath(
+        new URL("./typescript/model-runtime/cost.ts", import.meta.url),
+      ),
     },
   },
 });


### PR DESCRIPTION
## Problem
Two intermittent failures in the responses turn loop, both with weak models behind chat adapters:
1. Empty completion — a round with no text and no tool call was treated as a real end of turn, so an adapter-woken user could get no reply.
2. Duplicate send — a weak model loops on send_adapter_message and delivers the same reply as several near-identical variants. The loop only ends when the model calls no tool, and with no round cap it never stops.

## Change
runResponsesTurnLoop gains two bounded guards:
- Empty-completion retry — a round producing nothing is retried up to 2x without consuming the tool-round-trip budget.
- Duplicate-send guard — once a reply has gone out, a further send_adapter_message with no real tool call in between is skipped; a round that is nothing but duplicate sends ends the turn. Any real tool call resets the state, so a genuine "acknowledge -> do work -> report result" sequence still sends twice.

## Tests
shouldRetryEmptyCompletion is a pure function with unit tests. A loop integration test drives a fake runtime and asserts (a) a repeat send with no work between is skipped and the turn ends, and (b) a send after real work is allowed. 128 tests pass. runResponsesTurnLoop is exported for the test.

Harness-side turn hardening — validated in a live Lark adapter deployment where the duplicate-send guard demonstrably stopped a weak model from blasting the same reply multiple times.
