### PR TITLE
harness: coerce BigInts when serializing guest→host messages

### DIFF
--- a/typescript/harness/runner.ts
+++ b/typescript/harness/runner.ts
@@ -694,7 +694,18 @@ class ProtocolClient {
   }
 
   private async send(message: GuestToHostMessage): Promise<void> {
-    process.stdout.write(`${JSON.stringify(message)}\n`);
+    // A model can produce a value that JSON.stringify refuses to serialize —
+    // most commonly a BigInt (e.g. a 19-digit Discord channel id that arrives
+    // as a bare number). Unhandled, JSON.stringify throws before the line is
+    // ever written, taking the whole turn down with an opaque TypeError. Coerce
+    // BigInts to strings so the message is always emittable. This is the
+    // guest-side counterpart to the host-side decode guard in #138: that guards
+    // an emitted line the host cannot decode; this guards a message the guest
+    // cannot even emit.
+    const serialized = JSON.stringify(message, (_key, value) =>
+      typeof value === "bigint" ? value.toString() : value,
+    );
+    process.stdout.write(`${serialized}\n`);
   }
 
   private enqueueInit(payload: RawTypeScriptInitPayload): void {


### PR DESCRIPTION
## What

`ProtocolClient.send` serializes every guest→host message with a bare `JSON.stringify(message)`. If the message contains a value `JSON.stringify` refuses to serialize — in practice a **`BigInt`** — it throws a `TypeError` *before the line is ever written*, and the whole turn dies with an opaque error instead of the message being delivered.

The way this shows up in the wild: a model emits a large integer as a bare number (e.g. a 19-digit Discord channel id) that ends up as a `BigInt` in a tool-call argument. The turn had done real work; it just couldn't emit the result.

```
TypeError: Do not know how to serialize a BigInt
    at JSON.stringify (<anonymous>)
    at ProtocolClient.send (typescript/harness/runner.ts)
```

## Fix

Add a replacer that coerces `BigInt` values to strings, so a guest→host message is always emittable:

```ts
const serialized = JSON.stringify(message, (_key, value) =>
  typeof value === "bigint" ? value.toString() : value,
);
```

## Relationship to #138

This is the **guest-side counterpart** to #138 ("don't crash the turn on an undecodable guest message"). #138 guards the host against a line it *received but cannot decode*; this guards the guest against a message it *cannot even emit*. Different failure, opposite direction — #138 doesn't cover this case because the failure happens at serialize time, before any line reaches the host.

## Testing

- `pnpm check` green (lint + typecheck + 121 tests).
- Reproduced the exact failure and the fix in isolation: `JSON.stringify({ channel: 1511385388416237612n })` throws `TypeError: Do not know how to serialize a BigInt`; with the replacer it yields `{"channel":"1511385388416237612"}`, which round-trips through a strict JSON parser.

Kept minimal (no new test file) because `ProtocolClient.send` is private on a self-executing module (`void main()` at the bottom), so exercising it in a unit test needs restructuring out of proportion to a one-line guard. Happy to extract a testable seam if you'd prefer one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
