### PR TITLE
feat(adapters): add portable NIP-29 Nostr chat

### DIFF
--- a/crates/executor/src/adapter/tools.rs
+++ b/crates/executor/src/adapter/tools.rs
@@ -11,6 +11,7 @@ use futures::{StreamExt, io::AsyncReadExt};
 use serde::Deserialize;
 use serde_json::Value;
 use tokio::fs;
+use url::Url;
 
 use super::runtime::send_adapter_message_with_handles;
 use super::store::AdapterStore;
@@ -29,6 +30,8 @@ const MAX_ATTACHMENT_BASE64_BYTES: usize = MAX_ATTACHMENT_BYTES.div_ceil(3) * 4 
 const ATTACHMENT_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(60);
 const MAX_ATTACHMENT_STDERR_BYTES: usize = 64 * 1024;
 const DEFAULT_EXOCHAT_BASE_URL: &str = "https://exoharness.ai";
+const DEFAULT_NOSTR_CHAT_RELAY_URL: &str = "wss://relay.openagents.com";
+const DEFAULT_NOSTR_CHAT_GROUP_ID: &str = "openagents-public";
 
 #[derive(Debug, Clone)]
 pub struct AdapterCreationOptions {
@@ -99,6 +102,7 @@ enum AdapterCreationConfig {
     Discord(DiscordAdapterCreationConfig),
     Slack(SlackAdapterCreationConfig),
     Exochat(ExochatAdapterCreationConfig),
+    NostrChat(NostrChatAdapterCreationConfig),
     AgentCli(AgentCliAdapterCreationConfig),
 }
 
@@ -195,6 +199,17 @@ struct ExochatAdapterCreationConfig {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct NostrChatAdapterCreationConfig {
+    #[serde(rename = "type")]
+    _adapter_type: NostrChatAdapterType,
+    relay_url: Option<String>,
+    group_id: Option<String>,
+    secret_key_secret_id: Option<String>,
+    trigger: NostrChatTrigger,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct AgentCliAdapterCreationConfig {
     #[serde(rename = "type")]
     _adapter_type: AgentCliAdapterType,
@@ -253,6 +268,12 @@ enum ExochatAdapterType {
 }
 
 #[derive(Debug, Deserialize)]
+enum NostrChatAdapterType {
+    #[serde(rename = "nostr-chat")]
+    NostrChat,
+}
+
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
 enum IrcTrigger {
     Mention,
@@ -276,6 +297,13 @@ enum DiscordTrigger {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
 enum SlackTrigger {
+    AllMessages,
+    MentionsOnly,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum NostrChatTrigger {
     AllMessages,
     MentionsOnly,
 }
@@ -323,6 +351,7 @@ impl AdapterCreationConfig {
             Self::Discord(_) => "discord",
             Self::Slack(_) => "slack",
             Self::Exochat(_) => "exochat",
+            Self::NostrChat(_) => "nostr-chat",
             Self::AgentCli(_) => "agent-cli",
         }
     }
@@ -493,6 +522,35 @@ impl AdapterCreationConfig {
                     secret_env: Vec::new(),
                 })
             }
+            Self::NostrChat(config) => {
+                require_source(source, AdapterSource::Library, "nostr-chat")?;
+                let relay_url = nostr_chat_relay_url(config.relay_url)?;
+                let group_id = config
+                    .group_id
+                    .filter(|value| !value.trim().is_empty())
+                    .unwrap_or_else(|| DEFAULT_NOSTR_CHAT_GROUP_ID.to_string());
+                let secret_env = config
+                    .secret_key_secret_id
+                    .filter(|value| !value.trim().is_empty())
+                    .map(|secret_id| {
+                        vec![WorkerSecretEnvVar {
+                            env: "EXO_NOSTR_SECRET_KEY".to_string(),
+                            secret_id,
+                        }]
+                    })
+                    .unwrap_or_default();
+                Ok(AdapterConfig {
+                    adapter_type: "nostr-chat".to_string(),
+                    worker_command: options.worker_command("nostr-chat"),
+                    initialization: serde_json::json!({
+                        "relayUrl": relay_url,
+                        "groupId": group_id,
+                        "trigger": config.trigger.as_str(),
+                    }),
+                    state_dir: None,
+                    secret_env,
+                })
+            }
             Self::AgentCli(config) => {
                 require_source(source, AdapterSource::BuiltIn, "agent-cli")?;
                 if !config.mount_root.starts_with('/') {
@@ -534,6 +592,15 @@ impl ChatTrigger {
         match self {
             Self::AllMessages => "all_messages",
             Self::ContactsOnly => "contacts_only",
+        }
+    }
+}
+
+impl NostrChatTrigger {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::AllMessages => "all_messages",
+            Self::MentionsOnly => "mentions_only",
         }
     }
 }
@@ -596,6 +663,24 @@ fn exochat_base_url(value: Option<String>) -> Result<String> {
         bail!("exochat baseUrl must start with http:// or https://");
     }
     Ok(value)
+}
+
+fn nostr_chat_relay_url(value: Option<String>) -> Result<String> {
+    let relay_url = value
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_NOSTR_CHAT_RELAY_URL.to_string());
+    let parsed = Url::parse(&relay_url).context("nostr-chat relayUrl must be a valid URL")?;
+    if parsed.scheme() != "wss" && parsed.scheme() != "ws" {
+        bail!("nostr-chat relayUrl must start with wss:// or ws://");
+    }
+    if !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || parsed.query().is_some()
+        || parsed.fragment().is_some()
+    {
+        bail!("nostr-chat relayUrl must not contain credentials, a query, or a fragment");
+    }
+    Ok(relay_url)
 }
 
 fn exochat_secret() -> String {
@@ -1449,6 +1534,81 @@ mod tests {
             .into_adapter_config(AdapterSource::Library, &test_creation_options())
             .unwrap_err();
         assert!(error.to_string().contains("channelId and secret"));
+    }
+
+    #[test]
+    fn nostr_chat_config_applies_portable_defaults_and_secret_binding() {
+        let parse = |relay_url: serde_json::Value,
+                     group_id: serde_json::Value,
+                     secret_key_secret_id: serde_json::Value|
+         -> AdapterCreationConfig {
+            serde_json::from_value(serde_json::json!({
+                "type": "nostr-chat",
+                "relayUrl": relay_url,
+                "groupId": group_id,
+                "secretKeySecretId": secret_key_secret_id,
+                "trigger": "mentions_only",
+            }))
+            .unwrap()
+        };
+        let adapter_config = parse(
+            serde_json::Value::Null,
+            serde_json::Value::Null,
+            serde_json::Value::Null,
+        )
+        .into_adapter_config(AdapterSource::Library, &test_creation_options())
+        .unwrap();
+        assert_eq!(adapter_config.adapter_type, "nostr-chat");
+        assert!(
+            adapter_config.worker_command[2].ends_with("/tmp/exo-adapters/nostr-chat/worker.ts")
+        );
+        assert_eq!(
+            adapter_config.initialization,
+            serde_json::json!({
+                "relayUrl": DEFAULT_NOSTR_CHAT_RELAY_URL,
+                "groupId": DEFAULT_NOSTR_CHAT_GROUP_ID,
+                "trigger": "mentions_only",
+            })
+        );
+        assert!(adapter_config.secret_env.is_empty());
+
+        let adapter_config = parse(
+            serde_json::json!("wss://relay.example.test"),
+            serde_json::json!("agents"),
+            serde_json::json!("nostr-agent"),
+        )
+        .into_adapter_config(AdapterSource::Library, &test_creation_options())
+        .unwrap();
+        assert_eq!(
+            adapter_config.initialization["relayUrl"],
+            "wss://relay.example.test"
+        );
+        assert_eq!(adapter_config.initialization["groupId"], "agents");
+        assert_eq!(
+            adapter_config.secret_env,
+            vec![WorkerSecretEnvVar {
+                env: "EXO_NOSTR_SECRET_KEY".to_string(),
+                secret_id: "nostr-agent".to_string(),
+            }]
+        );
+
+        let error = parse(
+            serde_json::json!("https://relay.example.test"),
+            serde_json::json!("agents"),
+            serde_json::Value::Null,
+        )
+        .into_adapter_config(AdapterSource::Library, &test_creation_options())
+        .unwrap_err();
+        assert!(error.to_string().contains("wss:// or ws://"));
+
+        let error = parse(
+            serde_json::Value::Null,
+            serde_json::Value::Null,
+            serde_json::Value::Null,
+        )
+        .into_adapter_config(AdapterSource::BuiltIn, &test_creation_options())
+        .unwrap_err();
+        assert!(error.to_string().contains("source"));
     }
 
     #[tokio::test]

--- a/examples/exo/README.md
+++ b/examples/exo/README.md
@@ -78,6 +78,23 @@ Notes:
 - For a minimal start without Docker defaults or adapter setup:
   `./exo.sh --template minimal --pull-sandbox`
 
+## Setting up Nostr chat
+
+Exo can join a public NIP-29 group through the library Nostr chat adapter:
+
+```bash
+./exo.sh --setup nostr-chat
+```
+
+The default setup joins `openagents-public` at
+`wss://relay.openagents.com`. Pass another relay URL and group ID in the
+adapter configuration to use any compatible NIP-29 deployment. Exo generates
+and protects a new adapter key unless the configuration names an existing Exo
+secret.
+
+See [`adapters/nostr-chat/README.md`](adapters/nostr-chat/README.md) for the
+protocol, identity, and trigger details.
+
 ## Setting up Discord
 
 Exo can connect to Discord through the library Discord adapter. The short
@@ -253,9 +270,9 @@ reconnect behavior, inbound message parsing, event history, and conversation
 wake-ups. Agents configure adapters with tools, and the local adapter runner
 started by `./exo.sh` keeps them connected.
 
-Exo ships with ExoChat, IRC, WhatsApp, Signal, Discord, and agent-cli adapters
-(see `adapters/agent-cli/README.md` for the shell CLI). The default canonical
-setup turns on ExoChat:
+Exo ships with ExoChat, Nostr chat, IRC, WhatsApp, Signal, Discord, and
+agent-cli adapters (see `adapters/agent-cli/README.md` for the shell CLI). The
+default canonical setup turns on ExoChat:
 
 ```bash
 ./exo.sh

--- a/examples/exo/adapters/nostr-chat/README.md
+++ b/examples/exo/adapters/nostr-chat/README.md
@@ -1,0 +1,61 @@
+# Nostr Chat Adapter
+
+The Nostr chat adapter connects Exo to a public NIP-29 group. It uses standard
+Nostr relay frames, verifies event signatures, verifies group state against the
+relay's NIP-11 `self` key, and completes NIP-42 authentication when the relay
+requests it.
+
+The default configuration joins the public `openagents-public` group at
+`wss://relay.openagents.com`. These values are only defaults. Set another relay
+URL and group ID to use any compatible NIP-29 relay. The adapter does not use an
+OpenAgents account, API, session, or proprietary message format.
+
+## Setup
+
+Install dependencies from the repository root, then start Exo with the setup
+prompt:
+
+```bash
+pnpm install
+./exo.sh fresh --setup nostr-chat
+```
+
+The setup prompt creates a library adapter similar to:
+
+```json
+{
+  "name": "nostr-chat",
+  "source": "library",
+  "config": {
+    "type": "nostr-chat",
+    "relayUrl": null,
+    "groupId": null,
+    "secretKeySecretId": null,
+    "trigger": "all_messages"
+  }
+}
+```
+
+`relayUrl: null` and `groupId: null` use the documented defaults. Set both
+values to join another NIP-29 group.
+
+When `secretKeySecretId` is null, the worker generates a new Nostr key and
+stores it with mode `0600` in the adapter state directory. To use an existing
+identity, put a 32-byte hex key or `nsec` in an Exo secret and set
+`secretKeySecretId` to that secret ID. The worker receives it as
+`EXO_NOSTR_SECRET_KEY`; it does not print the key.
+
+## Behavior
+
+- Initial history fills the NIP-29 timeline cursor without waking the agent.
+- New signed kind-9 events wake Exo according to the trigger policy.
+- `all_messages` wakes on every new message except the adapter's own events.
+- `mentions_only` wakes for a matching `p` tag, hex public key, or `npub`.
+- Outbound messages include the group `h` tag and up to three eight-character
+  `previous` references from the most recent 50 foreign events.
+- A matching relay `OK` receipt is required before Exo acknowledges a send.
+- Reconnect replay is deduplicated by event ID.
+
+The first version sends text and public links. NIP-92 media URLs remain in the
+message text, so compatible clients can render them. Direct Exo attachment
+upload is not part of this adapter yet.

--- a/examples/exo/adapters/nostr-chat/nostr-chat.test.ts
+++ b/examples/exo/adapters/nostr-chat/nostr-chat.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { generateSecretKey, verifyEvent, type Event } from "nostr-tools/pure";
+
+import {
+  createChatEvent,
+  isGroupChatEvent,
+  normalizeRelayUrl,
+  parseSecretKey,
+  publicIdentity,
+  relayInformationUrl,
+  selectPreviousPrefixes,
+  shouldTrigger,
+} from "./nostr-chat";
+
+describe("Nostr chat worker helpers", () => {
+  it("normalizes relay and relay-information URLs", () => {
+    expect(normalizeRelayUrl("wss://relay.example.test")).toBe(
+      "wss://relay.example.test/",
+    );
+    expect(relayInformationUrl("wss://relay.example.test")).toBe(
+      "https://relay.example.test/",
+    );
+    expect(() => normalizeRelayUrl("https://relay.example.test")).toThrow(
+      "wss:// or ws://",
+    );
+    expect(() =>
+      normalizeRelayUrl("wss://user@relay.example.test?secret=yes"),
+    ).toThrow("must not contain credentials");
+  });
+
+  it("parses hex and nsec secret keys", () => {
+    const secretKey = generateSecretKey();
+    const hex = Buffer.from(secretKey).toString("hex");
+    expect(parseSecretKey(hex)).toEqual(secretKey);
+    expect(() => parseSecretKey("not-a-key")).toThrow(
+      "64 hex characters or an nsec",
+    );
+  });
+
+  it("creates a signed NIP-29 kind-9 event", () => {
+    const secretKey = generateSecretKey();
+    const event = createChatEvent(
+      "hello",
+      "group-one",
+      ["12345678", "abcdef01"],
+      secretKey,
+      1_700_000_000,
+    );
+    expect(event.kind).toBe(9);
+    expect(event.tags).toEqual([
+      ["h", "group-one"],
+      ["previous", "12345678", "abcdef01"],
+    ]);
+    expect(verifyEvent(event)).toBe(true);
+    expect(isGroupChatEvent(event, "group-one")).toBe(true);
+    expect(isGroupChatEvent(event, "group-two")).toBe(false);
+  });
+
+  it("selects three recent foreign timeline prefixes", () => {
+    const events = [
+      event("11111111aaaaaaaa", "alice", 10),
+      event("22222222bbbbbbbb", "self", 12),
+      event("33333333cccccccc", "bob", 11),
+      event("11111111dddddddd", "carol", 9),
+      event("44444444eeeeeeee", "dave", 8),
+    ];
+    expect(selectPreviousPrefixes(events, "self")).toEqual([
+      "33333333",
+      "11111111",
+      "44444444",
+    ]);
+  });
+
+  it("supports all-message and explicit-mention wake policies", () => {
+    const secretKey = generateSecretKey();
+    const identity = publicIdentity(secretKey);
+    const base = event("11111111aaaaaaaa", "alice", 10);
+    expect(shouldTrigger("all_messages", base, identity.pubkey)).toBe(true);
+    expect(shouldTrigger("mentions_only", base, identity.pubkey)).toBe(false);
+    expect(
+      shouldTrigger(
+        "mentions_only",
+        { ...base, tags: [["p", identity.pubkey]] },
+        identity.pubkey,
+      ),
+    ).toBe(true);
+    expect(
+      shouldTrigger(
+        "mentions_only",
+        { ...base, content: `hello nostr:${identity.npub}` },
+        identity.pubkey,
+      ),
+    ).toBe(true);
+    expect(
+      shouldTrigger(
+        "all_messages",
+        { ...base, pubkey: identity.pubkey },
+        identity.pubkey,
+      ),
+    ).toBe(false);
+  });
+});
+
+function event(id: string, pubkey: string, createdAt: number): Event {
+  return {
+    id,
+    pubkey,
+    created_at: createdAt,
+    kind: 9,
+    tags: [["h", "group-one"]],
+    content: "",
+    sig: "0".repeat(128),
+  };
+}

--- a/examples/exo/adapters/nostr-chat/nostr-chat.ts
+++ b/examples/exo/adapters/nostr-chat/nostr-chat.ts
@@ -1,0 +1,123 @@
+import {
+  finalizeEvent,
+  getPublicKey,
+  verifyEvent,
+  type Event,
+  type VerifiedEvent,
+} from "nostr-tools/pure";
+import { decode, npubEncode } from "nostr-tools/nip19";
+
+export type NostrChatTrigger = "all_messages" | "mentions_only";
+
+export function normalizeRelayUrl(value: string): string {
+  const url = new URL(value);
+  if (url.protocol !== "wss:" && url.protocol !== "ws:") {
+    throw new Error("Nostr relay URL must use wss:// or ws://");
+  }
+  if (url.username || url.password || url.search || url.hash) {
+    throw new Error(
+      "Nostr relay URL must not contain credentials, a query, or a fragment",
+    );
+  }
+  return url.toString();
+}
+
+export function relayInformationUrl(relayUrl: string): string {
+  const url = new URL(normalizeRelayUrl(relayUrl));
+  url.protocol = url.protocol === "wss:" ? "https:" : "http:";
+  return url.toString();
+}
+
+export function parseSecretKey(value: string): Uint8Array {
+  const trimmed = value.trim();
+  if (/^[0-9a-f]{64}$/i.test(trimmed)) {
+    return Uint8Array.from(Buffer.from(trimmed, "hex"));
+  }
+  if (trimmed.startsWith("nsec1")) {
+    const decoded = decode(trimmed);
+    if (decoded.type === "nsec") {
+      return decoded.data;
+    }
+  }
+  throw new Error("Nostr secret key must be 64 hex characters or an nsec");
+}
+
+export function selectPreviousPrefixes(
+  events: Event[],
+  ownPubkey: string,
+  limit = 3,
+): string[] {
+  return [...events]
+    .sort(
+      (left, right) =>
+        right.created_at - left.created_at || right.id.localeCompare(left.id),
+    )
+    .filter((event) => event.pubkey !== ownPubkey)
+    .map((event) => event.id.slice(0, 8))
+    .filter((prefix, index, prefixes) => prefixes.indexOf(prefix) === index)
+    .slice(0, limit);
+}
+
+export function createChatEvent(
+  text: string,
+  groupId: string,
+  previousPrefixes: string[],
+  secretKey: Uint8Array,
+  createdAt = Math.floor(Date.now() / 1_000),
+): VerifiedEvent {
+  const tags = [["h", groupId]];
+  if (previousPrefixes.length > 0) {
+    tags.push(["previous", ...previousPrefixes]);
+  }
+  return finalizeEvent(
+    {
+      kind: 9,
+      content: text,
+      created_at: createdAt,
+      tags,
+    },
+    secretKey,
+  );
+}
+
+export function isGroupChatEvent(
+  event: Event,
+  groupId: string,
+): event is VerifiedEvent {
+  return (
+    event.kind === 9 &&
+    event.tags.some(
+      (tag) => tag[0] === "h" && tag.length === 2 && tag[1] === groupId,
+    ) &&
+    verifyEvent(event)
+  );
+}
+
+export function shouldTrigger(
+  trigger: NostrChatTrigger,
+  event: Event,
+  ownPubkey: string,
+): boolean {
+  if (event.pubkey === ownPubkey) {
+    return false;
+  }
+  if (trigger === "all_messages") {
+    return true;
+  }
+  const npub = npubEncode(ownPubkey);
+  return (
+    event.tags.some(
+      (tag) => tag[0] === "p" && tag.length >= 2 && tag[1] === ownPubkey,
+    ) ||
+    event.content.toLowerCase().includes(ownPubkey.toLowerCase()) ||
+    event.content.toLowerCase().includes(npub.toLowerCase())
+  );
+}
+
+export function publicIdentity(secretKey: Uint8Array): {
+  pubkey: string;
+  npub: string;
+} {
+  const pubkey = getPublicKey(secretKey);
+  return { pubkey, npub: npubEncode(pubkey) };
+}

--- a/examples/exo/adapters/nostr-chat/setup-prompt.md
+++ b/examples/exo/adapters/nostr-chat/setup-prompt.md
@@ -1,0 +1,20 @@
+Set up a public Nostr chat adapter for this conversation.
+
+Create a library Nostr chat adapter if one does not already exist for this
+conversation. Use these settings:
+
+- name: `nostr-chat`
+- source: `library`
+- type: `nostr-chat`
+- relayUrl: `null`
+- groupId: `null`
+- secretKeySecretId: `null`
+- trigger: `all_messages`
+
+Null relay and group values use the documented public defaults. The adapter
+generates and protects a new Nostr key when `secretKeySecretId` is null. Do not
+request, print, or expose the generated secret key.
+
+After the adapter is ready, report its ID, relay URL, and NIP-29 group ID. The
+worker prints its public `npub` when it connects. Explain that the user can
+replace the relay and group values with any compatible NIP-29 deployment.

--- a/examples/exo/adapters/nostr-chat/worker.ts
+++ b/examples/exo/adapters/nostr-chat/worker.ts
@@ -1,0 +1,332 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import readline from "node:readline/promises";
+
+import {
+  finalizeEvent,
+  generateSecretKey,
+  verifyEvent,
+  type Event,
+} from "nostr-tools/pure";
+import { Relay } from "nostr-tools/relay";
+
+import {
+  adapterConfig,
+  optionalStringField,
+  parseWorkerCommand,
+  stringField,
+  writeWorkerEvent,
+} from "../protocol";
+import {
+  createChatEvent,
+  isGroupChatEvent,
+  normalizeRelayUrl,
+  parseSecretKey,
+  publicIdentity,
+  relayInformationUrl,
+  selectPreviousPrefixes,
+  shouldTrigger,
+  type NostrChatTrigger,
+} from "./nostr-chat";
+
+const config = adapterConfig();
+const relayUrl = normalizeRelayUrl(
+  optionalStringField(config, "relayUrl") ?? "wss://relay.openagents.com",
+);
+const groupId = optionalStringField(config, "groupId") ?? "openagents-public";
+const trigger = stringField(config, "trigger") as NostrChatTrigger;
+if (trigger !== "all_messages" && trigger !== "mentions_only") {
+  throw new Error("Nostr chat trigger must be all_messages or mentions_only");
+}
+
+const stateDir =
+  process.env.EXO_ADAPTER_STATE_DIR ??
+  `.exo/adapters/nostr-chat/${process.env.EXO_ADAPTER_ID ?? "default"}`;
+const secretKeyPath = path.join(stateDir, "secret.key");
+const secretKey = await loadOrCreateSecretKey();
+const identity = publicIdentity(secretKey);
+const relaySelfPubkey = await fetchRelaySelfPubkey(relayUrl);
+const relay = new Relay(relayUrl, {
+  enablePing: true,
+  enableReconnect: true,
+});
+
+relay.onauth = async (template) => finalizeEvent(template, secretKey);
+relay.onnotice = (message) => {
+  writeWorkerEvent({
+    type: "lifecycle",
+    name: "relay_notice",
+    metadata: { message, relayUrl },
+  });
+};
+relay.onclose = () => {
+  writeWorkerEvent({
+    type: "disconnected",
+    reason: `Nostr relay connection closed: ${relayUrl}`,
+  });
+};
+await relay.connect({ timeout: 10_000 });
+
+const timeline: Event[] = [];
+const seenEventIds = new Set<string>();
+let historyCurrent = false;
+let stateCurrent = false;
+let connectedEmitted = false;
+
+relay.subscribe([{ kinds: [9], "#h": [groupId], limit: 50 }], {
+  onevent: handleChatEvent,
+  oninvalidevent: () => {
+    writeWorkerEvent({
+      type: "error",
+      message: "Nostr relay sent an event with an invalid signature",
+    });
+  },
+  oneose: () => {
+    historyCurrent = true;
+    emitConnectedWhenCurrent();
+  },
+  onclose: (reason) => {
+    writeWorkerEvent({
+      type: "error",
+      message: `Nostr chat subscription closed: ${reason}`,
+    });
+  },
+});
+
+relay.subscribe(
+  [
+    {
+      kinds: [39000, 39001, 39003, 39005],
+      authors: [relaySelfPubkey],
+      "#d": [groupId],
+    },
+  ],
+  {
+    onevent: (event) => {
+      if (!verifyEvent(event) || event.pubkey !== relaySelfPubkey) {
+        writeWorkerEvent({
+          type: "error",
+          message:
+            "Rejected NIP-29 group state that was not signed by the relay",
+        });
+      }
+    },
+    oninvalidevent: () => {
+      writeWorkerEvent({
+        type: "error",
+        message: "Nostr relay sent invalid NIP-29 group state",
+      });
+    },
+    oneose: () => {
+      stateCurrent = true;
+      emitConnectedWhenCurrent();
+    },
+    onclose: (reason) => {
+      writeWorkerEvent({
+        type: "error",
+        message: `NIP-29 group-state subscription closed: ${reason}`,
+      });
+    },
+  },
+);
+
+const input = readline.createInterface({
+  input: process.stdin,
+  crlfDelay: Number.POSITIVE_INFINITY,
+});
+
+input.on("error", (error) => {
+  writeWorkerEvent({
+    type: "error",
+    message: `Nostr chat command stream error: ${error.message}`,
+  });
+});
+
+for await (const line of input) {
+  if (line.trim().length === 0) {
+    continue;
+  }
+  let commandId: string | null = null;
+  try {
+    const command = parseWorkerCommand(JSON.parse(line));
+    commandId = command.id;
+    const target = command.target ?? groupId;
+    if (target !== groupId) {
+      throw new Error(
+        `Nostr chat target must be null or the configured group id ${groupId}`,
+      );
+    }
+    if (command.attachments.length > 0) {
+      throw new Error(
+        "Nostr chat attachments are not available yet; send public HTTPS media URLs in the message text",
+      );
+    }
+    const event = createChatEvent(
+      command.text,
+      groupId,
+      selectPreviousPrefixes(timeline, identity.pubkey),
+      secretKey,
+    );
+    writeWorkerEvent({
+      type: "lifecycle",
+      name: "send_starting",
+      metadata: { eventId: event.id, groupId, relayUrl },
+    });
+    await publishWithAuthRetry(event);
+    rememberTimelineEvent(event);
+    writeWorkerEvent({
+      type: "lifecycle",
+      name: "send_result",
+      metadata: { eventId: event.id, groupId, relayUrl },
+    });
+    writeWorkerEvent({ type: "command_ack", command_id: command.id });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    writeWorkerEvent({ type: "error", message });
+    if (commandId !== null) {
+      writeWorkerEvent({
+        type: "command_nack",
+        command_id: commandId,
+        message,
+      });
+    }
+  }
+}
+
+function handleChatEvent(event: Event): void {
+  if (!isGroupChatEvent(event, groupId)) {
+    writeWorkerEvent({
+      type: "error",
+      message: "Rejected an invalid NIP-29 chat event",
+    });
+    return;
+  }
+  if (seenEventIds.has(event.id)) {
+    return;
+  }
+  seenEventIds.add(event.id);
+  rememberTimelineEvent(event);
+  if (!historyCurrent || !shouldTrigger(trigger, event, identity.pubkey)) {
+    return;
+  }
+  writeWorkerEvent({
+    type: "message",
+    target: groupId,
+    sender: event.pubkey,
+    text: event.content,
+    message_id: event.id,
+    metadata: {
+      createdAt: event.created_at,
+      eventId: event.id,
+      groupId,
+      kind: event.kind,
+      relayUrl,
+      source: "nostr-chat",
+    },
+  });
+}
+
+function rememberTimelineEvent(event: Event): void {
+  if (!timeline.some((candidate) => candidate.id === event.id)) {
+    timeline.push(event);
+  }
+  timeline.sort(
+    (left, right) =>
+      right.created_at - left.created_at || right.id.localeCompare(left.id),
+  );
+  timeline.splice(50);
+  if (seenEventIds.size > 1_000) {
+    const retained = new Set(timeline.map((candidate) => candidate.id));
+    for (const eventId of seenEventIds) {
+      if (!retained.has(eventId)) {
+        seenEventIds.delete(eventId);
+      }
+    }
+  }
+}
+
+function emitConnectedWhenCurrent(): void {
+  if (connectedEmitted || !historyCurrent || !stateCurrent) {
+    return;
+  }
+  connectedEmitted = true;
+  process.stderr.write(
+    `[nostr-chat-adapter] connected ${relayUrl}#${groupId} as ${identity.npub}\n`,
+  );
+  writeWorkerEvent({
+    type: "connected",
+    subject: `${relayUrl}#${groupId}`,
+    metadata: {
+      groupId,
+      npub: identity.npub,
+      pubkey: identity.pubkey,
+      relaySelfPubkey,
+      relayUrl,
+    },
+  });
+}
+
+async function publishWithAuthRetry(event: Event): Promise<void> {
+  try {
+    await relay.publish(event);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (!message.startsWith("auth-required:")) {
+      throw error;
+    }
+    if (!relay.onauth) {
+      throw new Error("Nostr relay requested authentication without a signer");
+    }
+    await relay.auth(relay.onauth);
+    await relay.publish(event);
+  }
+}
+
+async function loadOrCreateSecretKey(): Promise<Uint8Array> {
+  const configured = process.env.EXO_NOSTR_SECRET_KEY;
+  if (configured) {
+    return parseSecretKey(configured);
+  }
+  await fs.mkdir(stateDir, { recursive: true, mode: 0o700 });
+  try {
+    return parseSecretKey(await fs.readFile(secretKeyPath, "utf8"));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+  const generated = generateSecretKey();
+  await fs.writeFile(
+    secretKeyPath,
+    `${Buffer.from(generated).toString("hex")}\n`,
+    { mode: 0o600 },
+  );
+  return generated;
+}
+
+async function fetchRelaySelfPubkey(url: string): Promise<string> {
+  const response = await fetch(relayInformationUrl(url), {
+    headers: { accept: "application/nostr+json" },
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Nostr relay information request failed with HTTP ${response.status}`,
+    );
+  }
+  const document = (await response.json()) as unknown;
+  if (
+    !isRecord(document) ||
+    typeof document.self !== "string" ||
+    !/^[0-9a-f]{64}$/i.test(document.self)
+  ) {
+    throw new Error(
+      "Nostr relay information does not contain a valid self key",
+    );
+  }
+  return document.self.toLowerCase();
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "discord.js": "^14.26.4",
     "linkedom": "^0.18.12",
     "lucide-react": "^1.21.0",
+    "nostr-tools": "2.24.1",
     "openai": "6.33.0",
     "opusscript": "^0.1.1",
     "prism-media": "^1.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       lucide-react:
         specifier: ^1.21.0
         version: 1.21.0(react@19.2.7)
+      nostr-tools:
+        specifier: 2.24.1
+        version: 2.24.1(typescript@5.9.3)
       openai:
         specifier: 6.33.0
         version: 6.33.0(ws@8.21.0)(zod@4.3.6)
@@ -1088,6 +1091,18 @@ packages:
 
   '@next/env@14.2.35':
     resolution: {integrity: sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==}
+
+  '@noble/ciphers@2.1.1':
+    resolution: {integrity: sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/curves@2.0.1':
+    resolution: {integrity: sha512-vs1Az2OOTBiP4q0pwjW5aF0xp9n4MxVrmkFBxc6EKZc6ddYx5gaZiAsZoq0uRRXWbi3AT/sBqn05eRPtn1JCPw==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@2.0.1':
+    resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
+    engines: {node: '>= 20.19.0'}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2298,6 +2313,15 @@ packages:
   '@sapphire/snowflake@3.5.5':
     resolution: {integrity: sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==}
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
+
+  '@scure/base@2.0.0':
+    resolution: {integrity: sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==}
+
+  '@scure/bip32@2.0.1':
+    resolution: {integrity: sha512-4Md1NI5BzoVP+bhyJaY3K6yMesEFzNS1sE/cP+9nuvE7p/b0kx9XbpDHHFl8dHtufcbdHRUUQdRqLIPHN/s7yA==}
+
+  '@scure/bip39@2.0.1':
+    resolution: {integrity: sha512-PsxdFj/d2AcJcZDX1FXN3dDgitDDTmwf78rKZq1a6c1P1Nan1X/Sxc7667zU3U+AN60g7SxxP0YCVw2H/hBycg==}
 
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
@@ -4297,6 +4321,17 @@ packages:
     resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
     engines: {node: '>=6'}
     hasBin: true
+
+  nostr-tools@2.24.1:
+    resolution: {integrity: sha512-KdrKjC74n/rr6J3eCSfZj8dcbZFvolHYe4S22SefNZ5YWbhHiB0KL/mmJjEZ0u6B9mZK0YcQtl+WQ46KzwapeQ==}
+    peerDependencies:
+      typescript: '>=5.0.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  nostr-wasm@0.1.0:
+    resolution: {integrity: sha512-78BTryCLcLYv96ONU8Ws3Q1JzjlAt+43pWQhIl86xZmWeegYCNLPml7yQ+gG3vR6V5h4XGj+TxO+SS5dsThQIA==}
 
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
@@ -6365,6 +6400,14 @@ snapshots:
 
   '@next/env@14.2.35': {}
 
+  '@noble/ciphers@2.1.1': {}
+
+  '@noble/curves@2.0.1':
+    dependencies:
+      '@noble/hashes': 2.0.1
+
+  '@noble/hashes@2.0.1': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -7412,6 +7455,19 @@ snapshots:
   '@sapphire/snowflake@3.5.3': {}
 
   '@sapphire/snowflake@3.5.5': {}
+
+  '@scure/base@2.0.0': {}
+
+  '@scure/bip32@2.0.1':
+    dependencies:
+      '@noble/curves': 2.0.1
+      '@noble/hashes': 2.0.1
+      '@scure/base': 2.0.0
+
+  '@scure/bip39@2.0.1':
+    dependencies:
+      '@noble/hashes': 2.0.1
+      '@scure/base': 2.0.0
 
   '@sec-ant/readable-stream@0.4.1': {}
 
@@ -9462,6 +9518,20 @@ snapshots:
     dependencies:
       abbrev: 1.1.1
     optional: true
+
+  nostr-tools@2.24.1(typescript@5.9.3):
+    dependencies:
+      '@noble/ciphers': 2.1.1
+      '@noble/curves': 2.0.1
+      '@noble/hashes': 2.0.1
+      '@scure/base': 2.0.0
+      '@scure/bip32': 2.0.1
+      '@scure/bip39': 2.0.1
+      nostr-wasm: 0.1.0
+    optionalDependencies:
+      typescript: 5.9.3
+
+  nostr-wasm@0.1.0: {}
 
   npm-run-path@4.0.1:
     dependencies:

--- a/typescript/harness/adapter-tools.ts
+++ b/typescript/harness/adapter-tools.ts
@@ -42,7 +42,7 @@ function createAdapterTool(): ToolInstance {
     definition: {
       name: "create_adapter",
       description:
-        "Create and enable a long-running adapter for this conversation. Use source 'built_in' with config type 'irc' or 'agent-cli'. Use source 'library' with config type 'exochat', 'whatsapp', 'signal', 'discord', or 'slack' for shipped library adapters.",
+        "Create and enable a long-running adapter for this conversation. Use source 'built_in' with config type 'irc' or 'agent-cli'. Use source 'library' with config type 'exochat', 'nostr-chat', 'whatsapp', 'signal', 'discord', or 'slack' for shipped library adapters.",
       parameters: {
         type: "object",
         additionalProperties: false,
@@ -519,6 +519,41 @@ function adapterConfigSchema(): ToolDefinition["parameters"] {
         type: "object",
         additionalProperties: false,
         properties: {
+          type: { type: "string", enum: ["nostr-chat"] },
+          relayUrl: {
+            type: ["string", "null"],
+            description:
+              "NIP-29 relay WebSocket URL. Use null for the documented public default.",
+          },
+          groupId: {
+            type: ["string", "null"],
+            description:
+              "NIP-29 group id. Use null for the documented public default.",
+          },
+          secretKeySecretId: {
+            type: ["string", "null"],
+            description:
+              "Optional Exo secret id containing a 32-byte hex key or nsec. Use null to generate a protected adapter key.",
+          },
+          trigger: {
+            type: "string",
+            enum: ["all_messages", "mentions_only"],
+            description:
+              "Wake on all new foreign messages or only messages that mention the adapter identity.",
+          },
+        },
+        required: [
+          "type",
+          "relayUrl",
+          "groupId",
+          "secretKeySecretId",
+          "trigger",
+        ],
+      },
+      {
+        type: "object",
+        additionalProperties: false,
+        properties: {
           type: { type: "string", enum: ["agent-cli"] },
           socketPath: {
             type: ["string", "null"],
@@ -557,6 +592,7 @@ function validateAdapterSource(source: string, type: string): void {
   }
   if (
     (type === "exochat" ||
+      type === "nostr-chat" ||
       type === "whatsapp" ||
       type === "signal" ||
       type === "discord" ||


### PR DESCRIPTION
## Summary

- Add a shipped `nostr-chat` library adapter under
  `examples/exo/adapters/nostr-chat`.
- Add the Rust adapter configuration and the model-visible TypeScript schema.
- Use `nostr-tools` for event signing, signature verification, relay
  subscriptions, and NIP-42 authentication.
- Add setup documentation and a reusable `./exo.sh --setup nostr-chat` prompt.

## Why Nostr and why this adapter

Nostr is an open protocol for signed events exchanged through interchangeable
relays: an identity is a key pair, not an account owned by a chat vendor.

This makes Nostr a useful agent-chat transport for Exo. It supplies the small
operational surface of IRC while adding cryptographic identity, authenticated
writes, portable groups, and standard rich-media references. The public demo
that motivated this adapter has exercised all five requirements:

1. **Simple join.** Claude received the public instructions and its signed
   introduction appeared in the channel in less than five seconds. The flow
   used no account, dashboard, email address, phone number, or API key. This
   adapter gives Exo the same path: configure a relay and group, then use an
   existing key or let the worker create an adapter-specific key.
2. **Rich content.** The production path uploaded a real JPEG through Blossom,
   published NIP-92 metadata, verified the SHA-256 digest, and rendered the
   media in the web reader. Nostr keeps media storage separate from chat
   transport. This pull request preserves those public media URLs in message
   text; direct Exo NIP-B7 upload is a clear follow-up rather than a proprietary
   attachment API.
3. **Web and mobile.** The same public group was tested at 1382×866 and
   390×844 without horizontal overflow. Web and mobile clients subscribe to the
   same relay events as Exo, so the adapter does not require a separate gateway
   or device-specific protocol.
4. **Channels and groups.** The demo is a real NIP-29 group with relay-signed
   group state and kind-9 history. This adapter makes the relay URL and NIP-29
   group ID explicit configuration and verifies group state against the
   relay's NIP-11 `self` key.
5. **IRC-simple with stronger authentication.** The operating model is one
   key, one relay, and one group. Writes use NIP-42 challenge/response, signed
   events, matching relay receipts, and timeline references. A caller can
   replace the relay and group without changing the adapter or depending on an
   OpenAgents session or proprietary protocol.

## Protocol behavior

The worker:

- reads signed kind-9 messages for one configured NIP-29 group;
- verifies NIP-29 group state against the relay's NIP-11 `self` key;
- waits for initial history and group state before it reports a current
  connection;
- does not wake the agent for startup history;
- supports `all_messages` and `mentions_only` wake policies;
- ignores its own messages and deduplicates reconnect replay by event ID;
- signs outbound kind-9 events with the required `h` tag;
- adds up to three eight-character `previous` references from the latest 50
  foreign events;
- completes NIP-42 authentication when the relay requests it; and
- requires the matching relay `OK` result before it acknowledges a send.

## Identity and security

The adapter can bind an existing Exo secret to `EXO_NOSTR_SECRET_KEY`. The
secret can contain a 32-byte hex key or an `nsec`. If the configuration does
not name a secret, the worker creates an adapter-specific key in its state
directory with mode `0600`.

The worker does not print the secret key. Relay URLs cannot contain
credentials, query values, or fragments.

## Defaults and portability

The documented defaults are:

- relay: `wss://relay.openagents.com`
- group: `openagents-public`

These are configuration defaults, not protocol dependencies. A caller can set
another relay URL and group ID. The worker uses standard Nostr relay frames and
does not require an OpenAgents account, API, session, or proprietary message
format.

## Rich content

This first adapter version preserves public media URLs in message text, so
NIP-92-aware clients can render media that is already present in the event.
Direct Exo attachment upload and NIP-B7 Blossom authorization are not included
in this pull request.

## Verification

- `pnpm check`
  - 13 test files passed
  - 126 tests passed
  - lint and TypeScript checks passed
- `pnpm format:check`
- `cargo +1.95.0 fmt --check`
- `cargo +1.95.0 test -p executor adapter::tools::tests::nostr_chat_config_applies_portable_defaults_and_secret_binding`
- Read-only smoke against the default relay:
  - fetched the NIP-11 relay document;
  - verified the relay `self` key;
  - reached EOSE for kind-9 history and NIP-29 group state; and
  - emitted the connected adapter identity without publishing an event.
