### PR TITLE
Repl Quality-of-Life Improvements: TUI upgrade + verbosity settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1348,7 +1348,7 @@ dependencies = [
  "jsonwebtoken",
  "lingua",
  "log",
- "lru",
+ "lru 0.16.4",
  "once_cell",
  "ordered-float",
  "parking_lot 0.12.5",
@@ -1501,6 +1501,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9"
 dependencies = [
  "bytes",
+]
+
+[[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -1695,6 +1710,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1879,6 +1908,32 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "futures-core",
+ "mio",
+ "parking_lot 0.12.5",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crypto-bigint"
@@ -2401,10 +2456,12 @@ dependencies = [
  "bytes",
  "clap",
  "cost",
+ "crossterm",
  "executor",
  "exoharness",
  "futures",
  "lingua",
+ "ratatui",
  "rustyline",
  "serde",
  "serde_json",
@@ -3398,6 +3455,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3414,6 +3480,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3825,6 +3904,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru"
@@ -4814,6 +4902,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.11.0",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru 0.12.5",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5556,6 +5665,27 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -6430,6 +6560,17 @@ name = "unicode-segmentation"
 version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2408,6 +2408,7 @@ dependencies = [
  "rustyline",
  "serde",
  "serde_json",
+ "shlex",
  "tabwriter",
  "tempfile",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ reqwest = { version = "0.12.23", default-features = false, features = [
   "rustls-tls",
   "stream",
 ] }
-crossterm = { version = "0.28", features = ["event-stream"] }
+crossterm = { version = "0.28", features = ["bracketed-paste", "event-stream"] }
 ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ reqwest = { version = "0.12.23", default-features = false, features = [
   "rustls-tls",
   "stream",
 ] }
+crossterm = { version = "0.28", features = ["event-stream"] }
+ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 shlex = "1.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ reqwest = { version = "0.12.23", default-features = false, features = [
 ] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
+shlex = "1.3.0"
 sqlx = { version = "0.8.6", default-features = false, features = [
   "runtime-tokio-rustls",
   "any",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,8 +17,10 @@ path = "src/main.rs"
 anyhow.workspace = true
 clap.workspace = true
 cost = { path = "../cost" }
+crossterm.workspace = true
 executor = { path = "../executor" }
 lingua.workspace = true
+ratatui.workspace = true
 rustyline = "15.0.0"
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -22,6 +22,7 @@ lingua.workspace = true
 rustyline = "15.0.0"
 serde.workspace = true
 serde_json.workspace = true
+shlex.workspace = true
 tabwriter.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -15,7 +15,7 @@ mod tui;
 mod tui_app;
 
 use std::collections::HashMap;
-use std::io::{self, Write};
+use std::io::{self, IsTerminal, Write};
 use std::net::{SocketAddr, TcpListener};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -413,9 +413,9 @@ enum Commands {
         /// How much tool detail to print: minimal, compact, or full.
         #[arg(long, value_enum, default_value_t = Verbosity::default())]
         verbosity: Verbosity,
-        /// Prototype full-screen TUI instead of the line-mode repl.
+        /// Use the legacy line-mode repl instead of the full-screen TUI.
         #[arg(long)]
-        tui: bool,
+        legacy_tui: bool,
     },
     Adapters {
         #[command(subcommand)]
@@ -861,7 +861,7 @@ async fn main() -> Result<()> {
             agent,
             conversation,
             verbosity,
-            tui,
+            legacy_tui,
         } => {
             let agent_slug =
                 agent.unwrap_or_else(|| default_repl_agent_slug(harness_selection.as_ref()));
@@ -935,10 +935,13 @@ async fn main() -> Result<()> {
                 }
             };
 
-            if tui {
-                tui_app::run_chat_tui(Arc::clone(&agent), conversation, verbosity).await?;
-            } else {
+            // Non-interactive stdin/stdout (pipes, CI) can't host the
+            // full-screen TUI; fall back to line mode automatically.
+            let interactive = io::stdin().is_terminal() && io::stdout().is_terminal();
+            if legacy_tui || !interactive {
                 run_chat_repl(Arc::clone(&agent), conversation, verbosity).await?;
+            } else {
+                tui_app::run_chat_tui(Arc::clone(&agent), conversation, verbosity).await?;
             }
         }
         Commands::Agent { command } => match command {
@@ -2893,7 +2896,7 @@ mod create_tests {
                 agent: None,
                 conversation: None,
                 verbosity: crate::render::Verbosity::Compact,
-                tui: false,
+                legacy_tui: false,
             }
         ));
     }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -12,6 +12,7 @@ mod repl_tests;
 #[cfg(test)]
 mod secret_tests;
 mod tui;
+mod tui_app;
 
 use std::collections::HashMap;
 use std::io::{self, Write};
@@ -412,6 +413,9 @@ enum Commands {
         /// How much tool detail to print: minimal, compact, or full.
         #[arg(long, value_enum, default_value_t = Verbosity::default())]
         verbosity: Verbosity,
+        /// Prototype full-screen TUI instead of the line-mode repl.
+        #[arg(long)]
+        tui: bool,
     },
     Adapters {
         #[command(subcommand)]
@@ -857,6 +861,7 @@ async fn main() -> Result<()> {
             agent,
             conversation,
             verbosity,
+            tui,
         } => {
             let agent_slug =
                 agent.unwrap_or_else(|| default_repl_agent_slug(harness_selection.as_ref()));
@@ -930,7 +935,11 @@ async fn main() -> Result<()> {
                 }
             };
 
-            run_chat_repl(Arc::clone(&agent), conversation, verbosity).await?;
+            if tui {
+                tui_app::run_chat_tui(Arc::clone(&agent), conversation, verbosity).await?;
+            } else {
+                run_chat_repl(Arc::clone(&agent), conversation, verbosity).await?;
+            }
         }
         Commands::Agent { command } => match command {
             AgentCommands::List => {
@@ -2884,6 +2893,7 @@ mod create_tests {
                 agent: None,
                 conversation: None,
                 verbosity: crate::render::Verbosity::Compact,
+                tui: false,
             }
         ));
     }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -6,6 +6,7 @@ mod env_tests;
 mod mount_tests;
 #[cfg(test)]
 mod naming_tests;
+mod render;
 #[cfg(test)]
 mod repl_tests;
 #[cfg(test)]
@@ -18,7 +19,6 @@ use std::net::{SocketAddr, TcpListener};
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Result, anyhow, bail};
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
@@ -37,13 +37,12 @@ use executor::{
     default_vercel_image, effective_sandbox_scope, load_agent_config, send_conversation_wakeup,
     serve_exoharness_http_listener_with_options,
 };
-use lingua::Message;
-use lingua::universal::{AssistantContent, AssistantContentPart, ToolContentPart, UserContent};
 use serde::Deserialize;
 use tabwriter::TabWriter;
 use tracing_subscriber::{Layer, layer::SubscriberExt, util::SubscriberInitExt};
 
 use crate::env::CliEnvironment;
+use crate::render::{Verbosity, print_message};
 use tui::run_chat_repl;
 
 #[derive(Debug, Parser)]
@@ -410,6 +409,9 @@ enum Commands {
         /// Conversation slug to use or create (default: a fresh generated slug).
         #[arg(long)]
         conversation: Option<String>,
+        /// How much tool detail to print: minimal, compact, or full.
+        #[arg(long, value_enum, default_value_t = Verbosity::default())]
+        verbosity: Verbosity,
     },
     Adapters {
         #[command(subcommand)]
@@ -854,6 +856,7 @@ async fn main() -> Result<()> {
             model,
             agent,
             conversation,
+            verbosity,
         } => {
             let agent_slug =
                 agent.unwrap_or_else(|| default_repl_agent_slug(harness_selection.as_ref()));
@@ -927,7 +930,7 @@ async fn main() -> Result<()> {
                 }
             };
 
-            run_chat_repl(Arc::clone(&agent), conversation).await?;
+            run_chat_repl(Arc::clone(&agent), conversation, verbosity).await?;
         }
         Commands::Agent { command } => match command {
             AgentCommands::List => {
@@ -1463,7 +1466,7 @@ async fn main() -> Result<()> {
                     conversation.record().id
                 );
                 if repl {
-                    run_chat_repl(Arc::clone(&agent), conversation).await?;
+                    run_chat_repl(Arc::clone(&agent), conversation, Verbosity::default()).await?;
                 } else {
                     println!(
                         "start chatting with it via `{}`",
@@ -1504,7 +1507,7 @@ async fn main() -> Result<()> {
                         .ok_or_else(|| {
                             anyhow!("forked conversation not found: {}", forked.record().slug)
                         })?;
-                    run_chat_repl(agent, conversation).await?;
+                    run_chat_repl(agent, conversation, Verbosity::default()).await?;
                 } else {
                     println!(
                         "start chatting with it via `{}`",
@@ -1828,7 +1831,7 @@ async fn main() -> Result<()> {
                 send_conversation_wakeup(conversation.as_ref(), prompt).await?;
                 let messages = conversation.messages().await?;
                 for message in &messages[previous_messages.len()..] {
-                    print_message(message);
+                    print_message(message, Verbosity::Full);
                 }
             }
             ConversationCommands::Delete {
@@ -2753,81 +2756,6 @@ async fn run_sandbox_shell_command(
     Ok(serde_json::from_value(result)?)
 }
 
-pub(crate) fn print_message(message: &Message) {
-    let timestamp = compact_timestamp();
-    match message {
-        Message::User { content } => {
-            println!("{timestamp} user: {}", render_user_content(content));
-        }
-        Message::Assistant { content, .. } => {
-            println!(
-                "{timestamp} assistant: {}",
-                render_assistant_content(content)
-            );
-        }
-        Message::Tool { content } => {
-            for part in content {
-                let ToolContentPart::ToolResult(result) = part;
-                println!("{timestamp} tool {}: {}", result.tool_name, result.output);
-            }
-        }
-        Message::System { content } => {
-            println!("{timestamp} system: {}", render_user_content(content));
-        }
-        Message::Developer { content } => {
-            println!("{timestamp} developer: {}", render_user_content(content));
-        }
-    }
-}
-
-pub(crate) fn compact_timestamp() -> String {
-    let seconds = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|duration| duration.as_secs() % 86_400)
-        .unwrap_or(0);
-    let hours = seconds / 3_600;
-    let minutes = (seconds % 3_600) / 60;
-    let seconds = seconds % 60;
-    format!("[{hours:02}:{minutes:02}:{seconds:02}]")
-}
-
-fn render_user_content(content: &UserContent) -> String {
-    match content {
-        UserContent::String(text) => text.clone(),
-        UserContent::Array(parts) => parts
-            .iter()
-            .map(|part| match part {
-                lingua::universal::UserContentPart::Text(text) => text.text.clone(),
-                _ => "[non-text user content]".to_string(),
-            })
-            .collect::<Vec<_>>()
-            .join(""),
-    }
-}
-
-pub(crate) fn render_assistant_content(content: &AssistantContent) -> String {
-    match content {
-        AssistantContent::String(text) => text.clone(),
-        AssistantContent::Array(parts) => parts
-            .iter()
-            .map(|part| match part {
-                AssistantContentPart::Text(text) => text.text.clone(),
-                AssistantContentPart::Reasoning { text, .. } => format!("[reasoning] {text}"),
-                AssistantContentPart::ToolCall {
-                    tool_name,
-                    arguments,
-                    ..
-                } => format!("[tool_call {tool_name}] {arguments}"),
-                AssistantContentPart::ToolResult {
-                    tool_name, output, ..
-                } => format!("[tool_result {tool_name}] {output}"),
-                AssistantContentPart::File { .. } => "[file]".to_string(),
-            })
-            .collect::<Vec<_>>()
-            .join(""),
-    }
-}
-
 fn repl_command(agent_slug: &str, conversation_slug: &str) -> String {
     format!("exo repl --agent {agent_slug} --conversation {conversation_slug}")
 }
@@ -2955,6 +2883,7 @@ mod create_tests {
                 model: None,
                 agent: None,
                 conversation: None,
+                verbosity: crate::render::Verbosity::Compact,
             }
         ));
     }

--- a/crates/cli/src/render.rs
+++ b/crates/cli/src/render.rs
@@ -67,12 +67,18 @@ pub(crate) fn print_message(message: &Message, verbosity: Verbosity) {
 /// Print a whole transcript. In compact mode, each tool result is folded into
 /// its originating call line (`→ shell: ls ✓`) instead of printing separately.
 pub(crate) fn print_transcript(messages: &[Message], verbosity: Verbosity) {
-    let fold = (verbosity == Verbosity::Compact).then(|| TranscriptFold::new(messages));
-    for message in messages {
-        for line in render_message_lines(message, verbosity, fold.as_ref()) {
-            println!("{line}");
-        }
+    for line in render_transcript_lines(messages, verbosity) {
+        println!("{line}");
     }
+}
+
+/// A whole transcript as display lines, with compact-mode result folding.
+pub(crate) fn render_transcript_lines(messages: &[Message], verbosity: Verbosity) -> Vec<String> {
+    let fold = (verbosity == Verbosity::Compact).then(|| TranscriptFold::new(messages));
+    messages
+        .iter()
+        .flat_map(|message| render_message_lines(message, verbosity, fold.as_ref()))
+        .collect()
 }
 
 /// Result statuses collected across a transcript so compact call lines can

--- a/crates/cli/src/render.rs
+++ b/crates/cli/src/render.rs
@@ -13,6 +13,9 @@ use lingua::universal::{
 };
 use serde_json::{Map, Value};
 
+/// Speaker label for model output in transcripts.
+pub(crate) const ASSISTANT_LABEL: &str = "agent";
+
 /// Longest compact tool-call summary before it is truncated with an ellipsis.
 const COMPACT_SUMMARY_MAX_CHARS: usize = 100;
 
@@ -195,7 +198,7 @@ fn render_assistant_message_lines(
 ) -> Vec<String> {
     if verbosity == Verbosity::Full {
         return vec![format!(
-            "{timestamp} assistant: {}",
+            "{timestamp} {ASSISTANT_LABEL}: {}",
             render_assistant_content(content, verbosity)
         )];
     }
@@ -203,7 +206,7 @@ fn render_assistant_message_lines(
     let mut lines = Vec::new();
     let text = render_assistant_content(content, verbosity);
     if !text.trim().is_empty() {
-        lines.push(format!("{timestamp} assistant: {text}"));
+        lines.push(format!("{timestamp} {ASSISTANT_LABEL}: {text}"));
     }
     if verbosity == Verbosity::Compact
         && let AssistantContent::Array(parts) = content
@@ -574,7 +577,7 @@ mod tests {
         );
 
         assert_eq!(lines.len(), 2);
-        assert!(lines[0].ends_with("assistant: running it"));
+        assert!(lines[0].ends_with("agent: running it"));
         assert_eq!(lines[1], "→ shell: ls");
     }
 
@@ -587,7 +590,7 @@ mod tests {
         );
 
         assert_eq!(lines.len(), 1);
-        assert!(lines[0].ends_with("assistant: running it"));
+        assert!(lines[0].ends_with("agent: running it"));
     }
 
     fn tool_result_message(exit_code: i64) -> Message {

--- a/crates/cli/src/render.rs
+++ b/crates/cli/src/render.rs
@@ -1,0 +1,629 @@
+//! Rendering of conversation messages and tool activity for the CLI, with a
+//! user-selectable verbosity level.
+
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::str::FromStr;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use clap::ValueEnum;
+use lingua::Message;
+use lingua::universal::{
+    AssistantContent, AssistantContentPart, ToolCallArguments, ToolContentPart, UserContent,
+};
+use serde_json::{Map, Value};
+
+/// Longest compact tool-call summary before it is truncated with an ellipsis.
+const COMPACT_SUMMARY_MAX_CHARS: usize = 100;
+
+/// Argument keys that identify what a tool call does, in priority order; the
+/// first one present is shown inline in compact mode (e.g. the shell command).
+const PRIMARY_ARGUMENT_KEYS: [&str; 3] = ["command", "cmd", "code"];
+
+/// How much of the tool machinery the repl prints.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum)]
+pub(crate) enum Verbosity {
+    /// Only user and assistant text; tool activity is hidden entirely.
+    Minimal,
+    /// One line per tool call (name plus its primary argument) and one line
+    /// per tool result.
+    #[default]
+    Compact,
+    /// Every tool call argument and result field, fully expanded.
+    Full,
+}
+
+impl fmt::Display for Verbosity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Verbosity::Minimal => "minimal",
+            Verbosity::Compact => "compact",
+            Verbosity::Full => "full",
+        })
+    }
+}
+
+impl FromStr for Verbosity {
+    type Err = anyhow::Error;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        match input {
+            "minimal" => Ok(Verbosity::Minimal),
+            "compact" => Ok(Verbosity::Compact),
+            "full" => Ok(Verbosity::Full),
+            other => {
+                anyhow::bail!("unknown verbosity `{other}` (expected minimal, compact, or full)")
+            }
+        }
+    }
+}
+
+pub(crate) fn print_message(message: &Message, verbosity: Verbosity) {
+    for line in render_message_lines(message, verbosity, None) {
+        println!("{line}");
+    }
+}
+
+/// Print a whole transcript. In compact mode, each tool result is folded into
+/// its originating call line (`→ shell: ls ✓`) instead of printing separately.
+pub(crate) fn print_transcript(messages: &[Message], verbosity: Verbosity) {
+    let fold = (verbosity == Verbosity::Compact).then(|| TranscriptFold::new(messages));
+    for message in messages {
+        for line in render_message_lines(message, verbosity, fold.as_ref()) {
+            println!("{line}");
+        }
+    }
+}
+
+/// Result statuses collected across a transcript so compact call lines can
+/// carry their outcome inline.
+struct TranscriptFold {
+    /// Status (`✓`, `✗ exit 2`, ...) by tool call id.
+    statuses: HashMap<String, String>,
+    /// Call ids that have a rendered call line to fold into.
+    calls: HashSet<String>,
+}
+
+impl TranscriptFold {
+    fn new(messages: &[Message]) -> Self {
+        let mut statuses = HashMap::new();
+        let mut calls = HashSet::new();
+        for message in messages {
+            match message {
+                Message::Tool { content } => {
+                    for part in content {
+                        let ToolContentPart::ToolResult(result) = part;
+                        statuses.insert(
+                            result.tool_call_id.clone(),
+                            compact_result_status(&to_workspace_json(&result.output)),
+                        );
+                    }
+                }
+                Message::Assistant {
+                    content: AssistantContent::Array(parts),
+                    ..
+                } => {
+                    for part in parts {
+                        match part {
+                            AssistantContentPart::ToolCall { tool_call_id, .. } => {
+                                calls.insert(tool_call_id.clone());
+                            }
+                            AssistantContentPart::ToolResult {
+                                tool_call_id,
+                                output,
+                                ..
+                            } => {
+                                statuses.insert(
+                                    tool_call_id.clone(),
+                                    compact_result_status(&to_workspace_json(output)),
+                                );
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+        Self { statuses, calls }
+    }
+}
+
+fn render_message_lines(
+    message: &Message,
+    verbosity: Verbosity,
+    fold: Option<&TranscriptFold>,
+) -> Vec<String> {
+    let timestamp = compact_timestamp();
+    match message {
+        Message::User { content } => {
+            vec![format!(
+                "{timestamp} user: {}",
+                render_user_content(content)
+            )]
+        }
+        Message::System { content } => {
+            vec![format!(
+                "{timestamp} system: {}",
+                render_user_content(content)
+            )]
+        }
+        Message::Developer { content } => {
+            vec![format!(
+                "{timestamp} developer: {}",
+                render_user_content(content)
+            )]
+        }
+        Message::Assistant { content, .. } => {
+            render_assistant_message_lines(&timestamp, content, verbosity, fold)
+        }
+        Message::Tool { content } => content
+            .iter()
+            .filter_map(|part| {
+                let ToolContentPart::ToolResult(result) = part;
+                // Folded results already show on their call line.
+                if fold.is_some_and(|fold| fold.calls.contains(&result.tool_call_id)) {
+                    return None;
+                }
+                match verbosity {
+                    Verbosity::Full => Some(format!(
+                        "{timestamp} tool {}: {}",
+                        result.tool_name, result.output
+                    )),
+                    _ => render_tool_result(
+                        &result.tool_name,
+                        &to_workspace_json(&result.output),
+                        verbosity,
+                    ),
+                }
+            })
+            .collect(),
+    }
+}
+
+fn render_assistant_message_lines(
+    timestamp: &str,
+    content: &AssistantContent,
+    verbosity: Verbosity,
+    fold: Option<&TranscriptFold>,
+) -> Vec<String> {
+    if verbosity == Verbosity::Full {
+        return vec![format!(
+            "{timestamp} assistant: {}",
+            render_assistant_content(content, verbosity)
+        )];
+    }
+
+    let mut lines = Vec::new();
+    let text = render_assistant_content(content, verbosity);
+    if !text.trim().is_empty() {
+        lines.push(format!("{timestamp} assistant: {text}"));
+    }
+    if verbosity == Verbosity::Compact
+        && let AssistantContent::Array(parts) = content
+    {
+        for part in parts {
+            match part {
+                AssistantContentPart::ToolCall {
+                    tool_call_id,
+                    tool_name,
+                    arguments,
+                    ..
+                } => {
+                    let arguments = match arguments {
+                        ToolCallArguments::Valid(map) => match to_workspace_json(map) {
+                            Value::Object(map) => map,
+                            _ => Map::new(),
+                        },
+                        ToolCallArguments::Invalid(_) => Map::new(),
+                    };
+                    let mut rendered = render_tool_call(tool_name, &arguments, verbosity);
+                    if let Some(line) = rendered.as_mut()
+                        && let Some(status) = fold.and_then(|fold| fold.statuses.get(tool_call_id))
+                    {
+                        line.push(' ');
+                        line.push_str(status);
+                    }
+                    lines.extend(rendered);
+                }
+                // Skip results already folded into their call line.
+                AssistantContentPart::ToolResult {
+                    tool_call_id,
+                    tool_name,
+                    output,
+                    ..
+                } if !fold.is_some_and(|fold| fold.calls.contains(tool_call_id)) => {
+                    lines.extend(render_tool_result(
+                        tool_name,
+                        &to_workspace_json(output),
+                        verbosity,
+                    ));
+                }
+                _ => {}
+            }
+        }
+    }
+    lines
+}
+
+/// Bridge from lingua's vendored serde_json fork to the workspace serde_json.
+/// Must go through JSON text: the fork has `arbitrary_precision` on, so its
+/// numbers serialize as a private newtype that `serde_json::to_value` would
+/// keep as an object instead of a number.
+fn to_workspace_json<T: serde::Serialize>(value: &T) -> Value {
+    lingua::serde_json::to_string(value)
+        .ok()
+        .and_then(|text| serde_json::from_str(&text).ok())
+        .unwrap_or(Value::Null)
+}
+
+pub(crate) fn compact_timestamp() -> String {
+    let seconds = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs() % 86_400)
+        .unwrap_or(0);
+    let hours = seconds / 3_600;
+    let minutes = (seconds % 3_600) / 60;
+    let seconds = seconds % 60;
+    format!("[{hours:02}:{minutes:02}:{seconds:02}]")
+}
+
+fn render_user_content(content: &UserContent) -> String {
+    match content {
+        UserContent::String(text) => text.clone(),
+        UserContent::Array(parts) => parts
+            .iter()
+            .map(|part| match part {
+                lingua::universal::UserContentPart::Text(text) => text.text.clone(),
+                _ => "[non-text user content]".to_string(),
+            })
+            .collect::<Vec<_>>()
+            .join(""),
+    }
+}
+
+/// Assistant content as a single string. At `Full`, every part (reasoning,
+/// tool calls, tool results) is inlined; below that, only the text parts.
+pub(crate) fn render_assistant_content(content: &AssistantContent, verbosity: Verbosity) -> String {
+    match content {
+        AssistantContent::String(text) => text.clone(),
+        AssistantContent::Array(parts) => parts
+            .iter()
+            .filter_map(|part| match part {
+                AssistantContentPart::Text(text) => Some(text.text.clone()),
+                AssistantContentPart::Reasoning { text, .. } => {
+                    (verbosity == Verbosity::Full).then(|| format!("[reasoning] {text}"))
+                }
+                AssistantContentPart::ToolCall {
+                    tool_name,
+                    arguments,
+                    ..
+                } => (verbosity == Verbosity::Full)
+                    .then(|| format!("[tool_call {tool_name}] {arguments}")),
+                AssistantContentPart::ToolResult {
+                    tool_name, output, ..
+                } => (verbosity == Verbosity::Full)
+                    .then(|| format!("[tool_result {tool_name}] {output}")),
+                AssistantContentPart::File { .. } => {
+                    (verbosity == Verbosity::Full).then(|| "[file]".to_string())
+                }
+            })
+            .collect::<Vec<_>>()
+            .join(""),
+    }
+}
+
+/// Render a tool call at the given verbosity; `None` means print nothing.
+pub(crate) fn render_tool_call(
+    tool_name: &str,
+    arguments: &Map<String, Value>,
+    verbosity: Verbosity,
+) -> Option<String> {
+    match verbosity {
+        Verbosity::Minimal => None,
+        Verbosity::Compact => Some(match primary_argument(arguments) {
+            Some(summary) => format!("→ {tool_name}: {summary}"),
+            None => format!("→ {tool_name}"),
+        }),
+        Verbosity::Full => {
+            let mut lines = vec![format!("tool call {tool_name}")];
+            append_object_fields(&mut lines, arguments, "  ");
+            Some(lines.join("\n"))
+        }
+    }
+}
+
+/// Render a standalone tool result line at the given verbosity; `None` means
+/// print nothing. In compact mode this is the fallback for results whose call
+/// line is not available to fold the status into.
+pub(crate) fn render_tool_result(
+    tool_name: &str,
+    result: &Value,
+    verbosity: Verbosity,
+) -> Option<String> {
+    match verbosity {
+        Verbosity::Minimal => None,
+        Verbosity::Compact => Some(format!("← {tool_name} {}", compact_result_status(result))),
+        Verbosity::Full => {
+            let mut lines = vec!["tool result".to_string()];
+            match result {
+                Value::Object(object) => append_object_fields(&mut lines, object, "  "),
+                other => lines.push(format!("  {}", render_value_inline(other))),
+            }
+            Some(lines.join("\n"))
+        }
+    }
+}
+
+fn primary_argument(arguments: &Map<String, Value>) -> Option<String> {
+    PRIMARY_ARGUMENT_KEYS
+        .iter()
+        .find_map(|key| match arguments.get(*key) {
+            Some(Value::String(text)) => Some(first_line_summary(text)),
+            _ => None,
+        })
+}
+
+fn first_line_summary(text: &str) -> String {
+    let trimmed = text.trim();
+    let mut line: String = trimmed.lines().next().unwrap_or("").trim_end().to_string();
+    let truncated_width = line.chars().count() > COMPACT_SUMMARY_MAX_CHARS;
+    if truncated_width {
+        line = line.chars().take(COMPACT_SUMMARY_MAX_CHARS).collect();
+    }
+    if truncated_width || trimmed.lines().count() > 1 {
+        line.push('…');
+    }
+    line
+}
+
+/// One-glyph outcome for compact tool lines: `✓` on success, `✗` plus the
+/// failure signal (nonzero exit code, error field) otherwise.
+pub(crate) fn compact_result_status(result: &Value) -> String {
+    if let Value::Object(object) = result {
+        if let Some(code) = object.get("exit_code").and_then(Value::as_i64)
+            && code != 0
+        {
+            return format!("✗ exit {code}");
+        }
+        if object.get("error").is_some_and(|error| !error.is_null()) {
+            return "✗ error".to_string();
+        }
+    }
+    "✓".to_string()
+}
+
+fn append_object_fields(lines: &mut Vec<String>, object: &Map<String, Value>, indent: &str) {
+    if object.is_empty() {
+        lines.push(format!("{indent}{{}}"));
+        return;
+    }
+
+    for (key, value) in object {
+        append_field(lines, key, value, indent);
+    }
+}
+
+fn append_field(lines: &mut Vec<String>, key: &str, value: &Value, indent: &str) {
+    match value {
+        Value::String(text) if text.contains('\n') => {
+            lines.push(format!("{indent}{key}:"));
+            for line in text.lines() {
+                lines.push(format!("{indent}  {line}"));
+            }
+            if text.ends_with('\n') {
+                lines.push(format!("{indent}  "));
+            }
+        }
+        Value::Object(object) => {
+            lines.push(format!("{indent}{key}:"));
+            append_object_fields(lines, object, &format!("{indent}  "));
+        }
+        other => lines.push(format!("{indent}{key}: {}", render_value_inline(other))),
+    }
+}
+
+fn render_value_inline(value: &Value) -> String {
+    match value {
+        Value::String(text) => format!("{text:?}"),
+        other => serde_json::to_string(other).unwrap_or_else(|_| "<unrenderable>".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        TranscriptFold, Verbosity, render_message_lines, render_tool_call, render_tool_result,
+    };
+    use lingua::Message;
+    use lingua::universal::{
+        AssistantContent, AssistantContentPart, TextContentPart, ToolCallArguments,
+        ToolContentPart, ToolResultContentPart,
+    };
+    use serde_json::{Map, Value, json};
+
+    fn shell_arguments(command: &str) -> Map<String, Value> {
+        Map::from_iter([("command".to_string(), Value::String(command.to_string()))])
+    }
+
+    #[test]
+    fn full_renders_multiline_tool_call_arguments_as_indented_block() {
+        let arguments = Map::from_iter([(
+            "code".to_string(),
+            Value::String("const x = 1;\nconst y = 2;".to_string()),
+        )]);
+
+        let rendered = render_tool_call("repl_execute", &arguments, Verbosity::Full)
+            .expect("full renders tool calls");
+
+        assert_eq!(
+            rendered,
+            "tool call repl_execute\n  code:\n    const x = 1;\n    const y = 2;"
+        );
+    }
+
+    #[test]
+    fn full_renders_multiline_tool_result_fields_as_indented_block() {
+        let result = json!({"error": null, "stdout": "line 1\nline 2"});
+
+        let rendered = render_tool_result("shell", &result, Verbosity::Full)
+            .expect("full renders tool results");
+
+        assert_eq!(
+            rendered,
+            "tool result\n  error: null\n  stdout:\n    line 1\n    line 2"
+        );
+    }
+
+    #[test]
+    fn compact_tool_call_shows_the_command_on_one_line() {
+        let rendered = render_tool_call("shell", &shell_arguments("ls -la"), Verbosity::Compact)
+            .expect("compact renders tool calls");
+
+        assert_eq!(rendered, "→ shell: ls -la");
+    }
+
+    #[test]
+    fn compact_tool_call_truncates_multiline_commands_to_the_first_line() {
+        let rendered = render_tool_call(
+            "shell",
+            &shell_arguments("echo one\necho two"),
+            Verbosity::Compact,
+        )
+        .expect("compact renders tool calls");
+
+        assert_eq!(rendered, "→ shell: echo one…");
+    }
+
+    #[test]
+    fn compact_tool_call_without_primary_argument_shows_only_the_name() {
+        let arguments = Map::from_iter([("path".to_string(), Value::String("/tmp".to_string()))]);
+
+        let rendered = render_tool_call("read_file", &arguments, Verbosity::Compact)
+            .expect("compact renders tool calls");
+
+        assert_eq!(rendered, "→ read_file");
+    }
+
+    #[test]
+    fn compact_tool_result_is_a_single_line_with_failure_signals() {
+        assert_eq!(
+            render_tool_result("shell", &json!({"stdout": "ok"}), Verbosity::Compact),
+            Some("← shell ✓".to_string())
+        );
+        assert_eq!(
+            render_tool_result("shell", &json!({"exit_code": 2}), Verbosity::Compact),
+            Some("← shell ✗ exit 2".to_string())
+        );
+        assert_eq!(
+            render_tool_result("shell", &json!({"error": "boom"}), Verbosity::Compact),
+            Some("← shell ✗ error".to_string())
+        );
+    }
+
+    #[test]
+    fn minimal_hides_tool_calls_and_results() {
+        assert_eq!(
+            render_tool_call("shell", &shell_arguments("ls"), Verbosity::Minimal),
+            None
+        );
+        assert_eq!(
+            render_tool_result("shell", &json!({}), Verbosity::Minimal),
+            None
+        );
+    }
+
+    fn assistant_message_with_tool_call() -> Message {
+        let arguments = lingua::serde_json::Map::from_iter([(
+            "command".to_string(),
+            lingua::serde_json::Value::String("ls".to_string()),
+        )]);
+        Message::Assistant {
+            content: AssistantContent::Array(vec![
+                AssistantContentPart::Text(TextContentPart {
+                    text: "running it".to_string(),
+                    encrypted_content: None,
+                    cache_control: None,
+                    provider_options: None,
+                }),
+                AssistantContentPart::ToolCall {
+                    tool_call_id: "call-1".to_string(),
+                    tool_name: "shell".to_string(),
+                    arguments: ToolCallArguments::Valid(arguments),
+                    encrypted_content: None,
+                    provider_options: None,
+                    provider_executed: None,
+                },
+            ]),
+            id: None,
+        }
+    }
+
+    #[test]
+    fn compact_assistant_message_renders_text_then_tool_lines() {
+        let lines = render_message_lines(
+            &assistant_message_with_tool_call(),
+            Verbosity::Compact,
+            None,
+        );
+
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].ends_with("assistant: running it"));
+        assert_eq!(lines[1], "→ shell: ls");
+    }
+
+    #[test]
+    fn minimal_assistant_message_renders_only_text() {
+        let lines = render_message_lines(
+            &assistant_message_with_tool_call(),
+            Verbosity::Minimal,
+            None,
+        );
+
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].ends_with("assistant: running it"));
+    }
+
+    fn tool_result_message(exit_code: i64) -> Message {
+        Message::Tool {
+            content: vec![ToolContentPart::ToolResult(ToolResultContentPart {
+                tool_call_id: "call-1".to_string(),
+                tool_name: "shell".to_string(),
+                output: lingua::serde_json::json!({"exit_code": exit_code, "stdout": "out"}),
+                provider_options: None,
+            })],
+        }
+    }
+
+    #[test]
+    fn compact_transcript_folds_results_into_their_call_lines() {
+        let messages = vec![assistant_message_with_tool_call(), tool_result_message(0)];
+        let fold = TranscriptFold::new(&messages);
+
+        let call_lines = render_message_lines(&messages[0], Verbosity::Compact, Some(&fold));
+        let result_lines = render_message_lines(&messages[1], Verbosity::Compact, Some(&fold));
+
+        assert_eq!(call_lines[1], "→ shell: ls ✓");
+        assert!(result_lines.is_empty());
+    }
+
+    #[test]
+    fn compact_transcript_marks_failed_calls() {
+        let messages = vec![assistant_message_with_tool_call(), tool_result_message(3)];
+        let fold = TranscriptFold::new(&messages);
+
+        let call_lines = render_message_lines(&messages[0], Verbosity::Compact, Some(&fold));
+
+        assert_eq!(call_lines[1], "→ shell: ls ✗ exit 3");
+    }
+
+    #[test]
+    fn compact_transcript_keeps_orphan_results_as_their_own_line() {
+        let messages = vec![tool_result_message(0)];
+        let fold = TranscriptFold::new(&messages);
+
+        let lines = render_message_lines(&messages[0], Verbosity::Compact, Some(&fold));
+
+        assert_eq!(lines, vec!["← shell ✓".to_string()]);
+    }
+}

--- a/crates/cli/src/tui.rs
+++ b/crates/cli/src/tui.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::Result;
+use clap::{CommandFactory, Parser};
 use executor::{
     ConversationHandle, EventData, EventId, EventKind, EventQuery, EventQueryDirection,
     ExecutionStreamEvent, HarnessAgent, HarnessConversation, SandboxId, SandboxProvider,
@@ -29,6 +30,99 @@ use crate::run_sandbox_shell_command;
 const DEFAULT_SHELL_PROGRAM: &str = "/bin/bash";
 const REMOTE_HISTORY_BASE: usize = 1_000_000;
 const REMOTE_HISTORY_PAGE_SIZE: u32 = 32;
+
+// Slash-command registry: names, aliases, arguments, and help all live in
+// this clap tree. `multicall` makes the first token the command name, and
+// clap's built-in `help` subcommand serves `/help`.
+#[derive(Debug, clap::Parser)]
+#[command(name = "repl", multicall = true, about = "repl slash commands")]
+struct ReplCli {
+    #[command(subcommand)]
+    command: ReplCommand,
+}
+
+#[derive(Debug, PartialEq, clap::Subcommand)]
+enum ReplCommand {
+    /// Exit the repl
+    #[command(alias = "exit")]
+    Quit,
+    /// Reprint the conversation transcript
+    History,
+    /// Summarize token usage and dollar cost
+    #[command(alias = "usage")]
+    Cost,
+    /// Show or set how much tool detail is printed
+    Verbosity {
+        #[arg(value_enum)]
+        level: Option<Verbosity>,
+    },
+    /// Run a command in the conversation's sandbox
+    #[command(alias = "sandbox")]
+    Shell {
+        /// Shell source, passed to the sandbox verbatim
+        command: String,
+    },
+    /// Snapshot a sandbox in this conversation (defaults to the latest one)
+    Snapshot { sandbox_id: Option<String> },
+    /// List snapshots taken in this conversation
+    Snapshots,
+    /// Restore the sandbox to a previous snapshot
+    Rewind { snapshot_id: String },
+    /// Move the live sandbox to another provider (e.g. daytona: snapshot + restore there)
+    Teleport { provider: String },
+}
+
+/// What a line of repl input means.
+#[derive(Debug, PartialEq)]
+enum ReplInput {
+    Empty,
+    /// Plain chat text for the model.
+    Chat(String),
+    Command(ReplCommand),
+}
+
+/// Whether the repl keeps reading input after a command.
+enum ReplFlow {
+    Continue,
+    Quit,
+}
+
+fn parse_repl_input(line: &str) -> Result<ReplInput, clap::Error> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return Ok(ReplInput::Empty);
+    }
+    let Some(stripped) = trimmed.strip_prefix('/') else {
+        return Ok(ReplInput::Chat(trimmed.to_string()));
+    };
+    // `//text` escapes to the chat message `/text`.
+    if stripped.starts_with('/') {
+        return Ok(ReplInput::Chat(stripped.to_string()));
+    }
+    // A lone `/` shows the command list.
+    if stripped.is_empty() {
+        return Err(ReplCli::try_parse_from(["help"])
+            .expect_err("the help subcommand always short-circuits into an error"));
+    }
+
+    let (head, rest) = match stripped.split_once(char::is_whitespace) {
+        Some((head, rest)) => (head, rest.trim()),
+        None => (stripped, ""),
+    };
+    // Shell source must reach the sandbox verbatim: shlex-splitting and
+    // rejoining would change quoting, expansion, pipes, and redirections.
+    let argv: Vec<String> = if matches!(head, "shell" | "sandbox") && !rest.is_empty() {
+        vec![head.to_string(), rest.to_string()]
+    } else {
+        shlex::split(stripped).ok_or_else(|| {
+            ReplCli::command().error(
+                clap::error::ErrorKind::InvalidValue,
+                "unbalanced quotes in command input",
+            )
+        })?
+    };
+    Ok(ReplInput::Command(ReplCli::try_parse_from(argv)?.command))
+}
 
 pub async fn run_chat_repl(
     agent: Arc<dyn HarnessAgent>,
@@ -475,139 +569,25 @@ impl ChatRepl {
             let _ = event_printer.await;
 
             match readline_result {
-                Ok(line) => {
-                    let trimmed = line.trim();
-                    if trimmed.is_empty() {
-                        continue;
+                Ok(line) => match parse_repl_input(&line) {
+                    Ok(ReplInput::Empty) => continue,
+                    Ok(ReplInput::Chat(text)) => {
+                        self.editor.add_history_entry(line.as_str())?;
+                        self.send(&text).await?;
                     }
-                    match trimmed {
-                        "/quit" | "/exit" => break,
-                        "/history" => self.print_transcript().await?,
-                        "/cost" | "/usage" => {
-                            if let Err(error) = self.print_cost().await {
-                                println!("cost summary failed: {error:#}");
-                            }
-                        }
-                        "/help" => print_help(),
-                        "/verbosity" => {
-                            println!("verbosity: {}", self.verbosity);
-                            println!("usage: /verbosity <minimal|compact|full>");
-                        }
-                        other if other.starts_with("/verbosity ") => {
-                            let arg = other
-                                .strip_prefix("/verbosity ")
-                                .expect("prefix checked")
-                                .trim();
-                            match arg.parse::<Verbosity>() {
-                                Ok(verbosity) => {
-                                    self.verbosity = verbosity;
-                                    println!("verbosity set to {verbosity}");
-                                }
-                                Err(error) => println!("{error}"),
-                            }
-                        }
-                        "/shell" | "/sandbox" => {
-                            println!("usage: /shell <command>");
-                            println!("alias: /sandbox <command>");
-                        }
-                        other
-                            if other
-                                .strip_prefix("/shell ")
-                                .or_else(|| other.strip_prefix("/sandbox "))
-                                .is_some() =>
-                        {
-                            let command = other
-                                .strip_prefix("/shell ")
-                                .or_else(|| other.strip_prefix("/sandbox "))
-                                .expect("shell prefix should exist")
-                                .trim();
-                            if command.is_empty() {
-                                println!("usage: /shell <command>");
-                                println!("alias: /sandbox <command>");
-                            } else {
-                                self.editor.add_history_entry(line.as_str())?;
-                                self.run_shell(command).await?;
-                            }
-                        }
-                        "/snapshot" => match self.snapshot_sandbox(None).await {
-                            Ok(snapshot_id) => println!("snapshot {snapshot_id}"),
-                            Err(error) => println!("snapshot failed: {error:#}"),
-                        },
-                        other if other.starts_with("/snapshot ") => {
-                            let arg = other
-                                .strip_prefix("/snapshot ")
-                                .expect("prefix checked")
-                                .trim();
-                            if arg.is_empty() {
-                                println!("usage: /snapshot [<sandbox-id>]");
-                            } else if arg.contains(char::is_whitespace) {
-                                println!("/snapshot takes at most one sandbox id; got: {arg:?}");
-                            } else {
-                                match self.snapshot_sandbox(Some(arg.to_string())).await {
-                                    Ok(snapshot_id) => println!("snapshot {snapshot_id}"),
-                                    Err(error) => println!("snapshot failed: {error:#}"),
-                                }
-                            }
-                        }
-                        "/snapshots" => match self.list_snapshots().await {
-                            Ok(snapshots) if snapshots.is_empty() => {
-                                println!("no snapshots yet for this conversation");
-                            }
-                            Ok(snapshots) => {
-                                println!("SNAPSHOT\tTAKEN\tSANDBOX");
-                                for (snapshot_id, sandbox_id) in snapshots {
-                                    // Snapshot ids are uuid7, so creation time
-                                    // is embedded in the id itself.
-                                    let taken = snapshot_id
-                                        .timestamp()
-                                        .map(|t| t.format("%Y-%m-%d %H:%M:%S UTC").to_string())
-                                        .unwrap_or_else(|| "-".to_string());
-                                    println!("{snapshot_id}\t{taken}\t{sandbox_id}");
-                                }
-                            }
-                            Err(error) => println!("listing snapshots failed: {error:#}"),
-                        },
-                        "/teleport" => {
-                            println!("usage: /teleport <provider> (e.g. /teleport daytona)");
-                        }
-                        other if other.starts_with("/teleport ") => {
-                            let arg = other
-                                .strip_prefix("/teleport ")
-                                .expect("prefix checked")
-                                .trim();
-                            if arg.is_empty() || arg.contains(char::is_whitespace) {
-                                println!("usage: /teleport <provider> (e.g. /teleport daytona)");
-                            } else {
-                                match self.teleport_sandbox(arg).await {
-                                    Ok((sandbox_id, provider)) => {
-                                        println!("sandbox {sandbox_id} teleported to {provider}");
-                                    }
-                                    Err(error) => println!("teleport failed: {error:#}"),
-                                }
-                            }
-                        }
-                        other if other.starts_with("/rewind ") => {
-                            let arg = other
-                                .strip_prefix("/rewind ")
-                                .expect("prefix checked")
-                                .trim();
-                            if arg.is_empty() {
-                                println!("usage: /rewind <snapshot-id>");
-                            } else if arg.contains(char::is_whitespace) {
-                                println!("/rewind takes exactly one snapshot id; got: {arg:?}");
-                            } else {
-                                match self.rewind_to_snapshot(arg).await {
-                                    Ok(()) => println!("rewound to snapshot {arg}"),
-                                    Err(error) => println!("rewind failed: {error:#}"),
-                                }
-                            }
-                        }
-                        _ => {
+                    Ok(ReplInput::Command(command)) => {
+                        if matches!(command, ReplCommand::Shell { .. }) {
                             self.editor.add_history_entry(line.as_str())?;
-                            self.send(trimmed).await?;
+                        }
+                        match self.execute_command(command).await? {
+                            ReplFlow::Continue => {}
+                            ReplFlow::Quit => break,
                         }
                     }
-                }
+                    Err(error) => {
+                        let _ = error.print();
+                    }
+                },
                 Err(ReadlineError::Interrupted) => {
                     println!();
                     continue;
@@ -625,6 +605,61 @@ impl ChatRepl {
         }
 
         Ok(())
+    }
+
+    async fn execute_command(&mut self, command: ReplCommand) -> Result<ReplFlow> {
+        match command {
+            ReplCommand::Quit => return Ok(ReplFlow::Quit),
+            ReplCommand::History => self.print_transcript().await?,
+            ReplCommand::Cost => {
+                if let Err(error) = self.print_cost().await {
+                    println!("cost summary failed: {error:#}");
+                }
+            }
+            ReplCommand::Verbosity { level } => match level {
+                Some(verbosity) => {
+                    self.verbosity = verbosity;
+                    println!("verbosity set to {verbosity}");
+                }
+                None => println!("verbosity: {}", self.verbosity),
+            },
+            ReplCommand::Shell { command } => self.run_shell(&command).await?,
+            ReplCommand::Snapshot { sandbox_id } => match self.snapshot_sandbox(sandbox_id).await {
+                Ok(snapshot_id) => println!("snapshot {snapshot_id}"),
+                Err(error) => println!("snapshot failed: {error:#}"),
+            },
+            ReplCommand::Snapshots => match self.list_snapshots().await {
+                Ok(snapshots) if snapshots.is_empty() => {
+                    println!("no snapshots yet for this conversation");
+                }
+                Ok(snapshots) => {
+                    println!("SNAPSHOT\tTAKEN\tSANDBOX");
+                    for (snapshot_id, sandbox_id) in snapshots {
+                        // Snapshot ids are uuid7, so creation time is embedded
+                        // in the id itself.
+                        let taken = snapshot_id
+                            .timestamp()
+                            .map(|t| t.format("%Y-%m-%d %H:%M:%S UTC").to_string())
+                            .unwrap_or_else(|| "-".to_string());
+                        println!("{snapshot_id}\t{taken}\t{sandbox_id}");
+                    }
+                }
+                Err(error) => println!("listing snapshots failed: {error:#}"),
+            },
+            ReplCommand::Rewind { snapshot_id } => {
+                match self.rewind_to_snapshot(&snapshot_id).await {
+                    Ok(()) => println!("rewound to snapshot {snapshot_id}"),
+                    Err(error) => println!("rewind failed: {error:#}"),
+                }
+            }
+            ReplCommand::Teleport { provider } => match self.teleport_sandbox(&provider).await {
+                Ok((sandbox_id, provider)) => {
+                    println!("sandbox {sandbox_id} teleported to {provider}");
+                }
+                Err(error) => println!("teleport failed: {error:#}"),
+            },
+        }
+        Ok(ReplFlow::Continue)
     }
 
     async fn snapshot_sandbox(&self, explicit_id: Option<SandboxId>) -> Result<SnapshotId> {
@@ -972,21 +1007,6 @@ fn truncate(value: &str, max: usize) -> String {
     }
 }
 
-fn print_help() {
-    println!("repl commands:");
-    println!("  /quit | /exit        exit the repl");
-    println!("  /history             reprint the conversation transcript");
-    println!("  /verbosity <level>   set tool output detail: minimal, compact, or full");
-    println!("  /cost | /usage       summarize token usage and dollar cost");
-    println!("  /snapshot [<id>]     snapshot a sandbox in this conversation");
-    println!("                       (defaults to the latest one if no id is given)");
-    println!("  /snapshots           list snapshots taken in this conversation");
-    println!("  /rewind <id>         restore the sandbox to a previous snapshot");
-    println!("  /teleport <provider> move the live sandbox to another provider");
-    println!("                       (e.g. /teleport daytona: snapshot + restore there)");
-    println!("  /help                show this message");
-}
-
 /// Walk the conversation's event log to find the latest `SandboxCreated`
 /// event, returning the sandbox id. Returns `None` if no sandbox has been
 /// created yet (e.g. nothing has been chatted with).
@@ -1073,10 +1093,106 @@ async fn sandbox_id_for_snapshot(
 
 #[cfg(test)]
 mod tests {
-    use super::{Verbosity, render_external_event, render_user_content_for_history};
+    use super::{
+        ReplCommand, ReplInput, Verbosity, parse_repl_input, render_external_event,
+        render_user_content_for_history,
+    };
     use executor::EventData;
     use lingua::Message;
     use lingua::universal::UserContent;
+
+    #[test]
+    fn parses_blank_and_chat_input() {
+        assert_eq!(parse_repl_input("   ").unwrap(), ReplInput::Empty);
+        assert_eq!(
+            parse_repl_input(" hello there ").unwrap(),
+            ReplInput::Chat("hello there".to_string())
+        );
+    }
+
+    #[test]
+    fn double_slash_escapes_to_slash_prefixed_chat() {
+        assert_eq!(
+            parse_repl_input("//quit is a command").unwrap(),
+            ReplInput::Chat("/quit is a command".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_commands_and_aliases() {
+        assert_eq!(
+            parse_repl_input("/quit").unwrap(),
+            ReplInput::Command(ReplCommand::Quit)
+        );
+        assert_eq!(
+            parse_repl_input("/exit").unwrap(),
+            ReplInput::Command(ReplCommand::Quit)
+        );
+        assert_eq!(
+            parse_repl_input("/usage").unwrap(),
+            ReplInput::Command(ReplCommand::Cost)
+        );
+        assert_eq!(
+            parse_repl_input("/verbosity full").unwrap(),
+            ReplInput::Command(ReplCommand::Verbosity {
+                level: Some(Verbosity::Full)
+            })
+        );
+        assert_eq!(
+            parse_repl_input("/snapshot abc").unwrap(),
+            ReplInput::Command(ReplCommand::Snapshot {
+                sandbox_id: Some("abc".to_string())
+            })
+        );
+    }
+
+    #[test]
+    fn shell_source_is_preserved_verbatim() {
+        let input = r#"/shell echo "a  b" | grep 'a' > /tmp/out"#;
+        assert_eq!(
+            parse_repl_input(input).unwrap(),
+            ReplInput::Command(ReplCommand::Shell {
+                command: r#"echo "a  b" | grep 'a' > /tmp/out"#.to_string()
+            })
+        );
+        assert_eq!(
+            parse_repl_input("/sandbox ls -la").unwrap(),
+            ReplInput::Command(ReplCommand::Shell {
+                command: "ls -la".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn shell_without_source_is_a_usage_error() {
+        let error = parse_repl_input("/shell").unwrap_err();
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+    }
+
+    #[test]
+    fn unknown_commands_error_instead_of_reaching_the_model() {
+        let error = parse_repl_input("/snapshoot abc").unwrap_err();
+        assert_eq!(error.kind(), clap::error::ErrorKind::InvalidSubcommand);
+        assert!(error.to_string().contains("snapshot"), "suggests the fix");
+    }
+
+    #[test]
+    fn extra_arguments_are_clap_errors() {
+        assert!(parse_repl_input("/snapshot one two").is_err());
+        assert!(parse_repl_input("/rewind").is_err());
+    }
+
+    #[test]
+    fn help_is_generated_from_the_command_tree() {
+        let error = parse_repl_input("/help").unwrap_err();
+        assert_eq!(error.kind(), clap::error::ErrorKind::DisplayHelp);
+        let rendered = error.to_string();
+        assert!(rendered.contains("snapshot"));
+        assert!(rendered.contains("teleport"));
+    }
 
     #[test]
     fn renders_scheduled_task_wakeup_user_messages() {

--- a/crates/cli/src/tui.rs
+++ b/crates/cli/src/tui.rs
@@ -36,13 +36,13 @@ const REMOTE_HISTORY_PAGE_SIZE: u32 = 32;
 // clap's built-in `help` subcommand serves `/help`.
 #[derive(Debug, clap::Parser)]
 #[command(name = "repl", multicall = true, about = "repl slash commands")]
-struct ReplCli {
+pub(crate) struct ReplCli {
     #[command(subcommand)]
     command: ReplCommand,
 }
 
 #[derive(Debug, PartialEq, clap::Subcommand)]
-enum ReplCommand {
+pub(crate) enum ReplCommand {
     /// Exit the repl
     #[command(alias = "exit")]
     Quit,
@@ -74,7 +74,7 @@ enum ReplCommand {
 
 /// What a line of repl input means.
 #[derive(Debug, PartialEq)]
-enum ReplInput {
+pub(crate) enum ReplInput {
     Empty,
     /// Plain chat text for the model.
     Chat(String),
@@ -87,7 +87,7 @@ enum ReplFlow {
     Quit,
 }
 
-fn parse_repl_input(line: &str) -> Result<ReplInput, clap::Error> {
+pub(crate) fn parse_repl_input(line: &str) -> Result<ReplInput, clap::Error> {
     let trimmed = line.trim();
     if trimmed.is_empty() {
         return Ok(ReplInput::Empty);
@@ -476,90 +476,6 @@ impl ChatRepl {
         Ok(())
     }
 
-    /// Summarize token usage and dollar cost for this conversation from the
-    /// `usage` records on its `messages` events. Paginates so it covers the
-    /// whole conversation, not just one page.
-    async fn print_cost(&self) -> Result<()> {
-        let handle = self.conversation.exoharness_handle();
-        let mut cursor: Option<EventId> = None;
-        let mut per_model: BTreeMap<String, ModelCost> = BTreeMap::new();
-        let mut unpriced = 0usize;
-        loop {
-            let result = handle
-                .get_events(Some(EventQuery {
-                    cursor,
-                    direction: Some(EventQueryDirection::Desc),
-                    limit: Some(REMOTE_HISTORY_PAGE_SIZE),
-                    session_id: None,
-                    turn_id: None,
-                    types: Some(vec![EventKind::MESSAGES]),
-                }))
-                .await?;
-            for event in &result.events {
-                if let EventData::Messages {
-                    usage: Some(usage), ..
-                } = &event.data
-                {
-                    let entry = per_model.entry(usage.model.clone()).or_default();
-                    entry.calls += 1;
-                    entry.prompt += usage.prompt_tokens.unwrap_or(0);
-                    entry.cached += usage.prompt_cached_tokens.unwrap_or(0);
-                    entry.completion += usage.completion_tokens.unwrap_or(0);
-                    match usage.cost_usd {
-                        Some(cost) => entry.cost += cost,
-                        None => unpriced += 1,
-                    }
-                }
-            }
-            match result.cursor {
-                Some(next) => cursor = Some(next),
-                None => break,
-            }
-        }
-
-        if per_model.is_empty() {
-            println!("no recorded model usage in this conversation yet");
-            return Ok(());
-        }
-
-        let mut total = ModelCost::default();
-        println!(
-            "{:<28} {:>6} {:>10} {:>10} {:>10} {:>12}",
-            "MODEL", "CALLS", "PROMPT", "CACHED", "OUT", "COST"
-        );
-        for (model, c) in &per_model {
-            println!(
-                "{:<28} {:>6} {:>10} {:>10} {:>10} {:>12}",
-                truncate(model, 28),
-                c.calls,
-                c.prompt,
-                c.cached,
-                c.completion,
-                fmt_usd(c.cost),
-            );
-            total.calls += c.calls;
-            total.prompt += c.prompt;
-            total.cached += c.cached;
-            total.completion += c.completion;
-            total.cost += c.cost;
-        }
-        println!(
-            "{:<28} {:>6} {:>10} {:>10} {:>10} {:>12}",
-            "TOTAL",
-            total.calls,
-            total.prompt,
-            total.cached,
-            total.completion,
-            fmt_usd(total.cost),
-        );
-        if unpriced > 0 {
-            println!(
-                "note: {unpriced} call(s) had no price (model not in the price table); cost excludes them"
-            );
-        }
-        Ok(())
-    }
-
     async fn run(&mut self) -> Result<()> {
         loop {
             let prompt = format!("{}> ", self.conversation.record().slug);
@@ -608,14 +524,11 @@ impl ChatRepl {
     }
 
     async fn execute_command(&mut self, command: ReplCommand) -> Result<ReplFlow> {
+        let conversation = self.conversation.as_ref();
         match command {
             ReplCommand::Quit => return Ok(ReplFlow::Quit),
             ReplCommand::History => self.print_transcript().await?,
-            ReplCommand::Cost => {
-                if let Err(error) = self.print_cost().await {
-                    println!("cost summary failed: {error:#}");
-                }
-            }
+            ReplCommand::Cost => print_lines(cost_lines(conversation).await),
             ReplCommand::Verbosity { level } => match level {
                 Some(verbosity) => {
                     self.verbosity = verbosity;
@@ -624,119 +537,18 @@ impl ChatRepl {
                 None => println!("verbosity: {}", self.verbosity),
             },
             ReplCommand::Shell { command } => self.run_shell(&command).await?,
-            ReplCommand::Snapshot { sandbox_id } => match self.snapshot_sandbox(sandbox_id).await {
-                Ok(snapshot_id) => println!("snapshot {snapshot_id}"),
-                Err(error) => println!("snapshot failed: {error:#}"),
-            },
-            ReplCommand::Snapshots => match self.list_snapshots().await {
-                Ok(snapshots) if snapshots.is_empty() => {
-                    println!("no snapshots yet for this conversation");
-                }
-                Ok(snapshots) => {
-                    println!("SNAPSHOT\tTAKEN\tSANDBOX");
-                    for (snapshot_id, sandbox_id) in snapshots {
-                        // Snapshot ids are uuid7, so creation time is embedded
-                        // in the id itself.
-                        let taken = snapshot_id
-                            .timestamp()
-                            .map(|t| t.format("%Y-%m-%d %H:%M:%S UTC").to_string())
-                            .unwrap_or_else(|| "-".to_string());
-                        println!("{snapshot_id}\t{taken}\t{sandbox_id}");
-                    }
-                }
-                Err(error) => println!("listing snapshots failed: {error:#}"),
-            },
-            ReplCommand::Rewind { snapshot_id } => {
-                match self.rewind_to_snapshot(&snapshot_id).await {
-                    Ok(()) => println!("rewound to snapshot {snapshot_id}"),
-                    Err(error) => println!("rewind failed: {error:#}"),
-                }
+            ReplCommand::Snapshot { sandbox_id } => {
+                print_lines(snapshot_lines(conversation, sandbox_id).await);
             }
-            ReplCommand::Teleport { provider } => match self.teleport_sandbox(&provider).await {
-                Ok((sandbox_id, provider)) => {
-                    println!("sandbox {sandbox_id} teleported to {provider}");
-                }
-                Err(error) => println!("teleport failed: {error:#}"),
-            },
+            ReplCommand::Snapshots => print_lines(snapshots_lines(conversation).await),
+            ReplCommand::Rewind { snapshot_id } => {
+                print_lines(rewind_lines(conversation, &snapshot_id).await);
+            }
+            ReplCommand::Teleport { provider } => {
+                print_lines(teleport_lines(conversation, &provider).await);
+            }
         }
         Ok(ReplFlow::Continue)
-    }
-
-    async fn snapshot_sandbox(&self, explicit_id: Option<SandboxId>) -> Result<SnapshotId> {
-        let sandbox_id = match explicit_id {
-            Some(id) => id,
-            None => latest_sandbox_id(self.conversation.as_ref())
-                .await?
-                .ok_or_else(|| {
-                    anyhow::anyhow!("no sandbox has been created in this conversation yet")
-                })?,
-        };
-        let id = self
-            .conversation
-            .exoharness_handle()
-            .snapshot_sandbox(sandbox_id)
-            .await?;
-        Ok(id)
-    }
-
-    async fn list_snapshots(&self) -> Result<Vec<(SnapshotId, SandboxId)>> {
-        list_snapshots(self.conversation.as_ref()).await
-    }
-
-    /// Teleport the conversation's live sandbox to another provider: snapshot
-    /// it where it runs now, then restore that snapshot under the target
-    /// provider. The sandbox id is stable across the move; only the backend
-    /// (and the machine actually running the container) changes.
-    async fn teleport_sandbox(&self, provider_str: &str) -> Result<(SandboxId, SandboxProvider)> {
-        let provider = provider_str
-            .parse::<SandboxProvider>()
-            .map_err(|error| anyhow::anyhow!("invalid provider `{provider_str}`: {error}"))?;
-        let sandbox_id = latest_sandbox_id(self.conversation.as_ref())
-            .await?
-            .ok_or_else(|| {
-                anyhow::anyhow!("no sandbox has been created in this conversation yet")
-            })?;
-        println!("snapshotting sandbox {sandbox_id}...");
-        let snapshot_id = self
-            .conversation
-            .exoharness_handle()
-            .snapshot_sandbox(sandbox_id.clone())
-            .await?;
-        println!("snapshot {snapshot_id} captured; restoring on {provider}...");
-        self.conversation
-            .exoharness_handle()
-            .start_sandbox(StartSandboxRequest {
-                id: sandbox_id.clone(),
-                snapshot_id,
-                idle_seconds: None,
-                provider: Some(provider),
-            })
-            .await?;
-        Ok((sandbox_id, provider))
-    }
-
-    /// Restore the conversation's sandbox to a previously-taken snapshot.
-    /// Stops the current container, decodes the snapshot payload, and starts
-    /// a fresh container from that state.
-    async fn rewind_to_snapshot(&self, snapshot_id_str: &str) -> Result<()> {
-        let snapshot_id = snapshot_id_str
-            .parse::<SnapshotId>()
-            .map_err(|error| anyhow::anyhow!("invalid snapshot id `{snapshot_id_str}`: {error}"))?;
-        let sandbox_id = sandbox_id_for_snapshot(self.conversation.as_ref(), snapshot_id)
-            .await?
-            .ok_or_else(|| {
-                anyhow::anyhow!("snapshot {snapshot_id} not found in this conversation")
-            })?;
-        self.conversation
-            .exoharness_handle()
-            .start_sandbox(StartSandboxRequest {
-                id: sandbox_id,
-                snapshot_id,
-                idle_seconds: None,
-                provider: None,
-            })
-            .await?;
-        Ok(())
     }
 
     async fn send(&mut self, input: &str) -> Result<()> {
@@ -894,12 +706,7 @@ impl ChatRepl {
     }
 
     async fn run_shell(&self, command: &str) -> Result<()> {
-        let mut config = self.conversation.config().await?;
-        if config.shell_program.is_none() {
-            config.shell_program = Some(DEFAULT_SHELL_PROGRAM.to_string());
-            self.conversation.put_config(config).await?;
-        }
-        let output = run_sandbox_shell_command(
+        let output = shell_output(
             self.agent.as_ref(),
             self.conversation.as_ref(),
             command.to_string(),
@@ -914,7 +721,7 @@ impl ChatRepl {
     }
 }
 
-fn chunk_text(chunk: &UniversalStreamChunk) -> String {
+pub(crate) fn chunk_text(chunk: &UniversalStreamChunk) -> String {
     let mut text = String::new();
     for choice in &chunk.choices {
         if let Some(delta) = choice.delta_view()
@@ -935,7 +742,7 @@ fn print_ttft(ttft: Duration) {
     }
 }
 
-fn render_external_event(data: &EventData, verbosity: Verbosity) -> Vec<String> {
+pub(crate) fn render_external_event(data: &EventData, verbosity: Verbosity) -> Vec<String> {
     let EventData::Messages { messages, .. } = data else {
         return Vec::new();
     };
@@ -1005,6 +812,272 @@ fn truncate(value: &str, max: usize) -> String {
     } else {
         format!("{}…", &value[..max.saturating_sub(1)])
     }
+}
+
+fn print_lines(lines: Vec<String>) {
+    for line in lines {
+        println!("{line}");
+    }
+}
+
+/// `/cost` output: summarize token usage and dollar cost for the conversation
+/// from the `usage` records on its `messages` events. Paginates so it covers
+/// the whole conversation, not just one page.
+pub(crate) async fn cost_lines(conversation: &dyn HarnessConversation) -> Vec<String> {
+    match cost_summary(conversation).await {
+        Ok(lines) => lines,
+        Err(error) => vec![format!("cost summary failed: {error:#}")],
+    }
+}
+
+async fn cost_summary(conversation: &dyn HarnessConversation) -> Result<Vec<String>> {
+    let handle = conversation.exoharness_handle();
+    let mut cursor: Option<EventId> = None;
+    let mut per_model: BTreeMap<String, ModelCost> = BTreeMap::new();
+    let mut unpriced = 0usize;
+    loop {
+        let result = handle
+            .get_events(Some(EventQuery {
+                cursor,
+                direction: Some(EventQueryDirection::Desc),
+                limit: Some(REMOTE_HISTORY_PAGE_SIZE),
+                session_id: None,
+                turn_id: None,
+                types: Some(vec![EventKind::MESSAGES]),
+            }))
+            .await?;
+        for event in &result.events {
+            if let EventData::Messages {
+                usage: Some(usage), ..
+            } = &event.data
+            {
+                let entry = per_model.entry(usage.model.clone()).or_default();
+                entry.calls += 1;
+                entry.prompt += usage.prompt_tokens.unwrap_or(0);
+                entry.cached += usage.prompt_cached_tokens.unwrap_or(0);
+                entry.completion += usage.completion_tokens.unwrap_or(0);
+                match usage.cost_usd {
+                    Some(cost) => entry.cost += cost,
+                    None => unpriced += 1,
+                }
+            }
+        }
+        match result.cursor {
+            Some(next) => cursor = Some(next),
+            None => break,
+        }
+    }
+
+    if per_model.is_empty() {
+        return Ok(vec![
+            "no recorded model usage in this conversation yet".to_string(),
+        ]);
+    }
+
+    let mut lines = Vec::new();
+    let mut total = ModelCost::default();
+    lines.push(format!(
+        "{:<28} {:>6} {:>10} {:>10} {:>10} {:>12}",
+        "MODEL", "CALLS", "PROMPT", "CACHED", "OUT", "COST"
+    ));
+    for (model, c) in &per_model {
+        lines.push(format!(
+            "{:<28} {:>6} {:>10} {:>10} {:>10} {:>12}",
+            truncate(model, 28),
+            c.calls,
+            c.prompt,
+            c.cached,
+            c.completion,
+            fmt_usd(c.cost),
+        ));
+        total.calls += c.calls;
+        total.prompt += c.prompt;
+        total.cached += c.cached;
+        total.completion += c.completion;
+        total.cost += c.cost;
+    }
+    lines.push(format!(
+        "{:<28} {:>6} {:>10} {:>10} {:>10} {:>12}",
+        "TOTAL",
+        total.calls,
+        total.prompt,
+        total.cached,
+        total.completion,
+        fmt_usd(total.cost),
+    ));
+    if unpriced > 0 {
+        lines.push(format!(
+            "note: {unpriced} call(s) had no price (model not in the price table); cost excludes them"
+        ));
+    }
+    Ok(lines)
+}
+
+/// `/snapshot` output: snapshot the given sandbox, or the conversation's
+/// latest one when no id is given.
+pub(crate) async fn snapshot_lines(
+    conversation: &dyn HarnessConversation,
+    explicit_id: Option<SandboxId>,
+) -> Vec<String> {
+    match snapshot_sandbox(conversation, explicit_id).await {
+        Ok(snapshot_id) => vec![format!("snapshot {snapshot_id}")],
+        Err(error) => vec![format!("snapshot failed: {error:#}")],
+    }
+}
+
+async fn snapshot_sandbox(
+    conversation: &dyn HarnessConversation,
+    explicit_id: Option<SandboxId>,
+) -> Result<SnapshotId> {
+    let sandbox_id = match explicit_id {
+        Some(id) => id,
+        None => latest_sandbox_id(conversation).await?.ok_or_else(|| {
+            anyhow::anyhow!("no sandbox has been created in this conversation yet")
+        })?,
+    };
+    let id = conversation
+        .exoharness_handle()
+        .snapshot_sandbox(sandbox_id)
+        .await?;
+    Ok(id)
+}
+
+/// `/snapshots` output: every snapshot taken in the conversation.
+pub(crate) async fn snapshots_lines(conversation: &dyn HarnessConversation) -> Vec<String> {
+    match list_snapshots(conversation).await {
+        Ok(snapshots) if snapshots.is_empty() => {
+            vec!["no snapshots yet for this conversation".to_string()]
+        }
+        Ok(snapshots) => {
+            let mut lines = vec!["SNAPSHOT\tTAKEN\tSANDBOX".to_string()];
+            for (snapshot_id, sandbox_id) in snapshots {
+                // Snapshot ids are uuid7, so creation time is embedded in the
+                // id itself.
+                let taken = snapshot_id
+                    .timestamp()
+                    .map(|t| t.format("%Y-%m-%d %H:%M:%S UTC").to_string())
+                    .unwrap_or_else(|| "-".to_string());
+                lines.push(format!("{snapshot_id}\t{taken}\t{sandbox_id}"));
+            }
+            lines
+        }
+        Err(error) => vec![format!("listing snapshots failed: {error:#}")],
+    }
+}
+
+/// `/rewind` output: restore the conversation's sandbox to a previous
+/// snapshot. Stops the current container, decodes the snapshot payload, and
+/// starts a fresh container from that state.
+pub(crate) async fn rewind_lines(
+    conversation: &dyn HarnessConversation,
+    snapshot_id: &str,
+) -> Vec<String> {
+    match rewind_to_snapshot(conversation, snapshot_id).await {
+        Ok(()) => vec![format!("rewound to snapshot {snapshot_id}")],
+        Err(error) => vec![format!("rewind failed: {error:#}")],
+    }
+}
+
+async fn rewind_to_snapshot(
+    conversation: &dyn HarnessConversation,
+    snapshot_id_str: &str,
+) -> Result<()> {
+    let snapshot_id = snapshot_id_str
+        .parse::<SnapshotId>()
+        .map_err(|error| anyhow::anyhow!("invalid snapshot id `{snapshot_id_str}`: {error}"))?;
+    let sandbox_id = sandbox_id_for_snapshot(conversation, snapshot_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("snapshot {snapshot_id} not found in this conversation"))?;
+    conversation
+        .exoharness_handle()
+        .start_sandbox(StartSandboxRequest {
+            id: sandbox_id,
+            snapshot_id,
+            idle_seconds: None,
+            provider: None,
+        })
+        .await?;
+    Ok(())
+}
+
+/// `/teleport` output: move the conversation's live sandbox to another
+/// provider by snapshotting it where it runs now, then restoring that
+/// snapshot under the target provider. The sandbox id is stable across the
+/// move; only the backend (and the machine actually running the container)
+/// changes.
+pub(crate) async fn teleport_lines(
+    conversation: &dyn HarnessConversation,
+    provider: &str,
+) -> Vec<String> {
+    match teleport_sandbox(conversation, provider).await {
+        Ok((sandbox_id, provider)) => {
+            vec![format!("sandbox {sandbox_id} teleported to {provider}")]
+        }
+        Err(error) => vec![format!("teleport failed: {error:#}")],
+    }
+}
+
+async fn teleport_sandbox(
+    conversation: &dyn HarnessConversation,
+    provider_str: &str,
+) -> Result<(SandboxId, SandboxProvider)> {
+    let provider = provider_str
+        .parse::<SandboxProvider>()
+        .map_err(|error| anyhow::anyhow!("invalid provider `{provider_str}`: {error}"))?;
+    let sandbox_id = latest_sandbox_id(conversation)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("no sandbox has been created in this conversation yet"))?;
+    let snapshot_id = conversation
+        .exoharness_handle()
+        .snapshot_sandbox(sandbox_id.clone())
+        .await?;
+    conversation
+        .exoharness_handle()
+        .start_sandbox(StartSandboxRequest {
+            id: sandbox_id.clone(),
+            snapshot_id,
+            idle_seconds: None,
+            provider: Some(provider),
+        })
+        .await?;
+    Ok((sandbox_id, provider))
+}
+
+/// `/shell` output as display lines. The line-mode repl streams raw bytes to
+/// stdout/stderr instead; this is for UIs that own the screen.
+pub(crate) async fn shell_lines(
+    agent: &dyn HarnessAgent,
+    conversation: &dyn HarnessConversation,
+    command: String,
+) -> Vec<String> {
+    match shell_output(agent, conversation, command).await {
+        Ok(output) => {
+            let mut lines: Vec<String> = output
+                .stdout
+                .lines()
+                .chain(output.stderr.lines())
+                .map(str::to_string)
+                .collect();
+            if output.exit_code != 0 {
+                lines.push(format!("[exit {}]", output.exit_code));
+            }
+            lines
+        }
+        Err(error) => vec![format!("shell failed: {error:#}")],
+    }
+}
+
+async fn shell_output(
+    agent: &dyn HarnessAgent,
+    conversation: &dyn HarnessConversation,
+    command: String,
+) -> Result<crate::SandboxShellOutput> {
+    let mut config = conversation.config().await?;
+    if config.shell_program.is_none() {
+        config.shell_program = Some(DEFAULT_SHELL_PROGRAM.to_string());
+        conversation.put_config(config).await?;
+    }
+    run_sandbox_shell_command(agent, conversation, command).await
 }
 
 /// Walk the conversation's event log to find the latest `SandboxCreated`

--- a/crates/cli/src/tui.rs
+++ b/crates/cli/src/tui.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::io::{self, Write};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -16,14 +16,15 @@ use lingua::{Message, UniversalStreamChunk};
 use rustyline::error::ReadlineError;
 use rustyline::history::{History, MemHistory, SearchDirection, SearchResult};
 use rustyline::{Cmd, Config, Editor, ExternalPrinter, KeyCode, KeyEvent, Modifiers};
-use serde_json::{Map, Value};
 use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
 use tokio_stream::StreamExt;
 
-use crate::{
-    compact_timestamp, print_message, render_assistant_content, run_sandbox_shell_command,
+use crate::render::{
+    Verbosity, compact_result_status, compact_timestamp, print_transcript,
+    render_assistant_content, render_tool_call, render_tool_result,
 };
+use crate::run_sandbox_shell_command;
 
 const DEFAULT_SHELL_PROGRAM: &str = "/bin/bash";
 const REMOTE_HISTORY_BASE: usize = 1_000_000;
@@ -32,8 +33,9 @@ const REMOTE_HISTORY_PAGE_SIZE: u32 = 32;
 pub async fn run_chat_repl(
     agent: Arc<dyn HarnessAgent>,
     conversation: Arc<dyn HarnessConversation>,
+    verbosity: Verbosity,
 ) -> Result<()> {
-    let mut repl = ChatRepl::new(agent, conversation)?;
+    let mut repl = ChatRepl::new(agent, conversation, verbosity)?;
     repl.print_transcript().await?;
     repl.run().await
 }
@@ -351,12 +353,14 @@ struct ChatRepl {
     editor: Editor<(), ChatHistory>,
     session_id: Option<SessionId>,
     watch_after: Arc<Mutex<Option<EventId>>>,
+    verbosity: Verbosity,
 }
 
 impl ChatRepl {
     fn new(
         agent: Arc<dyn HarnessAgent>,
         conversation: Arc<dyn HarnessConversation>,
+        verbosity: Verbosity,
     ) -> Result<Self> {
         let latest_event_id = conversation.record().latest_event_id;
         let history = ChatHistory::new(conversation.exoharness_handle(), latest_event_id);
@@ -368,13 +372,13 @@ impl ChatRepl {
             editor,
             session_id: None,
             watch_after: Arc::new(Mutex::new(latest_event_id)),
+            verbosity,
         })
     }
 
     async fn print_transcript(&self) -> Result<()> {
-        for message in self.conversation.messages().await? {
-            print_message(&message);
-        }
+        let messages = self.conversation.messages().await?;
+        print_transcript(&messages, self.verbosity);
         Ok(())
     }
 
@@ -485,6 +489,23 @@ impl ChatRepl {
                             }
                         }
                         "/help" => print_help(),
+                        "/verbosity" => {
+                            println!("verbosity: {}", self.verbosity);
+                            println!("usage: /verbosity <minimal|compact|full>");
+                        }
+                        other if other.starts_with("/verbosity ") => {
+                            let arg = other
+                                .strip_prefix("/verbosity ")
+                                .expect("prefix checked")
+                                .trim();
+                            match arg.parse::<Verbosity>() {
+                                Ok(verbosity) => {
+                                    self.verbosity = verbosity;
+                                    println!("verbosity set to {verbosity}");
+                                }
+                                Err(error) => println!("{error}"),
+                            }
+                        }
                         "/shell" | "/sandbox" => {
                             println!("usage: /shell <command>");
                             println!("alias: /sandbox <command>");
@@ -696,16 +717,27 @@ impl ChatRepl {
         let mut stdout = io::stdout();
         let mut printed_assistant = false;
         let mut streamed_text = String::new();
+        // Tool names by call id, so results (which only carry the id) can be
+        // labeled in compact mode.
+        let mut pending_tool_calls: HashMap<String, String> = HashMap::new();
+        // Compact call line left open (no newline) so the matching result can
+        // acknowledge receipt on the same line.
+        let mut open_call: Option<String> = None;
 
         while let Some(event) = stream.next().await {
             match event? {
                 ExecutionStreamEvent::FirstChunk { ttft } => {
-                    print_ttft(ttft);
+                    if self.verbosity == Verbosity::Full {
+                        print_ttft(ttft);
+                    }
                 }
                 ExecutionStreamEvent::Chunk(chunk) => {
                     let text = chunk_text(&chunk);
                     if text.is_empty() {
                         continue;
+                    }
+                    if open_call.take().is_some() {
+                        println!();
                     }
                     if !printed_assistant {
                         print!("{} assistant: ", compact_timestamp());
@@ -717,19 +749,50 @@ impl ChatRepl {
                     streamed_text.push_str(&text);
                 }
                 ExecutionStreamEvent::ToolCall {
+                    tool_call_id,
                     tool_name,
                     arguments,
-                    ..
                 } => {
-                    if printed_assistant && !streamed_text.ends_with('\n') {
+                    if open_call.take().is_some() {
                         println!();
                     }
-                    println!("{}", render_tool_call(&tool_name, &arguments));
-                    printed_assistant = false;
-                    streamed_text.clear();
+                    if printed_assistant && !streamed_text.ends_with('\n') {
+                        println!();
+                        printed_assistant = false;
+                        streamed_text.clear();
+                    }
+                    if let Some(rendered) = render_tool_call(&tool_name, &arguments, self.verbosity)
+                    {
+                        if self.verbosity == Verbosity::Compact {
+                            print!("{rendered}");
+                            stdout.flush()?;
+                            open_call = Some(tool_call_id.clone());
+                        } else {
+                            println!("{rendered}");
+                        }
+                        printed_assistant = false;
+                        streamed_text.clear();
+                    }
+                    pending_tool_calls.insert(tool_call_id, tool_name);
                 }
-                ExecutionStreamEvent::ToolResult { result, .. } => {
-                    println!("{}", render_tool_result(&result));
+                ExecutionStreamEvent::ToolResult {
+                    tool_call_id,
+                    result,
+                } => {
+                    let tool_name = pending_tool_calls
+                        .remove(&tool_call_id)
+                        .unwrap_or_else(|| "tool".to_string());
+                    if open_call.as_deref() == Some(tool_call_id.as_str()) {
+                        open_call = None;
+                        println!(" {}", compact_result_status(&result));
+                    } else if let Some(rendered) =
+                        render_tool_result(&tool_name, &result, self.verbosity)
+                    {
+                        if open_call.take().is_some() {
+                            println!();
+                        }
+                        println!("{rendered}");
+                    }
                 }
                 ExecutionStreamEvent::Completed(result) => {
                     self.session_id = Some(result.session_id);
@@ -738,13 +801,16 @@ impl ChatRepl {
                 }
             }
         }
+        if open_call.is_some() {
+            println!();
+        }
 
         if printed_assistant {
             println!();
         } else if let Some(last_message) = self.conversation.messages().await?.last().cloned()
             && let Message::Assistant { content, .. } = last_message
         {
-            let rendered = render_assistant_content(&content);
+            let rendered = render_assistant_content(&content, self.verbosity);
             if !rendered.is_empty() {
                 println!("{} assistant: {}", compact_timestamp(), rendered);
             }
@@ -756,6 +822,7 @@ impl ChatRepl {
     fn spawn_event_printer(&mut self) -> Result<JoinHandle<()>> {
         let conversation = self.conversation.exoharness_handle();
         let watch_after = Arc::clone(&self.watch_after);
+        let verbosity = self.verbosity;
         let mut printer = self.editor.create_external_printer()?;
         Ok(tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs(1));
@@ -777,7 +844,7 @@ impl ChatRepl {
                         for event in result.events {
                             *watch_after.lock().expect("chat event watch poisoned") =
                                 Some(event.id);
-                            for rendered in render_external_event(&event.data) {
+                            for rendered in render_external_event(&event.data, verbosity) {
                                 let _ = printer.print(format!("{rendered}\n"));
                             }
                         }
@@ -833,59 +900,7 @@ fn print_ttft(ttft: Duration) {
     }
 }
 
-fn render_tool_call(tool_name: &str, arguments: &Map<String, Value>) -> String {
-    let mut lines = vec![format!("tool call {tool_name}")];
-    append_object_fields(&mut lines, arguments, "  ");
-    lines.join("\n")
-}
-
-fn render_tool_result(result: &Value) -> String {
-    let mut lines = vec!["tool result".to_string()];
-    match result {
-        Value::Object(object) => append_object_fields(&mut lines, object, "  "),
-        other => lines.push(format!("  {}", render_value_inline(other))),
-    }
-    lines.join("\n")
-}
-
-fn append_object_fields(lines: &mut Vec<String>, object: &Map<String, Value>, indent: &str) {
-    if object.is_empty() {
-        lines.push(format!("{indent}{{}}"));
-        return;
-    }
-
-    for (key, value) in object {
-        append_field(lines, key, value, indent);
-    }
-}
-
-fn append_field(lines: &mut Vec<String>, key: &str, value: &Value, indent: &str) {
-    match value {
-        Value::String(text) if text.contains('\n') => {
-            lines.push(format!("{indent}{key}:"));
-            for line in text.lines() {
-                lines.push(format!("{indent}  {line}"));
-            }
-            if text.ends_with('\n') {
-                lines.push(format!("{indent}  "));
-            }
-        }
-        Value::Object(object) => {
-            lines.push(format!("{indent}{key}:"));
-            append_object_fields(lines, object, &format!("{indent}  "));
-        }
-        other => lines.push(format!("{indent}{key}: {}", render_value_inline(other))),
-    }
-}
-
-fn render_value_inline(value: &Value) -> String {
-    match value {
-        Value::String(text) => format!("{text:?}"),
-        other => serde_json::to_string(other).unwrap_or_else(|_| "<unrenderable>".to_string()),
-    }
-}
-
-fn render_external_event(data: &EventData) -> Vec<String> {
+fn render_external_event(data: &EventData, verbosity: Verbosity) -> Vec<String> {
     let EventData::Messages { messages, .. } = data else {
         return Vec::new();
     };
@@ -895,7 +910,7 @@ fn render_external_event(data: &EventData) -> Vec<String> {
             Message::User { content } => render_external_user_content(content)
                 .map(|rendered| format!("{} user: {rendered}", compact_timestamp())),
             Message::Assistant { content, .. } => {
-                let rendered = render_assistant_content(content);
+                let rendered = render_assistant_content(content, verbosity);
                 (!rendered.is_empty())
                     .then(|| format!("{} assistant: {rendered}", compact_timestamp()))
             }
@@ -961,6 +976,7 @@ fn print_help() {
     println!("repl commands:");
     println!("  /quit | /exit        exit the repl");
     println!("  /history             reprint the conversation transcript");
+    println!("  /verbosity <level>   set tool output detail: minimal, compact, or full");
     println!("  /cost | /usage       summarize token usage and dollar cost");
     println!("  /snapshot [<id>]     snapshot a sandbox in this conversation");
     println!("                       (defaults to the latest one if no id is given)");
@@ -1057,59 +1073,25 @@ async fn sandbox_id_for_snapshot(
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        render_external_event, render_tool_call, render_tool_result,
-        render_user_content_for_history,
-    };
+    use super::{Verbosity, render_external_event, render_user_content_for_history};
     use executor::EventData;
     use lingua::Message;
     use lingua::universal::UserContent;
-    use serde_json::{Map, Value};
-
-    #[test]
-    fn renders_multiline_tool_call_arguments_as_indented_block() {
-        let arguments = Map::from_iter([(
-            "code".to_string(),
-            Value::String("const x = 1;\nconst y = 2;".to_string()),
-        )]);
-
-        let rendered = render_tool_call("repl_execute", &arguments);
-
-        assert_eq!(
-            rendered,
-            "tool call repl_execute\n  code:\n    const x = 1;\n    const y = 2;"
-        );
-    }
-
-    #[test]
-    fn renders_multiline_tool_result_fields_as_indented_block() {
-        let result = Value::Object(Map::from_iter([
-            ("error".to_string(), Value::Null),
-            (
-                "stdout".to_string(),
-                Value::String("line 1\nline 2".to_string()),
-            ),
-        ]));
-
-        let rendered = render_tool_result(&result);
-
-        assert_eq!(
-            rendered,
-            "tool result\n  error: null\n  stdout:\n    line 1\n    line 2"
-        );
-    }
 
     #[test]
     fn renders_scheduled_task_wakeup_user_messages() {
-        let rendered = render_external_event(&EventData::Messages {
-            messages: vec![Message::User {
-                content: UserContent::String(
-                    "Scheduled task `joke` completed.\n\nstdout preview:\nhello".to_string(),
-                ),
-            }],
-            response_id: None,
-            usage: None,
-        });
+        let rendered = render_external_event(
+            &EventData::Messages {
+                messages: vec![Message::User {
+                    content: UserContent::String(
+                        "Scheduled task `joke` completed.\n\nstdout preview:\nhello".to_string(),
+                    ),
+                }],
+                response_id: None,
+                usage: None,
+            },
+            Verbosity::Compact,
+        );
 
         assert_eq!(rendered.len(), 1);
         assert!(rendered[0].contains("user: Scheduled task `joke` completed."));

--- a/crates/cli/src/tui.rs
+++ b/crates/cli/src/tui.rs
@@ -22,7 +22,7 @@ use tokio::task::JoinHandle;
 use tokio_stream::StreamExt;
 
 use crate::render::{
-    Verbosity, compact_result_status, compact_timestamp, print_transcript,
+    ASSISTANT_LABEL, Verbosity, compact_result_status, compact_timestamp, print_transcript,
     render_assistant_content, render_tool_call, render_tool_result,
 };
 use crate::run_sandbox_shell_command;
@@ -587,7 +587,7 @@ impl ChatRepl {
                         println!();
                     }
                     if !printed_assistant {
-                        print!("{} assistant: ", compact_timestamp());
+                        print!("{} {ASSISTANT_LABEL}: ", compact_timestamp());
                         stdout.flush()?;
                         printed_assistant = true;
                     }
@@ -659,7 +659,7 @@ impl ChatRepl {
         {
             let rendered = render_assistant_content(&content, self.verbosity);
             if !rendered.is_empty() {
-                println!("{} assistant: {}", compact_timestamp(), rendered);
+                println!("{} {ASSISTANT_LABEL}: {}", compact_timestamp(), rendered);
             }
         }
         println!();
@@ -754,7 +754,7 @@ pub(crate) fn render_external_event(data: &EventData, verbosity: Verbosity) -> V
             Message::Assistant { content, .. } => {
                 let rendered = render_assistant_content(content, verbosity);
                 (!rendered.is_empty())
-                    .then(|| format!("{} assistant: {rendered}", compact_timestamp()))
+                    .then(|| format!("{} {ASSISTANT_LABEL}: {rendered}", compact_timestamp()))
             }
             _ => None,
         })

--- a/crates/cli/src/tui.rs
+++ b/crates/cli/src/tui.rs
@@ -6,7 +6,6 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::Result;
-use clap::{CommandFactory, Parser};
 use executor::{
     ConversationHandle, EventData, EventId, EventKind, EventQuery, EventQueryDirection,
     ExecutionStreamEvent, HarnessAgent, HarnessConversation, SandboxId, SandboxProvider,
@@ -30,99 +29,6 @@ use crate::run_sandbox_shell_command;
 const DEFAULT_SHELL_PROGRAM: &str = "/bin/bash";
 const REMOTE_HISTORY_BASE: usize = 1_000_000;
 const REMOTE_HISTORY_PAGE_SIZE: u32 = 32;
-
-// Slash-command registry: names, aliases, arguments, and help all live in
-// this clap tree. `multicall` makes the first token the command name, and
-// clap's built-in `help` subcommand serves `/help`.
-#[derive(Debug, clap::Parser)]
-#[command(name = "repl", multicall = true, about = "repl slash commands")]
-pub(crate) struct ReplCli {
-    #[command(subcommand)]
-    command: ReplCommand,
-}
-
-#[derive(Debug, PartialEq, clap::Subcommand)]
-pub(crate) enum ReplCommand {
-    /// Exit the repl
-    #[command(alias = "exit")]
-    Quit,
-    /// Reprint the conversation transcript
-    History,
-    /// Summarize token usage and dollar cost
-    #[command(alias = "usage")]
-    Cost,
-    /// Show or set how much tool detail is printed
-    Verbosity {
-        #[arg(value_enum)]
-        level: Option<Verbosity>,
-    },
-    /// Run a command in the conversation's sandbox
-    #[command(alias = "sandbox")]
-    Shell {
-        /// Shell source, passed to the sandbox verbatim
-        command: String,
-    },
-    /// Snapshot a sandbox in this conversation (defaults to the latest one)
-    Snapshot { sandbox_id: Option<String> },
-    /// List snapshots taken in this conversation
-    Snapshots,
-    /// Restore the sandbox to a previous snapshot
-    Rewind { snapshot_id: String },
-    /// Move the live sandbox to another provider (e.g. daytona: snapshot + restore there)
-    Teleport { provider: String },
-}
-
-/// What a line of repl input means.
-#[derive(Debug, PartialEq)]
-pub(crate) enum ReplInput {
-    Empty,
-    /// Plain chat text for the model.
-    Chat(String),
-    Command(ReplCommand),
-}
-
-/// Whether the repl keeps reading input after a command.
-enum ReplFlow {
-    Continue,
-    Quit,
-}
-
-pub(crate) fn parse_repl_input(line: &str) -> Result<ReplInput, clap::Error> {
-    let trimmed = line.trim();
-    if trimmed.is_empty() {
-        return Ok(ReplInput::Empty);
-    }
-    let Some(stripped) = trimmed.strip_prefix('/') else {
-        return Ok(ReplInput::Chat(trimmed.to_string()));
-    };
-    // `//text` escapes to the chat message `/text`.
-    if stripped.starts_with('/') {
-        return Ok(ReplInput::Chat(stripped.to_string()));
-    }
-    // A lone `/` shows the command list.
-    if stripped.is_empty() {
-        return Err(ReplCli::try_parse_from(["help"])
-            .expect_err("the help subcommand always short-circuits into an error"));
-    }
-
-    let (head, rest) = match stripped.split_once(char::is_whitespace) {
-        Some((head, rest)) => (head, rest.trim()),
-        None => (stripped, ""),
-    };
-    // Shell source must reach the sandbox verbatim: shlex-splitting and
-    // rejoining would change quoting, expansion, pipes, and redirections.
-    let argv: Vec<String> = if matches!(head, "shell" | "sandbox") && !rest.is_empty() {
-        vec![head.to_string(), rest.to_string()]
-    } else {
-        shlex::split(stripped).ok_or_else(|| {
-            ReplCli::command().error(
-                clap::error::ErrorKind::InvalidValue,
-                "unbalanced quotes in command input",
-            )
-        })?
-    };
-    Ok(ReplInput::Command(ReplCli::try_parse_from(argv)?.command))
-}
 
 pub async fn run_chat_repl(
     agent: Arc<dyn HarnessAgent>,
@@ -485,25 +391,121 @@ impl ChatRepl {
             let _ = event_printer.await;
 
             match readline_result {
-                Ok(line) => match parse_repl_input(&line) {
-                    Ok(ReplInput::Empty) => continue,
-                    Ok(ReplInput::Chat(text)) => {
-                        self.editor.add_history_entry(line.as_str())?;
-                        self.send(&text).await?;
+                Ok(line) => {
+                    let trimmed = line.trim();
+                    if trimmed.is_empty() {
+                        continue;
                     }
-                    Ok(ReplInput::Command(command)) => {
-                        if matches!(command, ReplCommand::Shell { .. }) {
+                    match trimmed {
+                        "/quit" | "/exit" => break,
+                        "/history" => self.print_transcript().await?,
+                        "/cost" | "/usage" => {
+                            print_lines(cost_lines(self.conversation.as_ref()).await);
+                        }
+                        "/help" => print_help(),
+                        "/verbosity" => {
+                            println!("verbosity: {}", self.verbosity);
+                            println!("usage: /verbosity <minimal|compact|full>");
+                        }
+                        other if other.starts_with("/verbosity ") => {
+                            let arg = other
+                                .strip_prefix("/verbosity ")
+                                .expect("prefix checked")
+                                .trim();
+                            match arg.parse::<Verbosity>() {
+                                Ok(verbosity) => {
+                                    self.verbosity = verbosity;
+                                    println!("verbosity set to {verbosity}");
+                                }
+                                Err(error) => println!("{error}"),
+                            }
+                        }
+                        "/shell" | "/sandbox" => {
+                            println!("usage: /shell <command>");
+                            println!("alias: /sandbox <command>");
+                        }
+                        other
+                            if other
+                                .strip_prefix("/shell ")
+                                .or_else(|| other.strip_prefix("/sandbox "))
+                                .is_some() =>
+                        {
+                            let command = other
+                                .strip_prefix("/shell ")
+                                .or_else(|| other.strip_prefix("/sandbox "))
+                                .expect("shell prefix should exist")
+                                .trim();
+                            if command.is_empty() {
+                                println!("usage: /shell <command>");
+                                println!("alias: /sandbox <command>");
+                            } else {
+                                self.editor.add_history_entry(line.as_str())?;
+                                self.run_shell(command).await?;
+                            }
+                        }
+                        "/snapshot" => {
+                            print_lines(snapshot_lines(self.conversation.as_ref(), None).await);
+                        }
+                        other if other.starts_with("/snapshot ") => {
+                            let arg = other
+                                .strip_prefix("/snapshot ")
+                                .expect("prefix checked")
+                                .trim();
+                            if arg.is_empty() {
+                                println!("usage: /snapshot [<sandbox-id>]");
+                            } else if arg.contains(char::is_whitespace) {
+                                println!("/snapshot takes at most one sandbox id; got: {arg:?}");
+                            } else {
+                                print_lines(
+                                    snapshot_lines(
+                                        self.conversation.as_ref(),
+                                        Some(arg.to_string()),
+                                    )
+                                    .await,
+                                );
+                            }
+                        }
+                        "/snapshots" => {
+                            print_lines(snapshots_lines(self.conversation.as_ref()).await);
+                        }
+                        "/teleport" => {
+                            println!("usage: /teleport <provider> (e.g. /teleport daytona)");
+                        }
+                        other if other.starts_with("/teleport ") => {
+                            let arg = other
+                                .strip_prefix("/teleport ")
+                                .expect("prefix checked")
+                                .trim();
+                            if arg.is_empty() || arg.contains(char::is_whitespace) {
+                                println!("usage: /teleport <provider> (e.g. /teleport daytona)");
+                            } else {
+                                match self.teleport_sandbox(arg).await {
+                                    Ok((sandbox_id, provider)) => {
+                                        println!("sandbox {sandbox_id} teleported to {provider}");
+                                    }
+                                    Err(error) => println!("teleport failed: {error:#}"),
+                                }
+                            }
+                        }
+                        other if other.starts_with("/rewind ") => {
+                            let arg = other
+                                .strip_prefix("/rewind ")
+                                .expect("prefix checked")
+                                .trim();
+                            if arg.is_empty() {
+                                println!("usage: /rewind <snapshot-id>");
+                            } else if arg.contains(char::is_whitespace) {
+                                println!("/rewind takes exactly one snapshot id; got: {arg:?}");
+                            } else {
+                                print_lines(rewind_lines(self.conversation.as_ref(), arg).await);
+                            }
+                        }
+                        _ => {
                             self.editor.add_history_entry(line.as_str())?;
-                        }
-                        match self.execute_command(command).await? {
-                            ReplFlow::Continue => {}
-                            ReplFlow::Quit => break,
+                            self.send(trimmed).await?;
                         }
                     }
-                    Err(error) => {
-                        let _ = error.print();
-                    }
-                },
+                }
                 Err(ReadlineError::Interrupted) => {
                     println!();
                     continue;
@@ -523,32 +525,36 @@ impl ChatRepl {
         Ok(())
     }
 
-    async fn execute_command(&mut self, command: ReplCommand) -> Result<ReplFlow> {
-        let conversation = self.conversation.as_ref();
-        match command {
-            ReplCommand::Quit => return Ok(ReplFlow::Quit),
-            ReplCommand::History => self.print_transcript().await?,
-            ReplCommand::Cost => print_lines(cost_lines(conversation).await),
-            ReplCommand::Verbosity { level } => match level {
-                Some(verbosity) => {
-                    self.verbosity = verbosity;
-                    println!("verbosity set to {verbosity}");
-                }
-                None => println!("verbosity: {}", self.verbosity),
-            },
-            ReplCommand::Shell { command } => self.run_shell(&command).await?,
-            ReplCommand::Snapshot { sandbox_id } => {
-                print_lines(snapshot_lines(conversation, sandbox_id).await);
-            }
-            ReplCommand::Snapshots => print_lines(snapshots_lines(conversation).await),
-            ReplCommand::Rewind { snapshot_id } => {
-                print_lines(rewind_lines(conversation, &snapshot_id).await);
-            }
-            ReplCommand::Teleport { provider } => {
-                print_lines(teleport_lines(conversation, &provider).await);
-            }
-        }
-        Ok(ReplFlow::Continue)
+    /// Teleport the conversation's live sandbox to another provider: snapshot
+    /// it where it runs now, then restore that snapshot under the target
+    /// provider. Prints progress between the slow steps, which is why the
+    /// line-mode repl doesn't use the TUI's silent `teleport_lines`.
+    async fn teleport_sandbox(&self, provider_str: &str) -> Result<(SandboxId, SandboxProvider)> {
+        let provider = provider_str
+            .parse::<SandboxProvider>()
+            .map_err(|error| anyhow::anyhow!("invalid provider `{provider_str}`: {error}"))?;
+        let sandbox_id = latest_sandbox_id(self.conversation.as_ref())
+            .await?
+            .ok_or_else(|| {
+                anyhow::anyhow!("no sandbox has been created in this conversation yet")
+            })?;
+        println!("snapshotting sandbox {sandbox_id}...");
+        let snapshot_id = self
+            .conversation
+            .exoharness_handle()
+            .snapshot_sandbox(sandbox_id.clone())
+            .await?;
+        println!("snapshot {snapshot_id} captured; restoring on {provider}...");
+        self.conversation
+            .exoharness_handle()
+            .start_sandbox(StartSandboxRequest {
+                id: sandbox_id.clone(),
+                snapshot_id,
+                idle_seconds: None,
+                provider: Some(provider),
+            })
+            .await?;
+        Ok((sandbox_id, provider))
     }
 
     async fn send(&mut self, input: &str) -> Result<()> {
@@ -818,6 +824,21 @@ fn print_lines(lines: Vec<String>) {
     for line in lines {
         println!("{line}");
     }
+}
+
+fn print_help() {
+    println!("repl commands:");
+    println!("  /quit | /exit        exit the repl");
+    println!("  /history             reprint the conversation transcript");
+    println!("  /verbosity <level>   set tool output detail: minimal, compact, or full");
+    println!("  /cost | /usage       summarize token usage and dollar cost");
+    println!("  /snapshot [<id>]     snapshot a sandbox in this conversation");
+    println!("                       (defaults to the latest one if no id is given)");
+    println!("  /snapshots           list snapshots taken in this conversation");
+    println!("  /rewind <id>         restore the sandbox to a previous snapshot");
+    println!("  /teleport <provider> move the live sandbox to another provider");
+    println!("                       (e.g. /teleport daytona: snapshot + restore there)");
+    println!("  /help                show this message");
 }
 
 /// `/cost` output: summarize token usage and dollar cost for the conversation
@@ -1166,106 +1187,10 @@ async fn sandbox_id_for_snapshot(
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        ReplCommand, ReplInput, Verbosity, parse_repl_input, render_external_event,
-        render_user_content_for_history,
-    };
+    use super::{Verbosity, render_external_event, render_user_content_for_history};
     use executor::EventData;
     use lingua::Message;
     use lingua::universal::UserContent;
-
-    #[test]
-    fn parses_blank_and_chat_input() {
-        assert_eq!(parse_repl_input("   ").unwrap(), ReplInput::Empty);
-        assert_eq!(
-            parse_repl_input(" hello there ").unwrap(),
-            ReplInput::Chat("hello there".to_string())
-        );
-    }
-
-    #[test]
-    fn double_slash_escapes_to_slash_prefixed_chat() {
-        assert_eq!(
-            parse_repl_input("//quit is a command").unwrap(),
-            ReplInput::Chat("/quit is a command".to_string())
-        );
-    }
-
-    #[test]
-    fn parses_commands_and_aliases() {
-        assert_eq!(
-            parse_repl_input("/quit").unwrap(),
-            ReplInput::Command(ReplCommand::Quit)
-        );
-        assert_eq!(
-            parse_repl_input("/exit").unwrap(),
-            ReplInput::Command(ReplCommand::Quit)
-        );
-        assert_eq!(
-            parse_repl_input("/usage").unwrap(),
-            ReplInput::Command(ReplCommand::Cost)
-        );
-        assert_eq!(
-            parse_repl_input("/verbosity full").unwrap(),
-            ReplInput::Command(ReplCommand::Verbosity {
-                level: Some(Verbosity::Full)
-            })
-        );
-        assert_eq!(
-            parse_repl_input("/snapshot abc").unwrap(),
-            ReplInput::Command(ReplCommand::Snapshot {
-                sandbox_id: Some("abc".to_string())
-            })
-        );
-    }
-
-    #[test]
-    fn shell_source_is_preserved_verbatim() {
-        let input = r#"/shell echo "a  b" | grep 'a' > /tmp/out"#;
-        assert_eq!(
-            parse_repl_input(input).unwrap(),
-            ReplInput::Command(ReplCommand::Shell {
-                command: r#"echo "a  b" | grep 'a' > /tmp/out"#.to_string()
-            })
-        );
-        assert_eq!(
-            parse_repl_input("/sandbox ls -la").unwrap(),
-            ReplInput::Command(ReplCommand::Shell {
-                command: "ls -la".to_string()
-            })
-        );
-    }
-
-    #[test]
-    fn shell_without_source_is_a_usage_error() {
-        let error = parse_repl_input("/shell").unwrap_err();
-        assert_eq!(
-            error.kind(),
-            clap::error::ErrorKind::MissingRequiredArgument
-        );
-    }
-
-    #[test]
-    fn unknown_commands_error_instead_of_reaching_the_model() {
-        let error = parse_repl_input("/snapshoot abc").unwrap_err();
-        assert_eq!(error.kind(), clap::error::ErrorKind::InvalidSubcommand);
-        assert!(error.to_string().contains("snapshot"), "suggests the fix");
-    }
-
-    #[test]
-    fn extra_arguments_are_clap_errors() {
-        assert!(parse_repl_input("/snapshot one two").is_err());
-        assert!(parse_repl_input("/rewind").is_err());
-    }
-
-    #[test]
-    fn help_is_generated_from_the_command_tree() {
-        let error = parse_repl_input("/help").unwrap_err();
-        assert_eq!(error.kind(), clap::error::ErrorKind::DisplayHelp);
-        let rendered = error.to_string();
-        assert!(rendered.contains("snapshot"));
-        assert!(rendered.contains("teleport"));
-    }
 
     #[test]
     fn renders_scheduled_task_wakeup_user_messages() {

--- a/crates/cli/src/tui_app.rs
+++ b/crates/cli/src/tui_app.rs
@@ -1,0 +1,654 @@
+//! Prototype full-screen TUI for the chat repl (`exo repl --tui`).
+//!
+//! Unlike the line-mode repl, the transcript is app state we own, so streamed
+//! text, tool-call lines, and their `✓`/`✗` receipts are just mutations of a
+//! line buffer — no terminal tricks, and typing never interleaves with output.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use anyhow::Result;
+use crossterm::event::{
+    DisableMouseCapture, EnableMouseCapture, Event, EventStream, KeyCode, KeyEventKind,
+    KeyModifiers, MouseEventKind,
+};
+use executor::{
+    EventId, EventQuery, EventQueryDirection, ExecutionStreamEvent, HarnessAgent,
+    HarnessConversation, SendRequest, SessionId,
+};
+use lingua::Message;
+use lingua::universal::UserContent;
+use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
+use tokio::sync::mpsc;
+use tokio_stream::StreamExt;
+
+use crate::render::{
+    Verbosity, compact_result_status, compact_timestamp, render_tool_call, render_tool_result,
+    render_transcript_lines,
+};
+use crate::tui::{
+    ReplCommand, ReplInput, chunk_text, cost_lines, parse_repl_input, render_external_event,
+    rewind_lines, shell_lines, snapshot_lines, snapshots_lines, teleport_lines,
+};
+
+const SPINNER: [&str; 4] = ["|", "/", "-", "\\"];
+
+/// The input box grows with wrapped content up to this many text rows, then
+/// scrolls vertically.
+const MAX_INPUT_ROWS: u16 = 8;
+
+/// Wrap input at exact character boundaries so the cursor position stays a
+/// simple row/column computation (word-wrap would make it unpredictable).
+/// The cursor sits at the end, so a line that exactly fills the width rolls
+/// over to a fresh empty line.
+fn wrap_input_chars(input: &str, width: usize) -> Vec<String> {
+    let mut lines = vec![String::new()];
+    let mut column = 0;
+    for ch in input.chars() {
+        if column == width {
+            lines.push(String::new());
+            column = 0;
+        }
+        lines.last_mut().expect("lines never empty").push(ch);
+        column += 1;
+    }
+    if column == width {
+        lines.push(String::new());
+    }
+    lines
+}
+
+/// Everything the UI task can be woken by besides key presses.
+enum AppEvent {
+    Stream(ExecutionStreamEvent),
+    StreamError(String),
+    /// A send or background command finished; clear the busy state.
+    StreamDone,
+    /// Finished output of a background slash command.
+    CommandOutput(Vec<String>),
+    External(Vec<String>),
+}
+
+pub async fn run_chat_tui(
+    agent: Arc<dyn HarnessAgent>,
+    conversation: Arc<dyn HarnessConversation>,
+    verbosity: Verbosity,
+) -> Result<()> {
+    let terminal = ratatui::init();
+    // Capture the mouse so wheel motion reaches us as scroll events; without
+    // this the terminal fakes arrow keys, which would page the input history.
+    let _ = crossterm::execute!(std::io::stdout(), EnableMouseCapture);
+    let result = TuiApp::new(agent, conversation, verbosity)
+        .run(terminal)
+        .await;
+    let _ = crossterm::execute!(std::io::stdout(), DisableMouseCapture);
+    ratatui::restore();
+    result
+}
+
+struct TuiApp {
+    agent: Arc<dyn HarnessAgent>,
+    conversation: Arc<dyn HarnessConversation>,
+    verbosity: Verbosity,
+    transcript: Vec<Line<'static>>,
+    input: String,
+    input_history: Vec<String>,
+    history_pos: Option<usize>,
+    /// Lines scrolled up from the bottom; 0 means follow new output.
+    scrollback: u16,
+    busy: bool,
+    spinner_frame: usize,
+    session_id: Option<SessionId>,
+    watch_after: Arc<Mutex<Option<EventId>>>,
+    /// Transcript index of the assistant line currently streaming.
+    open_assistant: Option<usize>,
+    /// Whether the streaming assistant message already got its prefix line.
+    assistant_prefixed: bool,
+    /// Transcript index of each unresolved tool-call line, by call id.
+    open_calls: HashMap<String, usize>,
+    /// Tool names by call id, for full-mode results and fallbacks.
+    pending_tool_names: HashMap<String, String>,
+}
+
+impl TuiApp {
+    fn new(
+        agent: Arc<dyn HarnessAgent>,
+        conversation: Arc<dyn HarnessConversation>,
+        verbosity: Verbosity,
+    ) -> Self {
+        let watch_after = Arc::new(Mutex::new(conversation.record().latest_event_id));
+        Self {
+            agent,
+            conversation,
+            verbosity,
+            transcript: Vec::new(),
+            input: String::new(),
+            input_history: Vec::new(),
+            history_pos: None,
+            scrollback: 0,
+            busy: false,
+            spinner_frame: 0,
+            session_id: None,
+            watch_after,
+            open_assistant: None,
+            assistant_prefixed: false,
+            open_calls: HashMap::new(),
+            pending_tool_names: HashMap::new(),
+        }
+    }
+
+    async fn run(mut self, mut terminal: ratatui::DefaultTerminal) -> Result<()> {
+        self.load_transcript().await?;
+
+        let (tx, mut rx) = mpsc::unbounded_channel::<AppEvent>();
+        let watcher = self.spawn_event_watcher(tx.clone());
+        let mut keys = EventStream::new();
+        let mut tick = tokio::time::interval(Duration::from_millis(120));
+
+        let outcome = loop {
+            terminal.draw(|frame| self.draw(frame))?;
+            tokio::select! {
+                key = keys.next() => match key {
+                    Some(Ok(event)) => {
+                        if self.handle_terminal_event(event, &tx).await? {
+                            break Ok(());
+                        }
+                    }
+                    Some(Err(error)) => break Err(error.into()),
+                    None => break Ok(()),
+                },
+                app_event = rx.recv() => {
+                    if let Some(app_event) = app_event {
+                        self.handle_app_event(app_event);
+                    }
+                }
+                _ = tick.tick() => {
+                    if self.busy {
+                        self.spinner_frame = self.spinner_frame.wrapping_add(1);
+                    }
+                }
+            }
+        };
+
+        watcher.abort();
+        if let Some(session_id) = self.session_id.take() {
+            self.conversation.close_session(session_id).await?;
+        }
+        outcome
+    }
+
+    async fn load_transcript(&mut self) -> Result<()> {
+        let messages = self.conversation.messages().await?;
+        self.transcript = render_transcript_lines(&messages, self.verbosity)
+            .iter()
+            .flat_map(|rendered| rendered.split('\n'))
+            .map(|line| style_transcript_line(line.to_string()))
+            .collect();
+        Ok(())
+    }
+
+    /// Returns true when the app should exit.
+    async fn handle_terminal_event(
+        &mut self,
+        event: Event,
+        tx: &mpsc::UnboundedSender<AppEvent>,
+    ) -> Result<bool> {
+        if let Event::Mouse(mouse) = event {
+            match mouse.kind {
+                MouseEventKind::ScrollUp => self.scrollback = self.scrollback.saturating_add(3),
+                MouseEventKind::ScrollDown => self.scrollback = self.scrollback.saturating_sub(3),
+                _ => {}
+            }
+            return Ok(false);
+        }
+        let Event::Key(key) = event else {
+            return Ok(false);
+        };
+        if key.kind != KeyEventKind::Press {
+            return Ok(false);
+        }
+        match (key.modifiers, key.code) {
+            (KeyModifiers::CONTROL, KeyCode::Char('c') | KeyCode::Char('d')) => return Ok(true),
+            (KeyModifiers::CONTROL, KeyCode::Char('u')) => self.input.clear(),
+            (_, KeyCode::Enter) => return self.submit_input(tx).await,
+            (_, KeyCode::Backspace) => {
+                self.input.pop();
+            }
+            (_, KeyCode::Up) => self.history_step(-1),
+            (_, KeyCode::Down) => self.history_step(1),
+            (_, KeyCode::PageUp) => {
+                self.scrollback = self.scrollback.saturating_add(10);
+            }
+            (_, KeyCode::PageDown) => {
+                self.scrollback = self.scrollback.saturating_sub(10);
+            }
+            (_, KeyCode::Esc) => self.scrollback = 0,
+            (_, KeyCode::Char(ch)) => self.input.push(ch),
+            _ => {}
+        }
+        Ok(false)
+    }
+
+    /// Returns true when the app should exit.
+    async fn submit_input(&mut self, tx: &mpsc::UnboundedSender<AppEvent>) -> Result<bool> {
+        let line = std::mem::take(&mut self.input);
+        self.history_pos = None;
+        match parse_repl_input(&line) {
+            Ok(ReplInput::Empty) => {}
+            Ok(ReplInput::Chat(text)) => {
+                if self.busy {
+                    self.push_notice("still waiting on the previous turn");
+                    self.input = line;
+                    return Ok(false);
+                }
+                self.input_history.push(line);
+                self.push_user_line(&text);
+                self.start_send(text, tx.clone());
+            }
+            Ok(ReplInput::Command(command)) => {
+                self.input_history.push(line);
+                return self.execute_command(command, tx).await;
+            }
+            Err(error) => {
+                for rendered in error.to_string().lines() {
+                    self.push_notice(rendered);
+                }
+            }
+        }
+        Ok(false)
+    }
+
+    /// Returns true when the app should exit.
+    async fn execute_command(
+        &mut self,
+        command: ReplCommand,
+        tx: &mpsc::UnboundedSender<AppEvent>,
+    ) -> Result<bool> {
+        // Sandbox and model operations run on a worker task so the UI keeps
+        // drawing; one at a time keeps their output readable.
+        if self.busy && !matches!(command, ReplCommand::Quit) {
+            self.push_notice("still waiting on the previous operation");
+            return Ok(false);
+        }
+        let conversation = Arc::clone(&self.conversation);
+        match command {
+            ReplCommand::Quit => return Ok(true),
+            ReplCommand::History => self.load_transcript().await?,
+            ReplCommand::Verbosity { level } => match level {
+                Some(verbosity) => {
+                    self.verbosity = verbosity;
+                    self.push_notice(&format!("verbosity set to {verbosity}"));
+                    self.load_transcript().await?;
+                }
+                None => {
+                    let verbosity = self.verbosity;
+                    self.push_notice(&format!("verbosity: {verbosity}"));
+                }
+            },
+            ReplCommand::Cost => {
+                self.spawn_command(tx, async move { cost_lines(conversation.as_ref()).await })
+            }
+            ReplCommand::Shell { command } => {
+                let agent = Arc::clone(&self.agent);
+                self.spawn_command(tx, async move {
+                    shell_lines(agent.as_ref(), conversation.as_ref(), command).await
+                });
+            }
+            ReplCommand::Snapshot { sandbox_id } => self.spawn_command(tx, async move {
+                snapshot_lines(conversation.as_ref(), sandbox_id).await
+            }),
+            ReplCommand::Snapshots => {
+                self.spawn_command(
+                    tx,
+                    async move { snapshots_lines(conversation.as_ref()).await },
+                )
+            }
+            ReplCommand::Rewind { snapshot_id } => self.spawn_command(tx, async move {
+                rewind_lines(conversation.as_ref(), &snapshot_id).await
+            }),
+            ReplCommand::Teleport { provider } => self.spawn_command(tx, async move {
+                teleport_lines(conversation.as_ref(), &provider).await
+            }),
+        }
+        Ok(false)
+    }
+
+    /// Run a slash command on a worker task, feeding its finished output back
+    /// through the app-event channel.
+    fn spawn_command(
+        &mut self,
+        tx: &mpsc::UnboundedSender<AppEvent>,
+        work: impl Future<Output = Vec<String>> + Send + 'static,
+    ) {
+        self.busy = true;
+        let tx = tx.clone();
+        tokio::spawn(async move {
+            let lines = work.await;
+            let _ = tx.send(AppEvent::CommandOutput(lines));
+            let _ = tx.send(AppEvent::StreamDone);
+        });
+    }
+
+    fn start_send(&mut self, text: String, tx: mpsc::UnboundedSender<AppEvent>) {
+        self.busy = true;
+        self.open_assistant = None;
+        self.assistant_prefixed = false;
+        self.open_calls.clear();
+        let conversation = Arc::clone(&self.conversation);
+        let session_id = self.session_id;
+        tokio::spawn(async move {
+            let request = SendRequest {
+                input: vec![Message::User {
+                    content: UserContent::String(text),
+                }],
+                session_id,
+            };
+            match conversation.send_stream(request).await {
+                Ok(mut stream) => {
+                    while let Some(event) = stream.next().await {
+                        let app_event = match event {
+                            Ok(event) => AppEvent::Stream(event),
+                            Err(error) => AppEvent::StreamError(format!("{error:#}")),
+                        };
+                        if tx.send(app_event).is_err() {
+                            return;
+                        }
+                    }
+                }
+                Err(error) => {
+                    let _ = tx.send(AppEvent::StreamError(format!("{error:#}")));
+                }
+            }
+            let _ = tx.send(AppEvent::StreamDone);
+        });
+    }
+
+    fn handle_app_event(&mut self, event: AppEvent) {
+        match event {
+            AppEvent::Stream(event) => self.handle_stream_event(event),
+            AppEvent::StreamError(error) => self.push_notice(&format!("stream error: {error}")),
+            AppEvent::StreamDone => {
+                self.busy = false;
+                self.open_assistant = None;
+                self.assistant_prefixed = false;
+            }
+            AppEvent::CommandOutput(lines) => {
+                for line in lines {
+                    // Tabs come from table-shaped output; ratatui renders
+                    // them poorly.
+                    self.transcript
+                        .push(style_transcript_line(line.replace('\t', "    ")));
+                }
+            }
+            AppEvent::External(lines) => {
+                for rendered in lines {
+                    for line in rendered.split('\n') {
+                        self.transcript
+                            .push(style_transcript_line(line.to_string()));
+                    }
+                }
+            }
+        }
+    }
+
+    fn handle_stream_event(&mut self, event: ExecutionStreamEvent) {
+        match event {
+            ExecutionStreamEvent::FirstChunk { .. } => {}
+            ExecutionStreamEvent::Chunk(chunk) => {
+                let text = chunk_text(&chunk);
+                if !text.is_empty() {
+                    self.append_assistant_text(&text);
+                }
+            }
+            ExecutionStreamEvent::ToolCall {
+                tool_call_id,
+                tool_name,
+                arguments,
+            } => {
+                self.open_assistant = None;
+                self.assistant_prefixed = false;
+                if let Some(rendered) = render_tool_call(&tool_name, &arguments, self.verbosity) {
+                    for (index, line) in rendered.lines().enumerate() {
+                        self.transcript
+                            .push(style_transcript_line(line.to_string()));
+                        if index == 0 && self.verbosity == Verbosity::Compact {
+                            self.open_calls
+                                .insert(tool_call_id.clone(), self.transcript.len() - 1);
+                        }
+                    }
+                }
+                self.pending_tool_names.insert(tool_call_id, tool_name);
+            }
+            ExecutionStreamEvent::ToolResult {
+                tool_call_id,
+                result,
+            } => {
+                let tool_name = self
+                    .pending_tool_names
+                    .remove(&tool_call_id)
+                    .unwrap_or_else(|| "tool".to_string());
+                if let Some(index) = self.open_calls.remove(&tool_call_id) {
+                    let status = compact_result_status(&result);
+                    self.transcript[index]
+                        .spans
+                        .push(Span::styled(format!(" {status}"), status_style(&status)));
+                } else if let Some(rendered) =
+                    render_tool_result(&tool_name, &result, self.verbosity)
+                {
+                    for line in rendered.lines() {
+                        self.transcript
+                            .push(style_transcript_line(line.to_string()));
+                    }
+                }
+            }
+            ExecutionStreamEvent::Completed(result) => {
+                self.session_id = Some(result.session_id);
+                *self.watch_after.lock().expect("watch cursor poisoned") =
+                    Some(result.latest_event_id);
+            }
+        }
+    }
+
+    fn append_assistant_text(&mut self, text: &str) {
+        for (index, piece) in text.split('\n').enumerate() {
+            if index > 0 {
+                self.open_assistant = None;
+            }
+            if piece.is_empty() {
+                continue;
+            }
+            let line_index = match self.open_assistant {
+                Some(line_index) => line_index,
+                None => {
+                    // Only the first line of a message carries the prefix;
+                    // continuation lines stay bare.
+                    let prefix = if self.assistant_prefixed {
+                        String::new()
+                    } else {
+                        self.assistant_prefixed = true;
+                        format!("{} assistant: ", compact_timestamp())
+                    };
+                    self.transcript.push(Line::from(vec![
+                        Span::styled(prefix, Style::new().dim()),
+                        Span::raw(String::new()),
+                    ]));
+                    let line_index = self.transcript.len() - 1;
+                    self.open_assistant = Some(line_index);
+                    line_index
+                }
+            };
+            if let Some(span) = self.transcript[line_index].spans.last_mut() {
+                span.content.to_mut().push_str(piece);
+            }
+        }
+    }
+
+    fn push_user_line(&mut self, text: &str) {
+        self.transcript.push(Line::from(vec![
+            Span::styled(
+                format!("{} user: ", compact_timestamp()),
+                Style::new().dim(),
+            ),
+            Span::styled(text.to_string(), Style::new().bold()),
+        ]));
+        self.scrollback = 0;
+    }
+
+    fn push_notice(&mut self, text: &str) {
+        self.transcript
+            .push(Line::styled(text.to_string(), Style::new().dim().italic()));
+    }
+
+    fn history_step(&mut self, direction: isize) {
+        if self.input_history.is_empty() {
+            return;
+        }
+        let last = self.input_history.len() - 1;
+        let next = match (self.history_pos, direction) {
+            (None, -1) => Some(last),
+            (None, _) => None,
+            (Some(0), -1) => Some(0),
+            (Some(pos), -1) => Some(pos - 1),
+            (Some(pos), 1) if pos < last => Some(pos + 1),
+            (Some(_), 1) => {
+                self.history_pos = None;
+                self.input.clear();
+                return;
+            }
+            (pos, _) => pos,
+        };
+        if let Some(pos) = next {
+            self.history_pos = Some(pos);
+            self.input = self.input_history[pos].clone();
+        }
+    }
+
+    fn spawn_event_watcher(
+        &self,
+        tx: mpsc::UnboundedSender<AppEvent>,
+    ) -> tokio::task::JoinHandle<()> {
+        let conversation = self.conversation.exoharness_handle();
+        let watch_after = Arc::clone(&self.watch_after);
+        let verbosity = self.verbosity;
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(1));
+            loop {
+                interval.tick().await;
+                let cursor = *watch_after.lock().expect("watch cursor poisoned");
+                let Ok(result) = conversation
+                    .get_events(Some(EventQuery {
+                        cursor,
+                        direction: Some(EventQueryDirection::Asc),
+                        limit: Some(100),
+                        session_id: None,
+                        turn_id: None,
+                        types: None,
+                    }))
+                    .await
+                else {
+                    return;
+                };
+                for event in result.events {
+                    *watch_after.lock().expect("watch cursor poisoned") = Some(event.id);
+                    let lines = render_external_event(&event.data, verbosity);
+                    if !lines.is_empty() && tx.send(AppEvent::External(lines)).is_err() {
+                        return;
+                    }
+                }
+            }
+        })
+    }
+
+    fn draw(&mut self, frame: &mut Frame) {
+        // The input box wraps and grows with its content (bounded), so its
+        // height must be known before the layout is split.
+        let input_width = usize::from(frame.area().width.saturating_sub(2)).max(1);
+        let input_lines = wrap_input_chars(&self.input, input_width);
+        let input_height = (input_lines.len() as u16).min(MAX_INPUT_ROWS) + 2;
+
+        let [transcript_area, input_area, status_area] = Layout::vertical([
+            Constraint::Min(1),
+            Constraint::Length(input_height),
+            Constraint::Length(1),
+        ])
+        .areas(frame.area());
+
+        let title = format!(
+            " {} · {} ",
+            self.agent.record().slug,
+            self.conversation.record().slug
+        );
+        // Count lines before attaching the block: line_count includes the
+        // block's border rows, which would over-scroll by two.
+        let transcript =
+            Paragraph::new(Text::from(self.transcript.clone())).wrap(Wrap { trim: false });
+        let inner_width = transcript_area.width.saturating_sub(2);
+        let inner_height = transcript_area.height.saturating_sub(2);
+        let total = transcript.line_count(inner_width) as u16;
+        let bottom = total.saturating_sub(inner_height);
+        self.scrollback = self.scrollback.min(bottom);
+        let scroll = bottom - self.scrollback;
+        frame.render_widget(
+            transcript
+                .scroll((scroll, 0))
+                .block(Block::new().borders(Borders::ALL).title(title)),
+            transcript_area,
+        );
+
+        // Once the input outgrows its bounded height, scroll vertically so
+        // the cursor row (always the last line) stays visible.
+        let cursor_col = input_lines.last().map_or(0, |line| line.chars().count()) as u16;
+        let total_rows = input_lines.len() as u16;
+        let input_scroll = total_rows.saturating_sub(MAX_INPUT_ROWS);
+        let input = Paragraph::new(Text::from(
+            input_lines.into_iter().map(Line::from).collect::<Vec<_>>(),
+        ))
+        .scroll((input_scroll, 0))
+        .block(
+            Block::new()
+                .borders(Borders::ALL)
+                .title(" message or /command "),
+        );
+        frame.render_widget(input, input_area);
+        frame.set_cursor_position(Position::new(
+            input_area.x + 1 + cursor_col,
+            input_area.y + 1 + (total_rows - 1 - input_scroll),
+        ));
+
+        let state = if self.busy {
+            format!("{} thinking…", SPINNER[self.spinner_frame % SPINNER.len()])
+        } else {
+            "idle".to_string()
+        };
+        let status = Line::from(format!(
+            " {state} · verbosity {} · wheel/PgUp scroll · ↑↓ history · Esc follow · Ctrl+C quit",
+            self.verbosity
+        ))
+        .style(Style::new().dim());
+        frame.render_widget(Paragraph::new(status), status_area);
+    }
+}
+
+/// Basic styling for pre-rendered transcript strings, keyed off the line
+/// shape the render module produces.
+fn style_transcript_line(line: String) -> Line<'static> {
+    let style = if line.starts_with('→') || line.starts_with('←') {
+        Style::new().cyan()
+    } else if line.contains("] user: ") {
+        Style::new().bold()
+    } else {
+        Style::new()
+    };
+    Line::styled(line, style)
+}
+
+fn status_style(status: &str) -> Style {
+    if status.starts_with('✓') {
+        Style::new().green()
+    } else {
+        Style::new().red()
+    }
+}

--- a/crates/cli/src/tui_app.rs
+++ b/crates/cli/src/tui_app.rs
@@ -375,8 +375,7 @@ impl TuiApp {
         let messages = self.conversation.messages().await?;
         self.transcript = render_transcript_lines(&messages, self.verbosity)
             .iter()
-            .flat_map(|rendered| rendered.split('\n'))
-            .map(|line| style_transcript_line(line.to_string()))
+            .flat_map(|rendered| styled_message_lines(rendered))
             .collect();
         Ok(())
     }
@@ -598,10 +597,7 @@ impl TuiApp {
             }
             AppEvent::External(lines) => {
                 for rendered in lines {
-                    for line in rendered.split('\n') {
-                        self.transcript
-                            .push(style_transcript_line(line.to_string()));
-                    }
+                    self.transcript.extend(styled_message_lines(&rendered));
                 }
             }
         }
@@ -871,14 +867,30 @@ impl TuiApp {
 /// Basic styling for pre-rendered transcript strings, keyed off the line
 /// shape the render module produces.
 fn style_transcript_line(line: String) -> Line<'static> {
-    let style = if line.starts_with('→') || line.starts_with('←') {
+    let style = transcript_line_style(&line);
+    Line::styled(line, style)
+}
+
+fn transcript_line_style(line: &str) -> Style {
+    if line.starts_with('→') || line.starts_with('←') {
         Style::new().cyan()
     } else if line.contains("] user: ") {
         Style::new().bold()
     } else {
         Style::new()
-    };
-    Line::styled(line, style)
+    }
+}
+
+/// One logical message line as visual lines: the style is decided once from
+/// the whole message (whose first line carries the speaker prefix), then
+/// applied to every line after splitting on embedded newlines — so
+/// continuation lines keep the message's look.
+fn styled_message_lines(rendered: &str) -> Vec<Line<'static>> {
+    let style = transcript_line_style(rendered);
+    rendered
+        .split('\n')
+        .map(|line| Line::styled(line.to_string(), style))
+        .collect()
 }
 
 fn status_style(status: &str) -> Style {

--- a/crates/cli/src/tui_app.rs
+++ b/crates/cli/src/tui_app.rs
@@ -860,7 +860,7 @@ impl TuiApp {
             "mouse released: select text freely, Ctrl+T to restore scrolling"
         };
         let status = Line::from(format!(
-            " {state} · verbosity {} · wheel/PgUp scroll · ↑↓ history · Esc follow · {mouse} · Ctrl+C quit",
+            " {state} · verbosity {} · {mouse} · Ctrl+C quit",
             self.verbosity
         ))
         .style(Style::new().dim());

--- a/crates/cli/src/tui_app.rs
+++ b/crates/cli/src/tui_app.rs
@@ -34,39 +34,131 @@ const SPINNER: [&str; 4] = ["|", "/", "-", "\\"];
 // live in this clap tree. `multicall` makes the first token the command name,
 // and clap's built-in `help` subcommand serves `/help`.
 #[derive(Debug, clap::Parser)]
-#[command(name = "repl", multicall = true, about = "repl slash commands")]
+#[command(
+    name = "repl",
+    multicall = true,
+    disable_help_flag = true,
+    about = "repl slash commands"
+)]
 struct ReplCli {
     #[command(subcommand)]
     command: ReplCommand,
 }
 
+// `override_usage` keeps generated usage in slash form; `disable_help_flag`
+// drops the `-h, --help` flag noise (per-command help stays available via
+// `/help <command>`).
 #[derive(Debug, PartialEq, clap::Subcommand)]
 enum ReplCommand {
     /// Exit the repl
-    #[command(alias = "exit")]
+    #[command(
+        visible_alias = "exit",
+        override_usage = "/quit",
+        disable_help_flag = true
+    )]
     Quit,
     /// Summarize token usage and dollar cost
-    #[command(alias = "usage")]
+    #[command(
+        visible_alias = "usage",
+        override_usage = "/cost",
+        disable_help_flag = true
+    )]
     Cost,
     /// Show or set how much tool detail is printed
+    #[command(
+        override_usage = "/verbosity [minimal|compact|full]",
+        disable_help_flag = true
+    )]
     Verbosity {
         #[arg(value_enum)]
         level: Option<Verbosity>,
     },
     /// Run a command in the conversation's sandbox
-    #[command(alias = "sandbox")]
+    #[command(
+        visible_alias = "sandbox",
+        override_usage = "/shell <command>",
+        disable_help_flag = true
+    )]
     Shell {
         /// Shell source, passed to the sandbox verbatim
         command: String,
     },
     /// Snapshot a sandbox in this conversation (defaults to the latest one)
+    #[command(override_usage = "/snapshot [<sandbox-id>]", disable_help_flag = true)]
     Snapshot { sandbox_id: Option<String> },
     /// List snapshots taken in this conversation
+    #[command(override_usage = "/snapshots", disable_help_flag = true)]
     Snapshots,
     /// Restore the sandbox to a previous snapshot
+    #[command(override_usage = "/rewind <snapshot-id>", disable_help_flag = true)]
     Rewind { snapshot_id: String },
     /// Move the live sandbox to another provider (e.g. daytona: snapshot + restore there)
+    #[command(override_usage = "/teleport <provider>", disable_help_flag = true)]
     Teleport { provider: String },
+}
+
+/// `/help` listing, generated from the clap tree but formatted for the
+/// transcript instead of clap's CLI-shaped help screen.
+fn command_help_lines() -> Vec<String> {
+    use clap::CommandFactory;
+
+    let mut cmd = ReplCli::command();
+    let mut entries: Vec<(String, String)> = Vec::new();
+    for sub in cmd
+        .get_subcommands_mut()
+        .filter(|sub| sub.get_name() != "help")
+    {
+        let aliases: Vec<String> = sub
+            .get_visible_aliases()
+            .map(|alias| format!("/{alias}"))
+            .collect();
+        let mut about = sub.get_about().map(ToString::to_string).unwrap_or_default();
+        if !aliases.is_empty() {
+            about = format!("{about} (alias {})", aliases.join(", "));
+        }
+        let synopsis = sub
+            .render_usage()
+            .to_string()
+            .trim_start_matches("Usage:")
+            .trim()
+            .to_string();
+        entries.push((synopsis, about));
+    }
+    entries.push((
+        "/help [<command>]".to_string(),
+        "show this message".to_string(),
+    ));
+
+    let width = entries
+        .iter()
+        .map(|(synopsis, _)| synopsis.chars().count())
+        .max()
+        .unwrap_or(0);
+    let mut lines = vec!["commands:".to_string()];
+    for (synopsis, about) in entries {
+        lines.push(format!("  {synopsis:<width$}  {about}"));
+    }
+    lines
+}
+
+/// clap's error text is written for a shell CLI; trim the parts that make no
+/// sense inside the repl (help-flag hints and the bare top-level usage line).
+fn clap_error_lines(error: &clap::Error) -> Vec<String> {
+    let rendered = error.to_string();
+    let mut lines: Vec<String> = rendered
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("For more information"))
+        .filter(|line| line.trim() != "Usage: <COMMAND>")
+        .map(str::to_string)
+        .collect();
+    lines.dedup_by(|a, b| a.trim().is_empty() && b.trim().is_empty());
+    while lines.last().is_some_and(|line| line.trim().is_empty()) {
+        lines.pop();
+    }
+    while lines.first().is_some_and(|line| line.trim().is_empty()) {
+        lines.remove(0);
+    }
+    lines
 }
 
 /// What a line of repl input means.
@@ -333,6 +425,13 @@ impl TuiApp {
     async fn submit_input(&mut self, tx: &mpsc::UnboundedSender<AppEvent>) -> Result<bool> {
         let line = std::mem::take(&mut self.input);
         self.history_pos = None;
+        // The bare help listing is ours, not clap's CLI-shaped help screen.
+        if matches!(line.trim(), "/" | "/help") {
+            for rendered in command_help_lines() {
+                self.push_notice(&rendered);
+            }
+            return Ok(false);
+        }
         match parse_repl_input(&line) {
             Ok(ReplInput::Empty) => {}
             Ok(ReplInput::Chat(text)) => {
@@ -350,8 +449,8 @@ impl TuiApp {
                 return self.execute_command(command, tx).await;
             }
             Err(error) => {
-                for rendered in error.to_string().lines() {
-                    self.push_notice(rendered);
+                for rendered in clap_error_lines(&error) {
+                    self.push_notice(&rendered);
                 }
             }
         }

--- a/crates/cli/src/tui_app.rs
+++ b/crates/cli/src/tui_app.rs
@@ -26,8 +26,8 @@ use tokio::sync::mpsc;
 use tokio_stream::StreamExt;
 
 use crate::render::{
-    Verbosity, compact_result_status, compact_timestamp, render_tool_call, render_tool_result,
-    render_transcript_lines,
+    ASSISTANT_LABEL, Verbosity, compact_result_status, compact_timestamp, render_tool_call,
+    render_tool_result, render_transcript_lines,
 };
 use crate::tui::{
     ReplCommand, ReplInput, chunk_text, cost_lines, parse_repl_input, render_external_event,
@@ -469,7 +469,7 @@ impl TuiApp {
                         String::new()
                     } else {
                         self.assistant_prefixed = true;
-                        format!("{} assistant: ", compact_timestamp())
+                        format!("{} {ASSISTANT_LABEL}: ", compact_timestamp())
                     };
                     self.transcript.push(Line::from(vec![
                         Span::styled(prefix, Style::new().dim()),

--- a/crates/cli/src/tui_app.rs
+++ b/crates/cli/src/tui_app.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::future::Future;
+use std::io::Write;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -7,7 +8,7 @@ use std::time::Duration;
 use anyhow::Result;
 use crossterm::event::{
     DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture, Event,
-    EventStream, KeyCode, KeyEventKind, KeyModifiers, MouseEventKind,
+    EventStream, KeyCode, KeyEventKind, KeyModifiers, MouseButton, MouseEventKind,
 };
 use executor::{
     EventId, EventQuery, EventQueryDirection, ExecutionStreamEvent, HarnessAgent,
@@ -290,6 +291,13 @@ struct TuiApp {
     /// Whether the terminal reports mouse events to us (wheel scrolling).
     /// Toggled off to let the terminal's native text selection work.
     mouse_captured: bool,
+    /// Screen-cell selection anchors (start, head) while drag-selecting.
+    selection: Option<(Position, Position)>,
+    /// Transcript area inside its borders, from the last draw; selection is
+    /// clamped to it so copies never include border bars or box padding.
+    transcript_inner: Rect,
+    /// A finished drag is waiting to be copied from the rendered buffer.
+    copy_pending: bool,
     spinner_frame: usize,
     session_id: Option<SessionId>,
     watch_after: Arc<Mutex<Option<EventId>>>,
@@ -321,6 +329,9 @@ impl TuiApp {
             scrollback: 0,
             busy: Arc::new(AtomicBool::new(false)),
             mouse_captured: true,
+            selection: None,
+            transcript_inner: Rect::ZERO,
+            copy_pending: false,
             spinner_frame: 0,
             session_id: None,
             watch_after,
@@ -346,6 +357,15 @@ impl TuiApp {
                     Some(Ok(event)) => {
                         if self.handle_terminal_event(event, &tx).await? {
                             break Ok(());
+                        }
+                        if self.copy_pending {
+                            self.copy_pending = false;
+                            // After a draw the current buffer is the cleared
+                            // next frame; render once more and read the
+                            // completed frame's cells instead.
+                            let completed = terminal.draw(|frame| self.draw(frame))?;
+                            let buffer = completed.buffer.clone();
+                            self.copy_selection(&buffer);
                         }
                     }
                     Some(Err(error)) => break Err(error.into()),
@@ -387,9 +407,28 @@ impl TuiApp {
         tx: &mpsc::UnboundedSender<AppEvent>,
     ) -> Result<bool> {
         if let Event::Mouse(mouse) = event {
+            let position = Position::new(mouse.column, mouse.row);
             match mouse.kind {
                 MouseEventKind::ScrollUp => self.scrollback = self.scrollback.saturating_add(3),
                 MouseEventKind::ScrollDown => self.scrollback = self.scrollback.saturating_sub(3),
+                // Drag-select: the terminal won't select natively while it
+                // reports the mouse to us, so we track the region ourselves
+                // and copy it from the rendered buffer on release.
+                MouseEventKind::Down(MouseButton::Left) => {
+                    self.selection = Some((position, position));
+                }
+                MouseEventKind::Drag(MouseButton::Left) => {
+                    if let Some((_, head)) = self.selection.as_mut() {
+                        *head = position;
+                    }
+                }
+                MouseEventKind::Up(MouseButton::Left) => {
+                    if self.selection.is_some_and(|(start, head)| start != head) {
+                        self.copy_pending = true;
+                    } else {
+                        self.selection = None;
+                    }
+                }
                 _ => {}
             }
             return Ok(false);
@@ -406,7 +445,16 @@ impl TuiApp {
             return Ok(false);
         }
         match (key.modifiers, key.code) {
-            (KeyModifiers::CONTROL, KeyCode::Char('c') | KeyCode::Char('d')) => return Ok(true),
+            // Ctrl+C clears a non-empty input first (like the line repl's
+            // interrupt) and only exits when there is nothing to clear.
+            (KeyModifiers::CONTROL, KeyCode::Char('c')) => {
+                if self.input.is_empty() {
+                    return Ok(true);
+                }
+                self.input.clear();
+                self.history_pos = None;
+            }
+            (KeyModifiers::CONTROL, KeyCode::Char('d')) => return Ok(true),
             (KeyModifiers::CONTROL, KeyCode::Char('u')) => self.input.clear(),
             // Release the mouse so the terminal's native text selection works,
             // at the cost of wheel scrolling; toggle back when done.
@@ -697,17 +745,16 @@ impl TuiApp {
 
     fn push_user_line(&mut self, text: &str) {
         // Ratatui lines cannot hold newlines; multi-line messages become one
-        // transcript line each, with the prefix only on the first.
+        // transcript line each, with the prefix only on the first. The whole
+        // message, prefix included, is bold so user turns stand out.
         for (index, piece) in text.split('\n').enumerate() {
-            let mut spans = Vec::new();
-            if index == 0 {
-                spans.push(Span::styled(
-                    format!("{} user: ", compact_timestamp()),
-                    Style::new().dim(),
-                ));
-            }
-            spans.push(Span::styled(piece.to_string(), Style::new().bold()));
-            self.transcript.push(Line::from(spans));
+            let line = if index == 0 {
+                format!("{} user: {piece}", compact_timestamp())
+            } else {
+                piece.to_string()
+            };
+            self.transcript
+                .push(Line::styled(line, Style::new().bold()));
         }
         self.scrollback = 0;
     }
@@ -719,6 +766,36 @@ impl TuiApp {
 
     fn is_busy(&self) -> bool {
         self.busy.load(Ordering::Relaxed)
+    }
+
+    /// Pull the drag-selected cells out of the last rendered frame (row-major,
+    /// like terminal-native selection) and push them to the system clipboard
+    /// via OSC 52, which works through tmux and ssh in most terminals.
+    fn copy_selection(&mut self, buffer: &Buffer) {
+        let Some((anchor, head)) = self.selection else {
+            return;
+        };
+        let mut lines = Vec::new();
+        for (row, from, to) in selection_rows(anchor, head, self.transcript_inner) {
+            let mut text = String::new();
+            for column in from..=to {
+                if let Some(cell) = buffer.cell(Position::new(column, row)) {
+                    text.push_str(cell.symbol());
+                }
+            }
+            lines.push(text.trim_end().to_string());
+        }
+        let text = lines.join("\n");
+        // Send regardless (harmless if swallowed), but report honestly when a
+        // known hop is configured to drop it.
+        let mut stdout = std::io::stdout();
+        let _ = write!(stdout, "\x1b]52;c;{}\x07", base64_encode(text.as_bytes()));
+        let _ = stdout.flush();
+        match clipboard_block_reason() {
+            Some(reason) => self.push_notice(&reason),
+            None => self.push_notice(&format!("copied {} characters", text.chars().count())),
+        }
+        self.selection = None;
     }
 
     fn history_step(&mut self, direction: isize) {
@@ -804,7 +881,7 @@ impl TuiApp {
         .areas(frame.area());
 
         let title = format!(
-            " {} · {} ",
+            " ⧓ {} · {} ",
             self.agent.record().slug,
             self.conversation.record().slug
         );
@@ -812,6 +889,7 @@ impl TuiApp {
         // block's border rows, which would over-scroll by two.
         let transcript =
             Paragraph::new(Text::from(self.transcript.clone())).wrap(Wrap { trim: false });
+        self.transcript_inner = Block::new().borders(Borders::ALL).inner(transcript_area);
         let inner_width = transcript_area.width.saturating_sub(2);
         let inner_height = transcript_area.height.saturating_sub(2);
         let total = transcript.line_count(inner_width) as u16;
@@ -851,9 +929,9 @@ impl TuiApp {
             "idle".to_string()
         };
         let mouse = if self.mouse_captured {
-            "Ctrl+T to select text"
+            "drag to copy text"
         } else {
-            "mouse released: select text freely, Ctrl+T to restore scrolling"
+            "mouse released: native selection, Ctrl+T to restore scrolling"
         };
         let status = Line::from(format!(
             " {state} · verbosity {} · {mouse} · Ctrl+C quit",
@@ -861,7 +939,99 @@ impl TuiApp {
         ))
         .style(Style::new().dim());
         frame.render_widget(Paragraph::new(status), status_area);
+
+        // Reverse-video the drag selection so it reads like terminal-native
+        // selection while the mouse is captured.
+        if let Some((anchor, head)) = self.selection {
+            let inner = self.transcript_inner;
+            let buffer = frame.buffer_mut();
+            for (row, from, to) in selection_rows(anchor, head, inner) {
+                buffer.set_style(
+                    Rect::new(from, row, to - from + 1, 1),
+                    Style::new().reversed(),
+                );
+            }
+        }
     }
+}
+
+/// Detectable reasons an OSC 52 clipboard write will never arrive: tmux
+/// swallows application clipboard escapes unless `set-clipboard` is `on`.
+/// Checked per copy so fixing the setting takes effect immediately.
+fn clipboard_block_reason() -> Option<String> {
+    std::env::var_os("TMUX")?;
+    let output = std::process::Command::new("tmux")
+        .args(["show", "-gv", "set-clipboard"])
+        .output()
+        .ok()
+        .filter(|output| output.status.success())?;
+    let value = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (value != "on").then(|| {
+        format!(
+            "copy blocked: tmux set-clipboard is `{value}`; run `tmux set -g set-clipboard on`, \
+             or hold Shift/Alt while dragging to select natively"
+        )
+    })
+}
+
+/// Row-major ordering for the two selection anchors.
+fn order_selection(a: Position, b: Position) -> (Position, Position) {
+    if (a.y, a.x) <= (b.y, b.x) {
+        (a, b)
+    } else {
+        (b, a)
+    }
+}
+
+/// The per-row column spans of a selection, clamped to the transcript's
+/// inner area so border bars and box padding never highlight or copy.
+fn selection_rows(anchor: Position, head: Position, inner: Rect) -> Vec<(u16, u16, u16)> {
+    let (start, end) = order_selection(anchor, head);
+    if inner.width == 0 || inner.height == 0 {
+        return Vec::new();
+    }
+    let (min_x, max_x) = (inner.left(), inner.right().saturating_sub(1));
+    let mut rows = Vec::new();
+    for row in start.y.max(inner.top())..=end.y.min(inner.bottom().saturating_sub(1)) {
+        let from = if row == start.y {
+            start.x.max(min_x)
+        } else {
+            min_x
+        };
+        let to = if row == end.y {
+            end.x.min(max_x)
+        } else {
+            max_x
+        };
+        if from <= to {
+            rows.push((row, from, to));
+        }
+    }
+    rows
+}
+
+/// Minimal base64 for OSC 52 payloads; not worth a dependency.
+fn base64_encode(data: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(data.len().div_ceil(3) * 4);
+    for chunk in data.chunks(3) {
+        let bits = (u32::from(chunk[0]) << 16)
+            | (u32::from(*chunk.get(1).unwrap_or(&0)) << 8)
+            | u32::from(*chunk.get(2).unwrap_or(&0));
+        out.push(ALPHABET[(bits >> 18) as usize & 63] as char);
+        out.push(ALPHABET[(bits >> 12) as usize & 63] as char);
+        out.push(if chunk.len() > 1 {
+            ALPHABET[(bits >> 6) as usize & 63] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            ALPHABET[bits as usize & 63] as char
+        } else {
+            '='
+        });
+    }
+    out
 }
 
 /// Basic styling for pre-rendered transcript strings, keyed off the line
@@ -886,11 +1056,44 @@ fn transcript_line_style(line: &str) -> Style {
 /// applied to every line after splitting on embedded newlines — so
 /// continuation lines keep the message's look.
 fn styled_message_lines(rendered: &str) -> Vec<Line<'static>> {
+    if let Some(lines) = styled_speaker_lines(rendered) {
+        return lines;
+    }
     let style = transcript_line_style(rendered);
     rendered
         .split('\n')
         .map(|line| Line::styled(line.to_string(), style))
         .collect()
+}
+
+/// Match the live rendering for agent messages: dim `[ts] agent: ` prefix,
+/// plain text, continuation lines without a prefix. User messages fall
+/// through to the whole-line bold style instead.
+fn styled_speaker_lines(rendered: &str) -> Option<Vec<Line<'static>>> {
+    const TIMESTAMP_LEN: usize = "[HH:MM:SS]".len();
+    let anchored = rendered.len() > TIMESTAMP_LEN
+        && rendered.as_bytes()[0] == b'['
+        && rendered.as_bytes()[TIMESTAMP_LEN - 1] == b']';
+    if !anchored {
+        return None;
+    }
+    let rest = &rendered[TIMESTAMP_LEN..];
+    let agent_marker = format!(" {ASSISTANT_LABEL}: ");
+    if !rest.starts_with(&agent_marker) {
+        return None;
+    }
+    let (marker_len, text_style) = (agent_marker.len(), Style::new());
+    let (prefix, text) = rendered.split_at(TIMESTAMP_LEN + marker_len);
+    let mut lines = Vec::new();
+    for (index, piece) in text.split('\n').enumerate() {
+        let mut spans = Vec::new();
+        if index == 0 {
+            spans.push(Span::styled(prefix.to_string(), Style::new().dim()));
+        }
+        spans.push(Span::styled(piece.to_string(), text_style));
+        lines.push(Line::from(spans));
+    }
+    Some(lines)
 }
 
 fn status_style(status: &str) -> Style {

--- a/crates/cli/src/tui_app.rs
+++ b/crates/cli/src/tui_app.rs
@@ -11,8 +11,8 @@ use std::time::Duration;
 
 use anyhow::Result;
 use crossterm::event::{
-    DisableMouseCapture, EnableMouseCapture, Event, EventStream, KeyCode, KeyEventKind,
-    KeyModifiers, MouseEventKind,
+    DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture, Event,
+    EventStream, KeyCode, KeyEventKind, KeyModifiers, MouseEventKind,
 };
 use executor::{
     EventId, EventQuery, EventQueryDirection, ExecutionStreamEvent, HarnessAgent,
@@ -42,15 +42,19 @@ const MAX_INPUT_ROWS: u16 = 8;
 
 /// Wrap input at exact character boundaries so the cursor position stays a
 /// simple row/column computation (word-wrap would make it unpredictable).
-/// The cursor sits at the end, so a line that exactly fills the width rolls
-/// over to a fresh empty line.
+/// Embedded newlines (pasted or Alt+Enter) are hard breaks. The cursor sits
+/// at the end, so a line that exactly fills the width rolls over to a fresh
+/// empty line.
 fn wrap_input_chars(input: &str, width: usize) -> Vec<String> {
     let mut lines = vec![String::new()];
     let mut column = 0;
     for ch in input.chars() {
-        if column == width {
+        if ch == '\n' || column == width {
             lines.push(String::new());
             column = 0;
+            if ch == '\n' {
+                continue;
+            }
         }
         lines.last_mut().expect("lines never empty").push(ch);
         column += 1;
@@ -80,11 +84,17 @@ pub async fn run_chat_tui(
     let terminal = ratatui::init();
     // Capture the mouse so wheel motion reaches us as scroll events; without
     // this the terminal fakes arrow keys, which would page the input history.
-    let _ = crossterm::execute!(std::io::stdout(), EnableMouseCapture);
+    // Bracketed paste keeps pasted newlines literal instead of sending the
+    // message once per line.
+    let _ = crossterm::execute!(std::io::stdout(), EnableMouseCapture, EnableBracketedPaste);
     let result = TuiApp::new(agent, conversation, verbosity)
         .run(terminal)
         .await;
-    let _ = crossterm::execute!(std::io::stdout(), DisableMouseCapture);
+    let _ = crossterm::execute!(
+        std::io::stdout(),
+        DisableMouseCapture,
+        DisableBracketedPaste
+    );
     ratatui::restore();
     result
 }
@@ -204,6 +214,11 @@ impl TuiApp {
             }
             return Ok(false);
         }
+        if let Event::Paste(text) = event {
+            // Terminals report pasted line breaks as `\r`.
+            self.input.push_str(&text.replace('\r', "\n"));
+            return Ok(false);
+        }
         let Event::Key(key) = event else {
             return Ok(false);
         };
@@ -213,6 +228,7 @@ impl TuiApp {
         match (key.modifiers, key.code) {
             (KeyModifiers::CONTROL, KeyCode::Char('c') | KeyCode::Char('d')) => return Ok(true),
             (KeyModifiers::CONTROL, KeyCode::Char('u')) => self.input.clear(),
+            (KeyModifiers::ALT, KeyCode::Enter) => self.input.push('\n'),
             (_, KeyCode::Enter) => return self.submit_input(tx).await,
             (_, KeyCode::Backspace) => {
                 self.input.pop();

--- a/crates/cli/src/tui_app.rs
+++ b/crates/cli/src/tui_app.rs
@@ -700,13 +700,19 @@ impl TuiApp {
     }
 
     fn push_user_line(&mut self, text: &str) {
-        self.transcript.push(Line::from(vec![
-            Span::styled(
-                format!("{} user: ", compact_timestamp()),
-                Style::new().dim(),
-            ),
-            Span::styled(text.to_string(), Style::new().bold()),
-        ]));
+        // Ratatui lines cannot hold newlines; multi-line messages become one
+        // transcript line each, with the prefix only on the first.
+        for (index, piece) in text.split('\n').enumerate() {
+            let mut spans = Vec::new();
+            if index == 0 {
+                spans.push(Span::styled(
+                    format!("{} user: ", compact_timestamp()),
+                    Style::new().dim(),
+                ));
+            }
+            spans.push(Span::styled(piece.to_string(), Style::new().bold()));
+            self.transcript.push(Line::from(spans));
+        }
         self.scrollback = 0;
     }
 

--- a/crates/cli/src/tui_app.rs
+++ b/crates/cli/src/tui_app.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::future::Future;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -282,7 +283,13 @@ struct TuiApp {
     history_pos: Option<usize>,
     /// Lines scrolled up from the bottom; 0 means follow new output.
     scrollback: u16,
-    busy: bool,
+    /// A turn or command is in flight. Shared with the event watcher, which
+    /// pauses while set so it never re-renders messages the streaming path
+    /// already displayed.
+    busy: Arc<AtomicBool>,
+    /// Whether the terminal reports mouse events to us (wheel scrolling).
+    /// Toggled off to let the terminal's native text selection work.
+    mouse_captured: bool,
     spinner_frame: usize,
     session_id: Option<SessionId>,
     watch_after: Arc<Mutex<Option<EventId>>>,
@@ -312,7 +319,8 @@ impl TuiApp {
             input_history: Vec::new(),
             history_pos: None,
             scrollback: 0,
-            busy: false,
+            busy: Arc::new(AtomicBool::new(false)),
+            mouse_captured: true,
             spinner_frame: 0,
             session_id: None,
             watch_after,
@@ -349,7 +357,7 @@ impl TuiApp {
                     }
                 }
                 _ = tick.tick() => {
-                    if self.busy {
+                    if self.is_busy() {
                         self.spinner_frame = self.spinner_frame.wrapping_add(1);
                     }
                 }
@@ -401,6 +409,16 @@ impl TuiApp {
         match (key.modifiers, key.code) {
             (KeyModifiers::CONTROL, KeyCode::Char('c') | KeyCode::Char('d')) => return Ok(true),
             (KeyModifiers::CONTROL, KeyCode::Char('u')) => self.input.clear(),
+            // Release the mouse so the terminal's native text selection works,
+            // at the cost of wheel scrolling; toggle back when done.
+            (KeyModifiers::CONTROL, KeyCode::Char('t')) => {
+                self.mouse_captured = !self.mouse_captured;
+                let _ = if self.mouse_captured {
+                    crossterm::execute!(std::io::stdout(), EnableMouseCapture)
+                } else {
+                    crossterm::execute!(std::io::stdout(), DisableMouseCapture)
+                };
+            }
             (KeyModifiers::ALT, KeyCode::Enter) => self.input.push('\n'),
             (_, KeyCode::Enter) => return self.submit_input(tx).await,
             (_, KeyCode::Backspace) => {
@@ -435,7 +453,7 @@ impl TuiApp {
         match parse_repl_input(&line) {
             Ok(ReplInput::Empty) => {}
             Ok(ReplInput::Chat(text)) => {
-                if self.busy {
+                if self.is_busy() {
                     self.push_notice("still waiting on the previous turn");
                     self.input = line;
                     return Ok(false);
@@ -465,7 +483,7 @@ impl TuiApp {
     ) -> Result<bool> {
         // Sandbox and model operations run on a worker task so the UI keeps
         // drawing; one at a time keeps their output readable.
-        if self.busy && !matches!(command, ReplCommand::Quit) {
+        if self.is_busy() && !matches!(command, ReplCommand::Quit) {
             self.push_notice("still waiting on the previous operation");
             return Ok(false);
         }
@@ -518,7 +536,7 @@ impl TuiApp {
         tx: &mpsc::UnboundedSender<AppEvent>,
         work: impl Future<Output = Vec<String>> + Send + 'static,
     ) {
-        self.busy = true;
+        self.busy.store(true, Ordering::Relaxed);
         let tx = tx.clone();
         tokio::spawn(async move {
             let lines = work.await;
@@ -528,7 +546,7 @@ impl TuiApp {
     }
 
     fn start_send(&mut self, text: String, tx: mpsc::UnboundedSender<AppEvent>) {
-        self.busy = true;
+        self.busy.store(true, Ordering::Relaxed);
         self.open_assistant = None;
         self.assistant_prefixed = false;
         self.open_calls.clear();
@@ -566,7 +584,7 @@ impl TuiApp {
             AppEvent::Stream(event) => self.handle_stream_event(event),
             AppEvent::StreamError(error) => self.push_notice(&format!("stream error: {error}")),
             AppEvent::StreamDone => {
-                self.busy = false;
+                self.busy.store(false, Ordering::Relaxed);
                 self.open_assistant = None;
                 self.assistant_prefixed = false;
             }
@@ -697,6 +715,10 @@ impl TuiApp {
             .push(Line::styled(text.to_string(), Style::new().dim().italic()));
     }
 
+    fn is_busy(&self) -> bool {
+        self.busy.load(Ordering::Relaxed)
+    }
+
     fn history_step(&mut self, direction: isize) {
         if self.input_history.is_empty() {
             return;
@@ -727,11 +749,19 @@ impl TuiApp {
     ) -> tokio::task::JoinHandle<()> {
         let conversation = self.conversation.exoharness_handle();
         let watch_after = Arc::clone(&self.watch_after);
+        let busy = Arc::clone(&self.busy);
         let verbosity = self.verbosity;
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs(1));
             loop {
                 interval.tick().await;
+                // While a turn streams, the watcher's cursor lags the events
+                // being written; polling now would replay messages the
+                // streaming path already rendered. `Completed` advances the
+                // cursor before busy clears.
+                if busy.load(Ordering::Relaxed) {
+                    continue;
+                }
                 let cursor = *watch_after.lock().expect("watch cursor poisoned");
                 let Ok(result) = conversation
                     .get_events(Some(EventQuery {
@@ -813,13 +843,18 @@ impl TuiApp {
             input_area.y + 1 + (total_rows - 1 - input_scroll),
         ));
 
-        let state = if self.busy {
+        let state = if self.is_busy() {
             format!("{} thinking…", SPINNER[self.spinner_frame % SPINNER.len()])
         } else {
             "idle".to_string()
         };
+        let mouse = if self.mouse_captured {
+            "Ctrl+T to select text"
+        } else {
+            "mouse released: select text freely, Ctrl+T to restore scrolling"
+        };
         let status = Line::from(format!(
-            " {state} · verbosity {} · wheel/PgUp scroll · ↑↓ history · Esc follow · Ctrl+C quit",
+            " {state} · verbosity {} · wheel/PgUp scroll · ↑↓ history · Esc follow · {mouse} · Ctrl+C quit",
             self.verbosity
         ))
         .style(Style::new().dim());

--- a/crates/cli/src/tui_app.rs
+++ b/crates/cli/src/tui_app.rs
@@ -1,9 +1,3 @@
-//! Prototype full-screen TUI for the chat repl (`exo repl --tui`).
-//!
-//! Unlike the line-mode repl, the transcript is app state we own, so streamed
-//! text, tool-call lines, and their `✓`/`✗` receipts are just mutations of a
-//! line buffer — no terminal tricks, and typing never interleaves with output.
-
 use std::collections::HashMap;
 use std::future::Future;
 use std::sync::{Arc, Mutex};
@@ -38,8 +32,7 @@ const SPINNER: [&str; 4] = ["|", "/", "-", "\\"];
 
 // Slash-command registry for the TUI: names, aliases, arguments, and help all
 // live in this clap tree. `multicall` makes the first token the command name,
-// and clap's built-in `help` subcommand serves `/help`. The line-mode repl
-// keeps its own simpler handwritten parser.
+// and clap's built-in `help` subcommand serves `/help`.
 #[derive(Debug, clap::Parser)]
 #[command(name = "repl", multicall = true, about = "repl slash commands")]
 struct ReplCli {
@@ -52,8 +45,6 @@ enum ReplCommand {
     /// Exit the repl
     #[command(alias = "exit")]
     Quit,
-    /// Reprint the conversation transcript
-    History,
     /// Summarize token usage and dollar cost
     #[command(alias = "usage")]
     Cost,
@@ -382,7 +373,6 @@ impl TuiApp {
         let conversation = Arc::clone(&self.conversation);
         match command {
             ReplCommand::Quit => return Ok(true),
-            ReplCommand::History => self.load_transcript().await?,
             ReplCommand::Verbosity { level } => match level {
                 Some(verbosity) => {
                     self.verbosity = verbosity;

--- a/crates/cli/src/tui_app.rs
+++ b/crates/cli/src/tui_app.rs
@@ -30,11 +30,101 @@ use crate::render::{
     render_tool_result, render_transcript_lines,
 };
 use crate::tui::{
-    ReplCommand, ReplInput, chunk_text, cost_lines, parse_repl_input, render_external_event,
-    rewind_lines, shell_lines, snapshot_lines, snapshots_lines, teleport_lines,
+    chunk_text, cost_lines, render_external_event, rewind_lines, shell_lines, snapshot_lines,
+    snapshots_lines, teleport_lines,
 };
 
 const SPINNER: [&str; 4] = ["|", "/", "-", "\\"];
+
+// Slash-command registry for the TUI: names, aliases, arguments, and help all
+// live in this clap tree. `multicall` makes the first token the command name,
+// and clap's built-in `help` subcommand serves `/help`. The line-mode repl
+// keeps its own simpler handwritten parser.
+#[derive(Debug, clap::Parser)]
+#[command(name = "repl", multicall = true, about = "repl slash commands")]
+struct ReplCli {
+    #[command(subcommand)]
+    command: ReplCommand,
+}
+
+#[derive(Debug, PartialEq, clap::Subcommand)]
+enum ReplCommand {
+    /// Exit the repl
+    #[command(alias = "exit")]
+    Quit,
+    /// Reprint the conversation transcript
+    History,
+    /// Summarize token usage and dollar cost
+    #[command(alias = "usage")]
+    Cost,
+    /// Show or set how much tool detail is printed
+    Verbosity {
+        #[arg(value_enum)]
+        level: Option<Verbosity>,
+    },
+    /// Run a command in the conversation's sandbox
+    #[command(alias = "sandbox")]
+    Shell {
+        /// Shell source, passed to the sandbox verbatim
+        command: String,
+    },
+    /// Snapshot a sandbox in this conversation (defaults to the latest one)
+    Snapshot { sandbox_id: Option<String> },
+    /// List snapshots taken in this conversation
+    Snapshots,
+    /// Restore the sandbox to a previous snapshot
+    Rewind { snapshot_id: String },
+    /// Move the live sandbox to another provider (e.g. daytona: snapshot + restore there)
+    Teleport { provider: String },
+}
+
+/// What a line of repl input means.
+#[derive(Debug, PartialEq)]
+enum ReplInput {
+    Empty,
+    /// Plain chat text for the model.
+    Chat(String),
+    Command(ReplCommand),
+}
+
+fn parse_repl_input(line: &str) -> Result<ReplInput, clap::Error> {
+    use clap::{CommandFactory, Parser};
+
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return Ok(ReplInput::Empty);
+    }
+    let Some(stripped) = trimmed.strip_prefix('/') else {
+        return Ok(ReplInput::Chat(trimmed.to_string()));
+    };
+    // `//text` escapes to the chat message `/text`.
+    if stripped.starts_with('/') {
+        return Ok(ReplInput::Chat(stripped.to_string()));
+    }
+    // A lone `/` shows the command list.
+    if stripped.is_empty() {
+        return Err(ReplCli::try_parse_from(["help"])
+            .expect_err("the help subcommand always short-circuits into an error"));
+    }
+
+    let (head, rest) = match stripped.split_once(char::is_whitespace) {
+        Some((head, rest)) => (head, rest.trim()),
+        None => (stripped, ""),
+    };
+    // Shell source must reach the sandbox verbatim: shlex-splitting and
+    // rejoining would change quoting, expansion, pipes, and redirections.
+    let argv: Vec<String> = if matches!(head, "shell" | "sandbox") && !rest.is_empty() {
+        vec![head.to_string(), rest.to_string()]
+    } else {
+        shlex::split(stripped).ok_or_else(|| {
+            ReplCli::command().error(
+                clap::error::ErrorKind::InvalidValue,
+                "unbalanced quotes in command input",
+            )
+        })?
+    };
+    Ok(ReplInput::Command(ReplCli::try_parse_from(argv)?.command))
+}
 
 /// The input box grows with wrapped content up to this many text rows, then
 /// scrolls vertically.
@@ -666,5 +756,104 @@ fn status_style(status: &str) -> Style {
         Style::new().green()
     } else {
         Style::new().red()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ReplCommand, ReplInput, parse_repl_input};
+    use crate::render::Verbosity;
+
+    #[test]
+    fn parses_blank_and_chat_input() {
+        assert_eq!(parse_repl_input("   ").unwrap(), ReplInput::Empty);
+        assert_eq!(
+            parse_repl_input(" hello there ").unwrap(),
+            ReplInput::Chat("hello there".to_string())
+        );
+    }
+
+    #[test]
+    fn double_slash_escapes_to_slash_prefixed_chat() {
+        assert_eq!(
+            parse_repl_input("//quit is a command").unwrap(),
+            ReplInput::Chat("/quit is a command".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_commands_and_aliases() {
+        assert_eq!(
+            parse_repl_input("/quit").unwrap(),
+            ReplInput::Command(ReplCommand::Quit)
+        );
+        assert_eq!(
+            parse_repl_input("/exit").unwrap(),
+            ReplInput::Command(ReplCommand::Quit)
+        );
+        assert_eq!(
+            parse_repl_input("/usage").unwrap(),
+            ReplInput::Command(ReplCommand::Cost)
+        );
+        assert_eq!(
+            parse_repl_input("/verbosity full").unwrap(),
+            ReplInput::Command(ReplCommand::Verbosity {
+                level: Some(Verbosity::Full)
+            })
+        );
+        assert_eq!(
+            parse_repl_input("/snapshot abc").unwrap(),
+            ReplInput::Command(ReplCommand::Snapshot {
+                sandbox_id: Some("abc".to_string())
+            })
+        );
+    }
+
+    #[test]
+    fn shell_source_is_preserved_verbatim() {
+        let input = r#"/shell echo "a  b" | grep 'a' > /tmp/out"#;
+        assert_eq!(
+            parse_repl_input(input).unwrap(),
+            ReplInput::Command(ReplCommand::Shell {
+                command: r#"echo "a  b" | grep 'a' > /tmp/out"#.to_string()
+            })
+        );
+        assert_eq!(
+            parse_repl_input("/sandbox ls -la").unwrap(),
+            ReplInput::Command(ReplCommand::Shell {
+                command: "ls -la".to_string()
+            })
+        );
+    }
+
+    #[test]
+    fn shell_without_source_is_a_usage_error() {
+        let error = parse_repl_input("/shell").unwrap_err();
+        assert_eq!(
+            error.kind(),
+            clap::error::ErrorKind::MissingRequiredArgument
+        );
+    }
+
+    #[test]
+    fn unknown_commands_error_instead_of_reaching_the_model() {
+        let error = parse_repl_input("/snapshoot abc").unwrap_err();
+        assert_eq!(error.kind(), clap::error::ErrorKind::InvalidSubcommand);
+        assert!(error.to_string().contains("snapshot"), "suggests the fix");
+    }
+
+    #[test]
+    fn extra_arguments_are_clap_errors() {
+        assert!(parse_repl_input("/snapshot one two").is_err());
+        assert!(parse_repl_input("/rewind").is_err());
+    }
+
+    #[test]
+    fn help_is_generated_from_the_command_tree() {
+        let error = parse_repl_input("/help").unwrap_err();
+        assert_eq!(error.kind(), clap::error::ErrorKind::DisplayHelp);
+        let rendered = error.to_string();
+        assert!(rendered.contains("snapshot"));
+        assert!(rendered.contains("teleport"));
     }
 }


### PR DESCRIPTION
## Summary

This PR contains a large QOL improvement for our TUI, moving to be using [ratatui](https://ratatui.rs/) instead of being hand-rolled. EDIT: I am leaving the old tui still available by adding the --legacy-tui flag in the cli when using repl, in case anybody wants it in the short term. We can remove it in a week or two. Preferring tos et this as the new default because it is much friendly and easier to look at.

`./target/debug/exo repl --conversation <slug>` to launch.

The main changes are...

Verbosity support:
 - added /verbosity [minimal,compact,full], which changes how tool calls are displayed.

Some examples for a relevant query for me about weather in Ethiopia and London:

Compact -> shows single line per toolcall
<img width="1074" height="279" alt="image" src="https://github.com/user-attachments/assets/875aad97-df91-4062-9b86-c7a7c2b3a4d8" />
Full -> shows as it does today, full json of the tool call, good for full inspection/debugging
<img width="1086" height="748" alt="image" src="https://github.com/user-attachments/assets/35bf7815-6aa1-457d-b9c8-4d127debadb7" />
Minimal -> hides toolcalls, shows chat only
<img width="1082" height="218" alt="image" src="https://github.com/user-attachments/assets/76a1e44c-97a9-4ae6-bad6-08cb34511d1d" />

The new default is Compact, which is much easier to use.


TUI features:
 - verbosity changes re-render all text immediately, hides/shows details
 - scroll history via scroll-wheel
 - bring past messages in via up/down arrow
 - shows "thinking" while agent is processing
 - agent name and convo name shown at top
 - quit via ctrl+c
 - command handling *greatly* improved:
   - typos in commands get caught, rather than being sent to the model as a user message
   - /help content is autogenerated from commands, not manually written
 - user input box handles pastes, resizing to accommodate larger text, & alt + enter for new lines
  