### PR TITLE
adapters: add a Feishu (Lark) library adapter

### DIFF
--- a/crates/executor/src/adapter/tools.rs
+++ b/crates/executor/src/adapter/tools.rs
@@ -98,6 +98,7 @@ enum AdapterCreationConfig {
     Signal(SignalAdapterCreationConfig),
     Discord(DiscordAdapterCreationConfig),
     Slack(SlackAdapterCreationConfig),
+    Feishu(FeishuAdapterCreationConfig),
     Exochat(ExochatAdapterCreationConfig),
     AgentCli(AgentCliAdapterCreationConfig),
 }
@@ -185,6 +186,20 @@ struct SlackAdapterCreationConfig {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct FeishuAdapterCreationConfig {
+    #[serde(rename = "type")]
+    _adapter_type: FeishuAdapterType,
+    app_id: String,
+    app_secret_secret_id: String,
+    #[serde(default)]
+    domain: Option<FeishuDomain>,
+    trigger: FeishuTrigger,
+    #[serde(default)]
+    default_target: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
 struct ExochatAdapterCreationConfig {
     #[serde(rename = "type")]
     _adapter_type: ExochatAdapterType,
@@ -248,6 +263,19 @@ enum SlackAdapterType {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "lowercase")]
+enum FeishuAdapterType {
+    Feishu,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum FeishuDomain {
+    Feishu,
+    Lark,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
 enum ExochatAdapterType {
     Exochat,
 }
@@ -276,6 +304,13 @@ enum DiscordTrigger {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
 enum SlackTrigger {
+    AllMessages,
+    MentionsOnly,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum FeishuTrigger {
     AllMessages,
     MentionsOnly,
 }
@@ -322,6 +357,7 @@ impl AdapterCreationConfig {
             Self::Signal(_) => "signal",
             Self::Discord(_) => "discord",
             Self::Slack(_) => "slack",
+            Self::Feishu(_) => "feishu",
             Self::Exochat(_) => "exochat",
             Self::AgentCli(_) => "agent-cli",
         }
@@ -473,6 +509,28 @@ impl AdapterCreationConfig {
                     ],
                 })
             }
+            Self::Feishu(config) => {
+                require_source(source, AdapterSource::Library, "feishu")?;
+                if config.app_id.trim().is_empty() {
+                    bail!("feishu appId must not be empty");
+                }
+                Ok(AdapterConfig {
+                    adapter_type: "feishu".to_string(),
+                    worker_command: options.worker_command("feishu"),
+                    initialization: serde_json::json!({
+                        "appId": config.app_id,
+                        "appSecretEnv": "EXO_FEISHU_APP_SECRET",
+                        "domain": config.domain.map(|domain| domain.as_str()).unwrap_or("feishu"),
+                        "trigger": config.trigger.as_str(),
+                        "defaultTarget": config.default_target,
+                    }),
+                    state_dir: None,
+                    secret_env: vec![WorkerSecretEnvVar {
+                        env: "EXO_FEISHU_APP_SECRET".to_string(),
+                        secret_id: config.app_secret_secret_id,
+                    }],
+                })
+            }
             Self::Exochat(config) => {
                 require_source(source, AdapterSource::Library, "exochat")?;
                 let channel_id = config.channel_id.filter(|value| !value.trim().is_empty());
@@ -579,6 +637,24 @@ impl SlackProgressMode {
             Self::Update => "update",
             Self::Stream => "stream",
             Self::Off => "off",
+        }
+    }
+}
+
+impl FeishuTrigger {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::AllMessages => "all_messages",
+            Self::MentionsOnly => "mentions_only",
+        }
+    }
+}
+
+impl FeishuDomain {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Feishu => "feishu",
+            Self::Lark => "lark",
         }
     }
 }
@@ -1379,6 +1455,62 @@ mod tests {
             resolve_send_target("slack", Some("C123:1700000000.000000"), Some("dm:U123")).unwrap(),
             Some("dm:U123".into())
         );
+    }
+
+    #[tokio::test]
+    async fn create_feishu_adapter_binds_app_secret() {
+        let tempdir = TempDir::new().unwrap();
+        let exoharness = BasicExoHarness::new(local_test_config(tempdir.path().join("exoharness")))
+            .await
+            .unwrap();
+        let agent = exoharness
+            .new_agent(NewAgentRequest {
+                slug: "agent".to_string(),
+                name: "Agent".to_string(),
+            })
+            .await
+            .unwrap();
+        let conversation = agent
+            .new_conversation(NewConversationRequest {
+                slug: Some("conversation".to_string()),
+                name: Some("Conversation".to_string()),
+            })
+            .await
+            .unwrap();
+        let store = AdapterStore::new(tempdir.path().join("adapters"));
+        let create_result = execute_create_adapter_tool(
+            agent.as_ref(),
+            conversation.as_ref(),
+            &store,
+            &test_creation_options(),
+            &tool_request(
+                "create_adapter",
+                serde_json::json!({
+                    "name": "feishu",
+                    "source": "library",
+                    "config": {
+                        "type": "feishu",
+                        "appId": "cli_test_app",
+                        "appSecretSecretId": "feishu-app-secret",
+                        "domain": "lark",
+                        "trigger": "mentions_only",
+                        "defaultTarget": null
+                    }
+                }),
+            ),
+        )
+        .await
+        .unwrap();
+        assert_eq!(create_result["ok"], true);
+        let adapter_id = create_result["adapter"]["id"].as_str().unwrap();
+        let adapter = store.get_adapter(adapter_id).await.unwrap().unwrap();
+        assert!(adapter.config.worker_command[2].ends_with("/tmp/exo-adapters/feishu/worker.ts"));
+        assert_eq!(adapter.config.secret_env.len(), 1);
+        assert_eq!(adapter.config.secret_env[0].env, "EXO_FEISHU_APP_SECRET");
+        assert_eq!(adapter.config.secret_env[0].secret_id, "feishu-app-secret");
+        assert_eq!(adapter.config.initialization["appId"], "cli_test_app");
+        assert_eq!(adapter.config.initialization["domain"], "lark");
+        assert_eq!(adapter.config.initialization["trigger"], "mentions_only");
     }
 
     #[tokio::test]

--- a/crates/executor/src/adapter/tools.rs
+++ b/crates/executor/src/adapter/tools.rs
@@ -191,8 +191,10 @@ struct FeishuAdapterCreationConfig {
     _adapter_type: FeishuAdapterType,
     app_id: String,
     app_secret_secret_id: String,
-    #[serde(default)]
-    domain: Option<FeishuDomain>,
+    // Required, matching the model-facing schema: defaulting an international
+    // Lark tenant to the feishu domain would silently target the wrong API
+    // endpoint.
+    domain: FeishuDomain,
     trigger: FeishuTrigger,
     #[serde(default)]
     default_target: Option<String>,
@@ -520,7 +522,7 @@ impl AdapterCreationConfig {
                     initialization: serde_json::json!({
                         "appId": config.app_id,
                         "appSecretEnv": "EXO_FEISHU_APP_SECRET",
-                        "domain": config.domain.map(|domain| domain.as_str()).unwrap_or("feishu"),
+                        "domain": config.domain.as_str(),
                         "trigger": config.trigger.as_str(),
                         "defaultTarget": config.default_target,
                     }),

--- a/exo/adapters/feishu/README.md
+++ b/exo/adapters/feishu/README.md
@@ -1,0 +1,67 @@
+# Feishu (Lark) Adapter
+
+The Feishu adapter is a local, non-central library adapter for Feishu (`feishu.cn`) and Lark (`larksuite.com`) tenants. It uses the open platform's long-connection mode: the worker opens an outbound WebSocket for inbound events and calls `im.message.create` for replies, so no public callback URL, tunnel, or relay is needed. This makes it the easiest adapter to run from mainland China networks, where it needs no proxy at all.
+
+The MVP is text-only. Group chats wake the agent on @-mentions by default; direct messages always wake it. Attachments are rejected with a clear error for now.
+
+## Setup
+
+### Chat Setup
+
+Start Exo normally:
+
+```bash
+./exo.sh
+```
+
+Then ask the agent:
+
+```text
+Help me set up Feishu.
+```
+
+The agent walks you through creating a custom app in the Feishu/Lark open platform console, granting bot permissions, enabling long-connection event subscriptions, storing the app secret, and creating the adapter.
+
+### Manual Setup
+
+1. Create a custom app at `https://open.feishu.cn` (or `https://open.larksuite.com` for Lark) and enable the **Bot** capability.
+2. Add permissions: `im:message:send_as_bot`, `im:message.group_at_msg`, `im:message.p2p_msg`.
+3. Under **Events & Callbacks**, select **long connection** mode and subscribe to `im.message.receive_v1`.
+4. Publish an app release, then copy the app credentials.
+5. Store the app secret:
+
+   ```bash
+   exo secret set feishu-app-secret --value '<app-secret>'
+   ```
+
+6. Create the adapter from the REPL by asking the agent, with config:
+
+   ```json
+   {
+     "type": "feishu",
+     "appId": "cli_...",
+     "appSecretSecretId": "feishu-app-secret",
+     "domain": "feishu",
+     "trigger": "mentions_only",
+     "defaultTarget": null
+   }
+   ```
+
+7. Add the bot to a group (group settings → Bots) or DM it, then @-mention it. Replies go back to the same chat.
+
+## Configuration
+
+| Field               | Meaning                                                                                                    |
+| ------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `appId`             | App id (`cli_...`) from the open platform console. Not a secret.                                           |
+| `appSecretSecretId` | Exo secret containing the app secret. The worker receives it as `EXO_FEISHU_APP_SECRET`.                   |
+| `domain`            | `feishu` for feishu.cn tenants, `lark` for larksuite.com tenants.                                          |
+| `trigger`           | `mentions_only` (default; DMs always wake) or `all_messages`.                                              |
+| `defaultTarget`     | Optional chat id (`oc_...`) or user open id (`ou_...`) used when `send_adapter_message` has a null target. |
+
+## Behavior notes
+
+- Inbound targets are Feishu chat ids (`oc_...`). Sends to targets starting with `ou_` are delivered as direct messages via `open_id`.
+- `mentions_only` counts any @-mention in a group as addressing the bot; distinguishing the bot's own mention would need an extra credentials call and is left for later.
+- The Lark SDK's internal loggers write non-JSON lines to stdout, which would corrupt the worker protocol; the worker installs a stdout filter before importing the SDK, so SDK noise lands on stderr instead.
+- The long connection reconnects automatically after network drops; `connected` is only reported after the first successful handshake.

--- a/exo/adapters/feishu/feishu.test.ts
+++ b/exo/adapters/feishu/feishu.test.ts
@@ -146,4 +146,16 @@ describe("Feishu send idempotency key", () => {
   it("stays inside Feishu's 50-character limit", () => {
     expect(feishuSendUuid("x".repeat(80))).toHaveLength(50);
   });
+
+  it("maps ids past the limit to a deterministic key", () => {
+    const longId = `019f6453-6208-7a41-9c2e-4f1d3b8a5c07-${"x".repeat(30)}`;
+    const key = feishuSendUuid(longId);
+    expect(key).toHaveLength(50);
+    expect(feishuSendUuid(longId)).toBe(key);
+  });
+
+  it("does not collapse long ids that share a 50-character prefix", () => {
+    const prefix = "d".repeat(60);
+    expect(feishuSendUuid(`${prefix}a`)).not.toBe(feishuSendUuid(`${prefix}b`));
+  });
 });

--- a/exo/adapters/feishu/feishu.test.ts
+++ b/exo/adapters/feishu/feishu.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import { parseInboundEvent, receiveIdTypeForTarget } from "./feishu";
+
+function textMessage(
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  return {
+    message_id: "om_1",
+    chat_id: "oc_group",
+    chat_type: "group",
+    message_type: "text",
+    content: JSON.stringify({ text: "hello" }),
+    mentions: [{ key: "@_user_1" }],
+    ...overrides,
+  };
+}
+
+const sender = { sender_id: { open_id: "ou_alice", user_id: "u_alice" } };
+
+describe("Feishu inbound parsing", () => {
+  it("reads the flattened event body the SDK actually delivers", () => {
+    expect(
+      parseInboundEvent({ message: textMessage(), sender }, "mentions_only"),
+    ).toEqual({
+      chatId: "oc_group",
+      chatType: "group",
+      sender: "ou_alice",
+      messageId: "om_1",
+      mentionedBot: true,
+      text: "hello",
+    });
+  });
+
+  it("also reads a nested event body", () => {
+    const parsed = parseInboundEvent(
+      { event: { message: textMessage(), sender } },
+      "mentions_only",
+    );
+    expect(parsed?.text).toBe("hello");
+    expect(parsed?.sender).toBe("ou_alice");
+  });
+
+  it("applies the mentions_only trigger to group chatter", () => {
+    expect(
+      parseInboundEvent(
+        { message: textMessage({ mentions: [] }), sender },
+        "mentions_only",
+      ),
+    ).toBeNull();
+    expect(
+      parseInboundEvent(
+        { message: textMessage({ mentions: [] }), sender },
+        "all_messages",
+      ),
+    ).not.toBeNull();
+  });
+
+  it("always wakes on direct messages", () => {
+    expect(
+      parseInboundEvent(
+        {
+          message: textMessage({
+            chat_type: "p2p",
+            chat_id: "oc_dm",
+            mentions: [],
+          }),
+          sender,
+        },
+        "mentions_only",
+      ),
+    ).not.toBeNull();
+  });
+
+  it("skips messages it cannot turn into text", () => {
+    expect(
+      parseInboundEvent(
+        { message: textMessage({ message_type: "image" }), sender },
+        "all_messages",
+      ),
+    ).toBeNull();
+    expect(
+      parseInboundEvent(
+        { message: textMessage({ content: "not json" }), sender },
+        "all_messages",
+      ),
+    ).toBeNull();
+    expect(
+      parseInboundEvent(
+        {
+          message: textMessage({ content: JSON.stringify({ text: "" }) }),
+          sender,
+        },
+        "all_messages",
+      ),
+    ).toBeNull();
+  });
+
+  it("skips events with no usable message", () => {
+    expect(parseInboundEvent(null, "all_messages")).toBeNull();
+    expect(parseInboundEvent({ sender }, "all_messages")).toBeNull();
+    expect(
+      parseInboundEvent(
+        { message: textMessage({ chat_id: undefined }), sender },
+        "all_messages",
+      ),
+    ).toBeNull();
+  });
+
+  it("falls back to user_id when the sender has no open_id", () => {
+    expect(
+      parseInboundEvent(
+        { message: textMessage(), sender: { sender_id: { user_id: "u_bob" } } },
+        "all_messages",
+      )?.sender,
+    ).toBe("u_bob");
+    expect(
+      parseInboundEvent({ message: textMessage() }, "all_messages")?.sender,
+    ).toBeNull();
+  });
+});
+
+describe("Feishu outbound targets", () => {
+  it("picks the receive id type from the target prefix", () => {
+    expect(receiveIdTypeForTarget("ou_alice")).toBe("open_id");
+    expect(receiveIdTypeForTarget("oc_group")).toBe("chat_id");
+  });
+});

--- a/exo/adapters/feishu/feishu.test.ts
+++ b/exo/adapters/feishu/feishu.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { parseInboundEvent, receiveIdTypeForTarget } from "./feishu";
+import {
+  feishuSendUuid,
+  parseInboundEvent,
+  receiveIdTypeForTarget,
+} from "./feishu";
 
 function textMessage(
   overrides: Record<string, unknown> = {},
@@ -124,5 +128,22 @@ describe("Feishu outbound targets", () => {
   it("picks the receive id type from the target prefix", () => {
     expect(receiveIdTypeForTarget("ou_alice")).toBe("open_id");
     expect(receiveIdTypeForTarget("oc_group")).toBe("chat_id");
+  });
+});
+
+describe("Feishu send idempotency key", () => {
+  it("passes a delivery id through unchanged", () => {
+    const deliveryId = "019f6453-6208-7a41-9c2e-4f1d3b8a5c07";
+    expect(feishuSendUuid(deliveryId)).toBe(deliveryId);
+  });
+
+  it("is stable for the same delivery id, so a redelivery reuses the key", () => {
+    expect(feishuSendUuid("019f6453-6208-7a41-9c2e-4f1d3b8a5c07")).toBe(
+      feishuSendUuid("019f6453-6208-7a41-9c2e-4f1d3b8a5c07"),
+    );
+  });
+
+  it("stays inside Feishu's 50-character limit", () => {
+    expect(feishuSendUuid("x".repeat(80))).toHaveLength(50);
   });
 });

--- a/exo/adapters/feishu/feishu.ts
+++ b/exo/adapters/feishu/feishu.ts
@@ -65,6 +65,16 @@ export function receiveIdTypeForTarget(target: string): "open_id" | "chat_id" {
   return target.startsWith("ou_") ? "open_id" : "chat_id";
 }
 
+// Feishu's idempotency key for message sends. Requests sharing a uuid deliver
+// at most one message per hour, which is what makes a redelivery safe. The
+// runtime's outbound message id is stable across delivery attempts, so it is
+// the right value; Feishu caps the field at 50 characters.
+const FEISHU_SEND_UUID_MAX_CHARS = 50;
+
+export function feishuSendUuid(deliveryId: string): string {
+  return deliveryId.slice(0, FEISHU_SEND_UUID_MAX_CHARS);
+}
+
 function extractText(message: Record<string, unknown>): string | null {
   // Text messages carry message.content as a JSON string like
   // {"text":"hello @_user_1 world"}. Mention placeholders are left in the text

--- a/exo/adapters/feishu/feishu.ts
+++ b/exo/adapters/feishu/feishu.ts
@@ -39,8 +39,7 @@ export function parseInboundEvent(
   const chatType =
     typeof message.chat_type === "string" ? message.chat_type : null;
   const mentionedBot = isMentionedBot(message);
-  // DMs always wake the agent; mentions_only only filters group chatter,
-  // matching the Slack adapter's wake semantics.
+  // DMs always wake the agent; mentions_only only filters group chatter.
   if (trigger === "mentions_only" && chatType !== "p2p" && !mentionedBot) {
     return null;
   }

--- a/exo/adapters/feishu/feishu.ts
+++ b/exo/adapters/feishu/feishu.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import { isRecord } from "../protocol";
 
 export type FeishuTriggerPolicy = "mentions_only" | "all_messages";
@@ -68,11 +70,25 @@ export function receiveIdTypeForTarget(target: string): "open_id" | "chat_id" {
 // Feishu's idempotency key for message sends. Requests sharing a uuid deliver
 // at most one message per hour, which is what makes a redelivery safe. The
 // runtime's outbound message id is stable across delivery attempts, so it is
-// the right value; Feishu caps the field at 50 characters.
+// the right value; Feishu caps the field at 50 characters. Today's delivery
+// ids are 36-char UUIDs and pass through unchanged. An id that ever exceeds
+// the cap maps deterministically to prefix + SHA-256: two long ids sharing a
+// prefix never collide into one dropped send, and a redelivery of the same
+// id keeps reusing the same key.
 const FEISHU_SEND_UUID_MAX_CHARS = 50;
+const FEISHU_SEND_UUID_DIGEST_CHARS = 32;
 
 export function feishuSendUuid(deliveryId: string): string {
-  return deliveryId.slice(0, FEISHU_SEND_UUID_MAX_CHARS);
+  if (deliveryId.length <= FEISHU_SEND_UUID_MAX_CHARS) {
+    return deliveryId;
+  }
+  const digest = createHash("sha256")
+    .update(deliveryId)
+    .digest("hex")
+    .slice(0, FEISHU_SEND_UUID_DIGEST_CHARS);
+  const prefixChars =
+    FEISHU_SEND_UUID_MAX_CHARS - FEISHU_SEND_UUID_DIGEST_CHARS - 1;
+  return `${deliveryId.slice(0, prefixChars)}-${digest}`;
 }
 
 function extractText(message: Record<string, unknown>): string | null {

--- a/exo/adapters/feishu/feishu.ts
+++ b/exo/adapters/feishu/feishu.ts
@@ -1,0 +1,115 @@
+import { isRecord } from "../protocol";
+
+export type FeishuTriggerPolicy = "mentions_only" | "all_messages";
+
+export type FeishuInboundMessage = {
+  chatId: string;
+  chatType: string | null;
+  sender: string | null;
+  messageId: string | null;
+  mentionedBot: boolean;
+  text: string;
+};
+
+// The Lark SDK's RequestHandle.parse spreads the event body flat into the object
+// handed to EventDispatcher handlers ({...header, ...event}) for both schema 1.0
+// and 2.0, so `message` / `sender` arrive at the top level — never nested under
+// `.event`. Reading `event.event.*` silently drops every inbound message. A
+// nested shape is accepted too, in case a future SDK version stops flattening.
+export function parseInboundEvent(
+  event: unknown,
+  trigger: FeishuTriggerPolicy,
+): FeishuInboundMessage | null {
+  if (!isRecord(event)) {
+    return null;
+  }
+  const body = isRecord(event.event) ? event.event : event;
+  const message = body.message;
+  if (!isRecord(message)) {
+    return null;
+  }
+
+  const chatId = typeof message.chat_id === "string" ? message.chat_id : null;
+  if (chatId === null) {
+    return null;
+  }
+
+  const chatType =
+    typeof message.chat_type === "string" ? message.chat_type : null;
+  const mentionedBot = isMentionedBot(message);
+  // DMs always wake the agent; mentions_only only filters group chatter,
+  // matching the Slack adapter's wake semantics.
+  if (trigger === "mentions_only" && chatType !== "p2p" && !mentionedBot) {
+    return null;
+  }
+
+  const text = extractText(message);
+  if (text === null || text.length === 0) {
+    return null;
+  }
+
+  return {
+    chatId,
+    chatType,
+    sender: pickSenderId(body.sender),
+    messageId:
+      typeof message.message_id === "string" ? message.message_id : null,
+    mentionedBot,
+    text,
+  };
+}
+
+// Inbound wakeups hand the agent chat ids (oc_...). Targets starting with ou_
+// are open ids for direct messages; everything else is a chat id.
+export function receiveIdTypeForTarget(target: string): "open_id" | "chat_id" {
+  return target.startsWith("ou_") ? "open_id" : "chat_id";
+}
+
+function extractText(message: Record<string, unknown>): string | null {
+  // Text messages carry message.content as a JSON string like
+  // {"text":"hello @_user_1 world"}. Mention placeholders are left in the text
+  // on purpose: the agent sees who was addressed via mentioned_bot and the raw
+  // placeholders carry no secrets.
+  if (message.message_type !== "text") {
+    return null;
+  }
+  if (typeof message.content !== "string") {
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(message.content);
+    if (!isRecord(parsed) || typeof parsed.text !== "string") {
+      return null;
+    }
+    return parsed.text;
+  } catch {
+    return null;
+  }
+}
+
+function isMentionedBot(message: Record<string, unknown>): boolean {
+  // With the recommended im:message.group_at_msg permission Feishu only
+  // delivers group messages that @-mention this bot, so any group message we
+  // see already addresses us. This check is a backstop for tenants that granted
+  // the broader im:message.group_msg permission; telling the bot's own mention
+  // apart from others would need an extra bot-info call.
+  const mentions = message.mentions;
+  return Array.isArray(mentions) && mentions.length > 0;
+}
+
+function pickSenderId(sender: unknown): string | null {
+  if (!isRecord(sender)) {
+    return null;
+  }
+  const senderId = sender.sender_id;
+  if (!isRecord(senderId)) {
+    return null;
+  }
+  if (typeof senderId.open_id === "string") {
+    return senderId.open_id;
+  }
+  if (typeof senderId.user_id === "string") {
+    return senderId.user_id;
+  }
+  return null;
+}

--- a/exo/adapters/feishu/setup-prompt.md
+++ b/exo/adapters/feishu/setup-prompt.md
@@ -1,0 +1,47 @@
+Set up a Feishu (Lark) adapter with an interactive wizard.
+
+Do not create the adapter immediately. First walk the user through Feishu app creation and local secret setup. Ask one short question at a time, wait for the user to confirm each step, and never ask the user to paste the app secret into chat.
+
+Feishu's open platform has a long-connection mode: the worker opens an outbound WebSocket to Feishu, so no public callback URL and no tunnel are needed. The whole setup runs on a laptop behind NAT.
+
+Use this flow:
+
+1. Ask whether their tenant is on Feishu (`feishu.cn`, mainland China) or Lark (`larksuite.com`, international). This selects the `domain` setting and which console they use:
+   - Feishu: `https://open.feishu.cn`
+   - Lark: `https://open.larksuite.com`
+
+2. Ask the user to create a **custom app** (企业自建应用 / Custom App) in that console and pick a bot name. Recommend the name `Exo`, but let the user choose. In the app's **Features** section they must enable the **Bot** capability.
+
+3. Ask the user to add these permissions (Permissions & Scopes):
+   - `im:message:send_as_bot` — send messages as the bot.
+   - `im:message.group_at_msg` — receive group messages that @-mention the bot.
+   - `im:message.p2p_msg` — receive direct messages.
+
+   For `all_messages` group coverage they should also add `im:message.group_msg` if their tenant offers it; mentions-only is the recommended default.
+
+4. Ask the user to open **Events & Callbacks**, set the subscription mode to **long connection** (长连接), and subscribe to the `im.message.receive_v1` event. This is what removes the need for a public URL.
+
+5. Ask the user to publish the app (create a release version and approve it; for custom apps this is usually instant self-approval), then copy the **App ID** (`cli_...`) from the app's credentials page and reply with it. The app id is not a secret and can be pasted into chat.
+
+6. Tell the user to copy the **App Secret** from the same page and store it locally with:
+
+   ```bash
+   exo secret set feishu-app-secret --value '<app-secret>'
+   ```
+
+   Tell the user not to paste the value into chat. Ask them to reply `app secret stored` when done.
+
+7. After the user confirms the secret is stored, create a library Feishu adapter if one does not already exist for this conversation. Use these settings:
+
+- name: `feishu-dev`
+- source: `library`
+- type: `feishu`
+- appId: the `cli_...` id from step 5
+- appSecretSecretId: `feishu-app-secret`
+- domain: `feishu` or `lark` from step 1
+- trigger: `mentions_only`
+- defaultTarget: `null`
+
+8. Tell the user to add the bot to a group chat (group settings → Bots → Add Bot) or open a direct chat with it, then @-mention the bot in the group or send it a DM. Confirm the message wakes this conversation and that the reply arrives back in Feishu.
+
+If adapter creation reports a missing app secret, tell the user to run the `exo secret set` command above and continue from adapter creation. If the long connection fails at startup, the most common causes are an unpublished app release, a wrong domain choice, or event subscription still set to callback mode instead of long connection.

--- a/exo/adapters/feishu/worker.ts
+++ b/exo/adapters/feishu/worker.ts
@@ -53,6 +53,7 @@ import {
 } from "../protocol";
 import {
   type FeishuTriggerPolicy,
+  feishuSendUuid,
   parseInboundEvent,
   receiveIdTypeForTarget,
 } from "./feishu";
@@ -170,7 +171,7 @@ for await (const line of input) {
         "the Feishu adapter does not support attachments yet; send text only",
       );
     }
-    await sendText(target, command.text);
+    await sendText(target, command.text, command.id);
     writeWorkerEvent({ type: "command_ack", command_id: command.id });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -215,13 +216,23 @@ function feishuTrigger(value: string): FeishuTriggerPolicy {
   return value;
 }
 
-async function sendText(target: string, text: string): Promise<void> {
+// Outbound delivery is at-least-once: a message claimed but not acked before
+// the worker dies is requeued and sent again. The runtime keeps the same
+// message id across those attempts, and Feishu dedupes by `uuid` for an hour,
+// so passing the id through turns a redelivery into a no-op on their side
+// instead of a second message in the chat.
+async function sendText(
+  target: string,
+  text: string,
+  deliveryId: string,
+): Promise<void> {
   const response = await client.im.message.create({
     params: { receive_id_type: receiveIdTypeForTarget(target) },
     data: {
       receive_id: target,
       msg_type: "text",
       content: JSON.stringify({ text }),
+      uuid: feishuSendUuid(deliveryId),
     },
   });
   if ((response.code ?? 0) !== 0) {

--- a/exo/adapters/feishu/worker.ts
+++ b/exo/adapters/feishu/worker.ts
@@ -1,6 +1,6 @@
 // Feishu (Lark) adapter worker.
 //
-// Mirrors the IRC / Slack worker pattern for Feishu and Lark:
+// Built on the official Lark SDK:
 //   - Lark.Client for outbound messages (im.message.create)
 //   - Lark.WSClient for inbound messages over the open platform's
 //     long-connection mode, so no public callback URL is required. The

--- a/exo/adapters/feishu/worker.ts
+++ b/exo/adapters/feishu/worker.ts
@@ -1,0 +1,244 @@
+// Feishu (Lark) adapter worker.
+//
+// Mirrors the IRC / Slack worker pattern for Feishu and Lark:
+//   - Lark.Client for outbound messages (im.message.create)
+//   - Lark.WSClient for inbound messages over the open platform's
+//     long-connection mode, so no public callback URL is required. The
+//     worker runs fine on a laptop behind NAT, which matches how exo is
+//     usually deployed.
+//
+// Required app permissions (Feishu/Lark open platform console):
+//   - im:message:send_as_bot
+//   - im:message.group_at_msg and/or im:message.p2p_msg
+// Event subscriptions must use "long connection" mode and subscribe to
+// `im.message.receive_v1`. See setup-prompt.md for the full walkthrough.
+
+// This shim must run before the Lark SDK is imported. The SDK's internal
+// loggers (Client, WSClient, EventDispatcher) write `[info]: ...` lines
+// straight to process.stdout even with loggerLevel configured, and the
+// adapter runtime parses our stdout as a strict JSON event protocol — one
+// stray line kills the worker and triggers a restart loop. Only JSON event
+// lines pass through; everything else is redirected to stderr where it
+// stays visible for debugging.
+const originalStdoutWrite = process.stdout.write.bind(process.stdout);
+process.stdout.write = ((chunk: unknown, ...args: unknown[]): boolean => {
+  const text =
+    typeof chunk === "string"
+      ? chunk
+      : Buffer.isBuffer(chunk)
+        ? chunk.toString("utf8")
+        : String(chunk);
+  if (text.trimStart().startsWith("{")) {
+    return originalStdoutWrite(
+      chunk as Parameters<typeof process.stdout.write>[0],
+      ...(args as never[]),
+    );
+  }
+  return process.stderr.write(
+    chunk as Parameters<typeof process.stderr.write>[0],
+    ...(args as never[]),
+  );
+}) as typeof process.stdout.write;
+
+import readline from "node:readline/promises";
+
+import * as Lark from "@larksuiteoapi/node-sdk";
+
+import {
+  adapterConfig,
+  optionalStringField,
+  parseWorkerCommand,
+  stringField,
+  writeWorkerEvent,
+} from "../protocol";
+import {
+  type FeishuTriggerPolicy,
+  parseInboundEvent,
+  receiveIdTypeForTarget,
+} from "./feishu";
+
+const config = adapterConfig();
+
+const appId = stringField(config, "appId");
+const appSecretEnv =
+  optionalStringField(config, "appSecretEnv") ?? "EXO_FEISHU_APP_SECRET";
+const appSecret = requiredEnv(appSecretEnv, "Feishu app secret");
+
+const domainName = optionalStringField(config, "domain") ?? "feishu";
+if (domainName !== "feishu" && domainName !== "lark") {
+  throw new Error("Feishu domain must be feishu or lark");
+}
+const domain = domainName === "lark" ? Lark.Domain.Lark : Lark.Domain.Feishu;
+
+const trigger: FeishuTriggerPolicy = feishuTrigger(
+  optionalStringField(config, "trigger") ?? "mentions_only",
+);
+const defaultTarget = optionalStringField(config, "defaultTarget");
+
+process.on("unhandledRejection", (reason) => {
+  reportWorkerError(
+    `Feishu adapter unhandled rejection: ${
+      reason instanceof Error ? reason.message : String(reason)
+    }`,
+  );
+});
+
+process.on("uncaughtException", (error) => {
+  reportWorkerError(`Feishu adapter uncaught exception: ${error.message}`);
+  process.exit(1);
+});
+
+// The SDK loggers still get loggerLevel as a second line of defense behind
+// the stdout shim above; errors go to stderr where they stay debuggable.
+const client = new Lark.Client({
+  appId,
+  appSecret,
+  appType: Lark.AppType.SelfBuild,
+  domain,
+  disableTokenCache: false,
+  loggerLevel: Lark.LoggerLevel.error,
+});
+
+const eventDispatcher = new Lark.EventDispatcher({}).register({
+  "im.message.receive_v1": async (event) => {
+    handleInboundMessage(event);
+    return { code: 0 };
+  },
+});
+
+// The SDK reports connection state through constructor callbacks: onReady
+// fires on the first successful handshake, onError only when the client
+// gives up for good (fatal config pull or exhausted retries), and the
+// reconnect pair covers transient drops. `connected` is emitted from
+// onReady instead of optimistically at spawn time.
+const wsClient = new Lark.WSClient({
+  appId,
+  appSecret,
+  domain,
+  loggerLevel: Lark.LoggerLevel.error,
+  onReady: () => {
+    writeWorkerEvent({
+      type: "connected",
+      subject: `feishu:${appId}`,
+      metadata: { domain: domainName },
+    });
+  },
+  onError: (error) => {
+    writeWorkerEvent({
+      type: "error",
+      message: `Feishu long connection failed: ${error.message}`,
+    });
+    process.exit(1);
+  },
+  onReconnecting: () => {
+    writeWorkerEvent({ type: "lifecycle", name: "reconnecting" });
+  },
+  onReconnected: () => {
+    writeWorkerEvent({ type: "lifecycle", name: "reconnected" });
+  },
+});
+
+writeWorkerEvent({
+  type: "lifecycle",
+  name: "starting",
+  metadata: { domain: domainName, trigger },
+});
+
+void wsClient.start({ eventDispatcher });
+
+const input = readline.createInterface({
+  input: process.stdin,
+  crlfDelay: Number.POSITIVE_INFINITY,
+});
+
+for await (const line of input) {
+  if (line.trim().length === 0) {
+    continue;
+  }
+  let commandId: string | null = null;
+  try {
+    const command = parseWorkerCommand(JSON.parse(line));
+    commandId = command.id;
+    const target = command.target ?? defaultTarget;
+    if (target === null) {
+      throw new Error(
+        "Feishu send_message needs a target (oc_/ou_ id from the inbound wakeup) or a defaultTarget in the adapter config",
+      );
+    }
+    if (command.attachments.length > 0) {
+      throw new Error(
+        "the Feishu adapter does not support attachments yet; send text only",
+      );
+    }
+    await sendText(target, command.text);
+    writeWorkerEvent({ type: "command_ack", command_id: command.id });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    reportWorkerError(message);
+    if (commandId !== null) {
+      writeWorkerEvent({
+        type: "command_nack",
+        command_id: commandId,
+        message,
+      });
+    }
+  }
+}
+
+// stdin EOF means the adapter runtime is gone; the open WS handle would
+// otherwise keep the process alive as an orphan.
+writeWorkerEvent({ type: "disconnected", reason: "stdin closed" });
+process.exit(0);
+
+function handleInboundMessage(event: unknown): void {
+  const inbound = parseInboundEvent(event, trigger);
+  if (inbound === null) {
+    return;
+  }
+  writeWorkerEvent({
+    type: "message",
+    target: inbound.chatId,
+    sender: inbound.sender,
+    text: inbound.text,
+    message_id: inbound.messageId,
+    metadata: {
+      chat_type: inbound.chatType,
+      mentioned_bot: inbound.mentionedBot,
+    },
+  });
+}
+
+function feishuTrigger(value: string): FeishuTriggerPolicy {
+  if (value !== "all_messages" && value !== "mentions_only") {
+    throw new Error("Feishu trigger must be all_messages or mentions_only");
+  }
+  return value;
+}
+
+async function sendText(target: string, text: string): Promise<void> {
+  const response = await client.im.message.create({
+    params: { receive_id_type: receiveIdTypeForTarget(target) },
+    data: {
+      receive_id: target,
+      msg_type: "text",
+      content: JSON.stringify({ text }),
+    },
+  });
+  if ((response.code ?? 0) !== 0) {
+    throw new Error(
+      `feishu send failed with code ${response.code}: ${response.msg ?? "unknown error"}`,
+    );
+  }
+}
+
+function requiredEnv(name: string, label: string): string {
+  const value = process.env[name];
+  if (!value || value.length === 0) {
+    throw new Error(`${label} env ${name} must be set`);
+  }
+  return value;
+}
+
+function reportWorkerError(message: string): void {
+  writeWorkerEvent({ type: "error", message });
+}

--- a/exoharness/typescript/harness/adapter-tools.ts
+++ b/exoharness/typescript/harness/adapter-tools.ts
@@ -357,6 +357,48 @@ function adapterConfigSchema(): ToolDefinition["parameters"] {
         type: "object",
         additionalProperties: false,
         properties: {
+          type: { type: "string", enum: ["feishu"] },
+          appId: {
+            type: "string",
+            description:
+              "Feishu/Lark app id (cli_...) from the open platform console. Not a secret.",
+          },
+          appSecretSecretId: {
+            type: "string",
+            description:
+              "Secret name or id containing the Feishu/Lark app secret. The worker receives it as EXO_FEISHU_APP_SECRET.",
+          },
+          domain: {
+            type: "string",
+            enum: ["feishu", "lark"],
+            description:
+              "API domain. Use feishu for feishu.cn tenants and lark for international larksuite.com tenants.",
+          },
+          trigger: {
+            type: "string",
+            enum: ["all_messages", "mentions_only"],
+            description:
+              "Wake policy for group chats. mentions_only wakes on @-mentions and always wakes on direct messages. all_messages wakes on every subscribed message.",
+          },
+          defaultTarget: {
+            type: ["string", "null"],
+            description:
+              "Optional chat id (oc_...) or user open id (ou_...) used when send_adapter_message target is null.",
+          },
+        },
+        required: [
+          "type",
+          "appId",
+          "appSecretSecretId",
+          "domain",
+          "trigger",
+          "defaultTarget",
+        ],
+      },
+      {
+        type: "object",
+        additionalProperties: false,
+        properties: {
           type: { type: "string", enum: ["signal"] },
           account: {
             type: ["string", "null"],
@@ -572,7 +614,8 @@ function validateAdapterSource(source: string, type: string): void {
       type === "whatsapp" ||
       type === "signal" ||
       type === "discord" ||
-      type === "slack") &&
+      type === "slack" ||
+      type === "feishu") &&
     source !== "library"
   ) {
     throw new Error(`${type} adapters must use source 'library'`);

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@braintrust/lingua-wasm": "^0.1.0",
     "@cursor/sdk": "^1.0.12",
     "@discordjs/voice": "^0.19.0",
+    "@larksuiteoapi/node-sdk": "^1.50.0",
     "@mozilla/readability": "^0.6.0",
     "@shadcn/react": "^0.1.0",
     "@whiskeysockets/baileys": "7.0.0-rc13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@discordjs/voice':
         specifier: ^0.19.0
         version: 0.19.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(opusscript@0.1.1)
+      '@larksuiteoapi/node-sdk':
+        specifier: ^1.50.0
+        version: 1.71.1
       '@mozilla/readability':
         specifier: ^0.6.0
         version: 0.6.0
@@ -131,7 +134,7 @@ importers:
         version: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)
       vitepress:
         specifier: ^1.6.4
-        version: 1.6.4(@algolia/client-search@5.55.1)(@types/node@25.5.0)(@types/react@19.2.17)(lightningcss@1.32.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(search-insights@2.17.3)(typescript@5.9.3)
+        version: 1.6.4(@algolia/client-search@5.55.1)(@types/node@25.5.0)(@types/react@19.2.17)(axios@1.18.1)(lightningcss@1.32.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(search-insights@2.17.3)(typescript@5.9.3)
       vitest:
         specifier: 4.1.2
         version: 4.1.2(@types/node@25.5.0)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0))
@@ -232,21 +235,25 @@ packages:
     resolution: {integrity: sha512-GO0BnIUw3LQ3XAy+nipAabkN0GwQGPhHB6ITI4XLoR99fLHB3TA6WfyvTf0fnpxd25A+c/+UsAoxz4zBQaHlhA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.126':
     resolution: {integrity: sha512-LM+mnfQsgI+1i5mYZwIPDDf14NGBu5wbhzm5U8P11dCa2p8sXmKoWpkbO16BFM2NxeW44I/RXCxE5qFsbz4zcg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.126':
     resolution: {integrity: sha512-ByJGO0+mu7EplxSFSCIHd7QWsXdrF3qgtzQ177o/j+oSppLoqR1ot5ktf8aw5oR3CC5lFHg4tqd6TnneQpEoIg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.126':
     resolution: {integrity: sha512-yaOTDcYCdscxC0LKg9w8IwSa5g+993WggFZJBTZpqvflA2+WMQeTarDnKlsFTCw9XUZkL8XZeBALYJGx0HutuA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.126':
     resolution: {integrity: sha512-gv3MOsOBkCx3LajOOIjD7AKsOtz/qNHsS2oshGt2GVoy7JA3XbCDeCetDjM6SorV4SE+7F/IH0UJdXe5ejI/Zg==}
@@ -925,89 +932,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1062,6 +1085,9 @@ packages:
 
   '@kwsites/promise-deferred@1.1.1':
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
+
+  '@larksuiteoapi/node-sdk@1.71.1':
+    resolution: {integrity: sha512-Z4cZmgWvwiE7tCHqGm+t7DKvbpNRRTH2HqVwcYiOMAwbjIytXSoQqWytsOVu3p+d0fIvrtyIPZok5HOV/VNxxw==}
 
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
@@ -1159,48 +1185,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.42.0':
     resolution: {integrity: sha512-+JA0YMlSdDqmacygGi2REp57c3fN+tzARD8nwsukx9pkCHK+6DkbAA9ojS4lNKsiBjIW8WWa0pBrBWhdZEqfuw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.42.0':
     resolution: {integrity: sha512-VfnET0j4Y5mdfCzh5gBt0NK28lgn5DKx+8WgSMLYYeSooHhohdbzwAStLki9pNuGy51y4I7IoW8bqwAaCMiJQg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.42.0':
     resolution: {integrity: sha512-gVlCbmBkB0fxBWbhBj9rcxezPydsQHf4MFKeHoTSPicOQ+8oGeTQgQ8EeesSybWeiFPVRx3bgdt4IJnH6nOjAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.42.0':
     resolution: {integrity: sha512-zN5OfstL0avgt/IgvRu0zjQzVh/EPkcLzs33E9LMAzpqlLWiPWeMDZyMGFlSRGOdDjuNmlZBCgj0pFnK5u32TQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.42.0':
     resolution: {integrity: sha512-9X6+H2L0qMc2sCAgO9HS03bkGLMKvOFjmEdchaFlany3vNZOjnVui//D8k/xZAtQv2vaCs1reD5KAgPoIU4msA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.42.0':
     resolution: {integrity: sha512-BajxJ6KQvMMdpXGPWhBGyjb2Jvx4uec0w+wi6TJZ6Tv7+MzPwe0pO8g5h1U0jyFgoaF7mDl6yKPW3ykWcbUJRw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.42.0':
     resolution: {integrity: sha512-0wV284I6vc5f0AqAhgAbHU2935B4bVpncPoe5n/WzVZY/KnHgqxC8iSFGeSyLWEgstFboIcWkOPck7tqbdHkzA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.42.0':
     resolution: {integrity: sha512-p4BG6HpGnhfgHk1rzZfyR6zcWkE7iLrWxyehHfXUy4Qa5j3e0roglFOdP/Nj5cJJ58MA3isQ5dlfkW2nNEpolw==}
@@ -1273,48 +1307,56 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.58.0':
     resolution: {integrity: sha512-zSoYRo5dxHLcUx93Stl2hW3hSNjPt99O70eRVWt5A1zwJ+FPjeCCANCD2a9R4JbHsdcl11TIQOjyigcRVOH2mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.58.0':
     resolution: {integrity: sha512-NQ0U/lqxH2/VxBYeAIvMNUK1y0a1bJ3ZicqkF2c6wfakbEciP9jvIE4yNzCFpZaqeIeRYaV7AVGqEO1yrfVPjA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.58.0':
     resolution: {integrity: sha512-X9J+kr3gIC9FT8GuZt0ekzpNUtkBVzMVU4KiKDSlocyQuEgi3gBbXYN8UkQiV77FTusLDPsovjo95YedHr+3yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.58.0':
     resolution: {integrity: sha512-CDze3pi1OO3Wvb/QsXjmLEY4XPKGM6kIo82ssNOgmcl1IdndF9VSGAE38YLhADWmOac7fjqhBw82LozuUVxD0Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.58.0':
     resolution: {integrity: sha512-b/89glbxFaEAcA6Uf1FvCNecBJEgcUTsV1quzrqXM/o4R1M4u+2KCVuyGCayN2UpsRWtGGLb+Ver0tBBpxaPog==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.58.0':
     resolution: {integrity: sha512-0/yYpkq9VJFCEcuRlrViGj8pJUFFvNS4EkEREaN7CB1EcLXJIaVSSa5eCihwBGXtOZxhnblWgxks9juRdNQI7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.58.0':
     resolution: {integrity: sha512-hr6FNvmcAXiH+JxSvaJ4SJ1HofkdqEElXICW9sm3/Rd5eC3t7kzvmLyRAB3NngKO2wzXRCAm4Z/mGWfrsS4X8w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.58.0':
     resolution: {integrity: sha512-R+O368VXgRql1K6Xar+FEo7NEwfo13EibPMoTv3sesYQedRXd6m30Dh/7lZMxnrQVFfeo4EOfYIP4FpcgWQNHg==}
@@ -2098,36 +2140,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
     resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
     resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
     resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
@@ -2192,66 +2240,79 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -2382,24 +2443,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@snazzah/davey-linux-arm64-musl@0.1.11':
     resolution: {integrity: sha512-e6pX6Hiabtz99q+H/YHNkm9JVlpqN8HGh0qPib8G2+UY4/SSH8WvqWipk3v581dMy2oyCHt7MOoY1aU1P1N/xA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@snazzah/davey-linux-x64-gnu@0.1.11':
     resolution: {integrity: sha512-TW5bSoqChOJMbvsDb4wAATYrxmAXuNnse7wFNVSAJUaZKSeRfZbu3UAiPWSNn7GwLwSfU6hg322KZUn8IWCuvg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@snazzah/davey-linux-x64-musl@0.1.11':
     resolution: {integrity: sha512-5j6Pmc+Wzv5lSxVP6quA7teYRJXibkZqQyYGfTDnTsUOO5dPpcojpqlXlkhyvsA1OAQTj4uxbOCciN3cVWwzug==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@snazzah/davey-wasm32-wasi@0.1.11':
     resolution: {integrity: sha512-rKOwZ/0J8lp+4VEyOdMDBRP9KR+PksZpa9V1Qn0veMzy4FqTVKthkxwGqewheFe0SFg9fdvt798l/PBFrfDeZw==}
@@ -2478,24 +2543,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
     resolution: {integrity: sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
     resolution: {integrity: sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.1':
     resolution: {integrity: sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.1':
     resolution: {integrity: sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==}
@@ -2911,6 +2980,9 @@ packages:
   async-mutex@0.5.0:
     resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
 
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
@@ -2918,6 +2990,9 @@ packages:
   atomically@1.7.0:
     resolution: {integrity: sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w==}
     engines: {node: '>=10.12.0'}
+
+  axios@1.18.1:
+    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
   b4a@1.8.1:
     resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
@@ -3161,6 +3236,10 @@ packages:
     resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
     hasBin: true
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
@@ -3310,6 +3389,10 @@ packages:
     resolution: {integrity: sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==}
     engines: {node: '>=12'}
 
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+
   delegates@1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
 
@@ -3439,6 +3522,10 @@ packages:
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
   esbuild@0.21.5:
@@ -3579,6 +3666,19 @@ packages:
   focus-trap@7.8.0:
     resolution: {integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==}
 
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -3682,6 +3782,10 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
   has-unicode@2.0.1:
     resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
 
@@ -3691,6 +3795,10 @@ packages:
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   hast-util-to-html@9.0.5:
@@ -3997,24 +4105,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -4047,6 +4159,15 @@ packages:
   locate-path@3.0.0:
     resolution: {integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==}
     engines: {node: '>=6'}
+
+  lodash.identity@3.0.0:
+    resolution: {integrity: sha512-AupTIzdLQxJS5wIYUQlgGyk2XRTfGXA+MCghDHqZk0pzUNYvd3EESS6dkChNauNYVIutcb0dfHw1ri9Q1yPV8Q==}
+
+  lodash.merge@4.6.2:
+    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.pickby@4.6.0:
+    resolution: {integrity: sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==}
 
   lodash.snakecase@4.1.1:
     resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
@@ -4572,6 +4693,10 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  proxy-from-env@2.1.0:
+    resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
+    engines: {node: '>=10'}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -6308,6 +6433,21 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
+  '@larksuiteoapi/node-sdk@1.71.1':
+    dependencies:
+      axios: 1.18.1
+      lodash.identity: 3.0.0
+      lodash.merge: 4.6.2
+      lodash.pickby: 4.6.0
+      protobufjs: 7.6.1
+      qs: 6.14.2
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+
   '@mixmark-io/domino@2.2.0': {}
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
@@ -7851,12 +7991,13 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/integrations@12.8.2(focus-trap@7.8.0)(typescript@5.9.3)':
+  '@vueuse/integrations@12.8.2(axios@1.18.1)(focus-trap@7.8.0)(typescript@5.9.3)':
     dependencies:
       '@vueuse/core': 12.8.2(typescript@5.9.3)
       '@vueuse/shared': 12.8.2(typescript@5.9.3)
       vue: 3.5.39(typescript@5.9.3)
     optionalDependencies:
+      axios: 1.18.1
       focus-trap: 7.8.0
     transitivePeerDependencies:
       - typescript
@@ -7908,7 +8049,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   agentkeepalive@4.6.0:
     dependencies:
@@ -7996,9 +8136,21 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  asynckit@0.4.0: {}
+
   atomic-sleep@1.0.0: {}
 
   atomically@1.7.0: {}
+
+  axios@1.18.1:
+    dependencies:
+      follow-redirects: 1.16.0
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   b4a@1.8.1: {}
 
@@ -8295,6 +8447,10 @@ snapshots:
   color-support@1.1.3:
     optional: true
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   comma-separated-tokens@2.0.3: {}
 
   commander@11.1.0: {}
@@ -8412,6 +8568,8 @@ snapshots:
   define-lazy-prop@2.0.0: {}
 
   define-lazy-prop@3.0.0: {}
+
+  delayed-stream@1.0.0: {}
 
   delegates@1.0.0:
     optional: true
@@ -8538,6 +8696,13 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.4
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -8803,6 +8968,16 @@ snapshots:
     dependencies:
       tabbable: 6.5.0
 
+  follow-redirects@1.16.0: {}
+
+  form-data@4.0.6:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
+
   forwarded@0.2.0: {}
 
   fresh@0.5.2: {}
@@ -8904,6 +9079,10 @@ snapshots:
 
   has-symbols@1.1.0: {}
 
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
+
   has-unicode@2.0.1:
     optional: true
 
@@ -8912,6 +9091,10 @@ snapshots:
       hookified: 1.15.1
 
   hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 
@@ -8978,7 +9161,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   human-signals@2.1.0: {}
 
@@ -9207,6 +9389,12 @@ snapshots:
     dependencies:
       p-locate: 3.0.0
       path-exists: 3.0.0
+
+  lodash.identity@3.0.0: {}
+
+  lodash.merge@4.6.2: {}
+
+  lodash.pickby@4.6.0: {}
 
   lodash.snakecase@4.1.1: {}
 
@@ -9767,6 +9955,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  proxy-from-env@2.1.0: {}
 
   pump@3.0.4:
     dependencies:
@@ -10643,7 +10833,7 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitepress@1.6.4(@algolia/client-search@5.55.1)(@types/node@25.5.0)(@types/react@19.2.17)(lightningcss@1.32.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(search-insights@2.17.3)(typescript@5.9.3):
+  vitepress@1.6.4(@algolia/client-search@5.55.1)(@types/node@25.5.0)(@types/react@19.2.17)(axios@1.18.1)(lightningcss@1.32.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(search-insights@2.17.3)(typescript@5.9.3):
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.55.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(search-insights@2.17.3)
@@ -10656,7 +10846,7 @@ snapshots:
       '@vue/devtools-api': 7.7.10
       '@vue/shared': 3.5.39
       '@vueuse/core': 12.8.2(typescript@5.9.3)
-      '@vueuse/integrations': 12.8.2(focus-trap@7.8.0)(typescript@5.9.3)
+      '@vueuse/integrations': 12.8.2(axios@1.18.1)(focus-trap@7.8.0)(typescript@5.9.3)
       focus-trap: 7.8.0
       mark.js: 8.11.1
       minisearch: 7.2.0


### PR DESCRIPTION
## Summary

- Add a shipped `feishu` library adapter under `examples/exo/adapters/feishu` (worker, parsing module, unit tests, README, setup prompt).
- Add the Rust adapter creation config and the model-visible TypeScript schema alongside the existing library types.
- Connect over Lark's long-connection (WebSocket) mode using `@larksuiteoapi/node-sdk`, with the app secret held as a host-resolved secret reference.

## Why Feishu

Feishu (Lark) is the dominant team-chat platform in mainland China, and the shipped library covers IRC, ExoChat, WhatsApp, Signal, Discord, and Slack but not this one. It is the same category as the Slack adapter rather than a new one, so this is the next instance of an existing pattern.

## Notes

Two things that are not obvious from the SDK docs and cost me real time:

- The app must be switched to long-connection mode in the open-platform console. The default HTTP webhook mode needs a public callback URL and is not usable for a locally running agent.
- The SDK's event dispatcher **flattens** the event body into the handler argument for both v1 and v2 events, so there is no `.event` nesting to read. Reading `event.event.*` drops every inbound message silently, with no error anywhere. The parser accepts either shape, in case a future SDK version stops flattening.

Inbound parsing and target resolution live in `feishu.ts` with unit tests, following the irc / discord / agent-cli split rather than a monolithic worker.

Credentials follow the existing pattern: `appId` is plain config, `appSecretSecretId` is a secret reference resolved by the host and delivered to the worker as `EXO_FEISHU_APP_SECRET`. The config schema is strict-mode clean — `additionalProperties: false`, every property in `required`, optional values as nullable types.

Group behaviour is configurable with `trigger`: `mentions_only` wakes on @-mentions and always on direct messages, `all_messages` wakes on everything subscribed.

## Test plan

- [x] `pnpm check` — lint, typecheck, 129 tests including the new `feishu.test.ts`
- [x] `cargo check -p executor`
- [x] End-to-end against a real Feishu tenant: inbound direct message and group @-mention wake the conversation, outbound `send_adapter_message` delivers.

## Follow-up

Rich media (image / file / audio / post) needs an authenticated resource download rather than a URL, plus mime sniffing from magic bytes because Feishu serves whatever format the sender uploaded. I have that working and will send it separately to keep this reviewable.

Happy to rebase onto #171 once it lands — it rewrites `adapter/{runtime,store,tools,types,worker}.rs` and `adapter-tools.ts`, which are exactly the two registration points this touches.
