### PR TITLE
fix(secrets): support macOS Keychain across worktrees and SSH

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -627,6 +627,8 @@ enum ConversationSandboxCommands {
 #[derive(Debug, Subcommand)]
 enum SecretCommands {
     List,
+    #[command(hide = true)]
+    Check,
     Set {
         name: String,
         #[arg(long, value_parser = parse_env_var_name)]
@@ -1859,6 +1861,11 @@ async fn main() -> Result<()> {
                         })
                         .collect(),
                 )?;
+            }
+            SecretCommands::Check => {
+                BasicExoHarness::new(exo_config.clone())
+                    .await?
+                    .verify_secret_key_access()?;
             }
             SecretCommands::Set { name, env, value } => {
                 let value = match (env, value) {

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -25,7 +25,7 @@ use crate::sandbox::{
     SandboxSpec, SnapshotKind, SnapshotPayload, sandbox_spec_hash,
 };
 #[cfg(feature = "apple-keychain")]
-use crate::secrets::AppleKeychainSecretKeyProvider;
+use crate::secrets::{AppleKeychainSecretKeyProvider, migrate_apple_keychain_master_key};
 use crate::secrets::{
     EncryptedSecret, FileBackedSecretKeyProvider, SecretCipher, SecretKeyProvider,
     StaticSecretKeyProvider, default_master_key_path,
@@ -772,6 +772,11 @@ impl BasicExoHarness {
         Self::new_with_backend(config, None).await
     }
 
+    /// Verify that the configured secret-key provider can open the master key.
+    pub fn verify_secret_key_access(&self) -> Result<()> {
+        self.inner.secret_cipher.verify_key_access()
+    }
+
     #[cfg(test)]
     pub(crate) async fn new_with_sandbox_backend(
         config: BasicExoHarnessConfig,
@@ -816,9 +821,15 @@ impl BasicExoHarness {
             cache.insert(sandbox_default, backend);
         }
 
+        let keychain_account = root.to_string_lossy().to_string();
         let storage = BasicObjectStore::local_filesystem(&root).await?;
-        let secret_cipher =
-            build_secret_cipher(secret_backend, root.to_string_lossy().to_string())?;
+        #[cfg(feature = "apple-keychain")]
+        let keychain_account = if matches!(&secret_backend, SecretBackendChoice::AppleKeychain) {
+            keychain_migration::prepare_keychain_account(&storage, &keychain_account).await?
+        } else {
+            keychain_account
+        };
+        let secret_cipher = build_secret_cipher(secret_backend, keychain_account)?;
         Ok(Self {
             inner: Arc::new(BasicExoHarnessInner {
                 storage,
@@ -4078,4 +4089,203 @@ fn build_secret_cipher(
         SecretBackendChoice::Static(key) => Arc::new(StaticSecretKeyProvider::new(key)),
     };
     Ok(SecretCipher::new(provider))
+}
+
+#[cfg(feature = "apple-keychain")]
+mod keychain_migration {
+    use super::*;
+
+    const SECRET_STORE_ID_PATH: &str = "metadata/secret-store.json";
+    const KEYCHAIN_MIGRATION_PATH: &str = "metadata/keychain-migration-v1.json";
+
+    #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+    struct SecretStoreIdentity {
+        id: uuid::Uuid,
+    }
+
+    pub(super) async fn prepare_keychain_account(
+        storage: &BasicObjectStore,
+        legacy_account: &str,
+    ) -> Result<String> {
+        let account = keychain_account_for_store(storage).await?;
+        migrate_keychain_account_if_needed(storage, &account, legacy_account).await?;
+        Ok(account)
+    }
+
+    async fn keychain_account_for_store(storage: &BasicObjectStore) -> Result<String> {
+        let identity = secret_store_identity(storage).await?;
+        Ok(format!("exo-secret-store:{}", identity.id))
+    }
+
+    async fn migrate_keychain_account_if_needed(
+        storage: &BasicObjectStore,
+        account: &str,
+        legacy_account: &str,
+    ) -> Result<()> {
+        let marker = Path::new(KEYCHAIN_MIGRATION_PATH);
+        if storage
+            .get_json_if_exists::<bool>(marker)
+            .await?
+            .unwrap_or(false)
+        {
+            return Ok(());
+        }
+        if has_stored_secret_records(storage).await? {
+            migrate_apple_keychain_master_key(account, legacy_account)?;
+        }
+        storage.put_json(marker, &true).await
+    }
+
+    async fn has_stored_secret_records(storage: &BasicObjectStore) -> Result<bool> {
+        Ok(storage.list_keys("").await?.iter().any(|key| {
+            let components = key.split('/').collect::<Vec<_>>();
+            matches!(
+                components.as_slice(),
+                ["secrets", file]
+                    | ["agents", _, "secrets", file]
+                    | ["agents", _, "conversations", _, "secrets", file]
+                    if file.ends_with(".json")
+            )
+        }))
+    }
+
+    async fn secret_store_identity(storage: &BasicObjectStore) -> Result<SecretStoreIdentity> {
+        let path = Path::new(SECRET_STORE_ID_PATH);
+        if let Some(identity) = storage
+            .get_json_if_exists::<SecretStoreIdentity>(path)
+            .await?
+        {
+            return Ok(identity);
+        }
+        let candidate = SecretStoreIdentity {
+            id: uuid::Uuid::new_v4(),
+        };
+        storage.put_json(path, &candidate).await?;
+        Ok(candidate)
+    }
+
+    #[cfg(test)]
+    mod keychain_account_tests {
+        use tempfile::TempDir;
+
+        use super::{
+            BasicObjectStore, KEYCHAIN_MIGRATION_PATH, has_stored_secret_records,
+            keychain_account_for_store, migrate_keychain_account_if_needed,
+        };
+
+        #[tokio::test]
+        async fn fresh_store_identity_is_stable_across_paths() {
+            let parent = TempDir::new().expect("parent tempdir");
+            let original_path = parent.path().join("original");
+            let moved_path = parent.path().join("moved");
+            tokio::fs::create_dir(&original_path)
+                .await
+                .expect("create original store");
+            let storage = BasicObjectStore::local_filesystem(&original_path)
+                .await
+                .expect("object store");
+            let first = keychain_account_for_store(&storage)
+                .await
+                .expect("first account");
+            drop(storage);
+            tokio::fs::rename(&original_path, &moved_path)
+                .await
+                .expect("move store");
+            let moved_storage = BasicObjectStore::local_filesystem(&moved_path)
+                .await
+                .expect("moved object store");
+            let moved = keychain_account_for_store(&moved_storage)
+                .await
+                .expect("moved account");
+
+            assert_eq!(first, moved);
+            assert!(first.starts_with("exo-secret-store:"));
+        }
+
+        #[tokio::test]
+        async fn distinct_stores_have_distinct_identities() {
+            let first_dir = TempDir::new().expect("first tempdir");
+            let second_dir = TempDir::new().expect("second tempdir");
+            let first_storage = BasicObjectStore::local_filesystem(first_dir.path())
+                .await
+                .expect("first object store");
+            let second_storage = BasicObjectStore::local_filesystem(second_dir.path())
+                .await
+                .expect("second object store");
+
+            let first = keychain_account_for_store(&first_storage)
+                .await
+                .expect("first account");
+            let second = keychain_account_for_store(&second_storage)
+                .await
+                .expect("second account");
+
+            assert_ne!(first, second);
+        }
+
+        #[tokio::test]
+        async fn fresh_stores_complete_migration_without_keychain_access() {
+            let tempdir = TempDir::new().expect("tempdir");
+            let storage = BasicObjectStore::local_filesystem(tempdir.path())
+                .await
+                .expect("object store");
+
+            migrate_keychain_account_if_needed(
+                &storage,
+                "unused-current-account",
+                "unused-legacy-account",
+            )
+            .await
+            .expect("complete migration");
+
+            assert!(
+                storage
+                    .get_json::<bool>(KEYCHAIN_MIGRATION_PATH)
+                    .await
+                    .expect("migration marker")
+            );
+        }
+
+        #[tokio::test]
+        async fn stored_secret_detection_checks_each_supported_scope() {
+            for secret_path in [
+                "secrets/root.json",
+                "agents/agent-id/secrets/agent.json",
+                "agents/agent-id/conversations/conversation-id/secrets/conversation.json",
+            ] {
+                let tempdir = TempDir::new().expect("tempdir");
+                let storage = BasicObjectStore::local_filesystem(tempdir.path())
+                    .await
+                    .expect("object store");
+                storage
+                    .put_json(secret_path, &"encrypted fixture")
+                    .await
+                    .expect("encrypted secret marker");
+
+                assert!(
+                    has_stored_secret_records(&storage)
+                        .await
+                        .expect("detect stored secret"),
+                    "failed to detect {secret_path}"
+                );
+            }
+
+            let tempdir = TempDir::new().expect("tempdir");
+            let storage = BasicObjectStore::local_filesystem(tempdir.path())
+                .await
+                .expect("object store");
+            storage
+                .put_json(
+                    "agents/agent-id/artifacts/secrets/not-a-secret.json",
+                    &"fixture",
+                )
+                .await
+                .expect("unrelated fixture");
+            assert!(
+                !has_stored_secret_records(&storage)
+                    .await
+                    .expect("check unrelated json")
+            );
+        }
+    }
 }

--- a/crates/exoharness/src/secrets.rs
+++ b/crates/exoharness/src/secrets.rs
@@ -65,11 +65,15 @@ impl SecretCipher {
     }
 
     pub(crate) fn verify_key_access(&self) -> Result<()> {
-        self.key_provider.get_or_create_key().map(|_| ())
+        if self.key_provider.get_key_if_exists()?.is_none() {
+            bail!("secret master key does not exist");
+        }
+        Ok(())
     }
 }
 
 pub(crate) trait SecretKeyProvider: Send + Sync {
+    fn get_key_if_exists(&self) -> Result<Option<[u8; MASTER_KEY_LEN]>>;
     fn get_or_create_key(&self) -> Result<[u8; MASTER_KEY_LEN]>;
 }
 
@@ -84,6 +88,10 @@ impl StaticSecretKeyProvider {
 }
 
 impl SecretKeyProvider for StaticSecretKeyProvider {
+    fn get_key_if_exists(&self) -> Result<Option<[u8; MASTER_KEY_LEN]>> {
+        Ok(Some(self.key))
+    }
+
     fn get_or_create_key(&self) -> Result<[u8; MASTER_KEY_LEN]> {
         Ok(self.key)
     }
@@ -107,29 +115,33 @@ impl AppleKeychainSecretKeyProvider {
 
 #[cfg(feature = "apple-keychain")]
 impl SecretKeyProvider for AppleKeychainSecretKeyProvider {
-    fn get_or_create_key(&self) -> Result<[u8; MASTER_KEY_LEN]> {
+    fn get_key_if_exists(&self) -> Result<Option<[u8; MASTER_KEY_LEN]>> {
         use keyring_core::{Entry, Error as KeyringError};
 
         if let Some(key) = self.key.get() {
-            return Ok(*key);
+            return Ok(Some(*key));
         }
         ensure_apple_keychain_store()?;
         let entry = Entry::new(KEYCHAIN_SERVICE, &self.account)?;
-        let key = match entry.get_password() {
-            Ok(serialized) => deserialize_key(&serialized)?,
-            Err(KeyringError::NoEntry) => {
-                let key = random_master_key();
-                entry
-                    .set_password(&serde_json::to_string(&key.to_vec())?)
-                    .context("failed to persist namespaced exoharness master key in keychain")?;
-                key
-            }
-            Err(error) => return Err(error.into()),
-        };
-        match self.key.set(key) {
-            Ok(()) => Ok(key),
-            Err(key) => Ok(self.key.get().copied().unwrap_or(key)),
+        match entry.get_password() {
+            Ok(serialized) => Ok(Some(cache_key(&self.key, deserialize_key(&serialized)?))),
+            Err(KeyringError::NoEntry) => Ok(None),
+            Err(error) => Err(error.into()),
         }
+    }
+
+    fn get_or_create_key(&self) -> Result<[u8; MASTER_KEY_LEN]> {
+        use keyring_core::Entry;
+
+        if let Some(key) = self.get_key_if_exists()? {
+            return Ok(key);
+        }
+        let key = random_master_key();
+        let entry = Entry::new(KEYCHAIN_SERVICE, &self.account)?;
+        entry
+            .set_password(&serde_json::to_string(&key.to_vec())?)
+            .context("failed to persist namespaced exoharness master key in keychain")?;
+        Ok(cache_key(&self.key, key))
     }
 }
 
@@ -241,25 +253,53 @@ impl FileBackedSecretKeyProvider {
 }
 
 impl SecretKeyProvider for FileBackedSecretKeyProvider {
-    fn get_or_create_key(&self) -> Result<[u8; MASTER_KEY_LEN]> {
+    fn get_key_if_exists(&self) -> Result<Option<[u8; MASTER_KEY_LEN]>> {
         if let Some(key) = self.key.get() {
-            return Ok(*key);
+            return Ok(Some(*key));
         }
-        let key = match std::fs::read(&self.path) {
-            Ok(bytes) => parse_master_key_bytes(&bytes)
-                .with_context(|| format!("reading master key at {}", self.path.display()))?,
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
-                let key = random_master_key();
-                write_master_key_file(&self.path, &key)?;
-                key
-            }
-            Err(error) => {
-                return Err(anyhow::Error::from(error)
-                    .context(format!("reading master key at {}", self.path.display())));
-            }
-        };
-        let _ = self.key.set(key);
-        Ok(key)
+        match std::fs::read(&self.path) {
+            Ok(bytes) => Ok(Some(cache_key(
+                &self.key,
+                parse_master_key_bytes(&bytes)
+                    .with_context(|| format!("reading master key at {}", self.path.display()))?,
+            ))),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(anyhow::Error::from(error)
+                .context(format!("reading master key at {}", self.path.display()))),
+        }
+    }
+
+    fn get_or_create_key(&self) -> Result<[u8; MASTER_KEY_LEN]> {
+        if let Some(key) = self.get_key_if_exists()? {
+            return Ok(key);
+        }
+        let key = random_master_key();
+        write_master_key_file(&self.path, &key)?;
+        Ok(cache_key(&self.key, key))
+    }
+}
+
+#[cfg(test)]
+mod key_provider_tests {
+    use std::sync::Arc;
+
+    use tempfile::TempDir;
+
+    use super::{FileBackedSecretKeyProvider, SecretCipher};
+
+    #[test]
+    fn verifying_key_access_does_not_create_a_missing_key() {
+        let tempdir = TempDir::new().expect("tempdir");
+        let key_path = tempdir.path().join("master.key");
+        let cipher =
+            SecretCipher::new(Arc::new(FileBackedSecretKeyProvider::new(key_path.clone())));
+
+        let error = cipher
+            .verify_key_access()
+            .expect_err("missing key should fail verification");
+
+        assert!(error.to_string().contains("master key does not exist"));
+        assert!(!key_path.exists());
     }
 }
 
@@ -292,6 +332,16 @@ fn random_master_key() -> [u8; MASTER_KEY_LEN] {
     key[..16].copy_from_slice(Uuid::new_v4().as_bytes());
     key[16..].copy_from_slice(Uuid::new_v4().as_bytes());
     key
+}
+
+fn cache_key(
+    cache: &OnceLock<[u8; MASTER_KEY_LEN]>,
+    key: [u8; MASTER_KEY_LEN],
+) -> [u8; MASTER_KEY_LEN] {
+    match cache.set(key) {
+        Ok(()) => key,
+        Err(key) => cache.get().copied().unwrap_or(key),
+    }
 }
 
 fn random_nonce() -> [u8; NONCE_LEN] {

--- a/crates/exoharness/src/secrets.rs
+++ b/crates/exoharness/src/secrets.rs
@@ -63,6 +63,10 @@ impl SecretCipher {
             .context("failed to decrypt secret payload")?;
         serde_json::from_slice(&plaintext).map_err(Into::into)
     }
+
+    pub(crate) fn verify_key_access(&self) -> Result<()> {
+        self.key_provider.get_or_create_key().map(|_| ())
+    }
 }
 
 pub(crate) trait SecretKeyProvider: Send + Sync {
@@ -117,7 +121,7 @@ impl SecretKeyProvider for AppleKeychainSecretKeyProvider {
                 let key = random_master_key();
                 entry
                     .set_password(&serde_json::to_string(&key.to_vec())?)
-                    .context("failed to persist exoharness master key in keychain")?;
+                    .context("failed to persist namespaced exoharness master key in keychain")?;
                 key
             }
             Err(error) => return Err(error.into()),
@@ -126,6 +130,99 @@ impl SecretKeyProvider for AppleKeychainSecretKeyProvider {
             Ok(()) => Ok(key),
             Err(key) => Ok(self.key.get().copied().unwrap_or(key)),
         }
+    }
+}
+
+#[cfg(feature = "apple-keychain")]
+pub(crate) fn migrate_apple_keychain_master_key(account: &str, legacy_account: &str) -> Result<()> {
+    use keyring_core::Entry;
+
+    ensure_apple_keychain_store()?;
+    let entry = Entry::new(KEYCHAIN_SERVICE, account)?;
+    let legacy_entry = Entry::new(KEYCHAIN_SERVICE, legacy_account)?;
+    migrate_keychain_master_key_entries(&entry, &legacy_entry, |serialized| {
+        entry.set_password(serialized).map_err(Into::into)
+    })
+}
+
+#[cfg(feature = "apple-keychain")]
+fn migrate_keychain_master_key_entries(
+    entry: &keyring_core::Entry,
+    legacy_entry: &keyring_core::Entry,
+    set_password: impl FnOnce(&str) -> Result<()>,
+) -> Result<()> {
+    use keyring_core::Error as KeyringError;
+
+    match entry.get_password() {
+        Ok(_) => return Ok(()),
+        Err(KeyringError::NoEntry) => {}
+        Err(error) => return Err(error.into()),
+    }
+
+    let serialized = match legacy_entry.get_password() {
+        Ok(serialized) => serialized,
+        Err(KeyringError::NoEntry) => bail!(
+            "existing encrypted secrets require the legacy keychain master key, but it was not found"
+        ),
+        Err(error) => return Err(error.into()),
+    };
+    deserialize_key(&serialized)?;
+    set_password(&serialized)
+        .context("failed to migrate exoharness master key to its namespaced keychain account")
+}
+
+#[cfg(all(test, feature = "apple-keychain"))]
+mod keychain_migration_tests {
+    use keyring_core::api::CredentialStoreApi;
+    use keyring_core::mock;
+
+    use super::{KEYCHAIN_SERVICE, migrate_keychain_master_key_entries};
+
+    #[test]
+    fn migration_copies_the_legacy_master_key() {
+        let store = mock::Store::new().expect("mock keychain");
+        let current = store
+            .build(KEYCHAIN_SERVICE, "current", None)
+            .expect("current entry");
+        let legacy = store
+            .build(KEYCHAIN_SERVICE, "legacy", None)
+            .expect("legacy entry");
+        let serialized = serde_json::to_string(&vec![7u8; 32]).expect("serialize key");
+        legacy.set_password(&serialized).expect("legacy key");
+
+        migrate_keychain_master_key_entries(&current, &legacy, |serialized| {
+            current.set_password(serialized).map_err(Into::into)
+        })
+        .expect("migrate key");
+
+        assert_eq!(current.get_password().expect("current key"), serialized);
+    }
+
+    #[test]
+    fn migration_does_not_replace_an_existing_namespaced_key() {
+        let store = mock::Store::new().expect("mock keychain");
+        let current = store
+            .build(KEYCHAIN_SERVICE, "current", None)
+            .expect("current entry");
+        let legacy = store
+            .build(KEYCHAIN_SERVICE, "legacy", None)
+            .expect("legacy entry");
+        let current_serialized = serde_json::to_string(&vec![3u8; 32]).expect("serialize current");
+        let legacy_serialized = serde_json::to_string(&vec![7u8; 32]).expect("serialize legacy");
+        current
+            .set_password(&current_serialized)
+            .expect("current key");
+        legacy.set_password(&legacy_serialized).expect("legacy key");
+
+        migrate_keychain_master_key_entries(&current, &legacy, |serialized| {
+            current.set_password(serialized).map_err(Into::into)
+        })
+        .expect("check migration");
+
+        assert_eq!(
+            current.get_password().expect("preserved current key"),
+            current_serialized
+        );
     }
 }
 

--- a/exo.sh
+++ b/exo.sh
@@ -2,6 +2,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/macos-keychain.sh
+. "$ROOT_DIR/scripts/macos-keychain.sh"
 
 # setup.sh installs node/pnpm/rust through mise; make its shims available even
 # in shells where mise was never activated (the harness runner spawns node).
@@ -306,6 +308,7 @@ configure_guardian_for_current_launch() {
 build_exo() {
   echo "Building exo binary..."
   (cd "$ROOT_DIR" && CARGO_TARGET_DIR=target cargo build -p exo --ignore-rust-version)
+  codesign_binary "$EXO_BIN"
 }
 
 build_exo_scheduler() {
@@ -313,6 +316,26 @@ build_exo_scheduler() {
   (cd "$ROOT_DIR" && CARGO_TARGET_DIR=target cargo build \
     --manifest-path examples/exo/scheduler-runner/Cargo.toml \
     --ignore-rust-version)
+  codesign_binary "$SCHEDULER_BIN"
+}
+
+# Give all macOS development binaries one stable, worktree-specific designated
+# requirement. Keychain records this identity when a binary creates an item, so
+# sharing it lets the CLI and scheduler retain access across rebuilds.
+codesign_binary() {
+  local binary="$1"
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    return
+  fi
+
+  local root_digest identifier requirement
+  root_digest="$(printf '%s' "$ROOT_DIR" | shasum -a 256)"
+  root_digest="${root_digest%% *}"
+  identifier="ai.exoharness.exo.dev.${root_digest:0:16}"
+  requirement="=designated => identifier \"$identifier\""
+  echo "Applying local development signature to $(basename "$binary")..."
+  codesign --force --sign - --identifier "$identifier" \
+    --requirements "$requirement" "$binary"
 }
 
 build_all() {
@@ -326,9 +349,13 @@ register_model() {
   [[ -n "$SECRET_NAME" ]] || die "register-model requires --secret-name"
   [[ -n "$SECRET_ENV" ]] || die "register-model requires --secret-env"
   ensure_exo_bin
+  # Repair access to an existing master key before the CLI opens the secret store.
+  exo_macos_prepare_keychain_for_ssh "$ROOT_DIR" "$EXO_BIN" "$SCHEDULER_BIN"
   local upstream="${UPSTREAM_MODEL:-$MODEL}"
   echo "Storing secret $SECRET_NAME from \$$SECRET_ENV..."
   exo secret set "$SECRET_NAME" --env "$SECRET_ENV"
+  # A fresh secret store creates its master key above; authorize the scheduler now.
+  exo_macos_prepare_keychain_for_ssh "$ROOT_DIR" "$EXO_BIN" "$SCHEDULER_BIN"
   echo "Registering model $MODEL -> $upstream..."
   local args=(model register "$MODEL" --model "$upstream" --secret "$SECRET_NAME")
   if [[ -n "$MODEL_BASE_URL" ]]; then
@@ -890,6 +917,10 @@ fresh_start() {
 
 run_repl() {
   ensure_exo_bin
+  if [[ "$START_SCHEDULER" == true ]]; then
+    ensure_scheduler_bin
+  fi
+  exo_macos_prepare_keychain_for_ssh "$ROOT_DIR" "$EXO_BIN" "$SCHEDULER_BIN"
   if [[ "$SETUP_PROFILE" == true ]]; then
     setup_local_profile
   fi

--- a/scripts/macos-keychain.sh
+++ b/scripts/macos-keychain.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+
+# Functions prefixed with _exo_macos_ are internal to this sourced script.
+_exo_macos_keychain_item_has_partitions() {
+  local keychain_path="$1"
+  local account="$2"
+  local partition_list="$3"
+
+  security dump-keychain -a "$keychain_path" 2>&1 |
+    awk -v account="$account" -v partitions="$partition_list" '
+      BEGIN { expected = split(partitions, partition, ",") }
+      /^keychain: / { has_account = 0 }
+      index($0, "\"acct\"<blob>=\"" account "\"") { has_account = 1 }
+      has_account {
+        for (i = 1; i <= expected; i++) {
+          if (index($0, partition[i])) {
+            found[i] = 1
+          }
+        }
+      }
+      END {
+        for (i = 1; i <= expected; i++) {
+          if (!found[i]) {
+            exit 1
+          }
+        }
+      }
+    '
+}
+
+# Resolve the account of an existing master-key item. New stores use their
+# persisted store ID; stores awaiting migration still use the legacy shared
+# account until Exo copies the key into the namespaced item.
+_exo_macos_keychain_account_for_existing_master_key() {
+  local root_dir="$1"
+  local keychain_path="$2"
+  local service="$3"
+  local legacy_account=".exo/exoharness"
+  local identity_file="$root_dir/.exo/exoharness/metadata/secret-store.json"
+
+  if [[ ! -f "$identity_file" ]]; then
+    printf '%s' "$legacy_account"
+    return 0
+  fi
+  if ! command -v node >/dev/null 2>&1; then
+    echo "error: node is required to read the Exo secret-store identity" >&2
+    return 1
+  fi
+
+  local store_id
+  if ! store_id="$(node -e '
+    const fs = require("node:fs");
+    const identity = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+    if (typeof identity.id !== "string" || identity.id.length === 0) {
+      throw new Error("invalid Exo secret-store identity");
+    }
+    process.stdout.write(identity.id);
+  ' "$identity_file")"; then
+    echo "error: could not read the Exo secret-store identity" >&2
+    return 1
+  fi
+
+  local namespaced_account="exo-secret-store:$store_id"
+  local find_status=0
+  security find-generic-password -a "$namespaced_account" -s "$service" \
+    "$keychain_path" >/dev/null 2>&1 || find_status=$?
+  case "$find_status" in
+    0) printf '%s' "$namespaced_account" ;;
+    # errSecItemNotFound (-25300) is truncated to an 8-bit shell status.
+    44) printf '%s' "$legacy_account" ;;
+    *)
+      echo "error: could not query the namespaced Exo master key" >&2
+      return "$find_status"
+      ;;
+  esac
+}
+
+_exo_macos_ensure_keychain_access() {
+  local exo_binary="$1"
+  local keychain_path="$2"
+
+  if "$exo_binary" secret check >/dev/null 2>&1; then
+    return 0
+  fi
+
+  echo "The macOS login keychain must be unlocked before Exo can use credentials over SSH."
+  echo "Enter the macOS login keychain password when prompted."
+  if ! security unlock-keychain "$keychain_path"; then
+    echo "error: could not unlock the macOS login keychain" >&2
+    return 1
+  fi
+  if ! "$exo_binary" secret check >/dev/null 2>&1; then
+    echo "error: Exo still cannot access the macOS login keychain" >&2
+    return 1
+  fi
+}
+
+# Over SSH, unlock the login keychain and authorize the current Exo CLI and
+# scheduler builds to read an existing master key. Stable signing preserves
+# their application identity, while the partition ACL permits headless access
+# for each build's CDHash.
+exo_macos_prepare_keychain_for_ssh() {
+  local root_dir="$1"
+  shift
+  local exo_binary="${1:-}"
+
+  if [[ "$(uname -s)" != "Darwin" ]] ||
+    [[ -z "${SSH_CONNECTION:-}" && -z "${SSH_TTY:-}" ]] ||
+    [[ "${EXO_SECRET_BACKEND:-apple-keychain}" != "apple-keychain" ]]; then
+    return 0
+  fi
+
+  if [[ ! -t 0 ]]; then
+    echo "error: macOS Keychain setup over SSH requires an interactive terminal" >&2
+    return 1
+  fi
+  if ! command -v security >/dev/null 2>&1; then
+    echo "error: the macOS security command is required for Keychain setup" >&2
+    return 1
+  fi
+  if ! command -v codesign >/dev/null 2>&1; then
+    echo "error: codesign is required to authorize Exo development builds" >&2
+    return 1
+  fi
+
+  local keychain_path
+  keychain_path="$(security default-keychain -d user |
+    sed 's/^[[:space:]]*"//; s/"[[:space:]]*$//')"
+  if [[ -z "$keychain_path" ]]; then
+    echo "error: could not determine the default user keychain" >&2
+    return 1
+  fi
+
+  local service="exo-exoharness-master-key"
+  local account
+  if ! account="$(_exo_macos_keychain_account_for_existing_master_key \
+    "$root_dir" "$keychain_path" "$service")"; then
+    return 1
+  fi
+
+  local find_status=0
+  security find-generic-password -a "$account" -s "$service" \
+    "$keychain_path" >/dev/null 2>&1 || find_status=$?
+  if [[ "$find_status" -eq 44 ]]; then
+    # A fresh store has no master-key item to authorize yet. The caller creates
+    # it by storing the first secret, then invokes this helper a second time.
+    return 0
+  elif [[ "$find_status" -ne 0 ]]; then
+    echo "error: could not query the Exo master key" >&2
+    return "$find_status"
+  fi
+
+  local partition_list=""
+  local binary cdhash partition
+  for binary in "$@"; do
+    if [[ ! -e "$binary" ]]; then
+      continue
+    fi
+    if [[ ! -x "$binary" ]]; then
+      echo "error: Exo development binary is not executable: $binary" >&2
+      return 1
+    fi
+    cdhash="$(codesign -dvvv "$binary" 2>&1 |
+      sed -n 's/^CDHash=//p' | head -n 1)"
+    if [[ ! "$cdhash" =~ ^[[:xdigit:]]{40}$ ]]; then
+      echo "error: could not determine the development build CDHash for $binary" >&2
+      return 1
+    fi
+    partition="cdhash:$cdhash"
+    if [[ -z "$partition_list" ]]; then
+      partition_list="$partition"
+    elif [[ ",$partition_list," != *",$partition,"* ]]; then
+      partition_list="$partition_list,$partition"
+    fi
+  done
+  if [[ -z "$partition_list" ]]; then
+    return 0
+  fi
+
+  if _exo_macos_keychain_item_has_partitions "$keychain_path" "$account" "$partition_list"; then
+    if ! _exo_macos_ensure_keychain_access "$exo_binary" "$keychain_path"; then
+      return 1
+    fi
+    return 0
+  fi
+
+  echo "The current Exo development binaries need access to the Keychain master key."
+  echo "Apple may label its password prompt below as '(deprecated)'."
+  echo "That label refers to the security command interface, not your password."
+  local security_output
+  if ! security_output="$(security set-generic-password-partition-list \
+    -a "$account" -s "$service" -S "$partition_list" \
+    "$keychain_path" 2>&1 >/dev/null)"; then
+    echo
+    if [[ -n "$security_output" ]]; then
+      echo "$security_output" >&2
+    fi
+    echo "error: could not authorize the Exo development binaries for Keychain access" >&2
+    return 1
+  fi
+  echo
+  if ! _exo_macos_keychain_item_has_partitions "$keychain_path" "$account" "$partition_list"; then
+    echo "error: macOS Keychain did not retain access for every Exo binary" >&2
+    return 1
+  fi
+
+  _exo_macos_ensure_keychain_access "$exo_binary" "$keychain_path"
+}

--- a/scripts/macos-keychain.sh
+++ b/scripts/macos-keychain.sh
@@ -75,6 +75,16 @@ _exo_macos_keychain_account_for_existing_master_key() {
   esac
 }
 
+_exo_macos_unlock_keychain() {
+  local keychain_path="$1"
+  echo "The macOS login keychain must be unlocked before Exo can use credentials over SSH."
+  echo "Enter the macOS login keychain password when prompted."
+  if ! security unlock-keychain "$keychain_path"; then
+    echo "error: could not unlock the macOS login keychain" >&2
+    return 1
+  fi
+}
+
 _exo_macos_ensure_keychain_access() {
   local exo_binary="$1"
   local keychain_path="$2"
@@ -83,10 +93,7 @@ _exo_macos_ensure_keychain_access() {
     return 0
   fi
 
-  echo "The macOS login keychain must be unlocked before Exo can use credentials over SSH."
-  echo "Enter the macOS login keychain password when prompted."
-  if ! security unlock-keychain "$keychain_path"; then
-    echo "error: could not unlock the macOS login keychain" >&2
+  if ! _exo_macos_unlock_keychain "$keychain_path"; then
     return 1
   fi
   if ! "$exo_binary" secret check >/dev/null 2>&1; then
@@ -142,8 +149,12 @@ exo_macos_prepare_keychain_for_ssh() {
   security find-generic-password -a "$account" -s "$service" \
     "$keychain_path" >/dev/null 2>&1 || find_status=$?
   if [[ "$find_status" -eq 44 ]]; then
-    # A fresh store has no master-key item to authorize yet. The caller creates
-    # it by storing the first secret, then invokes this helper a second time.
+    # A fresh store has no master-key item to authorize yet. Unlock the
+    # Keychain so the caller can create it by storing the first secret, then
+    # authorize the new item when this helper is invoked a second time.
+    if ! _exo_macos_unlock_keychain "$keychain_path"; then
+      return 1
+    fi
     return 0
   elif [[ "$find_status" -ne 0 ]]; then
     echo "error: could not query the Exo master key" >&2

--- a/setup.sh
+++ b/setup.sh
@@ -404,7 +404,8 @@ missing_has() {
 
 is_exo_checkout() {
   local dir="$1"
-  [[ -d "$dir/.git" && -f "$dir/exo.sh" ]]
+  # In linked Git worktrees, .git is a file rather than a directory.
+  [[ -e "$dir/.git" && -f "$dir/exo.sh" ]]
 }
 
 prompt_yes_no() {


### PR DESCRIPTION
Fixes keychain issues across the environments I work in (ssh and codex desktop's worktrees).

**Problems:**

1. `setup.sh`: in a worktree, `.git` is a file and not a folder, so detecting a git checkout should use `-e` instead of `-d`.
2. Having fixed that, `setup.sh` would encounter keychain/codesign issues in trying to store the API key. The two main issues were (1) worktrees colliding over the keychain account `root.to_string_lossy().to_string() -> .exo/exoharness`, and (2) when run over ssh, the GUI keychain prompt doesn't pop up.

```
==> Store secrets and register model
Storing secret openai from $OPENAI_API_KEY...
Error: Platform secure storage failure: User interaction is not allowed.

Caused by:
    User interaction is not allowed.
```

**Fixed by:**

1. Check `.git` with `-e` instead of `-d`.
2. Namespace the keychain account by assigning each secret store a UUID, now keychain identity survives relocation. This PR also migrates existing path-based keys. If you're ok dropping backwards compatibility, this part can be cleaned up further.
3. Unlock the keychain when necessary (e.g., over ssh). Ad-hoc sign the exo and scheduler binaries and add their CDHashes to partition ACL, basically it lets them read the keychain master key to then decrypt the stored API keys.

AI use: PR contents mostly generated with 5.6 Sol, though I've been actively getting it to rewrite some of its stupider decisions. I'm not particularly fond of macOS permissions, feel free to provide feedback/make edits.