### PR TITLE
website: add discord link to landing page and docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Rust](https://img.shields.io/badge/rust-stable-orange.svg?logo=rust)](Cargo.toml)
 [![TypeScript](https://img.shields.io/badge/typescript-5.x-3178c6.svg?logo=typescript&logoColor=white)](tsconfig.json)
 
-[Documentation](https://exoharness.ai/docs) · [Examples](examples/)
+[Documentation](https://exoharness.ai/docs) · [Examples](examples/) · [Discord](https://discord.gg/8x23hdBJU6)
 
 </div>
 

--- a/website/docs-src/index.md
+++ b/website/docs-src/index.md
@@ -22,6 +22,7 @@ any change — successful or not — can be inspected, rewound, or forked from.
 - [**Getting Started**](/getting-started/) — One setup script to a running agent you can chat with from your browser.
 - [**Concepts**](/concepts/) — The architecture: exoharness, executors, events, sandboxes, and time travel.
 - [**Tutorials**](/tutorials/) — Build your own harness with custom tools and context.
+- [**Discord**](https://discord.gg/8x23hdBJU6) — Join the community for help and discussion.
 ## How it stays safe
 
 Exo splits an agent into two halves:

--- a/website/index.html
+++ b/website/index.html
@@ -830,8 +830,7 @@
           <span class="md"> - [</span
           ><a href="https://discord.gg/8x23hdBJU6">discord</a
           ><span class="md">]</span>
-          <span class="md">(</span>https://discord.gg/8x23hdBJU6<span
-            class="md"
+          <span class="md">(</span>https://discord.gg/8x23hdBJU6<span class="md"
             >)</span
           >
           <span class="md"> - </span>mit

--- a/website/index.html
+++ b/website/index.html
@@ -827,6 +827,13 @@
             class="md"
             >)</span
           >
+          <span class="md"> - [</span
+          ><a href="https://discord.gg/8x23hdBJU6">discord</a
+          ><span class="md">]</span>
+          <span class="md">(</span>https://discord.gg/8x23hdBJU6<span
+            class="md"
+            >)</span
+          >
           <span class="md"> - </span>mit
         </nav>
         <p class="lede">


### PR DESCRIPTION
Adds the Discord invite (https://discord.gg/8x23hdBJU6) to:
- the exoharness.ai landing page header linkbar
- the main docs index page (/docs)