### PR TITLE
Codex: support ChatGPT subscription auth with ExoChat

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,10 @@ Exo was designed to be incredibly simple to use. With just a few commands you
 should have a fully functional agent who can do standard agent tasks (computer
 use, research, coding etc.) but can also extend itself as needed.
 
-To use Exo as an agent, you'll need an OpenAI or OpenRouter API key. If you
-have that, simply do the following:
+To use Exo as an agent, you'll usually need an OpenAI or OpenRouter API key.
+The Codex harness can instead use the Codex access included with your ChatGPT
+subscription; see [Coding agent harnesses](docs/coding-agent-harnesses.md#codex).
+Then simply do the following:
 
 ```
 curl -fsSL https://raw.githubusercontent.com/exoharness/exo/main/setup.sh -o setup.sh
@@ -112,6 +114,7 @@ the command line.
 
 ```
 ./exo.sh                # start the full stack (Docker sandbox, ExoChat) and open the CLI chat interface
+./exo.sh --harness codex # use ChatGPT subscription-backed Codex with ExoChat
 ./exo.sh list           # list agents and conversations
 ./exo.sh stop-all       # stop the scheduler and adapter runners; state is preserved
 ./exo.sh fresh          # rebuild, delete all agents/conversations, start clean
@@ -128,6 +131,12 @@ mounted at `/workspace/exo`, and ExoChat for remote access. Pass
 `--template dev` for a developer variant that sets up IRC and Discord instead
 of ExoChat, or `--template minimal` for a bare REPL with no Docker defaults or
 adapter setup.
+
+The Codex launch requires an Exo-scoped ChatGPT login, a registered model, and
+the Codex sandbox image. See
+[Coding agent harnesses](docs/coding-agent-harnesses.md#codex) for the one-time
+setup. In this mode Codex runs the model/tool loop while Exo supplies persisted
+agents, conversations, sandbox lifecycle, and adapters such as ExoChat.
 
 ## Understanding Exo
 

--- a/containers/codex-sandbox/Dockerfile
+++ b/containers/codex-sandbox/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:22-bookworm-slim
 
-ARG CODEX_PACKAGE=@openai/codex
+ARG CODEX_PACKAGE=@openai/codex@0.144.6
 
 ENV CODEX_HOME=/home/exo/.codex
 ENV HOME=/home/exo

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -16,11 +16,12 @@ use std::collections::HashMap;
 use std::io::{self, Write};
 use std::net::{SocketAddr, TcpListener};
 use std::path::{Path, PathBuf};
+use std::process::Stdio;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use anyhow::{Result, anyhow, bail};
+use anyhow::{Context, Result, anyhow, bail};
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 use executor::{
     AgentHarnessKind, BasicExoHarness, BasicExoHarnessConfig, BasicHarness, BasicToolRuntime,
@@ -399,6 +400,11 @@ enum Commands {
         #[command(subcommand)]
         command: SecretCommands,
     },
+    /// Manage the ChatGPT account used by Codex harnesses.
+    Codex {
+        #[command(subcommand)]
+        command: CodexCommands,
+    },
     /// Start an interactive REPL, creating a default agent and conversation when needed.
     Repl {
         /// Model binding to use (defaults to the first registered model).
@@ -637,14 +643,31 @@ enum SecretCommands {
 }
 
 #[derive(Debug, Subcommand)]
+enum CodexCommands {
+    /// Sign in with ChatGPT using an Exo-isolated Codex credential store.
+    Login {
+        /// Use the device-code flow instead of opening a local browser callback.
+        #[arg(long)]
+        device_auth: bool,
+    },
+    /// Show the active Exo Codex authentication method.
+    Status,
+    /// Sign out of the Exo Codex session.
+    Logout,
+}
+
+#[derive(Debug, Subcommand)]
 enum ModelCommands {
     List,
     Register {
         name: String,
+        /// Upstream provider model id when it differs from the binding name.
         #[arg(long)]
         model: Option<String>,
+        /// API-key secret. Omit for Codex ChatGPT subscription authentication.
         #[arg(long)]
-        secret: String,
+        secret: Option<String>,
+        /// Custom OpenAI-compatible endpoint. Codex subscription auth does not support this.
         #[arg(long)]
         base_url: Option<String>,
     },
@@ -813,8 +836,23 @@ async fn main() -> Result<()> {
         cli.braintrust_app_url,
         cli.braintrust_api_url,
     );
-    let env_vars = env.into_vars();
+    let mut env_vars = env.into_vars();
+    let codex_home = exo_codex_home(&env_vars)?;
+    env_vars.insert(
+        "EXO_CODEX_HOME".to_string(),
+        codex_home.to_string_lossy().into_owned(),
+    );
+    if let Some(codex_bin) = find_host_codex_bin(&env_vars) {
+        env_vars.insert(
+            "EXO_HOST_CODEX_BIN".to_string(),
+            codex_bin.to_string_lossy().into_owned(),
+        );
+    }
     let harness_selection = cli.harness.clone();
+    if let Commands::Codex { command } = &cli.command {
+        handle_codex_command(command, &codex_home, &env_vars).await?;
+        return Ok(());
+    }
     if let Some(config) = serve_config(&cli.command) {
         serve_exoharness_http(&exo_config, config).await?;
         return Ok(());
@@ -840,6 +878,7 @@ async fn main() -> Result<()> {
         &exo_config,
         exoharness,
         harness_kind,
+        harness_selection.as_ref(),
         runtime_config.clone(),
         env_vars.clone(),
         pricing,
@@ -1903,9 +1942,14 @@ async fn main() -> Result<()> {
                 secret,
                 base_url,
             } => {
-                let secret_id = find_secret_id(harness.exoharness_handle().as_ref(), &secret)
-                    .await?
-                    .ok_or_else(|| anyhow!("secret not found: {secret}"))?;
+                let secret_id = match secret {
+                    Some(secret) => Some(
+                        find_secret_id(harness.exoharness_handle().as_ref(), &secret)
+                            .await?
+                            .ok_or_else(|| anyhow!("secret not found: {secret}"))?,
+                    ),
+                    None => None,
+                };
                 let upstream_model = model.unwrap_or_else(|| name.clone());
                 let id = harness
                     .exoharness_handle()
@@ -1913,7 +1957,7 @@ async fn main() -> Result<()> {
                         name: name.clone(),
                         model: upstream_model,
                         base_url,
-                        secret_id: Some(secret_id),
+                        secret_id,
                     })
                     .await?;
                 println!("registered model {} ({})", name, id);
@@ -2053,6 +2097,9 @@ async fn main() -> Result<()> {
         Commands::Serve { .. } => {
             unreachable!("serve commands are handled before harness instantiation")
         }
+        Commands::Codex { .. } => {
+            unreachable!("codex auth commands are handled before harness instantiation")
+        }
     }
 
     harness.flush_tracing().await?;
@@ -2109,6 +2156,7 @@ fn command_agent_ref(command: &Commands) -> Option<&str> {
         },
         Commands::Repl { agent, .. } => Some(agent.as_deref().unwrap_or(DEFAULT_REPL_SLUG)),
         Commands::Secret { .. }
+        | Commands::Codex { .. }
         | Commands::Model { .. }
         | Commands::Provider { .. }
         | Commands::Adapters { .. }
@@ -2159,6 +2207,157 @@ async fn serve_exoharness_http(
         },
     )
     .await?;
+    Ok(())
+}
+
+const CODEX_FILE_AUTH_OVERRIDE: &str = "cli_auth_credentials_store=\"file\"";
+
+fn exo_codex_home(env: &HashMap<String, String>) -> Result<PathBuf> {
+    if let Some(path) = env
+        .get("EXO_CODEX_HOME")
+        .cloned()
+        .or_else(|| std::env::var("EXO_CODEX_HOME").ok())
+        .filter(|value| !value.trim().is_empty())
+    {
+        return Ok(PathBuf::from(path));
+    }
+
+    #[cfg(target_os = "macos")]
+    if let Some(home) = env
+        .get("HOME")
+        .cloned()
+        .or_else(|| std::env::var("HOME").ok())
+    {
+        return Ok(PathBuf::from(home)
+            .join("Library")
+            .join("Application Support")
+            .join("exo")
+            .join("codex"));
+    }
+
+    #[cfg(target_os = "windows")]
+    if let Some(local_app_data) = env
+        .get("LOCALAPPDATA")
+        .cloned()
+        .or_else(|| std::env::var("LOCALAPPDATA").ok())
+    {
+        return Ok(PathBuf::from(local_app_data).join("exo").join("codex"));
+    }
+
+    if let Some(data_home) = env
+        .get("XDG_DATA_HOME")
+        .cloned()
+        .or_else(|| std::env::var("XDG_DATA_HOME").ok())
+    {
+        return Ok(PathBuf::from(data_home).join("exo").join("codex"));
+    }
+    if let Some(home) = env
+        .get("HOME")
+        .cloned()
+        .or_else(|| std::env::var("HOME").ok())
+    {
+        return Ok(PathBuf::from(home)
+            .join(".local")
+            .join("share")
+            .join("exo")
+            .join("codex"));
+    }
+    bail!("could not determine Exo Codex auth directory; set EXO_CODEX_HOME")
+}
+
+fn find_host_codex_bin(env: &HashMap<String, String>) -> Option<PathBuf> {
+    if let Some(path) = env
+        .get("CODEX_BIN")
+        .cloned()
+        .or_else(|| std::env::var("CODEX_BIN").ok())
+        .filter(|value| !value.trim().is_empty())
+    {
+        return Some(PathBuf::from(path));
+    }
+    let workspace_bin = std::env::current_dir()
+        .ok()?
+        .join("node_modules")
+        .join(".bin")
+        .join(if cfg!(windows) { "codex.cmd" } else { "codex" });
+    if workspace_bin.is_file() {
+        return Some(workspace_bin);
+    }
+    Some(PathBuf::from("codex"))
+}
+
+async fn handle_codex_command(
+    command: &CodexCommands,
+    codex_home: &Path,
+    env: &HashMap<String, String>,
+) -> Result<()> {
+    std::fs::create_dir_all(codex_home)
+        .with_context(|| format!("creating Exo Codex home {}", codex_home.display()))?;
+    set_owner_only_directory_permissions(codex_home)?;
+
+    let executable =
+        find_host_codex_bin(env).ok_or_else(|| anyhow!("could not resolve Codex executable"))?;
+    let mut process = tokio::process::Command::new(&executable);
+    process
+        .arg("-c")
+        .arg(CODEX_FILE_AUTH_OVERRIDE)
+        .env("CODEX_HOME", codex_home)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit());
+    match command {
+        CodexCommands::Login { device_auth } => {
+            process.arg("login");
+            if *device_auth {
+                process.arg("--device-auth");
+            }
+        }
+        CodexCommands::Status => {
+            process.args(["login", "status"]);
+        }
+        CodexCommands::Logout => {
+            process.arg("logout");
+        }
+    }
+    let status = process.status().await.with_context(|| {
+        format!(
+            "starting Codex executable {}; install dependencies with `pnpm install` or set CODEX_BIN",
+            executable.display()
+        )
+    })?;
+    if !status.success() {
+        bail!("Codex authentication command exited with {status}");
+    }
+    set_owner_only_auth_file_permissions(codex_home)?;
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_owner_only_directory_permissions(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+        .with_context(|| format!("setting permissions on {}", path.display()))
+}
+
+#[cfg(not(unix))]
+fn set_owner_only_directory_permissions(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_owner_only_auth_file_permissions(codex_home: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let auth_file = codex_home.join("auth.json");
+    if auth_file.is_file() {
+        std::fs::set_permissions(&auth_file, std::fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("setting permissions on {}", auth_file.display()))?;
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_owner_only_auth_file_permissions(_codex_home: &Path) -> Result<()> {
     Ok(())
 }
 
@@ -2228,6 +2427,7 @@ async fn instantiate_harness(
     exo_config: &BasicExoHarnessConfig,
     exoharness: Arc<dyn ExoHarness>,
     kind: HarnessKind,
+    selection: Option<&HarnessSelection>,
     runtime_config: Option<BraintrustRuntimeConfig>,
     env_vars: HashMap<String, String>,
     pricing: Arc<cost::PricingTable>,
@@ -2253,6 +2453,21 @@ async fn instantiate_harness(
             )
             .await?,
         ),
+        HarnessKind::TypeScript
+            if matches!(
+                selection,
+                Some(HarnessSelection::TypeScriptPreset(
+                    TypeScriptHarnessPreset::Codex
+                ))
+            ) =>
+        {
+            Arc::new(TypeScriptHarness::<ExoToolRuntime>::exo_from_exoharness(
+                root,
+                exoharness,
+                runtime_config,
+                env_vars,
+            )?)
+        }
         HarnessKind::TypeScript => Arc::new(TypeScriptHarness::from_exoharness(
             exoharness,
             runtime_config,
@@ -2968,6 +3183,48 @@ mod create_tests {
             cli.command,
             super::Commands::Repl { model: Some(model), .. } if model == "gpt-5.4"
         ));
+    }
+
+    #[test]
+    fn codex_login_accepts_device_auth() {
+        use clap::Parser;
+        let cli = super::Cli::try_parse_from(["exo", "codex", "login", "--device-auth"])
+            .expect("codex device login parses");
+        assert!(matches!(
+            cli.command,
+            super::Commands::Codex {
+                command: super::CodexCommands::Login { device_auth: true }
+            }
+        ));
+    }
+
+    #[test]
+    fn model_register_allows_subscription_auth_without_secret() {
+        use clap::Parser;
+        let cli = super::Cli::try_parse_from(["exo", "model", "register", "gpt-5.5"])
+            .expect("secretless model registration parses");
+        assert!(matches!(
+            cli.command,
+            super::Commands::Model {
+                command: super::ModelCommands::Register {
+                    name,
+                    secret: None,
+                    ..
+                }
+            } if name == "gpt-5.5"
+        ));
+    }
+
+    #[test]
+    fn codex_home_honors_explicit_override() {
+        let env = std::collections::HashMap::from([(
+            "EXO_CODEX_HOME".to_string(),
+            "/tmp/exo-test-codex-home".to_string(),
+        )]);
+        assert_eq!(
+            super::exo_codex_home(&env).expect("codex home"),
+            std::path::PathBuf::from("/tmp/exo-test-codex-home")
+        );
     }
 
     #[test]

--- a/crates/executor/src/adapter/tools.rs
+++ b/crates/executor/src/adapter/tools.rs
@@ -33,21 +33,26 @@ const DEFAULT_EXOCHAT_BASE_URL: &str = "https://exoharness.ai";
 #[derive(Debug, Clone)]
 pub struct AdapterCreationOptions {
     worker_root: PathBuf,
+    tsx_cli_path: PathBuf,
     default_irc_nick_prefix: String,
     default_irc_username: String,
 }
 
 impl AdapterCreationOptions {
-    pub fn new(worker_root: impl Into<PathBuf>) -> Self {
+    pub fn new(worker_root: impl Into<PathBuf>, tsx_cli_path: impl Into<PathBuf>) -> Self {
         Self {
             worker_root: worker_root.into(),
+            tsx_cli_path: tsx_cli_path.into(),
             default_irc_nick_prefix: "exo".to_string(),
             default_irc_username: "exo".to_string(),
         }
     }
 
     fn worker_command(&self, adapter_type: &str) -> Vec<String> {
-        worker_command(self.worker_root.join(adapter_type).join("worker.ts"))
+        worker_command(
+            &self.tsx_cli_path,
+            self.worker_root.join(adapter_type).join("worker.ts"),
+        )
     }
 }
 
@@ -602,11 +607,11 @@ fn exochat_secret() -> String {
     URL_SAFE_NO_PAD.encode(format!("{}:{}", Uuid7::now(), Uuid7::now()))
 }
 
-fn worker_command(path: PathBuf) -> Vec<String> {
+fn worker_command(tsx_cli_path: &Path, worker_path: PathBuf) -> Vec<String> {
     vec![
-        "pnpm".to_string(),
-        "tsx".to_string(),
-        path.to_string_lossy().into_owned(),
+        "node".to_string(),
+        tsx_cli_path.to_string_lossy().into_owned(),
+        worker_path.to_string_lossy().into_owned(),
     ]
 }
 
@@ -1219,7 +1224,7 @@ mod tests {
     use crate::{AgentConfig, AgentHarnessKind, ConversationConfig};
 
     fn test_creation_options() -> AdapterCreationOptions {
-        AdapterCreationOptions::new("/tmp/exo-adapters")
+        AdapterCreationOptions::new("/tmp/exo-adapters", "/tmp/node_modules/tsx/dist/cli.mjs")
     }
 
     #[test]
@@ -1337,8 +1342,11 @@ mod tests {
             adapter.conversation_id,
             conversation.record().id.to_string()
         );
-        assert_eq!(adapter.config.worker_command[0], "pnpm");
-        assert_eq!(adapter.config.worker_command[1], "tsx");
+        assert_eq!(adapter.config.worker_command[0], "node");
+        assert_eq!(
+            adapter.config.worker_command[1],
+            "/tmp/node_modules/tsx/dist/cli.mjs"
+        );
         assert!(adapter.config.worker_command[2].ends_with("/tmp/exo-adapters/irc/worker.ts"));
 
         let list_result = execute_list_adapters_tool(

--- a/crates/executor/src/harness_tool.rs
+++ b/crates/executor/src/harness_tool.rs
@@ -46,11 +46,15 @@ impl ExoToolRuntime {
         scheduler_root: impl Into<PathBuf>,
         adapter_root: impl Into<PathBuf>,
         adapter_worker_root: impl Into<PathBuf>,
+        tsx_cli_path: impl Into<PathBuf>,
     ) -> Self {
         Self {
             scheduler_store: SchedulerStore::new(scheduler_root),
             adapter_store: AdapterStore::new(adapter_root),
-            adapter_creation_options: AdapterCreationOptions::new(adapter_worker_root),
+            adapter_creation_options: AdapterCreationOptions::new(
+                adapter_worker_root,
+                tsx_cli_path,
+            ),
         }
     }
 }

--- a/crates/executor/src/typescript.rs
+++ b/crates/executor/src/typescript.rs
@@ -872,21 +872,21 @@ impl TypeScriptHarness<BasicToolRuntime> {
 }
 
 impl TypeScriptHarness<ExoToolRuntime> {
-    pub async fn exo_from_root(
+    pub fn exo_from_exoharness(
         root: impl AsRef<Path>,
-        exo_config: BasicExoHarnessConfig,
+        exoharness: Arc<dyn ExoHarness>,
         runtime_config: Option<BraintrustRuntimeConfig>,
         env: HashMap<String, String>,
     ) -> Result<Self> {
         let workspace_root = std::env::current_dir()
             .context("failed to resolve current directory for Exo harness")?;
         let root = root.as_ref();
-        let exoharness: Arc<dyn ExoHarness> = Arc::new(BasicExoHarness::new(exo_config).await?);
         let adapter_worker_root = workspace_root.join("examples/exo/adapters");
         let tools = Arc::new(ExoToolRuntime::with_roots(
             root.join("scheduled-tasks"),
             root.join("adapters"),
             adapter_worker_root,
+            workspace_root.join("node_modules/tsx/dist/cli.mjs"),
         ));
         let runtime = ExecutorHarnessRuntime::new(
             TypeScriptExecutor::new(Arc::clone(&exoharness), workspace_root, env, tools),
@@ -895,6 +895,16 @@ impl TypeScriptHarness<ExoToolRuntime> {
         Ok(Self {
             inner: SharedHarness::new(exoharness, runtime),
         })
+    }
+
+    pub async fn exo_from_root(
+        root: impl AsRef<Path>,
+        exo_config: BasicExoHarnessConfig,
+        runtime_config: Option<BraintrustRuntimeConfig>,
+        env: HashMap<String, String>,
+    ) -> Result<Self> {
+        let exoharness: Arc<dyn ExoHarness> = Arc::new(BasicExoHarness::new(exo_config).await?);
+        Self::exo_from_exoharness(root, exoharness, runtime_config, env)
     }
 }
 

--- a/docs/coding-agent-harnesses.md
+++ b/docs/coding-agent-harnesses.md
@@ -40,21 +40,50 @@ For upgrades, downgrades, uninstall instructions, and building from source, see
 
 ## Codex
 
-Register an OpenAI model:
+Sign Exo in with ChatGPT, then register a secretless model binding. This uses
+the Codex access included with your ChatGPT plan rather than API billing:
+
+```bash
+./target/debug/exo codex login
+./target/debug/exo model register gpt-5.5
+```
+
+The Exo login is isolated from the Codex CLI and VS Code extension. Use
+`exo codex status` to inspect it, `exo codex logout` to remove it, and
+`exo codex login --device-auth` on a headless machine. Set `EXO_CODEX_HOME`
+to override Exo's platform-specific credential directory.
+
+To use API billing instead, register the model with an API-key secret:
 
 ```bash
 ./target/debug/exo secret set openai --env OPENAI_API_KEY
 ./target/debug/exo model register gpt-5.5 --secret openai
 ```
 
+ChatGPT subscription authentication is available only to the Codex harness.
+The basic, RLM, and direct Responses API harnesses still require API credentials.
+
 Build the sandbox image:
 
 ```bash
-container build \
+docker build \
   --platform linux/arm64 \
   -t exo-codex-sandbox:latest \
   containers/codex-sandbox
 ```
+
+To launch the normal Exo stack with the Codex harness, including Docker,
+ExoChat, the adapter runner, and the CLI chat, run:
+
+```bash
+./exo.sh --harness codex
+```
+
+The Codex harness owns the model turn and sandbox tool loop. Exo still owns
+agent and conversation state, sandbox lifecycle, adapter persistence, inbound
+wake-ups, and ExoChat delivery. The Codex preset currently exposes Exo's
+adapter tools; it does not combine the Codex loop with every tool and prompt
+from `examples/exo/harness.ts`.
 
 Create the agent and start a conversation:
 

--- a/examples/exo/README.md
+++ b/examples/exo/README.md
@@ -42,6 +42,19 @@ scheduler and adapter runner, sets up the ExoChat adapter, prints a browser
 chat URL using the hosted control plane at `https://exoharness.ai`, and drops
 you into a REPL.
 
+To use the ChatGPT subscription-backed Codex harness with the same launcher
+and ExoChat path, complete the
+[Codex setup](../../docs/coding-agent-harnesses.md#codex), then run:
+
+```bash
+./exo.sh --harness codex
+```
+
+Codex owns the model and sandbox tool loop in this mode. Exo continues to own
+the persisted agent/conversation, adapter runner, inbound wake-up, and ExoChat
+delivery path. The Codex preset exposes Exo's adapter tools, not the complete
+tool and prompt surface of this Exo harness.
+
 For developer testing with IRC and Discord instead, use the `dev` template:
 
 ```bash

--- a/examples/exo/scripts/exo-service-guardian
+++ b/examples/exo/scripts/exo-service-guardian
@@ -57,6 +57,7 @@ Commands:
   logs [scheduler|adapters] Print recent service logs
 
 Options:
+  --harness <harness>       Agent harness used by the adapter runner: exo or codex
   --env-file <path>         Env file to read if present (default: .env)
   --exo-bin <path>          exo binary path (default: ./target/debug/exo)
   --scheduler-bin <path>    Scheduler runner path
@@ -93,6 +94,7 @@ write_config() {
   {
     echo "# Exo guardian host-side launch settings."
     echo "# This file is local state and should not be committed."
+    quote_var "HARNESS" "$HARNESS"
     quote_var "EXO_BIN" "$EXO_BIN"
     quote_var "SCHEDULER_BIN" "$SCHEDULER_BIN"
     quote_var "ENV_FILE" "$ENV_FILE"
@@ -448,6 +450,14 @@ RESTART_REASON="restart-services"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --harness)
+      HARNESS="${2:-}"
+      case "$HARNESS" in
+        exo|codex) ;;
+        *) die "--harness must be exo or codex" ;;
+      esac
+      shift 2
+      ;;
     --env-file)
       ENV_FILE="${2:-}"
       [[ -n "$ENV_FILE" ]] || die "--env-file requires a value"

--- a/examples/typescript/codex-harness.test.ts
+++ b/examples/typescript/codex-harness.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import type { TurnContext } from "@exo/harness";
+
+import {
+  buildCodexDynamicTools,
+  codexChatgptLoginParams,
+  codexSandboxCommand,
+  codexSandboxEnv,
+  credentialFingerprint,
+  resolveCodexCredential,
+} from "./codex-harness";
+
+describe("Codex harness authentication", () => {
+  it("exposes Exo adapter tools through the Codex app-server", () => {
+    const tools = buildCodexDynamicTools({
+      conversationConfig: { shellProgram: "/bin/bash" },
+    } as TurnContext);
+
+    expect(
+      tools.map((tool) =>
+        typeof tool === "object" && tool !== null && !Array.isArray(tool)
+          ? tool.name
+          : null,
+      ),
+    ).toEqual([
+      "create_adapter",
+      "list_adapters",
+      "disable_adapter",
+      "delete_adapter",
+      "send_adapter_message",
+    ]);
+  });
+
+  it("passes API keys only through the API-key environment", () => {
+    const env = codexSandboxEnv(
+      { name: "gpt", model: "gpt-5.5", apiKey: "sk-test" },
+      {
+        kind: "api_key",
+        token: "sk-test",
+        fingerprint: credentialFingerprint("api_key", "sk-test"),
+      },
+    );
+
+    expect(env.OPENAI_API_KEY).toBe("sk-test");
+    expect(env.CODEX_ACCESS_TOKEN).toBeUndefined();
+    expect(env.CODEX_HOME).not.toContain("sk-test");
+  });
+
+  it("keeps ChatGPT access tokens out of the sandbox environment", () => {
+    const env = codexSandboxEnv(
+      { name: "gpt", model: "gpt-5.5" },
+      {
+        kind: "chatgpt",
+        token: "chatgpt-test-token",
+        accountId: "account-test",
+        fingerprint: credentialFingerprint("chatgpt", "chatgpt-test-token"),
+      },
+    );
+
+    expect(env.CODEX_ACCESS_TOKEN).toBeUndefined();
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+    expect(env.CODEX_HOME).not.toContain("chatgpt-test-token");
+  });
+
+  it("uses Codex external auth with the ChatGPT account ID", () => {
+    expect(
+      codexChatgptLoginParams("chatgpt-test-token", "account-test"),
+    ).toEqual({
+      type: "chatgptAuthTokens",
+      accessToken: "chatgpt-test-token",
+      chatgptAccountId: "account-test",
+    });
+  });
+
+  it("does not forward arbitrary host Codex variables", () => {
+    const previous = process.env.CODEX_BIN;
+    process.env.CODEX_BIN = "/host/secret/codex";
+    try {
+      const env = codexSandboxEnv(
+        { name: "gpt", model: "gpt-5.5", apiKey: "sk-test" },
+        {
+          kind: "api_key",
+          token: "sk-test",
+          fingerprint: credentialFingerprint("api_key", "sk-test"),
+        },
+      );
+      expect(env.CODEX_BIN).toBeUndefined();
+    } finally {
+      if (previous === undefined) {
+        delete process.env.CODEX_BIN;
+      } else {
+        process.env.CODEX_BIN = previous;
+      }
+    }
+  });
+
+  it("removes model credentials from command subprocess environments", () => {
+    const command = codexSandboxCommand({
+      conversationConfig: { shellProgram: "/bin/bash" },
+    } as TurnContext).join(" ");
+
+    expect(command).toContain("shell_environment_policy.exclude");
+    expect(command).toContain("OPENAI_API_KEY");
+    expect(command).toContain("CODEX_ACCESS_TOKEN");
+  });
+
+  it("rejects custom endpoints in subscription mode before authentication", async () => {
+    await expect(
+      resolveCodexCredential({
+        name: "custom",
+        model: "gpt-5.5",
+        baseUrl: "https://example.invalid/v1",
+      }),
+    ).rejects.toThrow("custom base URL but no API-key secret");
+  });
+
+  it("uses non-reversible credential fingerprints", () => {
+    const fingerprint = credentialFingerprint("chatgpt", "secret-token");
+    expect(fingerprint).toMatch(/^[0-9a-f]{64}$/);
+    expect(fingerprint).not.toContain("secret-token");
+    expect(credentialFingerprint("api_key", "secret-token")).not.toBe(
+      fingerprint,
+    );
+  });
+});

--- a/examples/typescript/codex-harness.ts
+++ b/examples/typescript/codex-harness.ts
@@ -1,20 +1,30 @@
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir, readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
 import {
   appendCustomEvent,
   assistantTextMessage,
+  createToolRegistry,
   defineHarness,
   messageText,
   messagesEvent,
+  registerAdapterTools,
   stringifyValue,
   toJsonValue,
   toolRequestedEvent,
   toolResultEvent,
   turnMetadata,
   type EventData,
+  type HarnessToolRegistry,
   type JsonObject,
   type JsonValue,
   type Message,
   type PendingToolCall,
   type SandboxProcess,
+  type ToolResult,
   type TurnContext,
 } from "@exo/harness";
 import {
@@ -26,7 +36,7 @@ import {
 import { responsesMessagesToLingua } from "@braintrust/lingua";
 import {
   errorMessage,
-  ResponsesRuntime,
+  traceExecutorTurn,
   tracedUnderParent,
   type TraceParent,
 } from "@exo/model-runtime/responses";
@@ -105,6 +115,25 @@ interface CodexWarmSessionRecord {
   threadId: string;
 }
 
+type CodexCredential =
+  | {
+      kind: "api_key";
+      token: string;
+      fingerprint: string;
+    }
+  | {
+      kind: "chatgpt";
+      token: string;
+      accountId: string;
+      fingerprint: string;
+    };
+
+interface CodexAuthStatus {
+  authMethod: string | null;
+  authToken: string | null;
+  requiresOpenaiAuth: boolean | null;
+}
+
 class CodexWarmSession {
   threadId: string | null;
   private current: CodexWarmTurnScope | null;
@@ -122,13 +151,14 @@ class CodexWarmSession {
   static async start(
     scope: CodexWarmTurnScope,
     modelBinding: ResolvedLlmBinding,
+    credential: CodexCredential,
     sessionKey: string,
   ): Promise<CodexWarmSession> {
     let session: CodexWarmSession | null = null;
     const pendingProtocol: CodexProtocolLogEntry[] = [];
     const process = await scope.context.startSandboxProcess({
       command: codexSandboxCommand(scope.context),
-      env: codexSandboxEnv(modelBinding),
+      env: codexSandboxEnv(modelBinding, credential),
       reuseKey: sessionKey,
     });
     const warmRecord = process.reused
@@ -149,6 +179,9 @@ class CodexWarmSession {
     const server = process.reused
       ? await CodexAppServer.attachToSandbox(options)
       : await CodexAppServer.startInSandbox(options);
+    if (credential.kind === "chatgpt") {
+      await loginCodexWithChatgptCredential(server, credential);
+    }
     session = new CodexWarmSession(
       server,
       process,
@@ -182,6 +215,9 @@ class CodexWarmSession {
   private handleServerRequest(
     request: CodexServerRequest,
   ): Promise<JsonValue | undefined> | JsonValue | undefined {
+    if (request.method === "account/chatgptAuthTokens/refresh") {
+      return refreshCodexChatgptCredential();
+    }
     const current = this.current;
     if (!current) {
       return undefined;
@@ -195,31 +231,214 @@ class CodexWarmSession {
 }
 
 const codexSessions = new WarmResourceCache<CodexWarmSession>();
+const codexSessionKeys = new Map<string, string>();
+let codexHostAuthBroker: Promise<CodexAppServer> | null = null;
 
 export default defineHarness({
   async runTurn(context) {
     const modelBinding = await resolveLlmBinding(context);
-    const runtime = ResponsesRuntime.fromModelBinding(
-      context.agentConfig,
-      modelBinding,
-    );
-    await runtime.runTurn(context, (turnParent) =>
-      runCodexTurn(context, turnParent, modelBinding),
+    const credential = await resolveCodexCredential(modelBinding);
+    await traceExecutorTurn(context, (turnParent) =>
+      runCodexTurn(context, turnParent, modelBinding, credential),
     );
   },
 });
+
+export async function resolveCodexCredential(
+  modelBinding: ResolvedLlmBinding,
+): Promise<CodexCredential> {
+  if (modelBinding.apiKey) {
+    return {
+      kind: "api_key",
+      token: modelBinding.apiKey,
+      fingerprint: credentialFingerprint("api_key", modelBinding.apiKey),
+    };
+  }
+  if (modelBinding.baseUrl) {
+    throw new Error(
+      `Codex model ${modelBinding.name} has a custom base URL but no API-key secret; ChatGPT subscription auth only supports the built-in OpenAI provider`,
+    );
+  }
+  const credential = await codexChatgptCredential();
+  return {
+    kind: "chatgpt",
+    token: credential.token,
+    accountId: credential.accountId,
+    fingerprint: credentialFingerprint("chatgpt", credential.token),
+  };
+}
+
+export function credentialFingerprint(
+  kind: CodexCredential["kind"],
+  token: string,
+) {
+  return createHash("sha256").update(`${kind}\0${token}`).digest("hex");
+}
+
+async function codexChatgptCredential(): Promise<{
+  token: string;
+  accountId: string;
+}> {
+  const broker = await getCodexHostAuthBroker();
+  try {
+    const status = await broker.request<CodexAuthStatus & JsonObject>(
+      "getAuthStatus",
+      {
+        includeToken: true,
+        refreshToken: true,
+      },
+    );
+    if (
+      !status.authMethod?.toLowerCase().startsWith("chatgpt") ||
+      !status.authToken
+    ) {
+      throw new Error(
+        "Exo is not signed in to ChatGPT; run `exo codex login` and retry",
+      );
+    }
+    const accountId = await codexChatgptAccountId();
+    return { token: status.authToken, accountId };
+  } catch (error) {
+    codexHostAuthBroker = null;
+    broker.close();
+    throw error;
+  }
+}
+
+async function codexChatgptAccountId(): Promise<string> {
+  const authPath = join(exoCodexHome(), "auth.json");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await readFile(authPath, "utf8")) as unknown;
+  } catch (error) {
+    throw new Error(
+      `Could not read the ChatGPT account ID from ${authPath}: ${errorMessage(error)}`,
+    );
+  }
+  const tokens = asRecord(asRecord(parsed).tokens);
+  const accountId = stringOrNull(tokens.account_id);
+  if (!accountId) {
+    throw new Error(
+      `The Codex login in ${authPath} does not include a ChatGPT account ID; run \`exo codex login\` again`,
+    );
+  }
+  return accountId;
+}
+
+async function loginCodexWithChatgptCredential(
+  server: CodexAppServer,
+  credential: Extract<CodexCredential, { kind: "chatgpt" }>,
+): Promise<void> {
+  await server.request(
+    "account/login/start",
+    codexChatgptLoginParams(credential.token, credential.accountId),
+  );
+}
+
+export function codexChatgptLoginParams(
+  accessToken: string,
+  accountId: string,
+): JsonObject {
+  return {
+    type: "chatgptAuthTokens",
+    accessToken,
+    chatgptAccountId: accountId,
+  };
+}
+
+async function refreshCodexChatgptCredential(): Promise<JsonValue> {
+  const credential = await codexChatgptCredential();
+  return {
+    accessToken: credential.token,
+    chatgptAccountId: credential.accountId,
+    chatgptPlanType: null,
+  };
+}
+
+async function getCodexHostAuthBroker(): Promise<CodexAppServer> {
+  codexHostAuthBroker ??= startCodexHostAuthBroker().catch((error: unknown) => {
+    codexHostAuthBroker = null;
+    throw error;
+  });
+  return codexHostAuthBroker;
+}
+
+async function startCodexHostAuthBroker(): Promise<CodexAppServer> {
+  const codexHome = exoCodexHome();
+  await mkdir(codexHome, { recursive: true, mode: 0o700 });
+  return CodexAppServer.start({
+    executable: hostCodexExecutable(),
+    env: {
+      CODEX_HOME: codexHome,
+      CODEX_ACCESS_TOKEN: undefined,
+      OPENAI_API_KEY: undefined,
+    },
+    configOverrides: ['cli_auth_credentials_store="file"'],
+  });
+}
+
+function exoCodexHome(): string {
+  const configured = process.env.EXO_CODEX_HOME?.trim();
+  if (configured) {
+    return configured;
+  }
+  const home = homedir();
+  if (process.platform === "darwin") {
+    return join(home, "Library", "Application Support", "exo", "codex");
+  }
+  if (process.platform === "win32") {
+    return join(
+      process.env.LOCALAPPDATA ?? join(home, "AppData", "Local"),
+      "exo",
+      "codex",
+    );
+  }
+  return join(
+    process.env.XDG_DATA_HOME ?? join(home, ".local", "share"),
+    "exo",
+    "codex",
+  );
+}
+
+function hostCodexExecutable(): string {
+  const configured =
+    process.env.EXO_HOST_CODEX_BIN?.trim() ?? process.env.CODEX_BIN?.trim();
+  if (configured) {
+    return configured;
+  }
+  const bundled = join(
+    process.cwd(),
+    "node_modules",
+    ".bin",
+    process.platform === "win32" ? "codex.cmd" : "codex",
+  );
+  return existsSync(bundled) ? bundled : "codex";
+}
 
 async function runCodexTurn(
   context: TurnContext,
   turnParent: TraceParent,
   modelBinding: ResolvedLlmBinding,
+  credential: CodexCredential,
 ): Promise<string | null> {
   await requireCodexSandboxNetworking(context);
 
   const { turn } = context.exoharness.current;
   const protocolLog = new CodexProtocolEventBuffer(context);
   const scope: CodexWarmTurnScope = { context, protocolLog, turnParent };
-  const sessionKey = codexWarmSessionKey(context, modelBinding);
+  const sessionKey = codexWarmSessionKey(
+    context,
+    modelBinding,
+    credential.fingerprint,
+  );
+  const sessionScope = codexSessionScope(context);
+  const previousSessionKey = codexSessionKeys.get(sessionScope);
+  if (previousSessionKey && previousSessionKey !== sessionKey) {
+    await codexSessions.delete(previousSessionKey, (session) =>
+      session.close(),
+    );
+  }
+  codexSessionKeys.set(sessionScope, sessionKey);
   const sandboxRuntime = codexSandboxRuntimeKey(context);
   const { resource: session, reused: appServerReused } = await traceCodexTask(
     turnParent,
@@ -232,7 +451,7 @@ async function runCodexTurn(
     },
     () =>
       codexSessions.get(sessionKey, () =>
-        CodexWarmSession.start(scope, modelBinding, sessionKey),
+        CodexWarmSession.start(scope, modelBinding, credential, sessionKey),
       ),
   );
   session.setTurnScope(scope);
@@ -620,6 +839,50 @@ async function executeDynamicToolCall(
 ): Promise<JsonValue> {
   const callId = stringOrNull(params.callId) ?? "dynamic-tool-call";
   const toolName = stringOrNull(params.tool);
+  if (!toolName) {
+    return dynamicToolErrorResponse("dynamic tool request omitted tool name");
+  }
+
+  const adapterTool = codexAdapterToolRegistry(context).get(toolName);
+  if (adapterTool) {
+    const args = objectArgs(asRecord(params.arguments));
+    const toolCall: PendingToolCall = {
+      toolCallId: callId,
+      request: {
+        functionName: toolName,
+        arguments: args,
+      },
+    };
+    await appendEvents(context, [toolRequestedEvent(toolCall)]);
+    try {
+      const result = await adapterTool.handler.execute(args, {
+        context,
+        toolCallId: callId,
+      });
+      await appendEvents(context, [toolResultEvent(callId, result)]);
+      await traceObservedToolCall(
+        context,
+        turnParent,
+        toolCall,
+        result,
+        "codex_dynamic_tool",
+      );
+      return codexDynamicToolResult(result);
+    } catch (error) {
+      const message = errorMessage(error);
+      const result = toJsonValue({ ok: false, error: message });
+      await appendEvents(context, [toolResultEvent(callId, result)]);
+      await traceObservedToolCall(
+        context,
+        turnParent,
+        toolCall,
+        result,
+        "codex_dynamic_tool",
+      );
+      return dynamicToolErrorResponse(message);
+    }
+  }
+
   if (toolName !== EXO_SHELL_DYNAMIC_TOOL) {
     return dynamicToolErrorResponse(`unsupported dynamic tool: ${toolName}`);
   }
@@ -995,15 +1258,18 @@ function codexDeveloperInstructions(context: TurnContext): string | null {
   return instructionsText(context.agentConfig.instructions) || null;
 }
 
-function buildCodexDynamicTools(context: TurnContext): JsonValue[] {
-  if (useCodexExternalSandbox()) {
-    return [];
-  }
-  if (!context.conversationConfig.shellProgram) {
-    return [];
-  }
-  return [
-    {
+export function buildCodexDynamicTools(context: TurnContext): JsonValue[] {
+  const tools = codexAdapterToolRegistry(context)
+    .definitions()
+    .map((definition) => ({
+      type: "function",
+      name: definition.name,
+      description: definition.description,
+      inputSchema: definition.parameters,
+    }));
+  if (!useCodexExternalSandbox() && context.conversationConfig.shellProgram) {
+    tools.push({
+      type: "function",
       name: EXO_SHELL_DYNAMIC_TOOL,
       description: `Run a shell command through the exoharness sandbox. Commands execute from ${sandboxCwd(context)}. Use this for command execution in exo conversations.`,
       inputSchema: {
@@ -1017,8 +1283,15 @@ function buildCodexDynamicTools(context: TurnContext): JsonValue[] {
         },
         required: ["command"],
       },
-    },
-  ];
+    });
+  }
+  return tools;
+}
+
+function codexAdapterToolRegistry(context: TurnContext): HarnessToolRegistry {
+  const tools = createToolRegistry(context);
+  registerAdapterTools(tools);
+  return tools;
 }
 
 function codexNativeSandboxPolicy(): JsonValue {
@@ -1068,7 +1341,7 @@ function codexEffectiveNetworking(context: TurnContext): boolean {
   return context.agentConfig.sandbox.enableNetworking;
 }
 
-function codexSandboxCommand(context: TurnContext): string[] {
+export function codexSandboxCommand(context: TurnContext): string[] {
   const shell = context.conversationConfig.shellProgram ?? "/bin/bash";
   const command = [
     "set -e;",
@@ -1076,30 +1349,32 @@ function codexSandboxCommand(context: TurnContext): string[] {
     'if [ -n "${OPENAI_API_KEY:-}" ] && [ ! -f "${CODEX_HOME:-/tmp/exo-codex-home}/auth.json" ]; then',
     'printf "%s" "$OPENAI_API_KEY" | codex login --with-api-key >/dev/null 2>/tmp/codex-login.stderr;',
     "fi;",
-    "exec codex app-server --listen stdio:// 2>/tmp/codex-app-server.stderr",
+    "exec codex -c",
+    `'shell_environment_policy.exclude=["OPENAI_API_KEY","CODEX_ACCESS_TOKEN"]'`,
+    "app-server --listen stdio:// 2>/tmp/codex-app-server.stderr",
   ].join(" ");
   return [shell, "-lc", command];
 }
 
-function codexSandboxEnv(
+export function codexSandboxEnv(
   modelBinding: ResolvedLlmBinding,
+  credential: CodexCredential,
 ): Record<string, string> {
   const env: Record<string, string> = {
-    ...pickEnv(
-      (key) =>
-        [
-          "BRAINTRUST_API_KEY",
-          "BRAINTRUST_APP_URL",
-          "OPENAI_ORG_ID",
-          "OPENAI_ORGANIZATION",
-          "OPENAI_PROJECT",
-        ].includes(key) || key.startsWith("CODEX_"),
+    ...pickEnv((key) =>
+      [
+        "BRAINTRUST_API_KEY",
+        "BRAINTRUST_APP_URL",
+        "OPENAI_ORG_ID",
+        "OPENAI_ORGANIZATION",
+        "OPENAI_PROJECT",
+      ].includes(key),
     ),
-    CODEX_HOME: "/tmp/exo-codex-home",
+    CODEX_HOME: `/tmp/exo-codex-home-${credential.fingerprint.slice(0, 16)}`,
     HOME: "/tmp/exo-home",
   };
-  if (modelBinding.apiKey) {
-    env.OPENAI_API_KEY = modelBinding.apiKey;
+  if (credential.kind === "api_key") {
+    env.OPENAI_API_KEY = credential.token;
   }
   if (modelBinding.baseUrl) {
     env.OPENAI_BASE_URL = modelBinding.baseUrl;
@@ -1119,6 +1394,13 @@ function dynamicToolResultResponse(
 
 function dynamicToolErrorResponse(message: string): JsonValue {
   return dynamicToolResultResponse(`Error: ${message}`, { success: false });
+}
+
+function codexDynamicToolResult(result: ToolResult): JsonValue {
+  const record = asRecord(result);
+  return dynamicToolResultResponse(stringifyValue(result), {
+    success: record.ok !== false,
+  });
 }
 
 function codexAppServerCwd(context: TurnContext): string {
@@ -1163,6 +1445,7 @@ function codexSandboxRuntimeKey(context: TurnContext): JsonValue {
 function codexWarmSessionKey(
   context: TurnContext,
   modelBinding: ResolvedLlmBinding,
+  authFingerprint: string,
 ): string {
   return JSON.stringify({
     agent_id: context.exoharness.current.agent.record.id,
@@ -1170,8 +1453,16 @@ function codexWarmSessionKey(
     model_binding: modelBinding.name,
     model: modelBinding.model,
     base_url: modelBinding.baseUrl ?? null,
+    auth_fingerprint: authFingerprint,
     sandbox_runtime: codexSandboxRuntimeKey(context),
   });
+}
+
+function codexSessionScope(context: TurnContext): string {
+  return [
+    context.exoharness.current.agent.record.id,
+    context.exoharness.current.conversation.record.id,
+  ].join(":");
 }
 
 function notificationItem(

--- a/examples/typescript/shared.ts
+++ b/examples/typescript/shared.ts
@@ -238,7 +238,7 @@ export async function resolveLlmBinding(
     .sort((left, right) => right.createdAt.localeCompare(left.createdAt))[0];
   if (!metadata) {
     throw new Error(
-      `model is not registered: ${name}; run \`exo model register ${name} --secret <secret>\``,
+      `model is not registered: ${name}; run \`exo model register ${name}\` for Codex subscription auth or add \`--secret <secret>\` for API-key auth`,
     );
   }
   const binding = await context.exoharness.current.conversation.getBinding(

--- a/exo.sh
+++ b/exo.sh
@@ -16,15 +16,15 @@ fi
 EXO_BIN="${EXO_BIN:-$ROOT_DIR/target/debug/exo}"
 SCHEDULER_BIN="${EXO_SCHEDULER_BIN:-$ROOT_DIR/target/debug/exo-scheduler-runner}"
 ENV_FILE="${EXO_ENV_FILE:-$ROOT_DIR/.env}"
-MODEL="${EXO_MODEL:-gpt-5.6-terra}"
-AGENT="${EXO_AGENT:-exo-agent}"
-AGENT_NAME="${EXO_AGENT_NAME:-Exo Agent}"
-CONVERSATION="${EXO_CONVERSATION:-dev}"
-CONVERSATION_NAME="${EXO_CONVERSATION_NAME:-Dev}"
-MODULE="${EXO_MODULE:-examples/exo/harness.ts}"
-HARNESS="exo"
+HARNESS="${EXO_HARNESS:-exo}"
+MODEL="${EXO_MODEL:-}"
+AGENT="${EXO_AGENT:-}"
+AGENT_NAME="${EXO_AGENT_NAME:-}"
+CONVERSATION="${EXO_CONVERSATION:-}"
+CONVERSATION_NAME="${EXO_CONVERSATION_NAME:-}"
+MODULE="${EXO_MODULE:-}"
 LOCAL_PROMPT_FILE="${EXO_LOCAL_PROMPT_FILE:-$ROOT_DIR/.exo/exo-profile.md}"
-SANDBOX_IMAGE="${EXO_SANDBOX_IMAGE:-ubuntu:24.04}"
+SANDBOX_IMAGE="${EXO_SANDBOX_IMAGE:-}"
 SANDBOX_PROVIDER="${EXO_SANDBOX_PROVIDER:-}"
 SANDBOX_BACKEND="${EXO_SANDBOX_BACKEND:-}"
 SELF_REPO_MOUNT_PATH="${EXO_REPO:-/workspace/exo}"
@@ -98,18 +98,21 @@ Subcommands:
                    image) without starting anything
 
 Options:
-  --model <model>              Model binding name (default: gpt-5.6-terra)
+  --harness <harness>          Agent harness: exo or codex (default: exo).
+                                Codex uses ChatGPT subscription auth.
+  --model <model>              Model binding name (default: gpt-5.6-terra for
+                                exo, gpt-5.5 for codex)
   --upstream-model <model>     Upstream model id for register-model (default: --model)
   --secret-name <name>         Secret name for register-model (e.g. openai)
   --secret-env <env-var>       Environment variable holding the API key for register-model
   --base-url <url>             Optional API base URL for register-model
   --user-name <name>           User name for write-profile (default: none)
-  --agent <slug>               Agent slug (default: exo-agent)
+  --agent <slug>               Agent slug (default: exo-agent or codex-agent)
   --conversation <slug>        Conversation slug (default: dev)
   --convo <slug>               Alias for --conversation
-  --agent-name <name>          Agent display name (default: Exo Agent)
+  --agent-name <name>          Agent display name (default: Exo Agent or Codex Agent)
   --conversation-name <name>   Conversation display name (default: Dev)
-  --module <path>              Exo TypeScript harness module
+  --module <path>              TypeScript module used by the exo harness
   --template <name>            Launch template (default: canonical):
                                  canonical  Docker sandbox, repo self-map mount, ExoChat
                                             setup, control logs, and guardian config
@@ -117,7 +120,8 @@ Options:
                                             instead of ExoChat
                                  minimal    No Docker defaults, adapter setup prompts,
                                             control console, or guardian config
-  --sandbox-image <image>      Sandbox image (default: ubuntu:24.04)
+  --sandbox-image <image>      Sandbox image (default: ubuntu:24.04 for exo,
+                                exo-codex-sandbox:latest for codex)
   --sandbox-provider <provider>
                                 Sandbox provider: daytona, apple-container, docker, or local-process
   --sandbox-backend <backend>   Local sandbox backend: apple-container, docker, or local-process.
@@ -155,7 +159,7 @@ Options:
   --help                       Show this help
 
 Environment overrides:
-  EXO_MODEL, EXO_AGENT, EXO_CONVERSATION, EXO_AGENT_NAME,
+  EXO_HARNESS, EXO_MODEL, EXO_AGENT, EXO_CONVERSATION, EXO_AGENT_NAME,
   EXO_CONVERSATION_NAME, EXO_MODULE, EXO_SANDBOX_IMAGE,
   EXO_SANDBOX_PROVIDER, EXO_SANDBOX_BACKEND, EXO_NETWORKING,
   EXO_SHELL_PROGRAM, EXO_SANDBOX_SCOPE, EXO_ENV_FILE, EXO_LOCAL_PROMPT_FILE,
@@ -258,6 +262,30 @@ add_setup_adapter() {
   SETUP_ADAPTERS+=("$adapter")
 }
 
+apply_harness_defaults() {
+  case "$HARNESS" in
+    exo)
+      MODEL="${MODEL:-gpt-5.6-terra}"
+      AGENT="${AGENT:-exo-agent}"
+      AGENT_NAME="${AGENT_NAME:-Exo Agent}"
+      MODULE="${MODULE:-examples/exo/harness.ts}"
+      SANDBOX_IMAGE="${SANDBOX_IMAGE:-ubuntu:24.04}"
+      ;;
+    codex)
+      MODEL="${MODEL:-gpt-5.5}"
+      AGENT="${AGENT:-codex-agent}"
+      AGENT_NAME="${AGENT_NAME:-Codex Agent}"
+      MODULE="${MODULE:-examples/typescript/codex-harness.ts}"
+      SANDBOX_IMAGE="${SANDBOX_IMAGE:-exo-codex-sandbox:latest}"
+      ;;
+    *)
+      die "--harness must be exo or codex"
+      ;;
+  esac
+  CONVERSATION="${CONVERSATION:-dev}"
+  CONVERSATION_NAME="${CONVERSATION_NAME:-Dev}"
+}
+
 apply_template_defaults() {
   if [[ "$TEMPLATE" == "minimal" ]]; then
     return
@@ -294,6 +322,7 @@ configure_guardian_for_current_launch() {
   fi
 
   "$ROOT_DIR/examples/exo/scripts/exo-service-guardian" configure \
+    --harness "$HARNESS" \
     --env-file "$ENV_FILE" \
     --exo-bin "$EXO_BIN" \
     --scheduler-bin "$SCHEDULER_BIN" \
@@ -389,7 +418,7 @@ append_exo_global_args() {
 exo() {
   EXO_GLOBAL_ARGS=()
   append_exo_global_args
-  "$EXO_BIN" "${EXO_GLOBAL_ARGS[@]}" "$@"
+  "$EXO_BIN" "${EXO_GLOBAL_ARGS[@]}" --harness "$HARNESS" "$@"
 }
 
 scheduler_pid_file() {
@@ -462,7 +491,12 @@ adapters_process_running() {
     return 1
   fi
   command_line="$(ps -p "$pid" -o command= 2>/dev/null || true)"
-  [[ "$command_line" == *"adapters run"* ]]
+  if [[ "$command_line" != *"--harness $HARNESS"*"adapters run"* ]]; then
+    echo "Restarting adapter runner for $HARNESS harness..."
+    terminate_process_tree "$pid"
+    return 1
+  fi
+  return 0
 }
 
 adapter_source_newer_than() {
@@ -607,12 +641,13 @@ ensure_agent() {
 
   echo "Creating agent $AGENT..."
   local args=(
-    --harness "$HARNESS"
     agent create "$AGENT_NAME"
     --slug "$AGENT"
-    --module "$MODULE"
     --model "$MODEL"
   )
+  if [[ "$HARNESS" == "exo" ]]; then
+    args+=(--module "$MODULE")
+  fi
   if [[ "$USE_SANDBOX" == true ]]; then
     args+=(--sandbox-image "$SANDBOX_IMAGE" --networking "$NETWORKING")
     if [[ -n "$SANDBOX_PROVIDER" ]]; then
@@ -918,6 +953,7 @@ run_repl() {
     EXO_GLOBAL_ARGS=()
     append_exo_global_args
     exec "$EXO_BIN" "${EXO_GLOBAL_ARGS[@]}" repl \
+      --harness "$HARNESS" \
       --agent "$AGENT" \
       --conversation "$CONVERSATION"
   fi
@@ -979,6 +1015,7 @@ run_control_repl() {
 
     local repl_exit
     if "$EXO_BIN" "${EXO_GLOBAL_ARGS[@]}" repl \
+      --harness "$HARNESS" \
       --agent "$AGENT" \
       --conversation "$CONVERSATION"; then
       repl_exit=0
@@ -1308,6 +1345,14 @@ while [[ $# -gt 0 ]]; do
       shift
       COMMAND="write-profile"
       ;;
+    --harness)
+      HARNESS="${2:-}"
+      case "$HARNESS" in
+        exo|codex) ;;
+        *) die "--harness must be exo or codex" ;;
+      esac
+      shift 2
+      ;;
     --model)
       MODEL="${2:-}"
       [[ -n "$MODEL" ]] || die "--model requires a value"
@@ -1525,6 +1570,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+apply_harness_defaults
 apply_template_defaults
 
 export EXO_LOCAL_PROMPT_FILE="$LOCAL_PROMPT_FILE"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@cursor/sdk": "^1.0.12",
     "@discordjs/voice": "^0.19.0",
     "@mozilla/readability": "^0.6.0",
+    "@openai/codex": "0.144.6",
     "@shadcn/react": "^0.1.0",
     "@whiskeysockets/baileys": "7.0.0-rc13",
     "braintrust": "3.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@mozilla/readability':
         specifier: ^0.6.0
         version: 0.6.0
+      '@openai/codex':
+        specifier: 0.144.6
+        version: 0.144.6
       '@shadcn/react':
         specifier: ^0.1.0
         version: 0.1.0(@types/react@19.2.17)(react@19.2.7)
@@ -1108,6 +1111,47 @@ packages:
     resolution: {integrity: sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==}
     engines: {node: '>=10'}
     deprecated: This functionality has been moved to @npmcli/fs
+
+  '@openai/codex@0.144.6':
+    resolution: {integrity: sha512-wk+2CWiBNXiJLBoN2D08N9RceWkSBnlgk5g2K1a4CXrP/C0gdlHyRUG7RFzm9y41DCK/7tvCct233JVxyFmznw==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  '@openai/codex@0.144.6-darwin-arm64':
+    resolution: {integrity: sha512-6zgvh70MzBNSeT17HEhSOrmmGGZGAKzSC7x6JAq+edkJkdPYA9P0I1tG7aJ49GlBkBxuC+MKBH1qm6+2Cghcww==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@openai/codex@0.144.6-darwin-x64':
+    resolution: {integrity: sha512-THRyPG0zSU6M8NQAge1LHEHsJDnoH4BpKsfJHB/qe3Fm+Wf6zqAmWJFlOKzBm27m0K2Hq3za4Ac2I5p5i4yp/A==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@openai/codex@0.144.6-linux-arm64':
+    resolution: {integrity: sha512-PGiLXMN+2IQRkf7tOLi64dMInjU1pRLbz0Rwfj/yt2Y97SZQqAjFQoi2wmswmqtqMDnfwCPTC1DRXVQkvU6T6Q==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@openai/codex@0.144.6-linux-x64':
+    resolution: {integrity: sha512-4E7EnzCg0OnBxCyYnwJ+qnZwWHYe0YScr5ucKWbngE9u4+0XrpWELqq2Kn9jl5GZK8MDjU7PrJwFIwusHOHjuw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@openai/codex@0.144.6-win32-arm64':
+    resolution: {integrity: sha512-SpMjXJLW43JzMP0K62mVcYfmFcpk0BK4AOgYmWSfyZHs3iRtHMd0UYw7605n/9lwkT2EqbwQLT2omZFeKJFzwA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@openai/codex@0.144.6-win32-x64':
+    resolution: {integrity: sha512-dN39VnjEthKz5io1RNWwZDtErdSn07nW3pGUgvlA6DMxgm/nuGaIAZO/sG/Hgxq/x5j9HteAENfrFgVkpZ0lFg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
 
   '@oxc-project/types@0.122.0':
     resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
@@ -6387,6 +6431,33 @@ snapshots:
     dependencies:
       mkdirp: 1.0.4
       rimraf: 3.0.2
+    optional: true
+
+  '@openai/codex@0.144.6':
+    optionalDependencies:
+      '@openai/codex-darwin-arm64': '@openai/codex@0.144.6-darwin-arm64'
+      '@openai/codex-darwin-x64': '@openai/codex@0.144.6-darwin-x64'
+      '@openai/codex-linux-arm64': '@openai/codex@0.144.6-linux-arm64'
+      '@openai/codex-linux-x64': '@openai/codex@0.144.6-linux-x64'
+      '@openai/codex-win32-arm64': '@openai/codex@0.144.6-win32-arm64'
+      '@openai/codex-win32-x64': '@openai/codex@0.144.6-win32-x64'
+
+  '@openai/codex@0.144.6-darwin-arm64':
+    optional: true
+
+  '@openai/codex@0.144.6-darwin-x64':
+    optional: true
+
+  '@openai/codex@0.144.6-linux-arm64':
+    optional: true
+
+  '@openai/codex@0.144.6-linux-x64':
+    optional: true
+
+  '@openai/codex@0.144.6-win32-arm64':
+    optional: true
+
+  '@openai/codex@0.144.6-win32-x64':
     optional: true
 
   '@oxc-project/types@0.122.0': {}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.95.0"
+profile = "minimal"
+components = ["clippy", "rustfmt"]

--- a/typescript/codex/app-server.ts
+++ b/typescript/codex/app-server.ts
@@ -27,6 +27,7 @@ export interface CodexAppServerOptions {
   executable?: string;
   cwd?: string;
   env?: NodeJS.ProcessEnv;
+  configOverrides?: string[];
   onProtocolMessage?: CodexProtocolLogger;
   onServerRequest?: CodexServerRequestHandler;
 }
@@ -89,11 +90,25 @@ export class CodexAppServer {
     options: CodexAppServerOptions = {},
   ): Promise<CodexAppServer> {
     const executable = options.executable ?? process.env.CODEX_BIN ?? "codex";
-    const child = spawn(executable, ["app-server", "--listen", "stdio://"], {
-      cwd: options.cwd,
-      env: { ...process.env, ...options.env },
-      stdio: "pipe",
-    }) as ChildProcessWithoutNullStreams;
+    const configArgs = (options.configOverrides ?? []).flatMap((override) => [
+      "-c",
+      override,
+    ]);
+    const childEnv = { ...process.env, ...options.env };
+    for (const [key, value] of Object.entries(childEnv)) {
+      if (value === undefined) {
+        delete childEnv[key];
+      }
+    }
+    const child = spawn(
+      executable,
+      [...configArgs, "app-server", "--listen", "stdio://"],
+      {
+        cwd: options.cwd,
+        env: childEnv,
+        stdio: "pipe",
+      },
+    ) as ChildProcessWithoutNullStreams;
     const server = new CodexAppServer(
       {
         stdout: nodeStreamChunks(child.stdout),

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,9 @@ export default defineConfig({
       "@exo/model-runtime/responses": fileURLToPath(
         new URL("./typescript/model-runtime/responses.ts", import.meta.url),
       ),
+      "@exo/codex/app-server": fileURLToPath(
+        new URL("./typescript/codex/app-server.ts", import.meta.url),
+      ),
     },
   },
 });


### PR DESCRIPTION
## Summary

- add Exo-scoped Codex login, status, and logout commands for ChatGPT subscription authentication
- broker host credentials into sandboxed Codex app-server sessions without persisting credentials in sandboxes
- expose Exo adapter tools through the Codex harness and run them with the Exo host tool runtime
- add `./exo.sh --harness codex` with Docker, guardian, adapter runner, and ExoChat support
- pin the Codex package/toolchain and document subscription-backed setup and architecture boundaries

## Validation

- repository precommit: lint, typecheck, 129 Vitest tests
- `cargo +1.95.0 test -p executor` (84 passed)
- `cargo +1.95.0 test -p exo` (CLI and backend suites passed; live tests ignored as declared)
- pre-push workspace `cargo check`
- real encrypted ExoChat -> subscription-backed Codex -> ExoChat round trip

## Architecture

Codex owns the model turn and sandbox tool loop. Exo continues to own persisted agents/conversations, sandbox lifecycle, adapter persistence, inbound wake-ups, and ExoChat delivery. The Codex preset currently exposes the Exo adapter tools rather than the complete prompt/tool surface from `examples/exo/harness.ts`.