### PR TITLE
Add ACP streaming transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2231,6 +2231,7 @@ version = "0.1.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
+ "async-trait",
  "bytes",
  "clap",
  "cost",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -182,7 +182,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -193,32 +193,12 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aead"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
-dependencies = [
- "crypto-common 0.1.7",
- "generic-array",
-]
-
-[[package]]
-name = "aead"
 version = "0.6.0-rc.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b657e772794c6b04730ea897b66a058ccd866c16d1967da05eeeecec39043fe"
 dependencies = [
  "crypto-common 0.2.1",
  "inout 0.2.2",
-]
-
-[[package]]
-name = "aegis"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78412fa53e6da95324e8902c3641b3ff32ab45258582ea997eb9169c68ffa219"
-dependencies = [
- "cc",
- "softaes",
 ]
 
 [[package]]
@@ -245,30 +225,66 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
-dependencies = [
- "aead 0.5.2",
- "aes 0.8.4",
- "cipher 0.4.4",
- "ctr 0.9.2",
- "ghash 0.5.1",
- "subtle",
-]
-
-[[package]]
-name = "aes-gcm"
 version = "0.11.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e22c0c90bbe8d4f77c3ca9ddabe41a1f8382d6fc1f7cea89459d0f320371f972"
 dependencies = [
- "aead 0.6.0-rc.10",
+ "aead",
  "aes 0.9.0",
  "cipher 0.5.1",
- "ctr 0.10.0",
- "ghash 0.6.0",
+ "ctr",
+ "ghash",
  "subtle",
+]
+
+[[package]]
+name = "agent-client-protocol"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d87bc7769eba641753ba5dc52f73ec3765d51022c6753bf040967125ddc86a8"
+dependencies = [
+ "agent-client-protocol-derive",
+ "agent-client-protocol-schema",
+ "async-io",
+ "async-process",
+ "blocking",
+ "futures",
+ "futures-concurrency",
+ "rustc-hash",
+ "rustix",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "shell-words",
+ "tracing",
+ "uuid",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "agent-client-protocol-derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3abd4080f51e4f24f5042beb7fb7a66ede29a2dc1c2582c329532e1c27264ddc"
+dependencies = [
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "agent-client-protocol-schema"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5c231915b4ab578c722eca2d1bd7df4d300bfd6cac3b8e9f0d1e3ddc95b187c"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "strum",
+ "tracing",
 ]
 
 [[package]]
@@ -300,20 +316,6 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
-
-[[package]]
-name = "android-native-keyring-store"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e473c725eac862e418e7c3296059e72cdb7bbfb6ffefe625a452be988b2cd44f"
-dependencies = [
- "base64",
- "jni",
- "keyring-core",
- "ndk-context",
- "thiserror 2.0.18",
- "tracing",
-]
 
 [[package]]
 name = "android_system_properties"
@@ -382,9 +384,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "apple-native-keyring-store"
-version = "0.2.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdab02b2a5e47c080382cb729e8fc53bedf4a498200fc72a4e6c691033a3f7b"
+checksum = "797f94b6a53d7d10b56dc18290e0d40a2158352f108bb4ff32350825081a9f29"
 dependencies = [
  "keyring-core",
  "log",
@@ -479,7 +481,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 1.1.4",
+ "rustix",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -510,7 +512,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix 1.1.4",
+ "rustix",
 ]
 
 [[package]]
@@ -521,7 +523,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -536,7 +538,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 1.1.4",
+ "rustix",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -556,7 +558,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -968,7 +970,7 @@ checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1084,29 +1086,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.11.0",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn",
- "which",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1117,9 +1096,6 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "block-buffer"
@@ -1173,7 +1149,7 @@ dependencies = [
  "boa_string",
  "indexmap 2.13.0",
  "num-bigint",
- "rustc-hash 2.1.2",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -1209,7 +1185,7 @@ dependencies = [
  "portable-atomic",
  "rand 0.8.5",
  "regress",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "ryu-js",
  "serde",
  "serde_json",
@@ -1246,7 +1222,7 @@ dependencies = [
  "indexmap 2.13.0",
  "once_cell",
  "phf",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "static_assertions",
 ]
 
@@ -1258,7 +1234,7 @@ checksum = "9fd3f870829131332587f607a7ff909f1af5fc523fd1b192db55fbbdf52e8d3c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -1278,7 +1254,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "regress",
- "rustc-hash 2.1.2",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -1295,7 +1271,7 @@ checksum = "7debc13fbf7997bf38bf8e9b20f1ad5e2a7d27a900e1f6039fe244ce30f589b5"
 dependencies = [
  "fast-float2",
  "paste",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "sptr",
  "static_assertions",
 ]
@@ -1322,7 +1298,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1407,15 +1383,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "branches"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e426eb5cc1900033930ec955317b302e68f19f326cc7bb0c8a86865a826cdf0c"
-dependencies = [
- "rustc_version",
-]
-
-[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1437,13 +1404,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "built"
-version = "0.7.7"
+name = "bs58"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56ed6191a7e78c36abdb16ab65341eefd73d64d303fffccdbb00d51e4205967b"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
- "chrono",
- "git2",
+ "tinyvec",
 ]
 
 [[package]]
@@ -1469,7 +1435,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1525,21 +1491,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1550,12 +1501,6 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
-name = "cfg_block"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18758054972164c3264f7c8386f5fc6da6114cb46b619fd365d4e3b2dc3ae487"
 
 [[package]]
 name = "chacha20"
@@ -1604,17 +1549,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
-]
-
-[[package]]
 name = "clap"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1645,7 +1579,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1683,16 +1617,6 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
-
-[[package]]
-name = "combine"
-version = "4.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
-dependencies = [
- "bytes",
- "memchr",
-]
 
 [[package]]
 name = "compression-codecs"
@@ -1865,16 +1789,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-skiplist"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df29de440c58ca2cc6e587ec3d22347551a32435fbde9d2bff64e78a9ffa151b"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1899,7 +1813,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1912,15 +1825,6 @@ dependencies = [
  "getrandom 0.4.2",
  "hybrid-array",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "ctr"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
-dependencies = [
- "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1965,7 +1869,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1988,7 +1892,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1999,7 +1903,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2027,7 +1931,6 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core 0.9.12",
- "serde",
 ]
 
 [[package]]
@@ -2035,59 +1938,6 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
-
-[[package]]
-name = "db-keystore"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98e7a76c30fd9fcb0b9e46a848028bb82d8cc9854fb3d4f9db8851b7db2648fe"
-dependencies = [
- "futures",
- "keyring-core",
- "regex",
- "turso",
- "uuid",
-]
-
-[[package]]
-name = "dbus"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
-dependencies = [
- "libc",
- "libdbus-sys",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "dbus-secret-service"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
-dependencies = [
- "aes 0.8.4",
- "block-padding",
- "cbc",
- "dbus",
- "fastrand",
- "hkdf",
- "num",
- "once_cell",
- "openssl",
- "sha2 0.10.9",
- "zeroize",
-]
-
-[[package]]
-name = "dbus-secret-service-keyring-store"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec3a0f31addb56ee6d5c55599068d2093bc737469a448b34e426603ef61f93e"
-dependencies = [
- "dbus-secret-service",
- "keyring-core",
-]
 
 [[package]]
 name = "deadpool"
@@ -2147,7 +1997,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn",
+ "syn 2.0.117",
  "unicode-xid",
 ]
 
@@ -2183,7 +2033,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2302,26 +2152,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "env_filter"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
-dependencies = [
- "log",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
-dependencies = [
- "env_filter",
- "log",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2389,6 +2220,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tracing",
  "url",
 ]
@@ -2397,6 +2229,7 @@ dependencies = [
 name = "exo"
 version = "0.1.0"
 dependencies = [
+ "agent-client-protocol",
  "anyhow",
  "bytes",
  "clap",
@@ -2412,8 +2245,10 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "wiremock",
 ]
 
@@ -2433,7 +2268,7 @@ name = "exoharness"
 version = "0.1.0"
 dependencies = [
  "actix-web",
- "aes-gcm 0.11.0-rc.3",
+ "aes-gcm",
  "anyhow",
  "async-trait",
  "aws-config",
@@ -2444,7 +2279,6 @@ dependencies = [
  "chrono",
  "futures",
  "keyring",
- "keyring-core",
  "lingua",
  "object_store",
  "reqwest",
@@ -2463,28 +2297,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fallible-iterator"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
-
-[[package]]
 name = "fast-float2"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
-
-[[package]]
-name = "fastbloom"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
-dependencies = [
- "getrandom 0.3.4",
- "libm",
- "rand 0.9.4",
- "siphasher",
-]
 
 [[package]]
 name = "fastrand"
@@ -2499,7 +2315,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -2524,6 +2340,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -2554,21 +2376,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2585,9 +2392,9 @@ checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2600,25 +2407,38 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
 dependencies = [
  "futures-core",
  "futures-sink",
 ]
 
 [[package]]
-name = "futures-core"
-version = "0.3.32"
+name = "futures-concurrency"
+version = "7.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
+dependencies = [
+ "fixedbitset",
+ "futures-core",
+ "futures-lite",
+ "pin-project",
+ "smallvec",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2627,9 +2447,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-lite"
@@ -2646,32 +2466,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2683,21 +2503,6 @@ dependencies = [
  "pin-project-lite",
  "slab",
 ]
-
-[[package]]
-name = "genawaiter"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86bd0361bcbde39b13475e6e36cb24c329964aa2611be285289d1e4b751c1a0"
-dependencies = [
- "genawaiter-macro",
-]
-
-[[package]]
-name = "genawaiter-macro"
-version = "0.99.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b32dfe1fdfc0bbde1f22a5da25355514b5e450c33a6af6770884c8750aedfbc"
 
 [[package]]
 name = "generic-array"
@@ -2753,41 +2558,12 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
-dependencies = [
- "opaque-debug",
- "polyval 0.6.2",
-]
-
-[[package]]
-name = "ghash"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eecf2d5dc9b66b732b97707a0210906b1d30523eb773193ab777c0c84b3e8d5"
 dependencies = [
- "polyval 0.7.1",
+ "polyval",
 ]
-
-[[package]]
-name = "git2"
-version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
-dependencies = [
- "bitflags 2.11.0",
- "libc",
- "libgit2-sys",
- "log",
- "url",
-]
-
-[[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "group"
@@ -3331,7 +3107,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3437,17 +3213,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-uring"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d09b98f7eace8982db770e4408e7470b028ce513ac28fecdc6bf4c30fe92b62"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "libc",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3468,15 +3233,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -3501,50 +3257,6 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
-
-[[package]]
-name = "jni"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
-dependencies = [
- "cesu8",
- "cfg-if",
- "combine",
- "jni-sys 0.3.1",
- "log",
- "thiserror 1.0.69",
- "walkdir",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
-dependencies = [
- "jni-sys 0.4.1",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
-dependencies = [
- "jni-sys-macros",
-]
-
-[[package]]
-name = "jni-sys-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
-dependencies = [
- "quote",
- "syn",
-]
 
 [[package]]
 name = "jobserver"
@@ -3594,39 +3306,23 @@ dependencies = [
 
 [[package]]
 name = "keyring"
-version = "4.0.0-rc.3"
+version = "4.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bbe20062ef0c05c6c0f215d3a84eb1288fea17c2c4fa3a10e9e8ec9ff741f0"
+checksum = "0298a59b384c540e408a600c8b375a09b49c3f97debc080e2c30675d79a6368a"
 dependencies = [
- "android-native-keyring-store",
  "apple-native-keyring-store",
- "base64",
- "clap",
- "db-keystore",
- "dbus-secret-service-keyring-store",
- "fastrand",
  "keyring-core",
- "linux-keyutils-keyring-store",
- "rpassword",
- "rprompt",
  "windows-native-keyring-store",
  "zbus-secret-service-keyring-store",
- "zeroize",
 ]
 
 [[package]]
 name = "keyring-core"
-version = "0.7.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f668c4c52e5e79879d9ce68b2da363b78a378c4becae267f8cfc26c55db4ed3"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
 dependencies = [
- "chrono",
- "dashmap 6.1.0",
  "log",
- "regex",
- "ron",
- "serde",
- "uuid",
 ]
 
 [[package]]
@@ -3645,12 +3341,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3663,63 +3353,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
-name = "libdbus-sys"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
-name = "libgit2-sys"
-version = "0.18.3+1.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "libmimalloc-sys"
-version = "0.1.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc89deee4af0429081d2a518c0431ae068222a5a262a3bc6ff4d8535ec2e02fe"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "lingua"
@@ -3748,32 +3385,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
 ]
-
-[[package]]
-name = "linux-keyutils"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
-dependencies = [
- "bitflags 2.11.0",
- "libc",
-]
-
-[[package]]
-name = "linux-keyutils-keyring-store"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07ce18cd294ff2e5de4ad61a8659a123e068859feafce12525511931f4f3d1a4"
-dependencies = [
- "keyring-core",
- "linux-keyutils",
-]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3841,15 +3452,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "matchers"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
-dependencies = [
- "regex-automata",
-]
-
-[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3875,37 +3477,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "miette"
-version = "7.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
-dependencies = [
- "cfg-if",
- "miette-derive",
- "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "miette-derive"
-version = "7.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "mimalloc"
-version = "0.1.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aca3c01a711f395b4257b81674c0e90e8dd1f1e62c4b7db45f684cc7a4fcb18a"
-dependencies = [
- "libmimalloc-sys",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3920,12 +3491,6 @@ dependencies = [
  "mime",
  "unicase",
 ]
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -3950,12 +3515,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ndk-context"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
-
-[[package]]
 name = "nibble_vec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3974,16 +3533,6 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -4121,7 +3670,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4184,64 +3733,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
-name = "openssl"
-version = "0.10.78"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-src"
-version = "300.6.0+3.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8e8cbfd3a4a8c8f089147fd7aaa33cf8c7450c4d09f8f80698a0cf093abeff4"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.114"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
-dependencies = [
- "cc",
- "libc",
- "openssl-src",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "ordered-float"
@@ -4290,15 +3785,6 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "sha2 0.10.9",
-]
-
-[[package]]
-name = "pack1"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6e7cd9bd638dc2c831519a0caa1c006cab771a92b1303403a8322773c5b72d6"
-dependencies = [
- "bytemuck",
 ]
 
 [[package]]
@@ -4416,7 +3902,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4445,7 +3931,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4508,7 +3994,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -4520,25 +4006,13 @@ checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
 name = "polyval"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "opaque-debug",
- "universal-hash 0.5.1",
-]
-
-[[package]]
-name = "polyval"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dfc63250416fea14f5749b90725916a6c903f599d51cb635aa7a52bfd03eede"
 dependencies = [
  "cpubits",
  "cpufeatures 0.3.0",
- "universal-hash 0.6.1",
+ "universal-hash",
 ]
 
 [[package]]
@@ -4578,7 +4052,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4609,29 +4083,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.14.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4652,7 +4103,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls 0.23.37",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -4672,7 +4123,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls 0.23.37",
  "rustls-pki-types",
  "slab",
@@ -4804,15 +4255,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
-name = "rapidhash"
-version = "4.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4847,7 +4289,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5010,50 +4452,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "roaring"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
-dependencies = [
- "bytemuck",
- "byteorder",
-]
-
-[[package]]
-name = "ron"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db09040cc89e461f1a265139777a2bde7f8d8c67c4936f700c63ce3e2904d468"
-dependencies = [
- "base64",
- "bitflags 2.11.0",
- "serde",
- "serde_derive",
- "unicode-ident",
-]
-
-[[package]]
-name = "rpassword"
-version = "7.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d4c8b64f049c6721ec8ccec37ddfc3d641c4a7fca57e8f2a89de509c73df39"
-dependencies = [
- "libc",
- "rtoolbox",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rprompt"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69abf524bb9ccb7c071f7231441288d74b48d176cb309eb00e6f77d186c6e035"
-dependencies = [
- "rtoolbox",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "rsa"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5074,22 +4472,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rtoolbox"
-version = "0.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50a0e551c1e27e1731aba276dbeaeac73f53c7cd34d1bda485d02bd1e0f36844"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5106,19 +4488,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.11.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -5126,7 +4495,7 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -5233,7 +4602,7 @@ dependencies = [
  "nix",
  "radix_trie",
  "unicode-segmentation",
- "unicode-width 0.2.0",
+ "unicode-width",
  "utf8parse",
  "windows-sys 0.59.0",
 ]
@@ -5288,8 +4657,21 @@ checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
+ "schemars_derive",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5408,7 +4790,18 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5417,6 +4810,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.13.0",
  "itoa",
  "memchr",
  "serde",
@@ -5432,7 +4826,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5449,11 +4843,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -5468,14 +4863,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5514,12 +4909,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1_smol"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5549,6 +4938,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -5595,15 +4990,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simsimd"
-version = "6.5.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fb3bc3cdce07a7d7d4caa4c54f8aa967f6be41690482b54b24100a2253fa70"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5640,12 +5026,6 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "softaes"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef461faaeb36c340b6c887167a9054a034f6acfc50a014ead26a02b4356b3de"
 
 [[package]]
 name = "spin"
@@ -5689,24 +5069,23 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5716,16 +5095,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
-name = "symlink"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
-
-[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5749,7 +5133,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5758,7 +5142,7 @@ version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fce91f2f0ec87dff7e6bcbbeb267439aa1188703003c6055193c821487400432"
 dependencies = [
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -5776,7 +5160,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -5821,7 +5205,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5832,7 +5216,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5938,7 +5322,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6095,19 +5479,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-appender"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
-dependencies = [
- "crossbeam-channel",
- "symlink",
- "thiserror 2.0.18",
- "time",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "tracing-attributes"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6115,7 +5486,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6145,14 +5516,10 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
- "matchers",
  "nu-ansi-term",
- "once_cell",
- "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
- "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -6181,7 +5548,7 @@ checksum = "ee6ff59666c9cbaec3533964505d39154dc4e0a56151fdea30a09ed0301f62e2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "termcolor",
 ]
 
@@ -6205,188 +5572,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "turso"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2fe423c2c954948babb36edda12b737e321d8541d4eae519694f7d512ecab6"
-dependencies = [
- "mimalloc",
- "thiserror 2.0.18",
- "tracing",
- "tracing-subscriber",
- "turso_sdk_kit",
- "turso_sync_sdk_kit",
-]
-
-[[package]]
-name = "turso_core"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a8b54994ee025964459322bcdb4f6f78c5dba82643863dabfac680f16c8afa8"
-dependencies = [
- "aegis",
- "aes 0.8.4",
- "aes-gcm 0.10.3",
- "arc-swap",
- "bitflags 2.11.0",
- "branches",
- "built",
- "bumpalo",
- "bytemuck",
- "cfg_block",
- "chrono",
- "crossbeam-skiplist",
- "either",
- "fallible-iterator",
- "fastbloom",
- "hex",
- "intrusive-collections",
- "io-uring",
- "libc",
- "libloading",
- "libm",
- "miette",
- "pack1",
- "parking_lot 0.12.5",
- "paste",
- "polling",
- "rand 0.9.4",
- "rapidhash",
- "regex",
- "regex-syntax",
- "roaring",
- "rustc-hash 2.1.2",
- "rustix 1.1.4",
- "ryu",
- "simsimd",
- "strum",
- "strum_macros",
- "tempfile",
- "thiserror 2.0.18",
- "tracing",
- "tracing-subscriber",
- "turso_ext",
- "turso_macros",
- "turso_parser",
- "twox-hash",
- "uncased",
- "uuid",
-]
-
-[[package]]
-name = "turso_ext"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2de917b4c5881bfb34ccbb1dcf4992773bc39853eacf248955f2ece7e3cb3049"
-dependencies = [
- "chrono",
- "getrandom 0.3.4",
- "turso_macros",
-]
-
-[[package]]
-name = "turso_macros"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2f62bb271d4cf202bc2acbeb8e2c3f764ec754924f144e704cdcba2e5b0c84"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "turso_parser"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ad89caa1c4888756bd027485499d1dc4c8420d15887ab32aa28b707c411221"
-dependencies = [
- "bitflags 2.11.0",
- "memchr",
- "miette",
- "strum",
- "strum_macros",
- "thiserror 2.0.18",
- "turso_macros",
-]
-
-[[package]]
-name = "turso_sdk_kit"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00ff5b2cadd6c8b749511648d50c95f69bfa52efc5d88cc2e2deedd0beeb6c89"
-dependencies = [
- "bindgen",
- "env_logger",
- "tracing",
- "tracing-appender",
- "tracing-subscriber",
- "turso_core",
- "turso_sdk_kit_macros",
-]
-
-[[package]]
-name = "turso_sdk_kit_macros"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "289f7ea7499419e6670363ca18e954ed53397bb1e03ab7eabbb267d9b05ab836"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "turso_sync_engine"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9860c615a7d8df43fc6ac4293636e9d743c1693513c81be22f0e9388624f58"
-dependencies = [
- "base64",
- "bytes",
- "genawaiter",
- "http 1.4.0",
- "libc",
- "prost",
- "roaring",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tracing",
- "turso_core",
- "turso_parser",
- "uuid",
-]
-
-[[package]]
-name = "turso_sync_sdk_kit"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b669b19a5f4bfa7cfdf5045af36ca4a2087431c0d2844ec539ddcf951b5c9d2"
-dependencies = [
- "bindgen",
- "env_logger",
- "genawaiter",
- "parking_lot 0.12.5",
- "tracing",
- "tracing-appender",
- "tracing-subscriber",
- "turso_core",
- "turso_sdk_kit",
- "turso_sdk_kit_macros",
- "turso_sync_engine",
-]
-
-[[package]]
-name = "twox-hash"
-version = "2.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
-dependencies = [
- "rand 0.9.4",
-]
-
-[[package]]
 name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6401,15 +5586,6 @@ dependencies = [
  "memoffset",
  "tempfile",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "uncased"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
-dependencies = [
- "version_check",
 ]
 
 [[package]]
@@ -6432,12 +5608,6 @@ checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
@@ -6447,16 +5617,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "universal-hash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
-dependencies = [
- "crypto-common 0.1.7",
- "subtle",
-]
 
 [[package]]
 name = "universal-hash"
@@ -6531,7 +5691,6 @@ dependencies = [
  "getrandom 0.3.4",
  "js-sys",
  "serde_core",
- "sha1_smol",
  "wasm-bindgen",
 ]
 
@@ -6540,12 +5699,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -6644,7 +5797,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -6758,18 +5911,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6821,7 +5962,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6832,7 +5973,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6843,9 +5984,9 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-native-keyring-store"
-version = "0.5.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e26ac29479a4b7f49d46afc9893122fc345430c6307d1fb7ac0d8d066c3f54"
+checksum = "063426e76fdec7438d56bb777f67e318a84a25c707b07e575cb8b78e10c028f8"
 dependencies = [
  "byteorder",
  "keyring-core",
@@ -6874,20 +6015,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -6896,7 +6028,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -6910,40 +6042,19 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
  "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -6953,21 +6064,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6983,21 +6082,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7007,21 +6094,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7100,7 +6175,7 @@ dependencies = [
  "heck",
  "indexmap 2.13.0",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -7116,7 +6191,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -7213,7 +6288,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -7225,7 +6300,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -7251,7 +6326,7 @@ dependencies = [
  "hex",
  "libc",
  "ordered-stream",
- "rustix 1.1.4",
+ "rustix",
  "serde",
  "serde_repr",
  "tracing",
@@ -7266,9 +6341,9 @@ dependencies = [
 
 [[package]]
 name = "zbus-secret-service-keyring-store"
-version = "0.2.2"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf419566ebb630f83a49d67ef0b6c719c827fa04a8486a19f0808102d5a7f9ea"
+checksum = "4ccede190ba363386a24e8021c7f3848393976609ec9f5d1f8c6c09ef37075b4"
 dependencies = [
  "keyring-core",
  "secret-service",
@@ -7284,7 +6359,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -7318,7 +6393,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7338,7 +6413,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -7359,7 +6434,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7403,7 +6478,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7414,7 +6489,7 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7474,7 +6549,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "zvariant_utils",
 ]
 
@@ -7487,6 +6562,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn",
+ "syn 2.0.117",
  "winnow 0.7.15",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = "1.95"
 
 [workspace.dependencies]
 anyhow = "1.0.100"
+agent-client-protocol = "=2.0.0"
 async-trait = "0.1.89"
 actix-web = "4.9.0"
 aws-config = "1.8.17"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -32,6 +32,7 @@ tracing-subscriber.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
+async-trait.workspace = true
 bytes.workspace = true
 exoharness = { path = "../exoharness", features = [
   "basic-backend",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow.workspace = true
+agent-client-protocol.workspace = true
 clap.workspace = true
 cost = { path = "../cost" }
 executor = { path = "../executor" }
@@ -25,8 +26,10 @@ serde_json.workspace = true
 tabwriter.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
+tokio-util.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 bytes.workspace = true

--- a/crates/cli/src/acp.rs
+++ b/crates/cli/src/acp.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 
 use agent_client_protocol::schema::ProtocolVersion;
 use agent_client_protocol::schema::v1 as acp;
-use agent_client_protocol::{Agent, ConnectionTo, Responder, Stdio};
+use agent_client_protocol::{Agent, ConnectTo, ConnectionTo, Responder, Stdio};
 use anyhow::Result;
 use executor::{
     ExecutionCancellation, ExecutionStreamEvent, HarnessConversation, SendRequest, SessionId,
@@ -91,6 +91,13 @@ impl SessionState {
 
 /// Serve the conversation until the ACP stdio transport closes.
 pub async fn serve(conversation: Arc<dyn HarnessConversation>) -> Result<()> {
+    serve_transport(conversation, Stdio::new()).await
+}
+
+async fn serve_transport(
+    conversation: Arc<dyn HarnessConversation>,
+    transport: impl ConnectTo<Agent>,
+) -> Result<()> {
     let state = SessionState::new(conversation);
     let new_state = state.clone();
     let prompt_state = state.clone();
@@ -180,7 +187,7 @@ pub async fn serve(conversation: Arc<dyn HarnessConversation>) -> Result<()> {
             },
             agent_client_protocol::on_receive_notification!(),
         )
-        .connect_to(Stdio::new())
+        .connect_to(transport)
         .await?;
     Ok(())
 }
@@ -319,6 +326,97 @@ fn chunk_text(chunk: &lingua::UniversalStreamChunk) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use agent_client_protocol::{Channel, Client};
+    use executor::{
+        ConversationConfig, ConversationHandle, ConversationModelConfig, ExecutionStreamHandle,
+        SendResult, Uuid7,
+    };
+    use exoharness::ConversationRecord;
+    use tokio_stream::wrappers::UnboundedReceiverStream;
+
+    struct FakeConversation {
+        record: ConversationRecord,
+    }
+
+    #[async_trait::async_trait]
+    impl HarnessConversation for FakeConversation {
+        fn record(&self) -> &ConversationRecord {
+            &self.record
+        }
+
+        fn exoharness_handle(&self) -> Arc<dyn ConversationHandle> {
+            panic!("the ACP transport does not ask for the raw conversation handle")
+        }
+
+        async fn config(&self) -> Result<ConversationConfig> {
+            Ok(ConversationConfig::default())
+        }
+
+        async fn put_config(&self, _config: ConversationConfig) -> Result<()> {
+            anyhow::bail!("not used")
+        }
+
+        async fn model_override(&self) -> Result<Option<ConversationModelConfig>> {
+            Ok(None)
+        }
+
+        async fn put_model_override(&self, _config: Option<ConversationModelConfig>) -> Result<()> {
+            anyhow::bail!("not used")
+        }
+
+        async fn messages(&self) -> Result<Vec<Message>> {
+            Ok(Vec::new())
+        }
+
+        async fn close_session(&self, _session_id: SessionId) -> Result<()> {
+            Ok(())
+        }
+
+        async fn send(&self, _request: SendRequest) -> Result<SendResult> {
+            anyhow::bail!("ACP uses the streaming send")
+        }
+
+        async fn send_stream(&self, request: SendRequest) -> Result<ExecutionStreamHandle> {
+            self.send_stream_with_cancellation(request, ExecutionCancellation::new())
+                .await
+        }
+
+        async fn send_stream_with_cancellation(
+            &self,
+            request: SendRequest,
+            _cancellation: ExecutionCancellation,
+        ) -> Result<ExecutionStreamHandle> {
+            let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+            let session_id = request.session_id.unwrap_or_else(Uuid7::now);
+            let turn_id = Uuid7::now();
+            let latest_event_id = Uuid7::now();
+            tx.send(Ok(ExecutionStreamEvent::Chunk(
+                lingua::UniversalStreamChunk::text_delta(0, "hello"),
+            )))
+            .map_err(|_| anyhow::anyhow!("test stream closed"))?;
+            tx.send(Ok(ExecutionStreamEvent::ToolCall {
+                tool_call_id: "call-1".into(),
+                tool_name: "shell".into(),
+                arguments: serde_json::Map::from_iter([(
+                    "command".into(),
+                    Value::String("printf ok".into()),
+                )]),
+            }))
+            .map_err(|_| anyhow::anyhow!("test stream closed"))?;
+            tx.send(Ok(ExecutionStreamEvent::ToolResult {
+                tool_call_id: "call-1".into(),
+                result: serde_json::json!({"stdout": "ok"}),
+            }))
+            .map_err(|_| anyhow::anyhow!("test stream closed"))?;
+            tx.send(Ok(ExecutionStreamEvent::Completed(SendResult {
+                session_id,
+                turn_id,
+                latest_event_id,
+            })))
+            .map_err(|_| anyhow::anyhow!("test stream closed"))?;
+            Ok(ExecutionStreamHandle::new(UnboundedReceiverStream::new(rx)))
+        }
+    }
 
     #[test]
     fn prompt_text_preserves_text_block_order() {
@@ -348,6 +446,78 @@ mod tests {
         assert_eq!(
             meta.get("exo.latest_event_id").and_then(Value::as_str),
             Some(result.latest_event_id.to_string().as_str())
+        );
+    }
+
+    #[tokio::test]
+    async fn acp_carries_text_tool_call_tool_result_and_completion() {
+        let conversation: Arc<dyn HarnessConversation> = Arc::new(FakeConversation {
+            record: ConversationRecord {
+                id: Uuid7::now(),
+                slug: "acp".into(),
+                name: "ACP".into(),
+                latest_event_id: None,
+            },
+        });
+        let updates = Arc::new(Mutex::new(Vec::<acp::SessionUpdate>::new()));
+        let notification_updates = Arc::clone(&updates);
+        let (agent_transport, client_transport) = Channel::duplex();
+        let server = tokio::spawn(serve_transport(conversation, agent_transport));
+
+        Client
+            .builder()
+            .on_receive_notification(
+                async move |notification: acp::SessionNotification,
+                            _connection: ConnectionTo<Agent>| {
+                    notification_updates
+                        .lock()
+                        .expect("updates")
+                        .push(notification.update);
+                    Ok(())
+                },
+                agent_client_protocol::on_receive_notification!(),
+            )
+            .connect_with(client_transport, async move |connection| {
+                connection
+                    .send_request(acp::InitializeRequest::new(ProtocolVersion::V1))
+                    .block_task()
+                    .await?;
+                let session = connection
+                    .send_request(acp::NewSessionRequest::new(
+                        std::env::current_dir().map_err(anyhow::Error::from)?,
+                    ))
+                    .block_task()
+                    .await?;
+                let response = connection
+                    .send_request(acp::PromptRequest::new(
+                        session.session_id,
+                        vec![acp::ContentBlock::Text(acp::TextContent::new("run"))],
+                    ))
+                    .block_task()
+                    .await?;
+                assert_eq!(response.stop_reason, acp::StopReason::EndTurn);
+                assert!(response.meta.is_some());
+                Ok(())
+            })
+            .await
+            .expect("ACP client");
+        server.await.expect("server task").expect("ACP server");
+
+        let updates = updates.lock().expect("updates");
+        assert!(
+            updates
+                .iter()
+                .any(|update| { matches!(update, acp::SessionUpdate::AgentMessageChunk(_)) })
+        );
+        assert!(
+            updates
+                .iter()
+                .any(|update| { matches!(update, acp::SessionUpdate::ToolCall(_)) })
+        );
+        assert!(
+            updates
+                .iter()
+                .any(|update| { matches!(update, acp::SessionUpdate::ToolCallUpdate(_)) })
         );
     }
 }

--- a/crates/cli/src/acp.rs
+++ b/crates/cli/src/acp.rs
@@ -1,0 +1,353 @@
+//! ACP stdio transport for one existing Exo conversation.
+//!
+//! Standard output belongs only to newline-framed ACP JSON-RPC. Exo continues
+//! to own its conversation, durable event log, model credentials, and sandbox.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use agent_client_protocol::schema::ProtocolVersion;
+use agent_client_protocol::schema::v1 as acp;
+use agent_client_protocol::{Agent, ConnectionTo, Responder, Stdio};
+use anyhow::Result;
+use executor::{
+    ExecutionCancellation, ExecutionStreamEvent, HarnessConversation, SendRequest, SessionId,
+};
+use lingua::Message;
+use lingua::universal::UserContent;
+use serde_json::Value;
+use tokio_stream::StreamExt;
+
+#[derive(Clone)]
+struct SessionState {
+    sessions: Arc<Mutex<HashMap<String, Option<SessionId>>>>,
+    active: Arc<Mutex<HashMap<String, ExecutionCancellation>>>,
+    conversation: Arc<dyn HarnessConversation>,
+}
+
+impl SessionState {
+    fn new(conversation: Arc<dyn HarnessConversation>) -> Self {
+        Self {
+            sessions: Arc::new(Mutex::new(HashMap::new())),
+            active: Arc::new(Mutex::new(HashMap::new())),
+            conversation,
+        }
+    }
+
+    fn new_session(&self) -> acp::SessionId {
+        let id = acp::SessionId::new(format!("exo-acp-{}", uuid::Uuid::now_v7()));
+        self.sessions
+            .lock()
+            .expect("ACP session map poisoned")
+            .insert(id.0.to_string(), None);
+        id
+    }
+
+    fn exo_session(&self, session_id: &acp::SessionId) -> Option<Option<SessionId>> {
+        self.sessions
+            .lock()
+            .expect("ACP session map poisoned")
+            .get(session_id.0.as_ref())
+            .copied()
+    }
+
+    fn set_exo_session(&self, session_id: &acp::SessionId, exo_session: SessionId) {
+        self.sessions
+            .lock()
+            .expect("ACP session map poisoned")
+            .insert(session_id.0.to_string(), Some(exo_session));
+    }
+
+    fn begin_turn(&self, session_id: &acp::SessionId, cancellation: ExecutionCancellation) -> bool {
+        let mut active = self.active.lock().expect("ACP active-turn map poisoned");
+        match active.entry(session_id.0.to_string()) {
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(cancellation);
+                true
+            }
+            std::collections::hash_map::Entry::Occupied(_) => false,
+        }
+    }
+
+    fn finish_turn(&self, session_id: &acp::SessionId) {
+        self.active
+            .lock()
+            .expect("ACP active-turn map poisoned")
+            .remove(session_id.0.as_ref());
+    }
+
+    fn cancel(&self, session_id: &acp::SessionId) {
+        if let Some(cancellation) = self
+            .active
+            .lock()
+            .expect("ACP active-turn map poisoned")
+            .get(session_id.0.as_ref())
+            .cloned()
+        {
+            cancellation.cancel();
+        }
+    }
+}
+
+/// Serve the conversation until the ACP stdio transport closes.
+pub async fn serve(conversation: Arc<dyn HarnessConversation>) -> Result<()> {
+    let state = SessionState::new(conversation);
+    let new_state = state.clone();
+    let prompt_state = state.clone();
+    let cancel_state = state;
+
+    Agent
+        .builder()
+        .name("exo-acp")
+        .on_receive_request(
+            async move |request: acp::InitializeRequest,
+                        responder: Responder<acp::InitializeResponse>,
+                        _connection: ConnectionTo<agent_client_protocol::Client>| {
+                let version = if request.protocol_version >= ProtocolVersion::V1 {
+                    ProtocolVersion::V1
+                } else {
+                    request.protocol_version
+                };
+                responder.respond(
+                    acp::InitializeResponse::new(version)
+                        .agent_capabilities(acp::AgentCapabilities::new())
+                        .agent_info(
+                            acp::Implementation::new("exo", env!("CARGO_PKG_VERSION")).title("Exo"),
+                        ),
+                )
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .on_receive_request(
+            async move |_request: acp::NewSessionRequest,
+                        responder: Responder<acp::NewSessionResponse>,
+                        _connection: ConnectionTo<agent_client_protocol::Client>| {
+                responder.respond(acp::NewSessionResponse::new(new_state.new_session()))
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .on_receive_request(
+            async move |request: acp::PromptRequest,
+                        responder: Responder<acp::PromptResponse>,
+                        connection: ConnectionTo<agent_client_protocol::Client>| {
+                let Some(exo_session) = prompt_state.exo_session(&request.session_id) else {
+                    return responder.respond_with_error(
+                        agent_client_protocol::Error::invalid_params()
+                            .data("unknown Exo ACP session"),
+                    );
+                };
+                let prompt = prompt_text(&request.prompt);
+                if prompt.is_empty() {
+                    return responder.respond_with_error(
+                        agent_client_protocol::Error::invalid_params()
+                            .data("the prompt contains no text"),
+                    );
+                }
+
+                let cancellation = ExecutionCancellation::new();
+                if !prompt_state.begin_turn(&request.session_id, cancellation.clone()) {
+                    return responder.respond_with_error(
+                        agent_client_protocol::Error::invalid_request()
+                            .data("this Exo ACP session already has an active turn"),
+                    );
+                }
+                let task_state = prompt_state.clone();
+                let prompt_connection = connection.clone();
+                connection.spawn(async move {
+                    let result = run_prompt(
+                        &task_state,
+                        request.session_id.clone(),
+                        exo_session,
+                        prompt,
+                        cancellation,
+                        prompt_connection,
+                    )
+                    .await;
+                    task_state.finish_turn(&request.session_id);
+                    match result {
+                        Ok(response) => responder.respond(response),
+                        Err(error) => responder.respond_with_internal_error(error),
+                    }
+                })
+            },
+            agent_client_protocol::on_receive_request!(),
+        )
+        .on_receive_notification(
+            async move |notification: acp::CancelNotification,
+                        _connection: ConnectionTo<agent_client_protocol::Client>| {
+                cancel_state.cancel(&notification.session_id);
+                Ok(())
+            },
+            agent_client_protocol::on_receive_notification!(),
+        )
+        .connect_to(Stdio::new())
+        .await?;
+    Ok(())
+}
+
+async fn run_prompt(
+    state: &SessionState,
+    session_id: acp::SessionId,
+    exo_session: Option<SessionId>,
+    prompt: String,
+    cancellation: ExecutionCancellation,
+    connection: ConnectionTo<agent_client_protocol::Client>,
+) -> Result<acp::PromptResponse> {
+    let mut stream = state
+        .conversation
+        .send_stream_with_cancellation(
+            SendRequest {
+                input: vec![Message::User {
+                    content: UserContent::String(prompt),
+                }],
+                session_id: exo_session,
+            },
+            cancellation,
+        )
+        .await?;
+
+    while let Some(event) = stream.next().await {
+        match event? {
+            ExecutionStreamEvent::FirstChunk { .. } => {}
+            ExecutionStreamEvent::Chunk(chunk) => {
+                let text = chunk_text(&chunk);
+                if !text.is_empty() {
+                    notify(
+                        &connection,
+                        &session_id,
+                        acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(text.into())),
+                    )?;
+                }
+            }
+            ExecutionStreamEvent::ToolCall {
+                tool_call_id,
+                tool_name,
+                arguments,
+            } => {
+                notify(
+                    &connection,
+                    &session_id,
+                    acp::SessionUpdate::ToolCall(
+                        acp::ToolCall::new(tool_call_id, tool_name.clone())
+                            .status(acp::ToolCallStatus::InProgress)
+                            .raw_input(Value::Object(arguments)),
+                    ),
+                )?;
+            }
+            ExecutionStreamEvent::ToolResult {
+                tool_call_id,
+                result,
+            } => {
+                notify(
+                    &connection,
+                    &session_id,
+                    acp::SessionUpdate::ToolCallUpdate(acp::ToolCallUpdate::new(
+                        tool_call_id,
+                        acp::ToolCallUpdateFields::new()
+                            .status(acp::ToolCallStatus::Completed)
+                            .raw_output(serde_json::to_value(result)?),
+                    )),
+                )?;
+            }
+            ExecutionStreamEvent::Completed(result) => {
+                state.set_exo_session(&session_id, result.session_id);
+                return Ok(
+                    acp::PromptResponse::new(acp::StopReason::EndTurn).meta(turn_meta(&result))
+                );
+            }
+            ExecutionStreamEvent::Cancelled(result) => {
+                state.set_exo_session(&session_id, result.session_id);
+                return Ok(
+                    acp::PromptResponse::new(acp::StopReason::Cancelled).meta(turn_meta(&result))
+                );
+            }
+        }
+    }
+
+    anyhow::bail!("Exo execution stream ended without completion")
+}
+
+fn turn_meta(result: &executor::SendResult) -> acp::Meta {
+    let mut meta = acp::Meta::new();
+    meta.insert(
+        "exo.session_id".into(),
+        Value::String(result.session_id.to_string()),
+    );
+    meta.insert(
+        "exo.turn_id".into(),
+        Value::String(result.turn_id.to_string()),
+    );
+    meta.insert(
+        "exo.latest_event_id".into(),
+        Value::String(result.latest_event_id.to_string()),
+    );
+    meta
+}
+
+fn notify(
+    connection: &ConnectionTo<agent_client_protocol::Client>,
+    session_id: &acp::SessionId,
+    update: acp::SessionUpdate,
+) -> Result<()> {
+    connection.send_notification(acp::SessionNotification::new(session_id.clone(), update))?;
+    Ok(())
+}
+
+fn prompt_text(blocks: &[acp::ContentBlock]) -> String {
+    blocks
+        .iter()
+        .filter_map(|block| match block {
+            acp::ContentBlock::Text(text) => Some(text.text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn chunk_text(chunk: &lingua::UniversalStreamChunk) -> String {
+    let mut text = String::new();
+    for choice in &chunk.choices {
+        if let Some(delta) = choice.delta_view()
+            && let Some(content) = delta.content
+        {
+            text.push_str(&content);
+        }
+    }
+    text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prompt_text_preserves_text_block_order() {
+        let prompt = vec![
+            acp::ContentBlock::Text(acp::TextContent::new("first")),
+            acp::ContentBlock::Text(acp::TextContent::new("second")),
+        ];
+        assert_eq!(prompt_text(&prompt), "first\nsecond");
+    }
+
+    #[test]
+    fn completion_metadata_carries_durable_exo_references() {
+        let result = executor::SendResult {
+            session_id: executor::Uuid7::now(),
+            turn_id: executor::Uuid7::now(),
+            latest_event_id: executor::Uuid7::now(),
+        };
+        let meta = turn_meta(&result);
+        assert_eq!(
+            meta.get("exo.session_id").and_then(Value::as_str),
+            Some(result.session_id.to_string().as_str())
+        );
+        assert_eq!(
+            meta.get("exo.turn_id").and_then(Value::as_str),
+            Some(result.turn_id.to_string().as_str())
+        );
+        assert_eq!(
+            meta.get("exo.latest_event_id").and_then(Value::as_str),
+            Some(result.latest_event_id.to_string().as_str())
+        );
+    }
+}

--- a/crates/cli/src/acp.rs
+++ b/crates/cli/src/acp.rs
@@ -336,6 +336,8 @@ mod tests {
 
     struct FakeConversation {
         record: ConversationRecord,
+        cancel_when_requested: bool,
+        turn_started: Arc<tokio::sync::Notify>,
     }
 
     #[async_trait::async_trait]
@@ -384,12 +386,24 @@ mod tests {
         async fn send_stream_with_cancellation(
             &self,
             request: SendRequest,
-            _cancellation: ExecutionCancellation,
+            cancellation: ExecutionCancellation,
         ) -> Result<ExecutionStreamHandle> {
             let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
             let session_id = request.session_id.unwrap_or_else(Uuid7::now);
             let turn_id = Uuid7::now();
             let latest_event_id = Uuid7::now();
+            if self.cancel_when_requested {
+                self.turn_started.notify_one();
+                tokio::spawn(async move {
+                    cancellation.cancelled().await;
+                    drop(tx.send(Ok(ExecutionStreamEvent::Cancelled(SendResult {
+                        session_id,
+                        turn_id,
+                        latest_event_id,
+                    }))));
+                });
+                return Ok(ExecutionStreamHandle::new(UnboundedReceiverStream::new(rx)));
+            }
             tx.send(Ok(ExecutionStreamEvent::Chunk(
                 lingua::UniversalStreamChunk::text_delta(0, "hello"),
             )))
@@ -458,6 +472,8 @@ mod tests {
                 name: "ACP".into(),
                 latest_event_id: None,
             },
+            cancel_when_requested: false,
+            turn_started: Arc::new(tokio::sync::Notify::new()),
         });
         let updates = Arc::new(Mutex::new(Vec::<acp::SessionUpdate>::new()));
         let notification_updates = Arc::clone(&updates);
@@ -519,5 +535,58 @@ mod tests {
                 .iter()
                 .any(|update| { matches!(update, acp::SessionUpdate::ToolCallUpdate(_)) })
         );
+    }
+
+    #[tokio::test]
+    async fn acp_cancel_notification_cancels_the_active_exo_turn() {
+        let turn_started = Arc::new(tokio::sync::Notify::new());
+        let conversation: Arc<dyn HarnessConversation> = Arc::new(FakeConversation {
+            record: ConversationRecord {
+                id: Uuid7::now(),
+                slug: "acp-cancel".into(),
+                name: "ACP cancel".into(),
+                latest_event_id: None,
+            },
+            cancel_when_requested: true,
+            turn_started: Arc::clone(&turn_started),
+        });
+        let (agent_transport, client_transport) = Channel::duplex();
+        let server = tokio::spawn(serve_transport(conversation, agent_transport));
+
+        Client
+            .builder()
+            .connect_with(client_transport, async move |connection| {
+                connection
+                    .send_request(acp::InitializeRequest::new(ProtocolVersion::V1))
+                    .block_task()
+                    .await?;
+                let session = connection
+                    .send_request(acp::NewSessionRequest::new(
+                        std::env::current_dir().map_err(anyhow::Error::from)?,
+                    ))
+                    .block_task()
+                    .await?;
+                let session_id = session.session_id;
+                let prompt_connection = connection.clone();
+                let prompt_session_id = session_id.clone();
+                let prompt = tokio::spawn(async move {
+                    prompt_connection
+                        .send_request(acp::PromptRequest::new(
+                            prompt_session_id,
+                            vec![acp::ContentBlock::Text(acp::TextContent::new("wait"))],
+                        ))
+                        .block_task()
+                        .await
+                });
+                turn_started.notified().await;
+                connection.send_notification(acp::CancelNotification::new(session_id))?;
+                let response = prompt.await.map_err(anyhow::Error::from)??;
+                assert_eq!(response.stop_reason, acp::StopReason::Cancelled);
+                assert!(response.meta.is_some());
+                Ok(())
+            })
+            .await
+            .expect("ACP client");
+        server.await.expect("server task").expect("ACP server");
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,3 +1,4 @@
+mod acp;
 mod adapters;
 mod env;
 #[cfg(test)]
@@ -374,6 +375,8 @@ impl From<SandboxScopeArg> for SandboxScope {
 
 #[derive(Debug, Subcommand)]
 enum Commands {
+    /// Serve one existing conversation over ACP on stdio.
+    Acp { agent: String, conversation: String },
     /// Manage agents and their executor configuration.
     Agent {
         #[command(subcommand)]
@@ -847,6 +850,14 @@ async fn main() -> Result<()> {
     .await?;
 
     match cli.command {
+        Commands::Acp {
+            agent,
+            conversation,
+        } => {
+            let conversation =
+                must_get_conversation(harness.as_ref(), &agent, &conversation).await?;
+            acp::serve(conversation).await?;
+        }
         Commands::Adapters { command } => {
             adapters::handle_adapter_command(&cli.root, Arc::clone(&harness), command).await?;
         }
@@ -2108,6 +2119,7 @@ fn command_agent_ref(command: &Commands) -> Option<&str> {
             },
         },
         Commands::Repl { agent, .. } => Some(agent.as_deref().unwrap_or(DEFAULT_REPL_SLUG)),
+        Commands::Acp { agent, .. } => Some(agent.as_str()),
         Commands::Secret { .. }
         | Commands::Model { .. }
         | Commands::Provider { .. }

--- a/crates/cli/src/tui.rs
+++ b/crates/cli/src/tui.rs
@@ -741,6 +741,12 @@ impl ChatRepl {
                     *self.watch_after.lock().expect("chat event watch poisoned") =
                         Some(result.latest_event_id);
                 }
+                ExecutionStreamEvent::Cancelled(result) => {
+                    self.session_id = Some(result.session_id);
+                    *self.watch_after.lock().expect("chat event watch poisoned") =
+                        Some(result.latest_event_id);
+                    println!("[cancelled]");
+                }
             }
         }
 

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -29,6 +29,7 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
+tokio-util.workspace = true
 tracing.workspace = true
 url.workspace = true
 

--- a/crates/executor/src/basic_tests.rs
+++ b/crates/executor/src/basic_tests.rs
@@ -450,6 +450,9 @@ async fn send_stream_emits_chunks_and_persists_final_response() {
             ExecutionStreamEvent::Completed(_) => {
                 panic!("executor stream should not emit completion")
             }
+            ExecutionStreamEvent::Cancelled(_) => {
+                panic!("executor stream should not emit cancellation")
+            }
         }
     }
 
@@ -476,6 +479,93 @@ async fn send_stream_emits_chunks_and_persists_final_response() {
             _ => false,
         }
     }));
+}
+
+struct TestExecutionTracer;
+
+#[async_trait]
+impl crate::execution_tracing::ExecutionTracer for TestExecutionTracer {
+    async fn flush(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn start_turn(
+        &self,
+        _config: Option<&BraintrustTracingConfig>,
+        _agent: &AgentRecord,
+        _conversation: &ConversationRecord,
+        _agent_config: &AgentConfig,
+        _session_id: SessionId,
+        _turn_id: TurnId,
+        _streamed: bool,
+    ) -> Option<Box<dyn crate::execution_tracing::TurnExecutionTrace>> {
+        None
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn cancelling_a_stream_closes_the_durable_turn() {
+    let agent_id = Uuid7::now();
+    let conversation_id = Uuid7::now();
+    let exoharness = Arc::new(FakeExoHarness::new(agent_id, conversation_id));
+    let agent = exoharness
+        .get_agent(&agent_id)
+        .await
+        .expect("get agent should succeed")
+        .expect("agent should exist");
+    let conversation = agent
+        .get_conversation(&conversation_id)
+        .await
+        .expect("get conversation should succeed")
+        .expect("conversation should exist");
+    let turn = conversation
+        .begin_turn(BeginTurnRequest {
+            session_id: None,
+            input: vec![user_message("wait")],
+        })
+        .await
+        .expect("begin turn should succeed");
+    let cancellation = ExecutionCancellation::new();
+    let mut stream = crate::shared::spawn_prepared_turn_stream(
+        Arc::new(TestExecutionTracer),
+        agent,
+        conversation.clone(),
+        turn,
+        default_agent_config(),
+        cancellation.clone(),
+        |_trace, _events| Box::pin(std::future::pending()),
+    );
+
+    cancellation.cancel();
+    let cancelled = stream
+        .next()
+        .await
+        .expect("cancellation event")
+        .expect("cancellation succeeds");
+    assert!(matches!(cancelled, ExecutionStreamEvent::Cancelled(_)));
+
+    let events = conversation
+        .get_events(Some(EventQuery {
+            cursor: None,
+            direction: Some(EventQueryDirection::Asc),
+            limit: None,
+            session_id: None,
+            turn_id: None,
+            types: None,
+        }))
+        .await
+        .expect("read events")
+        .events;
+    assert!(events.iter().any(|event| {
+        matches!(
+            &event.data,
+            EventData::Custom { event_type, .. } if event_type == "turn_cancelled"
+        )
+    }));
+    assert!(matches!(
+        events.last().map(|event| &event.data),
+        Some(EventData::TurnEnded)
+    ));
 }
 
 struct FakeModelClient {

--- a/crates/executor/src/executor_types.rs
+++ b/crates/executor/src/executor_types.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::sync::OwnedMutexGuard;
 use tokio_stream::{Stream, wrappers::UnboundedReceiverStream};
+use tokio_util::sync::CancellationToken;
 
 use crate::braintrust::BraintrustTracingConfig;
 
@@ -244,19 +245,58 @@ pub struct SendResult {
 pub struct ExecutionStreamHandle {
     event_stream: UnboundedReceiverStream<Result<ExecutionStreamEvent>>,
     _send_guard: Option<OwnedMutexGuard<()>>,
+    cancellation: ExecutionCancellation,
 }
 
 impl ExecutionStreamHandle {
     pub fn new(event_stream: UnboundedReceiverStream<Result<ExecutionStreamEvent>>) -> Self {
+        Self::with_cancellation(event_stream, ExecutionCancellation::new())
+    }
+
+    pub(crate) fn with_cancellation(
+        event_stream: UnboundedReceiverStream<Result<ExecutionStreamEvent>>,
+        cancellation: ExecutionCancellation,
+    ) -> Self {
         Self {
             event_stream,
             _send_guard: None,
+            cancellation,
         }
     }
 
     pub(crate) fn with_send_guard(mut self, send_guard: OwnedMutexGuard<()>) -> Self {
         self._send_guard = Some(send_guard);
         self
+    }
+
+    /// Return a handle that can cancel this turn without dropping its durable
+    /// finalization path.
+    pub fn cancellation(&self) -> ExecutionCancellation {
+        self.cancellation.clone()
+    }
+}
+
+/// A cloneable cancellation signal for one streamed turn.
+#[derive(Clone, Debug)]
+pub struct ExecutionCancellation(CancellationToken);
+
+impl ExecutionCancellation {
+    pub fn new() -> Self {
+        Self(CancellationToken::new())
+    }
+
+    pub fn cancel(&self) {
+        self.0.cancel();
+    }
+
+    pub(crate) async fn cancelled(&self) {
+        self.0.cancelled().await;
+    }
+}
+
+impl Default for ExecutionCancellation {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -276,6 +316,8 @@ pub enum ExecutionStreamEvent {
         result: ToolResult,
     },
     Completed(SendResult),
+    /// The turn was cancelled cooperatively and its durable log was closed.
+    Cancelled(SendResult),
 }
 
 impl Stream for ExecutionStreamHandle {

--- a/crates/executor/src/executor_types.rs
+++ b/crates/executor/src/executor_types.rs
@@ -289,7 +289,7 @@ impl ExecutionCancellation {
         self.0.cancel();
     }
 
-    pub(crate) async fn cancelled(&self) {
+    pub async fn cancelled(&self) {
         self.0.cancelled().await;
     }
 }

--- a/crates/executor/src/harness_executor.rs
+++ b/crates/executor/src/harness_executor.rs
@@ -18,8 +18,8 @@ use crate::shared::{
     spawn_prepared_turn_stream,
 };
 use crate::{
-    AgentConfig, ConversationConfig, ConversationModelConfig, ExecutionStreamEvent,
-    ExecutionStreamHandle, SendRequest, SendResult,
+    AgentConfig, ConversationConfig, ConversationModelConfig, ExecutionCancellation,
+    ExecutionStreamEvent, ExecutionStreamHandle, SendRequest, SendResult,
 };
 
 #[derive(Clone, Copy)]
@@ -207,11 +207,12 @@ where
         .await
     }
 
-    async fn send_stream(
+    async fn send_stream_with_cancellation(
         &self,
         agent: Arc<dyn AgentHandle>,
         conversation: Arc<dyn ConversationHandle>,
         request: SendRequest,
+        cancellation: ExecutionCancellation,
     ) -> Result<ExecutionStreamHandle> {
         let (mut agent_config, conversation_config, model_override) = tokio::try_join!(
             self.get_agent_config(agent.as_ref()),
@@ -246,6 +247,7 @@ where
             conversation,
             turn,
             trace_agent_config,
+            cancellation,
             move |turn_trace, event_tx| {
                 Box::pin(async move {
                     executor

--- a/crates/executor/src/harness_facade.rs
+++ b/crates/executor/src/harness_facade.rs
@@ -1,6 +1,9 @@
 use std::sync::Arc;
 
-use crate::{AgentConfig, ConversationConfig, ExecutionStreamHandle, SendRequest, SendResult};
+use crate::{
+    AgentConfig, ConversationConfig, ExecutionCancellation, ExecutionStreamHandle, SendRequest,
+    SendResult,
+};
 use async_trait::async_trait;
 use exoharness::{
     AgentHandle, AgentRecord, ConversationHandle, ConversationRecord, ExoHarness, NewAgentRequest,
@@ -36,11 +39,12 @@ pub(crate) trait HarnessRuntime: Send + Sync + Clone + 'static {
         conversation: Arc<dyn ConversationHandle>,
         request: SendRequest,
     ) -> Result<SendResult>;
-    async fn send_stream(
+    async fn send_stream_with_cancellation(
         &self,
         agent: Arc<dyn AgentHandle>,
         conversation: Arc<dyn ConversationHandle>,
         request: SendRequest,
+        cancellation: ExecutionCancellation,
     ) -> Result<ExecutionStreamHandle>;
     async fn flush_tracing(&self) -> Result<()>;
 }
@@ -341,14 +345,24 @@ where
     }
 
     async fn send_stream(&self, request: SendRequest) -> Result<ExecutionStreamHandle> {
+        self.send_stream_with_cancellation(request, ExecutionCancellation::new())
+            .await
+    }
+
+    async fn send_stream_with_cancellation(
+        &self,
+        request: SendRequest,
+        cancellation: ExecutionCancellation,
+    ) -> Result<ExecutionStreamHandle> {
         let send_lock = conversation_send_lock(&self.conversation.record().id.to_string());
         let send_guard = send_lock.lock_owned().await;
         let stream = self
             .runtime
-            .send_stream(
+            .send_stream_with_cancellation(
                 Arc::clone(&self.agent),
                 Arc::clone(&self.conversation),
                 request,
+                cancellation,
             )
             .await?;
         Ok(stream.with_send_guard(send_guard))

--- a/crates/executor/src/harness_types.rs
+++ b/crates/executor/src/harness_types.rs
@@ -9,8 +9,8 @@ use lingua::Message;
 
 use crate::{
     AgentConfig, AgentHarnessKind, BraintrustTracingConfig, ConversationConfig,
-    ConversationModelConfig, ExecutionStreamHandle, SandboxScope, SendRequest, SendResult,
-    TypeScriptHarnessConfig,
+    ConversationModelConfig, ExecutionCancellation, ExecutionStreamHandle, SandboxScope,
+    SendRequest, SendResult, TypeScriptHarnessConfig,
 };
 
 #[async_trait]
@@ -56,6 +56,11 @@ pub trait HarnessConversation: Send + Sync {
     async fn close_session(&self, session_id: SessionId) -> Result<()>;
     async fn send(&self, request: SendRequest) -> Result<SendResult>;
     async fn send_stream(&self, request: SendRequest) -> Result<ExecutionStreamHandle>;
+    async fn send_stream_with_cancellation(
+        &self,
+        request: SendRequest,
+        cancellation: ExecutionCancellation,
+    ) -> Result<ExecutionStreamHandle>;
 }
 
 #[derive(Debug, Clone)]

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -44,9 +44,9 @@ pub use braintrust::{BraintrustProject, BraintrustRuntimeConfig, BraintrustTraci
 pub use conversation_wakeup::send_conversation_wakeup;
 pub use executor_types::{
     AgentConfig, AgentHarnessKind, AgentSandboxConfig, ConversationConfig, ConversationModelConfig,
-    ExecutionStreamEvent, ExecutionStreamHandle, ModelClient, ModelRequest, ModelResponse,
-    ModelResponseStream, PendingToolCall, SandboxScope, SendRequest, SendResult, ToolDefinition,
-    ToolRuntime, TypeScriptHarnessConfig, effective_sandbox_scope,
+    ExecutionCancellation, ExecutionStreamEvent, ExecutionStreamHandle, ModelClient, ModelRequest,
+    ModelResponse, ModelResponseStream, PendingToolCall, SandboxScope, SendRequest, SendResult,
+    ToolDefinition, ToolRuntime, TypeScriptHarnessConfig, effective_sandbox_scope,
 };
 pub use exoharness::{
     AgentHandle, BasicExoHarness, BasicExoHarnessConfig, Binding, BindingRecord,

--- a/crates/executor/src/rlm_tests.rs
+++ b/crates/executor/src/rlm_tests.rs
@@ -320,6 +320,7 @@ async fn rlm_send_stream_suppresses_internal_control_text() {
             ExecutionStreamEvent::ToolCall { .. } => {}
             ExecutionStreamEvent::ToolResult { .. } => {}
             ExecutionStreamEvent::Completed(_) => {}
+            ExecutionStreamEvent::Cancelled(_) => {}
         }
     }
 

--- a/crates/executor/src/shared.rs
+++ b/crates/executor/src/shared.rs
@@ -6,13 +6,17 @@ use std::sync::{Arc, RwLock};
 
 use anyhow::Error;
 use exoharness::{
-    AgentHandle, AgentId, ConversationHandle, ConversationId, EventId, Result, TurnHandle,
+    AgentHandle, AgentId, ConversationHandle, ConversationId, EventData, EventId, Result,
+    TurnHandle,
 };
+use serde_json::json;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use crate::execution_tracing::{ExecutionTracer, TurnExecutionTrace};
-use crate::{AgentConfig, ExecutionStreamEvent, ExecutionStreamHandle, SendResult};
+use crate::{
+    AgentConfig, ExecutionCancellation, ExecutionStreamEvent, ExecutionStreamHandle, SendResult,
+};
 
 pub(crate) type TurnFuture<'a> = Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
 
@@ -88,6 +92,7 @@ pub(crate) fn spawn_prepared_turn_stream<Run>(
     conversation: Arc<dyn ConversationHandle>,
     turn: Arc<dyn TurnHandle>,
     agent_config: AgentConfig,
+    cancellation: ExecutionCancellation,
     run: Run,
 ) -> ExecutionStreamHandle
 where
@@ -100,6 +105,7 @@ where
 {
     let (event_tx, event_rx) = mpsc::unbounded_channel();
 
+    let task_cancellation = cancellation.clone();
     tokio::spawn(async move {
         let session_id = turn.record().session_id;
         let turn_id = turn.record().id;
@@ -114,13 +120,31 @@ where
                 true,
             )
             .await;
-        let send_result = finalize_turn(turn.as_ref(), run(turn_trace.as_deref(), &event_tx).await)
-            .await
-            .map(|latest_event_id| SendResult {
-                session_id,
-                turn_id,
-                latest_event_id,
-            });
+        let (send_result, was_cancelled) = tokio::select! {
+            result = run(turn_trace.as_deref(), &event_tx) => (
+                finalize_turn(turn.as_ref(), result).await.map(|latest_event_id| SendResult {
+                    session_id,
+                    turn_id,
+                    latest_event_id,
+                }),
+                false,
+            ),
+            () = task_cancellation.cancelled() => {
+                let result = async {
+                    turn.add_events(vec![EventData::Custom {
+                        event_type: "turn_cancelled".to_string(),
+                        payload: json!({ "source": "execution_stream" }),
+                    }]).await?;
+                    let latest_event_id = turn.finish().await?;
+                    Ok(SendResult {
+                        session_id,
+                        turn_id,
+                        latest_event_id,
+                    })
+                }.await;
+                (result, true)
+            },
+        };
 
         if let Some(turn_trace) = turn_trace {
             match &send_result {
@@ -136,11 +160,16 @@ where
         if let Err(error) = &send_result {
             try_send_stream_error(&event_tx, error);
         } else if let Ok(result) = &send_result {
-            try_send_stream_event(&event_tx, ExecutionStreamEvent::Completed(result.clone()));
+            let event = if was_cancelled {
+                ExecutionStreamEvent::Cancelled(result.clone())
+            } else {
+                ExecutionStreamEvent::Completed(result.clone())
+            };
+            try_send_stream_event(&event_tx, event);
         }
     });
 
-    ExecutionStreamHandle::new(UnboundedReceiverStream::new(event_rx))
+    ExecutionStreamHandle::with_cancellation(UnboundedReceiverStream::new(event_rx), cancellation)
 }
 
 async fn finish_turn_trace(

--- a/crates/exoharness/Cargo.toml
+++ b/crates/exoharness/Cargo.toml
@@ -20,7 +20,7 @@ basic-backend = [
   "dep:tracing",
   "dep:url",
 ]
-apple-keychain = ["dep:keyring", "dep:keyring-core"]
+apple-keychain = ["dep:keyring"]
 aws-agentcore = [
   "basic-backend",
   "dep:aws-config",
@@ -41,8 +41,7 @@ base64 = { version = "0.22.1", optional = true }
 bytes.workspace = true
 chrono.workspace = true
 futures.workspace = true
-keyring = { version = "4.0.0-rc.3", optional = true }
-keyring-core = { version = "0.7.2", optional = true }
+keyring = { version = "4.1.5", optional = true }
 lingua.workspace = true
 object_store = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }

--- a/crates/exoharness/src/secrets.rs
+++ b/crates/exoharness/src/secrets.rs
@@ -104,12 +104,11 @@ impl AppleKeychainSecretKeyProvider {
 #[cfg(feature = "apple-keychain")]
 impl SecretKeyProvider for AppleKeychainSecretKeyProvider {
     fn get_or_create_key(&self) -> Result<[u8; MASTER_KEY_LEN]> {
-        use keyring_core::{Entry, Error as KeyringError};
+        use keyring::{Entry, Error as KeyringError};
 
         if let Some(key) = self.key.get() {
             return Ok(*key);
         }
-        ensure_apple_keychain_store()?;
         let entry = Entry::new(KEYCHAIN_SERVICE, &self.account)?;
         let key = match entry.get_password() {
             Ok(serialized) => deserialize_key(&serialized)?,
@@ -201,21 +200,6 @@ fn random_nonce() -> [u8; NONCE_LEN] {
     let mut nonce = [0u8; NONCE_LEN];
     nonce.copy_from_slice(&Uuid::new_v4().as_bytes()[..NONCE_LEN]);
     nonce
-}
-
-#[cfg(feature = "apple-keychain")]
-fn ensure_apple_keychain_store() -> Result<()> {
-    use std::collections::HashMap;
-
-    static INIT: OnceLock<std::result::Result<(), String>> = OnceLock::new();
-    let result = INIT.get_or_init(|| {
-        keyring::use_apple_keychain_store(&HashMap::new())
-            .map_err(|error| format!("failed to initialize macOS keychain store: {error}"))
-    });
-    match result {
-        Ok(()) => Ok(()),
-        Err(message) => Err(anyhow!(message.clone())),
-    }
 }
 
 fn parse_master_key_bytes(bytes: &[u8]) -> Result<[u8; MASTER_KEY_LEN]> {


### PR DESCRIPTION
## What changed

- Add `exo acp <agent> <conversation>` as a standard ACP v1 server on stdio.
- Map live Exo text chunks, tool calls, tool results, completion, and cancellation to ACP session updates.
- Add cooperative cancellation to `ExecutionStreamHandle`.
- Close a cancelled Exo turn with a durable `turn_cancelled` event and `TurnEnded`.
- Return Exo session, turn, and latest-event references in ACP completion metadata.
- Update the macOS keyring dependency to a release that is compatible with ACP's current `futures` dependency.

## Why

Exo already has the correct in-process streaming event model, but only its terminal UI can consume it. ACP gives editors and other agent clients a standard streaming transport without adding an HTTP listener or an Exo-specific protocol.

## Compatibility and safety

- The transport uses stdin/stdout only. It does not expose `exo serve`.
- Exo continues to own its credentials, conversation state, sandbox, and durable event log.
- A second prompt on an active ACP session is refused.
- Cancellation is cooperative and closes the durable turn before ACP reports `Cancelled`.
- Existing CLI and REPL behavior is unchanged.

## Verification

- `cargo +1.95.0 test -p executor -p exo --no-fail-fast`
- `cargo +1.95.0 clippy -p executor -p exo --all-targets -- -D warnings`
- Duplex ACP test verifies text chunk → tool call → tool result → completion through both JSON-RPC endpoints.
- Cancellation test verifies `turn_cancelled` and `TurnEnded` persistence.
