### PR TITLE
cli: survive model-call failures in the REPL instead of crashing

### DIFF
--- a/crates/cli/src/tui.rs
+++ b/crates/cli/src/tui.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
-use std::io::{self, Write};
+use std::io::{self, IsTerminal, Write};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -467,8 +467,10 @@ impl ChatRepl {
             let prompt = format!("{}> ", self.conversation.record().slug);
             let event_printer = self.spawn_event_printer()?;
             let readline_result = self.editor.readline(&prompt);
-            event_printer.abort();
-            let _ = event_printer.await;
+            if let Some(event_printer) = event_printer {
+                event_printer.abort();
+                let _ = event_printer.await;
+            }
 
             match readline_result {
                 Ok(line) => {
@@ -583,7 +585,10 @@ impl ChatRepl {
                         }
                         _ => {
                             self.editor.add_history_entry(line.as_str())?;
-                            self.send(trimmed).await?;
+                            if let Err(error) = self.send(trimmed).await {
+                                println!();
+                                println!("turn failed: {error:#}");
+                            }
                         }
                     }
                 }
@@ -753,11 +758,17 @@ impl ChatRepl {
         Ok(())
     }
 
-    fn spawn_event_printer(&mut self) -> Result<JoinHandle<()>> {
+    /// Returns `None` when stdin is not a tty (piped/scripted input):
+    /// rustyline's external printer needs a terminal, and the printer only
+    /// echoes events from other sessions — a display nicety we can skip.
+    fn spawn_event_printer(&mut self) -> Result<Option<JoinHandle<()>>> {
+        if !io::stdin().is_terminal() {
+            return Ok(None);
+        }
         let conversation = self.conversation.exoharness_handle();
         let watch_after = Arc::clone(&self.watch_after);
         let mut printer = self.editor.create_external_printer()?;
-        Ok(tokio::spawn(async move {
+        Ok(Some(tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs(1));
             loop {
                 interval.tick().await;
@@ -788,7 +799,7 @@ impl ChatRepl {
                     }
                 }
             }
-        }))
+        })))
     }
 
     async fn run_shell(&self, command: &str) -> Result<()> {

--- a/crates/cli/src/tui.rs
+++ b/crates/cli/src/tui.rs
@@ -758,9 +758,6 @@ impl ChatRepl {
         Ok(())
     }
 
-    /// Returns `None` when stdin is not a tty (piped/scripted input):
-    /// rustyline's external printer needs a terminal, and the printer only
-    /// echoes events from other sessions — a display nicety we can skip.
     fn spawn_event_printer(&mut self) -> Result<Option<JoinHandle<()>>> {
         if !io::stdin().is_terminal() {
             return Ok(None);

--- a/crates/cli/tests/repl_model_error.rs
+++ b/crates/cli/tests/repl_model_error.rs
@@ -1,0 +1,148 @@
+//! Regression test: a model-call failure mid-turn must not kill the REPL.
+//!
+//! Exercises the real `exo repl` binary with piped stdin against a
+//! wiremock-backed fake OpenAI endpoint that always returns 500. Each sent
+//! line fails its turn; the REPL must print `turn failed: ...` and keep
+//! reading input instead of exiting non-zero after the first error.
+//!
+//! `#[ignore]`'d so `cargo test` skips it by default; the integration workflow
+//! runs `cargo test --workspace -- --ignored` and selects the sandbox provider
+//! via `EXO_TEST_SANDBOX_BACKEND` (defaults to `docker`), same as
+//! `integration_chat.rs`.
+
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use serde_json::json;
+use tempfile::TempDir;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn exo_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_exo"))
+}
+
+fn sandbox_provider_arg() -> String {
+    std::env::var("EXO_TEST_SANDBOX_BACKEND").unwrap_or_else(|_| "docker".into())
+}
+
+fn run_exo(args: &[&str], root: &str, xdg: &str) -> std::process::Output {
+    let output = Command::new(exo_bin())
+        .args(["--root", root])
+        .args(["--secret-backend", "file"])
+        .args(args)
+        .env("XDG_CONFIG_HOME", xdg)
+        .env("OPENAI_API_KEY", "sk-test-key")
+        .output()
+        .expect("failed to spawn exo");
+    if !output.status.success() {
+        panic!(
+            "exo {:?} failed: stdout={} stderr={}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+    output
+}
+
+#[tokio::test]
+#[ignore = "spawns real exo binary + real sandbox + wiremock; run with cargo test -- --ignored"]
+async fn repl_survives_model_call_failure() {
+    let root_dir = TempDir::new().expect("tempdir for --root");
+    let xdg_dir = TempDir::new().expect("tempdir for XDG_CONFIG_HOME");
+    let root = root_dir.path().to_string_lossy().into_owned();
+    let xdg = xdg_dir.path().to_string_lossy().into_owned();
+
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/responses"))
+        .respond_with(ResponseTemplate::new(500).set_body_json(json!({
+            "error": {
+                "message": "Our servers are currently overloaded. Please try again later.",
+                "type": "server_error"
+            }
+        })))
+        .mount(&mock_server)
+        .await;
+
+    run_exo(
+        &["secret", "set", "test-key", "--env", "OPENAI_API_KEY"],
+        &root,
+        &xdg,
+    );
+    run_exo(
+        &[
+            "model",
+            "register",
+            "gpt-test",
+            "--secret",
+            "test-key",
+            "--base-url",
+            &mock_server.uri(),
+        ],
+        &root,
+        &xdg,
+    );
+    run_exo(
+        &[
+            "agent",
+            "create",
+            "--slug",
+            "test-agent",
+            "--model",
+            "gpt-test",
+            "--sandbox-provider",
+            &sandbox_provider_arg(),
+            "Repl Error Test Agent",
+        ],
+        &root,
+        &xdg,
+    );
+
+    let mut repl = Command::new(exo_bin())
+        .args(["--root", &root])
+        .args(["--secret-backend", "file"])
+        .args(["repl", "--agent", "test-agent", "--conversation", "first"])
+        .env("XDG_CONFIG_HOME", &xdg)
+        .env("OPENAI_API_KEY", "sk-test-key")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn exo repl");
+
+    // Two turns: before the fix the process died on the first model error and
+    // never saw the second line.
+    repl.stdin
+        .take()
+        .expect("repl stdin piped")
+        .write_all(b"hello once\nhello twice\n")
+        .expect("write to repl stdin");
+
+    let output = repl.wait_with_output().expect("wait for repl");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        output.status.success(),
+        "repl should exit cleanly after failed turns; status={:?} stdout={stdout} stderr={stderr}",
+        output.status
+    );
+    let failed_turns = stdout.matches("turn failed:").count();
+    assert_eq!(
+        failed_turns, 2,
+        "expected both turns to fail without killing the repl; stdout={stdout} stderr={stderr}"
+    );
+
+    let recorded = mock_server.received_requests().await.unwrap_or_default();
+    let responses_calls = recorded
+        .iter()
+        .filter(|r| r.url.path() == "/responses")
+        .count();
+    assert!(
+        responses_calls >= 2,
+        "expected a model call per repl line; got {responses_calls}"
+    );
+}


### PR DESCRIPTION
## Problem

A mid-turn model provider error (e.g. a 529 "Our servers are currently overloaded") propagated out of the REPL's `send()` via `?` and killed the entire CLI process, losing the session.

## Fix

- `crates/cli/src/tui.rs`: catch `send()` errors in the REPL loop, print `turn failed: <error>` and return to the prompt — same pattern `/teleport` and `/rewind` already use. No retry logic added; the failed turn just reports.
- `spawn_event_printer` now skips rustyline's external printer when stdin is not a tty (it errors `ENOTTY` otherwise). This makes piped REPL input work (`echo hi | exo repl`) and enables the regression test. The printer only echoes other sessions' events, a tty-only nicety.

## Test

New `crates/cli/tests/repl_model_error.rs` (`#[ignore]`'d, runs in the integration workflow like `integration_chat.rs`): wiremock OpenAI endpoint returns 500 for every model call, two chat lines piped into the real `exo repl` binary. Asserts exit 0, `turn failed:` printed twice, and one model call per line. Verified it fails against the old code with the exact production error and passes with the fix.