### PR TITLE
harness: never cut a surrogate pair when truncating tool-result previews

### DIFF
--- a/typescript/harness/tools.test.ts
+++ b/typescript/harness/tools.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { previewText } from "./tools";
+
+const PREVIEW_CHARS = 4_000;
+
+function hasLoneSurrogate(text: string): boolean {
+  for (let i = 0; i < text.length; i += 1) {
+    const code = text.charCodeAt(i);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = text.charCodeAt(i + 1);
+      if (!(next >= 0xdc00 && next <= 0xdfff)) {
+        return true;
+      }
+      i += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
+}
+
+describe("previewText", () => {
+  it("returns short text unchanged", () => {
+    expect(previewText("hello 🚒")).toBe("hello 🚒");
+  });
+
+  it("truncates long text with a marker", () => {
+    const long = "a".repeat(PREVIEW_CHARS + 100);
+    const preview = previewText(long);
+    expect(preview.endsWith("\n...[truncated]")).toBe(true);
+    expect(preview.length).toBeLessThan(long.length);
+  });
+
+  it("never cuts inside a surrogate pair at the truncation boundary", () => {
+    // Emoji straddles the boundary: its high surrogate is the 4000th code
+    // unit, the low surrogate the 4001st. A naive slice keeps only the high
+    // half, which strict JSON parsers downstream reject.
+    const straddling = "a".repeat(PREVIEW_CHARS - 1) + "🚒 and more text";
+    const preview = previewText(straddling);
+    expect(hasLoneSurrogate(preview)).toBe(false);
+  });
+
+  it("keeps a pair that fits entirely inside the boundary", () => {
+    const fitting = "a".repeat(PREVIEW_CHARS - 2) + "🚒 and more text";
+    const preview = previewText(fitting);
+    expect(hasLoneSurrogate(preview)).toBe(false);
+    expect(preview.includes("🚒")).toBe(true);
+  });
+});

--- a/typescript/harness/tools.ts
+++ b/typescript/harness/tools.ts
@@ -254,10 +254,18 @@ function stringifyToolResult(result: ToolResult): string {
   return typeof result === "string" ? result : JSON.stringify(result, null, 2);
 }
 
-function previewText(text: string): string {
-  return text.length > TOOL_RESULT_PREVIEW_CHARS
-    ? `${text.slice(0, TOOL_RESULT_PREVIEW_CHARS)}\n...[truncated]`
-    : text;
+export function previewText(text: string): string {
+  if (text.length <= TOOL_RESULT_PREVIEW_CHARS) {
+    return text;
+  }
+  // Slicing by UTF-16 code units can cut a surrogate pair in half. A lone
+  // high surrogate serializes as an unpaired \ud8xx escape, which strict JSON
+  // parsers downstream reject — a single emoji at the boundary then fails the
+  // whole turn. Drop the dangling half instead of emitting it.
+  const cut = text
+    .slice(0, TOOL_RESULT_PREVIEW_CHARS)
+    .replace(/[\uD800-\uDBFF]$/, "");
+  return `${cut}\n...[truncated]`;
 }
 
 function sanitizePathSegment(value: string): string {


### PR DESCRIPTION
## Problem
`previewText` truncates tool-result previews with a plain `.slice(0, TOOL_RESULT_PREVIEW_CHARS)`, which cuts by UTF-16 code units. When an emoji (or any astral character) straddles the 4000-char boundary, the slice keeps only the high surrogate. The lone surrogate serializes as an unpaired `\ud8xx` escape, and a strict JSON parser consuming the serialized event downstream rejects the whole message — one emoji at the boundary fails the entire turn.

This is a production repro, not a hypothetical: my agent signs every reply with 🚒🕵️, so its conversation history is full of surrogate pairs. A scheduled task that read that history back through a tool hit the boundary and the turn died with `invalid TypeScript harness protocol message ... unexpected end of hex escape`.

## Fix
After slicing, drop a trailing lone high surrogate before appending the `...[truncated]` marker. `previewText` is exported so the boundary behavior can be unit-tested.

## Tests
Four cases in `tools.test.ts`: short text unchanged, plain truncation, an emoji straddling the boundary (fails on the old code), and a pair that fits entirely inside the boundary staying intact.

## Follow-up thought
This fixes the known producer, but as akrentsel noted on Discord, the executor could also tolerate a corrupted/unparseable protocol line more gracefully than failing the turn (skip + log, or surface a structured error event). Happy to take a stab at that separately if there's interest — it touches the Rust side, so I kept it out of this PR.
