### PR TITLE
Add optional namespace to ToolRequest

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2745,6 +2745,7 @@ async fn run_sandbox_shell_command(
             &agent_config,
             &config,
             &ToolRequest {
+                namespace: None,
                 function_name: "shell".to_string(),
                 arguments,
             },

--- a/crates/executor/src/adapter/tools.rs
+++ b/crates/executor/src/adapter/tools.rs
@@ -1703,6 +1703,7 @@ mod tests {
 
     fn tool_request(function_name: &str, arguments: serde_json::Value) -> ToolRequest {
         ToolRequest {
+            namespace: None,
             function_name: function_name.to_string(),
             arguments: arguments.as_object().unwrap().clone(),
         }

--- a/crates/executor/src/basic_tests.rs
+++ b/crates/executor/src/basic_tests.rs
@@ -137,6 +137,7 @@ async fn send_executes_tool_round_trip() {
             tool_calls: vec![PendingToolCall {
                 tool_call_id: tool_call_id.clone(),
                 request: ToolRequest {
+                    namespace: None,
                     function_name: "shell".to_string(),
                     arguments: Map::new(),
                 },
@@ -258,6 +259,7 @@ async fn send_records_tool_result_when_tool_execution_fails() {
             tool_calls: vec![PendingToolCall {
                 tool_call_id: tool_call_id.clone(),
                 request: ToolRequest {
+                    namespace: None,
                     function_name: "shell".to_string(),
                     arguments: Map::new(),
                 },

--- a/crates/executor/src/conversation_events.rs
+++ b/crates/executor/src/conversation_events.rs
@@ -140,6 +140,7 @@ mod tests {
 
     fn tool_request(arguments: serde_json::Value) -> ToolRequest {
         ToolRequest {
+            namespace: None,
             function_name: "list_conversation_events".to_string(),
             arguments: arguments.as_object().unwrap().clone(),
         }

--- a/crates/executor/src/harness_basic_tests.rs
+++ b/crates/executor/src/harness_basic_tests.rs
@@ -753,6 +753,7 @@ async fn send_executes_shell_tool_when_enabled() {
             tool_calls: vec![PendingToolCall {
                 tool_call_id: "call-1".to_string(),
                 request: ToolRequest {
+                    namespace: None,
                     function_name: "shell".to_string(),
                     arguments: shell_command_arguments("printf hello"),
                 },
@@ -945,6 +946,7 @@ async fn updating_mounts_recreates_conversation_sandbox() {
             tool_calls: vec![PendingToolCall {
                 tool_call_id: "call-1".to_string(),
                 request: ToolRequest {
+                    namespace: None,
                     function_name: "shell".to_string(),
                     arguments: shell_command_arguments("printf first"),
                 },
@@ -971,6 +973,7 @@ async fn updating_mounts_recreates_conversation_sandbox() {
             tool_calls: vec![PendingToolCall {
                 tool_call_id: "call-2".to_string(),
                 request: ToolRequest {
+                    namespace: None,
                     function_name: "shell".to_string(),
                     arguments: shell_command_arguments("printf second"),
                 },

--- a/crates/executor/src/harness_runtime.rs
+++ b/crates/executor/src/harness_runtime.rs
@@ -627,6 +627,7 @@ fn extract_tool_calls(messages: &[Message]) -> Result<Vec<PendingToolCall>> {
                 tool_calls.push(PendingToolCall {
                     tool_call_id: tool_call_id.clone(),
                     request: exoharness::ToolRequest {
+                        namespace: None,
                         function_name: tool_name.clone(),
                         arguments: to_exoharness_arguments(arguments)?,
                     },

--- a/crates/executor/src/harness_tool.rs
+++ b/crates/executor/src/harness_tool.rs
@@ -1115,6 +1115,7 @@ mod tests {
 
     fn tool_request(function_name: &str, arguments: serde_json::Value) -> ToolRequest {
         ToolRequest {
+            namespace: None,
             function_name: function_name.to_string(),
             arguments: arguments.as_object().unwrap().clone(),
         }

--- a/crates/executor/src/rlm_tests.rs
+++ b/crates/executor/src/rlm_tests.rs
@@ -36,6 +36,7 @@ async fn rlm_send_executes_repl_steps_and_persists_final_answer() {
             tool_calls: vec![PendingToolCall {
                 tool_call_id: "repl-1".to_string(),
                 request: ToolRequest {
+                    namespace: None,
                     function_name: "repl_execute".to_string(),
                     arguments: Map::from_iter([(
                         "code".to_string(),
@@ -145,6 +146,7 @@ async fn rlm_subquery_variable_can_store_final_answer() {
             tool_calls: vec![PendingToolCall {
                 tool_call_id: "repl-1".to_string(),
                 request: ToolRequest {
+                    namespace: None,
                     function_name: "repl_execute".to_string(),
                     arguments: Map::from_iter([(
                         "code".to_string(),
@@ -164,6 +166,7 @@ async fn rlm_subquery_variable_can_store_final_answer() {
             tool_calls: vec![PendingToolCall {
                 tool_call_id: "sub-1".to_string(),
                 request: ToolRequest {
+                    namespace: None,
                     function_name: "subquery_variable".to_string(),
                     arguments: Map::from_iter([
                         (
@@ -358,6 +361,7 @@ async fn rlm_exposes_history_via_get_messages() {
             tool_calls: vec![PendingToolCall {
                 tool_call_id: "repl-1".to_string(),
                 request: ToolRequest {
+                    namespace: None,
                     function_name: "repl_execute".to_string(),
                     arguments: Map::from_iter([(
                         "code".to_string(),
@@ -458,6 +462,7 @@ async fn rlm_can_finish_by_setting_final_in_repl() {
         tool_calls: vec![PendingToolCall {
             tool_call_id: "repl-1".to_string(),
             request: ToolRequest {
+                namespace: None,
                 function_name: "repl_execute".to_string(),
                 arguments: Map::from_iter([(
                     "code".to_string(),

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -458,6 +458,11 @@ impl EventData {
 pub struct ToolRequest {
     pub function_name: String,
     pub arguments: ToolArguments,
+    /// Namespace the tool lives in, for providers with namespaced tools (e.g.
+    /// the OpenAI Responses API requires function_call items to be replayed
+    /// with their namespace).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub namespace: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]


### PR DESCRIPTION
Some providers namespace their tools. For example, OpenAI's Responses API (as used by Codex) groups tools into namespaces and rejects a replayed `function_call` item for a namespaced tool unless the item includes its `namespace` field. `ToolRequest` has nowhere to record it, so a harness that rebuilds model input from recorded events cannot replay those calls.

This adds `namespace: Option<String>` to `ToolRequest`. It is backwards compatible: reading old events yields `None`, and the field is omitted from serialization when unset.

Tested with `cargo check --workspace --tests` and the executor tool/event tests.
