### PR TITLE
Add Tensorlake as a sandbox provider

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -34,10 +34,11 @@ use executor::{
     Harness, HarnessAgent, HarnessConversation, HttpExoHarness, LocalSandboxExoHarness,
     PutSecretRequest, RlmHarness, SANDBOX_MAIN_MOUNT_DIR, SandboxAttachment,
     SandboxBackendRegistration, SandboxProvider, SandboxProviderConfig, SandboxScope, Secret,
-    SecretBackendChoice, SpritesBackendSpec, ToolRequest, ToolRuntime, TypeScriptHarness,
-    TypeScriptHarnessConfig, Uuid7, VercelBackendSpec, default_aws_agentcore_image,
-    default_daytona_image, default_docker_image, default_e2b_template, default_vercel_image,
-    effective_sandbox_scope, finalize_rebuild_update_file, load_agent_config, record_host_event,
+    SecretBackendChoice, SpritesBackendSpec, TensorlakeBackendSpec,
+    ToolRequest, ToolRuntime, TypeScriptHarness, TypeScriptHarnessConfig, Uuid7, VercelBackendSpec,
+    default_aws_agentcore_image, default_daytona_image, default_docker_image, default_e2b_template,
+    default_tensorlake_image, default_vercel_image, effective_sandbox_scope,
+    finalize_rebuild_update_file, load_agent_config, record_host_event,
     send_conversation_wakeup, serve_exoharness_http_listener_with_options,
 };
 use serde::Deserialize;
@@ -220,6 +221,7 @@ enum SandboxProviderArg {
     E2b,
     #[value(name = "sprites")]
     Sprites,
+    Tensorlake,
     Vercel,
     #[value(name = "aws-agentcore")]
     AwsAgentCore,
@@ -236,6 +238,7 @@ impl From<SandboxProviderArg> for SandboxProvider {
             SandboxProviderArg::Daytona => Self::Daytona,
             SandboxProviderArg::E2b => Self::E2b,
             SandboxProviderArg::Sprites => Self::Sprites,
+            SandboxProviderArg::Tensorlake => Self::Tensorlake,
             SandboxProviderArg::Vercel => Self::Vercel,
             SandboxProviderArg::AwsAgentCore => Self::AwsAgentCore,
             SandboxProviderArg::AppleContainer => Self::AppleContainer,
@@ -300,6 +303,7 @@ fn default_sandbox_backends() -> Vec<SandboxBackendRegistration> {
         SandboxBackendRegistration::daytona(DaytonaBackendSpec::default()),
         SandboxBackendRegistration::e2b(E2bBackendSpec::default()),
         SandboxBackendRegistration::sprites(SpritesBackendSpec::default()),
+        SandboxBackendRegistration::tensorlake(TensorlakeBackendSpec::default()),
         SandboxBackendRegistration::vercel(VercelBackendSpec::with_conventional_secrets()),
         SandboxBackendRegistration::aws_agentcore(),
     ]
@@ -738,6 +742,12 @@ struct ProviderConfigureArgs {
     /// Extra Sprites labels (repeatable). Exo resume labels are added on create.
     #[arg(long = "label")]
     labels: Vec<String>,
+    /// Tensorlake: whole CPU cores per sandbox.
+    #[arg(long)]
+    cpus: Option<u32>,
+    /// Tensorlake: memory per sandbox in MiB.
+    #[arg(long = "memory-mb")]
+    memory_mb: Option<u64>,
 }
 
 #[derive(Debug, Clone, Default, Args)]
@@ -2092,6 +2102,8 @@ async fn main() -> Result<()> {
                     default_image,
                     url_auth,
                     labels,
+                    cpus,
+                    memory_mb,
                 } = *args;
                 let binding_name =
                     name.unwrap_or_else(|| SandboxProvider::from(provider).as_str().to_string());
@@ -2186,6 +2198,21 @@ async fn main() -> Result<()> {
                             url_auth,
                             organization: organization_id,
                             labels,
+                        }
+                    }
+                    SandboxProviderArg::Tensorlake => {
+                        let secret =
+                            secret.ok_or_else(|| anyhow!("--secret is required for tensorlake"))?;
+                        let secret_id =
+                            find_secret_id(harness.exoharness_handle().as_ref(), &secret)
+                                .await?
+                                .ok_or_else(|| anyhow!("secret not found: {secret}"))?;
+                        SandboxProviderConfig::Tensorlake {
+                            api_key_secret_id: secret_id,
+                            api_url,
+                            default_image: default_image.unwrap_or_else(default_tensorlake_image),
+                            cpus,
+                            memory_mb,
                         }
                     }
                     other => bail!("provider {other:?} has no binding-based config yet"),

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -34,12 +34,12 @@ use executor::{
     Harness, HarnessAgent, HarnessConversation, HttpExoHarness, LocalSandboxExoHarness,
     PutSecretRequest, RlmHarness, SANDBOX_MAIN_MOUNT_DIR, SandboxAttachment,
     SandboxBackendRegistration, SandboxProvider, SandboxProviderConfig, SandboxScope, Secret,
-    SecretBackendChoice, SpritesBackendSpec, TensorlakeBackendSpec,
-    ToolRequest, ToolRuntime, TypeScriptHarness, TypeScriptHarnessConfig, Uuid7, VercelBackendSpec,
+    SecretBackendChoice, SpritesBackendSpec, TensorlakeBackendSpec, ToolRequest, ToolRuntime,
+    TypeScriptHarness, TypeScriptHarnessConfig, Uuid7, VercelBackendSpec,
     default_aws_agentcore_image, default_daytona_image, default_docker_image, default_e2b_template,
     default_tensorlake_image, default_vercel_image, effective_sandbox_scope,
-    finalize_rebuild_update_file, load_agent_config, record_host_event,
-    send_conversation_wakeup, serve_exoharness_http_listener_with_options,
+    finalize_rebuild_update_file, load_agent_config, record_host_event, send_conversation_wakeup,
+    serve_exoharness_http_listener_with_options,
 };
 use serde::Deserialize;
 use tabwriter::TabWriter;
@@ -2111,6 +2111,11 @@ async fn main() -> Result<()> {
                     && session_storage_mount_path.is_some()
                 {
                     bail!("--session-storage-mount-path is only valid for aws-agentcore");
+                }
+                if !matches!(provider, SandboxProviderArg::Tensorlake)
+                    && (cpus.is_some() || memory_mb.is_some())
+                {
+                    bail!("--cpus and --memory-mb are only valid for tensorlake");
                 }
                 let config = match provider {
                     SandboxProviderArg::Daytona => {

--- a/crates/cli/tests/sandbox_start_process_live.rs
+++ b/crates/cli/tests/sandbox_start_process_live.rs
@@ -5,6 +5,9 @@
 //!
 //! Sprites (set `SPRITES_ORGANIZATION` when your token spans multiple orgs):
 //! `SPRITES_TOKEN=... cargo test -p exo --test sandbox_start_process_live sprites_ -- --ignored --nocapture`
+//!
+//! Tensorlake:
+//! `TENSORLAKE_API_KEY=... cargo test -p exo --test sandbox_start_process_live tensorlake_ -- --ignored --nocapture`
 
 use std::collections::HashMap;
 use std::env;
@@ -14,7 +17,7 @@ use std::time::{Duration, Instant};
 use exoharness::{
     E2bConfig, E2bSandboxBackend, ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand,
     SandboxKey, SandboxLifecycleConfig, SandboxNetworkPolicy, SandboxRequest, SandboxSpec,
-    SpritesConfig, SpritesSandboxBackend,
+    SpritesConfig, SpritesSandboxBackend, TensorlakeConfig, TensorlakeSandboxBackend,
 };
 use futures::io::AsyncReadExt;
 use tokio::time::timeout;
@@ -102,6 +105,42 @@ fn make_sprites_request(conversation_id: &str, sandbox_id: &str) -> SandboxReque
     }
 }
 
+fn tensorlake_image() -> String {
+    env::var("TENSORLAKE_IMAGE").unwrap_or_else(|_| exoharness::DEFAULT_TENSORLAKE_IMAGE.into())
+}
+
+fn tensorlake_config_from_env() -> Option<TensorlakeConfig> {
+    Some(TensorlakeConfig {
+        api_key: live_provider_secret("tensorlake", "TENSORLAKE_API_KEY")?,
+        api_url: env::var("TENSORLAKE_API_URL")
+            .unwrap_or_else(|_| exoharness::DEFAULT_TENSORLAKE_API_URL.into()),
+        default_image: tensorlake_image(),
+        cpus: None,
+        memory_mb: None,
+        sandbox_base_url: None,
+    })
+}
+
+fn make_tensorlake_request(conversation_id: &str, sandbox_id: &str) -> SandboxRequest {
+    SandboxRequest {
+        key: SandboxKey::ConversationSandbox {
+            conversation_id: conversation_id.into(),
+            sandbox_id: sandbox_id.into(),
+        },
+        spec: SandboxSpec {
+            image: tensorlake_image(),
+            mounts: Vec::new(),
+            durable_file_systems: Vec::new(),
+            network: SandboxNetworkPolicy::Enabled,
+            default_workdir: "/workspace".into(),
+        },
+        lifecycle: SandboxLifecycleConfig {
+            idle_ttl: Some(Duration::from_secs(300)),
+        },
+        provider_state: None,
+    }
+}
+
 #[tokio::test]
 #[ignore = "requires E2B_API_KEY"]
 async fn e2b_start_process_streams_incrementally() {
@@ -175,6 +214,46 @@ async fn sprites_start_process_contract() {
     )
     .await
     .expect("Sprites start_process contract");
+}
+
+#[tokio::test]
+#[ignore = "requires TENSORLAKE_API_KEY"]
+async fn tensorlake_start_process_streams_incrementally() {
+    let Some(config) = tensorlake_config_from_env() else {
+        return;
+    };
+    let backend = TensorlakeSandboxBackend::new(config).expect("TensorlakeSandboxBackend::new");
+
+    let handle = backend
+        .acquire(make_tensorlake_request(
+            "live-tensorlake-stream",
+            "sandbox-live-stream",
+        ))
+        .await
+        .expect("acquire Tensorlake sandbox");
+    assert_streaming_script(handle, "Tensorlake", "/workspace").await;
+}
+
+#[tokio::test]
+#[ignore = "requires TENSORLAKE_API_KEY"]
+async fn tensorlake_start_process_contract() {
+    let Some(config) = tensorlake_config_from_env() else {
+        return;
+    };
+    let backend = TensorlakeSandboxBackend::new(config).expect("TensorlakeSandboxBackend::new");
+
+    let handle = backend
+        .acquire(make_tensorlake_request(
+            "live-tensorlake-contract",
+            "sandbox-live-contract",
+        ))
+        .await
+        .expect("acquire Tensorlake sandbox");
+    exoharness::contract_tests::sandbox_handle_start_process_supports_interactive_stdio_and_env(
+        handle,
+    )
+    .await
+    .expect("Tensorlake start_process contract");
 }
 
 async fn assert_streaming_script(handle: Arc<dyn ManagedSandboxHandle>, provider: &str, cwd: &str) {

--- a/crates/cli/tests/tensorlake_backend.rs
+++ b/crates/cli/tests/tensorlake_backend.rs
@@ -893,3 +893,133 @@ async fn acquire_from_snapshot_rejects_a_manifest_from_another_sandbox() {
         "unexpected error: {error}"
     );
 }
+
+#[tokio::test]
+async fn terminate_deletes_the_named_sandbox_without_a_lookup() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-terminate", "sandbox-terminate");
+    let name = expected_sandbox_name(&request);
+    Mock::given(method("DELETE"))
+        .and(path(format!("/sandboxes/{name}")))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    backend.terminate(request).await.expect("terminate");
+    assert_eq!(server.received_requests().await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn terminate_tolerates_an_already_deleted_sandbox() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-absent", "sandbox-absent");
+    let name = expected_sandbox_name(&request);
+    Mock::given(method("DELETE"))
+        .and(path(format!("/sandboxes/{name}")))
+        .respond_with(ResponseTemplate::new(404))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    backend.terminate(request).await.expect("terminate");
+}
+
+#[tokio::test]
+async fn terminate_ignores_ephemeral_requests() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+
+    backend
+        .terminate(make_ephemeral_request(
+            "conv-ephemeral-terminate",
+            "sandbox-ephemeral-terminate",
+        ))
+        .await
+        .expect("terminate");
+    assert!(server.received_requests().await.unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn fork_sandbox_copies_under_the_target_name() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let source = make_request("conv-parent", "sandbox-1");
+    let target = make_request("conv-fork", "sandbox-1");
+    let source_name = expected_sandbox_name(&source);
+    let target_name = expected_sandbox_name(&target);
+    mount_running_sandbox(&server, &source_name, "sbx-parent").await;
+    Mock::given(method("POST"))
+        .and(path(format!("/sandboxes/{source_name}/copy")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "sandboxes": [{ "sandbox_id": "sbx-fork", "status": "running" }],
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    assert!(
+        backend
+            .fork_sandbox(source, target)
+            .await
+            .expect("fork sandbox")
+    );
+    let requests = server.received_requests().await.unwrap();
+    let copy = requests
+        .iter()
+        .find(|request| request.url.path().ends_with("/copy"))
+        .expect("copy request");
+    let query: std::collections::HashMap<_, _> = copy.url.query_pairs().into_owned().collect();
+    assert_eq!(query.get("name"), Some(&target_name));
+    assert_eq!(query.get("times"), Some(&"1".to_string()));
+}
+
+#[tokio::test]
+async fn fork_sandbox_starts_cold_when_the_source_does_not_exist() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let source = make_request("conv-cold", "sandbox-1");
+    let target = make_request("conv-cold-fork", "sandbox-1");
+    let source_name = expected_sandbox_name(&source);
+    Mock::given(method("GET"))
+        .and(path(format!("/sandboxes/{source_name}")))
+        .respond_with(ResponseTemplate::new(404))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    assert!(!backend.fork_sandbox(source, target).await.unwrap());
+    assert_eq!(server.received_requests().await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn fork_sandbox_rejects_a_copy_that_did_not_start() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let source = make_request("conv-slow", "sandbox-1");
+    let target = make_request("conv-slow-fork", "sandbox-1");
+    let source_name = expected_sandbox_name(&source);
+    mount_running_sandbox(&server, &source_name, "sbx-parent").await;
+    Mock::given(method("POST"))
+        .and(path(format!("/sandboxes/{source_name}/copy")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "sandboxes": [{
+                "sandbox_id": "sbx-fork",
+                "status": "pending",
+                "pending_reason": "no_resources_available",
+            }],
+        })))
+        .mount(&server)
+        .await;
+
+    let error = backend
+        .fork_sandbox(source, target)
+        .await
+        .expect_err("pending copy must fail");
+    assert!(
+        error.to_string().contains("no_resources_available"),
+        "unexpected error: {error}"
+    );
+}

--- a/crates/cli/tests/tensorlake_backend.rs
+++ b/crates/cli/tests/tensorlake_backend.rs
@@ -562,6 +562,11 @@ async fn snapshot_returns_a_tensorlake_manifest() {
         .expect(1)
         .mount(&server)
         .await;
+    Mock::given(method("GET"))
+        .and(path("/snapshots/snap-123"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "status": "completed" })))
+        .mount(&server)
+        .await;
 
     let handle = backend.acquire(request).await.expect("acquire");
     let payload = handle.snapshot().await.expect("snapshot");
@@ -785,4 +790,106 @@ fn touch_command() -> exoharness::SandboxCommand {
         cwd: None,
         timeout: None,
     }
+}
+
+/// The snapshot id is only worth persisting once the platform can restore from
+/// it; `POST /snapshot` returns before that is true.
+#[tokio::test]
+async fn snapshot_waits_for_the_platform_to_finish_writing_it() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-snap-wait", "sandbox-snap-wait");
+    let name = expected_sandbox_name(&request);
+    mount_running_sandbox(&server, &name, "sbx-snap-wait").await;
+
+    Mock::given(method("POST"))
+        .and(path("/sandboxes/sbx-snap-wait/snapshot"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "snapshot_id": "snap-slow",
+            "status": "in_progress",
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/snapshots/snap-slow"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "status": "in_progress" })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/snapshots/snap-slow"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "status": "completed" })))
+        .expect(1..)
+        .mount(&server)
+        .await;
+
+    let handle = backend.acquire(request).await.expect("acquire");
+    let payload = handle.snapshot().await.expect("snapshot");
+    let manifest: Value = serde_json::from_slice(&payload.bytes).expect("manifest json");
+    assert_eq!(manifest["snapshot_id"], json!("snap-slow"));
+}
+
+#[tokio::test]
+async fn snapshot_surfaces_a_failed_snapshot_instead_of_persisting_its_id() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-snap-fail", "sandbox-snap-fail");
+    let name = expected_sandbox_name(&request);
+    mount_running_sandbox(&server, &name, "sbx-snap-fail").await;
+
+    Mock::given(method("POST"))
+        .and(path("/sandboxes/sbx-snap-fail/snapshot"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "snapshot_id": "snap-bad",
+            "status": "in_progress",
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/snapshots/snap-bad"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "status": "failed",
+            "error": "export exceeded disk budget",
+        })))
+        .mount(&server)
+        .await;
+
+    let handle = backend.acquire(request).await.expect("acquire");
+    let error = match handle.snapshot().await {
+        Ok(_) => panic!("a failed snapshot must not yield a usable manifest"),
+        Err(error) => error,
+    };
+    assert!(
+        error.to_string().contains("export exceeded disk budget"),
+        "unexpected error: {error}"
+    );
+}
+
+/// Restoring one sandbox's filesystem under another's identity would hand the
+/// caller someone else's state.
+#[tokio::test]
+async fn acquire_from_snapshot_rejects_a_manifest_from_another_sandbox() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-restore", "sandbox-restore");
+
+    let payload = SnapshotPayload {
+        kind: SnapshotKind::TensorlakeSnapshot,
+        bytes: Bytes::from(
+            serde_json::to_vec(&json!({
+                "snapshot_id": "snap-elsewhere",
+                "sandbox_name": "exo-0000000000000000",
+            }))
+            .unwrap(),
+        ),
+    };
+
+    let error = match backend.acquire_from_snapshot(request, payload).await {
+        Ok(_) => panic!("expected a sandbox-identity mismatch"),
+        Err(error) => error,
+    };
+    assert!(
+        error.to_string().contains("exo-0000000000000000"),
+        "unexpected error: {error}"
+    );
 }

--- a/crates/cli/tests/tensorlake_backend.rs
+++ b/crates/cli/tests/tensorlake_backend.rs
@@ -1,0 +1,788 @@
+//! Wiremock-driven tests for the Tensorlake sandbox backend.
+//!
+//! The single mock server stands in for both the platform API (`/sandboxes/...`)
+//! and the per-sandbox proxy (`/api/v1/...`), which the backend is pointed at via
+//! `TensorlakeConfig::sandbox_base_url`.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use bytes::Bytes;
+use exoharness::{
+    ManagedSandboxBackend, SandboxKey, SandboxLifecycleConfig, SandboxMount, SandboxMountAccess,
+    SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotKind, SnapshotPayload,
+    TensorlakeConfig, TensorlakeSandboxBackend,
+};
+use serde_json::{Value, json};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn make_request(conversation_id: &str, sandbox_id: &str) -> SandboxRequest {
+    SandboxRequest {
+        key: SandboxKey::ConversationSandbox {
+            conversation_id: conversation_id.into(),
+            sandbox_id: sandbox_id.into(),
+        },
+        spec: SandboxSpec {
+            image: "tensorlake/ubuntu-minimal".into(),
+            mounts: Vec::new(),
+            durable_file_systems: Vec::new(),
+            network: SandboxNetworkPolicy::Enabled,
+            default_workdir: "/workspace".into(),
+        },
+        lifecycle: SandboxLifecycleConfig {
+            idle_ttl: Some(Duration::from_secs(300)),
+        },
+        provider_state: None,
+    }
+}
+
+/// A request with no idle TTL, which maps to an ephemeral Tensorlake sandbox.
+fn make_ephemeral_request(conversation_id: &str, sandbox_id: &str) -> SandboxRequest {
+    SandboxRequest {
+        lifecycle: SandboxLifecycleConfig { idle_ttl: None },
+        ..make_request(conversation_id, sandbox_id)
+    }
+}
+
+fn sandbox_spec_hash(spec: &SandboxSpec) -> String {
+    let mut hasher = DefaultHasher::new();
+    spec.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+fn expected_sandbox_name(request: &SandboxRequest) -> String {
+    let mut hasher = DefaultHasher::new();
+    request.key.hash(&mut hasher);
+    sandbox_spec_hash(&request.spec).hash(&mut hasher);
+    format!("exo-{:016x}", hasher.finish())
+}
+
+fn backend_for_mock(server: &MockServer) -> TensorlakeSandboxBackend {
+    backend_with_config(TensorlakeConfig {
+        api_key: "test-key".into(),
+        api_url: server.uri(),
+        default_image: "tensorlake/ubuntu-minimal".into(),
+        cpus: None,
+        memory_mb: None,
+        sandbox_base_url: Some(server.uri()),
+    })
+}
+
+fn backend_with_config(config: TensorlakeConfig) -> TensorlakeSandboxBackend {
+    TensorlakeSandboxBackend::new(config).expect("TensorlakeSandboxBackend::new")
+}
+
+fn sandbox_info_json(server: &MockServer, id: &str, status: &str) -> Value {
+    json!({
+        "id": id,
+        "namespace": "default",
+        "status": status,
+        "created_at": 1_773_950_042_728i64,
+        "resources": { "cpus": 1.0, "memory_mb": 1024 },
+        "timeout_secs": 300,
+        "allow_unauthenticated_access": false,
+        "ingress_endpoint": server.uri(),
+        "sandbox_url": server.uri(),
+    })
+}
+
+/// Body for `POST /sandboxes`; the backend polls `GET /sandboxes/{id}` right after.
+fn create_response_json(id: &str) -> Value {
+    json!({ "sandbox_id": id, "status": "pending" })
+}
+
+fn sse(frames: &[Value]) -> String {
+    frames
+        .iter()
+        .map(|frame| format!("data: {frame}\n\n"))
+        .collect()
+}
+
+async fn mount_running_sandbox(server: &MockServer, identifier: &str, id: &str) {
+    Mock::given(method("GET"))
+        .and(path(format!("/sandboxes/{identifier}")))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(sandbox_info_json(server, id, "running")),
+        )
+        .mount(server)
+        .await;
+}
+
+fn last_body(requests: &[wiremock::Request], method_name: &str, path_suffix: &str) -> Value {
+    let request = requests
+        .iter()
+        .rev()
+        .find(|request| {
+            request.method.as_str() == method_name && request.url.path().ends_with(path_suffix)
+        })
+        .unwrap_or_else(|| panic!("no {method_name} request to {path_suffix}"));
+    serde_json::from_slice(&request.body).expect("request body is JSON")
+}
+
+#[tokio::test]
+async fn acquire_creates_named_sandbox_when_missing() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-1", "sandbox-1");
+    let name = expected_sandbox_name(&request);
+
+    Mock::given(method("GET"))
+        .and(path(format!("/sandboxes/{name}")))
+        .respond_with(ResponseTemplate::new(404))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/sandboxes"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(create_response_json("sbx-1")))
+        .expect(1)
+        .mount(&server)
+        .await;
+    mount_running_sandbox(&server, "sbx-1", "sbx-1").await;
+
+    let handle = backend.acquire(request).await.expect("acquire");
+    assert_eq!(handle.id(), "tensorlake:conversation:conv-1:sandbox-1");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let create = last_body(&requests, "POST", "/sandboxes");
+    assert_eq!(create["name"], json!(name));
+    assert_eq!(create["image"], json!("tensorlake/ubuntu-minimal"));
+    assert_eq!(create["timeout_secs"], json!(300));
+    assert_eq!(create["network"]["allow_internet_access"], json!(true));
+}
+
+#[tokio::test]
+async fn acquire_reuses_running_named_sandbox() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-warm", "sandbox-warm");
+    let name = expected_sandbox_name(&request);
+
+    mount_running_sandbox(&server, &name, "sbx-warm").await;
+    Mock::given(method("POST"))
+        .and(path("/sandboxes"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(create_response_json("sbx-new")))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    backend.acquire(request).await.expect("acquire");
+}
+
+#[tokio::test]
+async fn acquire_resumes_suspended_named_sandbox() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-suspended", "sandbox-suspended");
+    let name = expected_sandbox_name(&request);
+
+    // The lookup by name reports suspended; the post-resume poll (by id) is running.
+    Mock::given(method("GET"))
+        .and(path(format!("/sandboxes/{name}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sandbox_info_json(
+            &server,
+            "sbx-suspended",
+            "suspended",
+        )))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/sandboxes/sbx-suspended/resume"))
+        .respond_with(ResponseTemplate::new(202))
+        .expect(1)
+        .mount(&server)
+        .await;
+    mount_running_sandbox(&server, "sbx-suspended", "sbx-suspended").await;
+    Mock::given(method("POST"))
+        .and(path("/sandboxes"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(create_response_json("sbx-new")))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    backend.acquire(request).await.expect("acquire");
+}
+
+#[tokio::test]
+async fn acquire_without_idle_ttl_creates_unnamed_sandbox() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_ephemeral_request("conv-ephemeral", "sandbox-ephemeral");
+
+    Mock::given(method("POST"))
+        .and(path("/sandboxes"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(create_response_json("sbx-eph")))
+        .expect(1)
+        .mount(&server)
+        .await;
+    mount_running_sandbox(&server, "sbx-eph", "sbx-eph").await;
+
+    backend.acquire(request).await.expect("acquire");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let create = last_body(&requests, "POST", "/sandboxes");
+    assert!(create.get("name").is_none(), "ephemeral create sent a name");
+    assert!(
+        create.get("timeout_secs").is_none(),
+        "ephemeral create pinned a timeout"
+    );
+}
+
+#[tokio::test]
+async fn acquire_disables_internet_access_for_a_disabled_network_policy() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let mut request = make_request("conv-net", "sandbox-net");
+    request.spec.network = SandboxNetworkPolicy::Disabled;
+    let name = expected_sandbox_name(&request);
+
+    Mock::given(method("GET"))
+        .and(path(format!("/sandboxes/{name}")))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/sandboxes"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(create_response_json("sbx-net")))
+        .mount(&server)
+        .await;
+    mount_running_sandbox(&server, "sbx-net", "sbx-net").await;
+
+    backend.acquire(request).await.expect("acquire");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let create = last_body(&requests, "POST", "/sandboxes");
+    assert_eq!(create["network"]["allow_internet_access"], json!(false));
+}
+
+#[tokio::test]
+async fn acquire_forwards_configured_resource_overrides() {
+    let server = MockServer::start().await;
+    let backend = backend_with_config(TensorlakeConfig {
+        api_key: "test-key".into(),
+        api_url: server.uri(),
+        default_image: "tensorlake/ubuntu-minimal".into(),
+        cpus: Some(4.0),
+        memory_mb: Some(8192),
+        sandbox_base_url: Some(server.uri()),
+    });
+    let request = make_request("conv-res", "sandbox-res");
+    let name = expected_sandbox_name(&request);
+
+    Mock::given(method("GET"))
+        .and(path(format!("/sandboxes/{name}")))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/sandboxes"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(create_response_json("sbx-res")))
+        .mount(&server)
+        .await;
+    mount_running_sandbox(&server, "sbx-res", "sbx-res").await;
+
+    backend.acquire(request).await.expect("acquire");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let create = last_body(&requests, "POST", "/sandboxes");
+    assert_eq!(create["resources"]["cpus"], json!(4.0));
+    assert_eq!(create["resources"]["memory_mb"], json!(8192));
+}
+
+#[tokio::test]
+async fn exec_collects_run_process_sse_output() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-exec", "sandbox-exec");
+    let name = expected_sandbox_name(&request);
+    mount_running_sandbox(&server, &name, "sbx-exec").await;
+
+    let stream = sse(&[
+        json!({ "handle": 1, "pid": 42, "started_at": 1_710_000_000_000i64 }),
+        json!({ "line": "hello", "timestamp": 1i64, "stream": "stdout" }),
+        json!({ "line": "world", "timestamp": 2i64, "stream": "stdout" }),
+        json!({ "line": "oops", "timestamp": 3i64, "stream": "stderr" }),
+        json!({ "exit_code": 0 }),
+    ]);
+    Mock::given(method("POST"))
+        .and(path("/api/v1/processes/run"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(stream, "text/event-stream"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend.acquire(request).await.expect("acquire");
+    let output = handle
+        .exec(&exoharness::SandboxCommand {
+            argv: vec!["echo".into(), "hello".into()],
+            env: [("MODE".to_string(), "prod".to_string())]
+                .into_iter()
+                .collect(),
+            display_argv: None,
+            cwd: None,
+            timeout: None,
+        })
+        .await
+        .expect("exec");
+
+    assert!(output.ok);
+    assert_eq!(output.exit_code, Some(0));
+    assert_eq!(output.stdout, "hello\nworld\n");
+    assert_eq!(output.stderr, "oops\n");
+    assert_eq!(output.cwd, "/workspace");
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let run = last_body(&requests, "POST", "/api/v1/processes/run");
+    assert_eq!(run["command"], json!("echo"));
+    assert_eq!(run["args"], json!(["hello"]));
+    assert_eq!(run["working_dir"], json!("/workspace"));
+    assert_eq!(run["env"]["MODE"], json!("prod"));
+}
+
+#[tokio::test]
+async fn exec_reports_a_non_zero_exit_code() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-fail", "sandbox-fail");
+    let name = expected_sandbox_name(&request);
+    mount_running_sandbox(&server, &name, "sbx-fail").await;
+
+    let stream = sse(&[
+        json!({ "line": "boom", "timestamp": 1i64, "stream": "stderr" }),
+        json!({ "exit_code": 3 }),
+    ]);
+    Mock::given(method("POST"))
+        .and(path("/api/v1/processes/run"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(stream, "text/event-stream"))
+        .mount(&server)
+        .await;
+
+    let handle = backend.acquire(request).await.expect("acquire");
+    let output = handle
+        .exec(&exoharness::SandboxCommand {
+            argv: vec!["false".into()],
+            env: Default::default(),
+            display_argv: None,
+            cwd: None,
+            timeout: None,
+        })
+        .await
+        .expect("exec");
+
+    assert!(!output.ok);
+    assert_eq!(output.exit_code, Some(3));
+    assert_eq!(output.stderr, "boom\n");
+}
+
+#[tokio::test]
+async fn exec_maps_a_signalled_process_to_a_shell_style_exit_code() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-signal", "sandbox-signal");
+    let name = expected_sandbox_name(&request);
+    mount_running_sandbox(&server, &name, "sbx-signal").await;
+
+    let stream = sse(&[json!({ "exit_code": null, "signal": 9 })]);
+    Mock::given(method("POST"))
+        .and(path("/api/v1/processes/run"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(stream, "text/event-stream"))
+        .mount(&server)
+        .await;
+
+    let handle = backend.acquire(request).await.expect("acquire");
+    let output = handle
+        .exec(&exoharness::SandboxCommand {
+            argv: vec!["sleep".into(), "100".into()],
+            env: Default::default(),
+            display_argv: None,
+            cwd: None,
+            timeout: None,
+        })
+        .await
+        .expect("exec");
+
+    assert!(!output.ok);
+    assert_eq!(output.exit_code, Some(137));
+}
+
+#[tokio::test]
+async fn start_process_bridges_stdin_output_and_exit() {
+    use futures::AsyncReadExt as _;
+    use futures::AsyncWriteExt as _;
+
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-stream", "sandbox-stream");
+    let name = expected_sandbox_name(&request);
+    mount_running_sandbox(&server, &name, "sbx-stream").await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/processes"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(json!({
+            "handle": 1,
+            "pid": 77,
+            "status": "running",
+            "stdin_writable": true,
+            "command": "cat",
+            "args": [],
+            "started_at": 1i64,
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/v1/processes/77/stdout/follow"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(
+            "event: output\ndata: {\"line\":\"streamed\",\"timestamp\":1}\n\nevent: eof\ndata: {}\n\n",
+            "text/event-stream",
+        ))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/v1/processes/77/stderr/follow"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_raw("event: eof\ndata: {}\n\n", "text/event-stream"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/api/v1/processes/77/stdin"))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/api/v1/processes/77/stdin/close"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/v1/processes/77"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "handle": 1,
+            "pid": 77,
+            "status": "exited",
+            "exit_code": 0,
+            "stdin_writable": false,
+            "command": "cat",
+            "args": [],
+            "started_at": 1i64,
+            "ended_at": 2i64,
+        })))
+        .mount(&server)
+        .await;
+
+    let handle = backend.acquire(request).await.expect("acquire");
+    let mut parts = handle
+        .start_process(&exoharness::SandboxCommand {
+            argv: vec!["cat".into()],
+            env: Default::default(),
+            display_argv: None,
+            cwd: None,
+            timeout: None,
+        })
+        .await
+        .expect("start_process");
+
+    parts.stdin.write_all(b"ping\n").await.expect("write stdin");
+    parts.stdin.close().await.expect("close stdin");
+
+    let mut stdout = String::new();
+    parts
+        .stdout
+        .read_to_string(&mut stdout)
+        .await
+        .expect("read stdout");
+    assert_eq!(stdout, "streamed\n");
+    assert_eq!(parts.wait.await.expect("wait"), 0);
+}
+
+#[tokio::test]
+async fn stop_suspends_a_named_sandbox() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-stop", "sandbox-stop");
+    let name = expected_sandbox_name(&request);
+    mount_running_sandbox(&server, &name, "sbx-stop").await;
+
+    Mock::given(method("POST"))
+        .and(path(format!("/sandboxes/{name}/suspend")))
+        .respond_with(ResponseTemplate::new(202))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend.acquire(request).await.expect("acquire");
+    handle.stop().await.expect("stop");
+}
+
+#[tokio::test]
+async fn stop_deletes_an_ephemeral_sandbox() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_ephemeral_request("conv-stop-eph", "sandbox-stop-eph");
+
+    Mock::given(method("POST"))
+        .and(path("/sandboxes"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(create_response_json("sbx-eph")))
+        .mount(&server)
+        .await;
+    mount_running_sandbox(&server, "sbx-eph", "sbx-eph").await;
+    Mock::given(method("DELETE"))
+        .and(path("/sandboxes/sbx-eph"))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend.acquire(request).await.expect("acquire");
+    handle.stop().await.expect("stop");
+}
+
+#[tokio::test]
+async fn snapshot_returns_a_tensorlake_manifest() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-snap", "sandbox-snap");
+    let name = expected_sandbox_name(&request);
+    mount_running_sandbox(&server, &name, "sbx-snap").await;
+
+    Mock::given(method("POST"))
+        .and(path("/sandboxes/sbx-snap/snapshot"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(json!({
+            "snapshot_id": "snap-123",
+            "status": "pending",
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend.acquire(request).await.expect("acquire");
+    let payload = handle.snapshot().await.expect("snapshot");
+
+    assert_eq!(payload.kind, SnapshotKind::TensorlakeSnapshot);
+    let manifest: Value = serde_json::from_slice(&payload.bytes).expect("manifest json");
+    assert_eq!(manifest["snapshot_id"], json!("snap-123"));
+    assert_eq!(manifest["sandbox_name"], json!(name));
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let snapshot = last_body(&requests, "POST", "/snapshot");
+    assert_eq!(snapshot["snapshot_type"], json!("filesystem"));
+}
+
+#[tokio::test]
+async fn acquire_from_snapshot_replaces_the_named_sandbox() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-restore", "sandbox-restore");
+    let name = expected_sandbox_name(&request);
+
+    mount_running_sandbox(&server, &name, "sbx-old").await;
+    Mock::given(method("DELETE"))
+        .and(path(format!("/sandboxes/{name}")))
+        .respond_with(ResponseTemplate::new(200))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/sandboxes"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(create_response_json("sbx-restored")),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+    mount_running_sandbox(&server, "sbx-restored", "sbx-restored").await;
+
+    let payload = SnapshotPayload {
+        kind: SnapshotKind::TensorlakeSnapshot,
+        bytes: Bytes::from(
+            serde_json::to_vec(&json!({ "snapshot_id": "snap-9", "sandbox_name": name }))
+                .expect("manifest"),
+        ),
+    };
+    let handle = backend
+        .acquire_from_snapshot(request, payload)
+        .await
+        .expect("acquire_from_snapshot");
+    assert_eq!(
+        handle.id(),
+        "tensorlake-restored:conversation:conv-restore:sandbox-restore"
+    );
+
+    let requests = server.received_requests().await.unwrap_or_default();
+    let create = last_body(&requests, "POST", "/sandboxes");
+    assert_eq!(create["snapshot_id"], json!("snap-9"));
+    assert_eq!(create["name"], json!(name));
+    assert!(
+        create.get("image").is_none(),
+        "restore should boot from the snapshot, not an image"
+    );
+}
+
+#[tokio::test]
+async fn acquire_from_snapshot_rejects_foreign_payload_kinds() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-foreign", "sandbox-foreign");
+
+    let payload = SnapshotPayload {
+        kind: SnapshotKind::DockerImageTar,
+        bytes: Bytes::from_static(b"not-a-tensorlake-manifest"),
+    };
+    let error = match backend.acquire_from_snapshot(request, payload).await {
+        Ok(_) => panic!("expected a snapshot kind mismatch error"),
+        Err(error) => error,
+    };
+    assert!(
+        error.to_string().contains("TensorlakeSnapshot"),
+        "unexpected error: {error}"
+    );
+}
+
+#[tokio::test]
+async fn acquire_rejects_host_bind_mounts() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let mut request = make_request("conv-mount", "sandbox-mount");
+    request.spec.mounts.push(SandboxMount {
+        host_path: PathBuf::from("/tmp"),
+        guest_path: "/workspace".into(),
+        access: SandboxMountAccess::ReadWrite,
+        internal: false,
+    });
+
+    let error = match backend.acquire(request).await {
+        Ok(_) => panic!("expected a host bind-mount rejection"),
+        Err(error) => error,
+    };
+    assert!(
+        error.to_string().contains("host bind-mounts"),
+        "unexpected error: {error}"
+    );
+}
+
+/// A command that already started must never be replayed: the run stream dying
+/// mid-flight is terminal, not a reason to re-POST `/processes/run`.
+#[tokio::test]
+async fn exec_does_not_rerun_a_command_after_a_mid_stream_failure() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-truncated", "sandbox-truncated");
+    let name = expected_sandbox_name(&request);
+    mount_running_sandbox(&server, &name, "sbx-truncated").await;
+
+    // The process started and emitted output, then the stream ended without the
+    // exit event — exactly the shape of a connection dropped mid-command.
+    let truncated = sse(&[
+        json!({ "handle": 1, "pid": 42, "started_at": 1_710_000_000_000i64 }),
+        json!({ "line": "side effect happened", "timestamp": 1i64, "stream": "stdout" }),
+    ]);
+    Mock::given(method("POST"))
+        .and(path("/api/v1/processes/run"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(truncated, "text/event-stream"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend.acquire(request).await.expect("acquire");
+    let error = match handle.exec(&touch_command()).await {
+        Ok(output) => panic!("expected a truncated-stream error, got {output:?}"),
+        Err(error) => error,
+    };
+    assert!(
+        error.to_string().contains("without an exit event"),
+        "unexpected error: {error}"
+    );
+}
+
+/// A proxy that reports the sandbox gone *before* the command is accepted is
+/// safe to retry, once, against a freshly resolved target.
+#[tokio::test]
+async fn exec_retries_once_when_the_proxy_reports_the_sandbox_gone() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-gone", "sandbox-gone");
+    let name = expected_sandbox_name(&request);
+    mount_running_sandbox(&server, &name, "sbx-gone").await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/processes/run"))
+        .respond_with(ResponseTemplate::new(404).set_body_string("sandbox not found"))
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+    let stream = sse(&[
+        json!({ "handle": 1, "pid": 43, "started_at": 1_710_000_000_000i64 }),
+        json!({ "line": "recovered", "timestamp": 1i64, "stream": "stdout" }),
+        json!({ "exit_code": 0 }),
+    ]);
+    Mock::given(method("POST"))
+        .and(path("/api/v1/processes/run"))
+        .respond_with(ResponseTemplate::new(200).set_body_raw(stream, "text/event-stream"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let handle = backend.acquire(request).await.expect("acquire");
+    let output = handle.exec(&touch_command()).await.expect("exec");
+
+    assert!(output.ok);
+    assert_eq!(output.stdout, "recovered\n");
+}
+
+/// Resume is rejected while a suspend is still in flight, so a `suspending`
+/// sandbox has to be waited out and resumed exactly once after it settles.
+#[tokio::test]
+async fn acquire_waits_out_a_suspending_sandbox_before_resuming() {
+    let server = MockServer::start().await;
+    let backend = backend_for_mock(&server);
+    let request = make_request("conv-suspending", "sandbox-suspending");
+    let name = expected_sandbox_name(&request);
+
+    Mock::given(method("GET"))
+        .and(path(format!("/sandboxes/{name}")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sandbox_info_json(
+            &server,
+            "sbx-suspending",
+            "suspending",
+        )))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/sandboxes/sbx-suspending"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(sandbox_info_json(
+            &server,
+            "sbx-suspending",
+            "suspended",
+        )))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    mount_running_sandbox(&server, "sbx-suspending", "sbx-suspending").await;
+    Mock::given(method("POST"))
+        .and(path("/sandboxes/sbx-suspending/resume"))
+        .respond_with(ResponseTemplate::new(202))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    backend.acquire(request).await.expect("acquire");
+}
+
+fn touch_command() -> exoharness::SandboxCommand {
+    exoharness::SandboxCommand {
+        argv: vec!["touch".into(), "side-effect".into()],
+        env: Default::default(),
+        display_argv: None,
+        cwd: None,
+        timeout: None,
+    }
+}

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -61,10 +61,10 @@ pub use exoharness::{
     HTTP_EXOHARNESS_TRACING_TARGET, HttpExoHarness, PutSecretRequest, SANDBOX_MAIN_MOUNT_DIR,
     SandboxAttachment, SandboxBackendRegistration, SandboxId, SandboxProvider,
     SandboxProviderConfig, Secret, SecretBackendChoice, SecretMetadata, SessionId, SnapshotId,
-    SpritesBackendSpec, StartSandboxRequest, ToolRequest, Uuid7, VercelBackendSpec,
-    default_aws_agentcore_image, default_daytona_image, default_docker_image, default_e2b_template,
-    default_vercel_image, serve_exoharness_http_listener,
-    serve_exoharness_http_listener_with_options,
+    SpritesBackendSpec, StartSandboxRequest, TensorlakeBackendSpec, ToolRequest, Uuid7,
+    VercelBackendSpec, default_aws_agentcore_image, default_daytona_image, default_docker_image,
+    default_e2b_template, default_tensorlake_image, default_vercel_image,
+    serve_exoharness_http_listener, serve_exoharness_http_listener_with_options,
 };
 pub use harness_basic::BasicHarness;
 pub use harness_config::load_agent_config;

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -167,6 +167,20 @@ impl SandboxBackendRegistration {
         })
     }
 
+    pub fn tensorlake(spec: TensorlakeBackendSpec) -> Self {
+        Self::from_factory(SandboxProvider::Tensorlake, move |inner| {
+            let spec = spec.clone();
+            Box::pin(async move {
+                let config = match inner.tensorlake_config_from_binding().await? {
+                    Some(config) => config,
+                    None => inner.tensorlake_config_from_spec(&spec).await?,
+                };
+                Ok(Arc::new(crate::TensorlakeSandboxBackend::new(config)?)
+                    as Arc<dyn ManagedSandboxBackend>)
+            })
+        })
+    }
+
     pub fn vercel(spec: VercelBackendSpec) -> Self {
         Self::from_factory(SandboxProvider::Vercel, move |inner| {
             let spec = spec.clone();
@@ -298,6 +312,29 @@ impl Default for SpritesBackendSpec {
             url_auth: None,
             organization: None,
             labels: Vec::new(),
+        }
+    }
+}
+
+/// Tensorlake connection config plus the secret-store name for the API key,
+/// resolved lazily on first use.
+#[derive(Debug, Clone)]
+pub struct TensorlakeBackendSpec {
+    pub api_url: String,
+    pub api_key_secret: String,
+    pub default_image: String,
+    pub cpus: Option<u32>,
+    pub memory_mb: Option<u64>,
+}
+
+impl Default for TensorlakeBackendSpec {
+    fn default() -> Self {
+        Self {
+            api_url: crate::DEFAULT_TENSORLAKE_API_URL.to_string(),
+            api_key_secret: "TENSORLAKE_API_KEY".to_string(),
+            default_image: crate::default_tensorlake_image(),
+            cpus: None,
+            memory_mb: None,
         }
     }
 }
@@ -520,6 +557,69 @@ impl BasicExoHarnessInner {
             url_auth,
             organization,
             extra_labels: labels,
+        }))
+    }
+
+    async fn tensorlake_config_from_spec(
+        &self,
+        spec: &TensorlakeBackendSpec,
+    ) -> Result<crate::TensorlakeConfig> {
+        let api_key = self
+            .secret_key(&spec.api_key_secret)
+            .await?
+            .ok_or_else(|| {
+                anyhow!(
+                    "tensorlake sandbox requested but secret {:?} is not set",
+                    spec.api_key_secret
+                )
+            })?;
+        Ok(crate::TensorlakeConfig {
+            api_key,
+            api_url: spec.api_url.clone(),
+            default_image: spec.default_image.clone(),
+            cpus: spec.cpus.map(f64::from),
+            memory_mb: spec.memory_mb,
+            sandbox_base_url: None,
+        })
+    }
+
+    async fn tensorlake_config_from_binding(&self) -> Result<Option<crate::TensorlakeConfig>> {
+        let bindings = list_binding_records(&self.storage, Path::new("bindings")).await?;
+        let Some((api_key_secret_id, api_url, default_image, cpus, memory_mb)) = bindings
+            .into_iter()
+            .rev()
+            .find_map(|record| match record.binding {
+                Binding::Sandbox {
+                    config:
+                        SandboxProviderConfig::Tensorlake {
+                            api_key_secret_id,
+                            api_url,
+                            default_image,
+                            cpus,
+                            memory_mb,
+                        },
+                    ..
+                } => Some((api_key_secret_id, api_url, default_image, cpus, memory_mb)),
+                _ => None,
+            })
+        else {
+            return Ok(None);
+        };
+        let api_key = self
+            .secret_key_by_id(api_key_secret_id)
+            .await?
+            .ok_or_else(|| {
+                anyhow!(
+                    "tensorlake sandbox binding references secret id {api_key_secret_id}, which is not set"
+                )
+            })?;
+        Ok(Some(crate::TensorlakeConfig {
+            api_key,
+            api_url: api_url.unwrap_or_else(|| crate::DEFAULT_TENSORLAKE_API_URL.to_string()),
+            default_image,
+            cpus: cpus.map(f64::from),
+            memory_mb,
+            sandbox_base_url: None,
         }))
     }
 

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -385,8 +385,9 @@ struct BasicExoHarnessInner {
     sandbox_registry: HashMap<SandboxProvider, SandboxBackendRegistration>,
     /// Backends built (and secrets read) lazily on first use, cached by provider.
     sandbox_backends: AsyncMutex<HashMap<SandboxProvider, Arc<dyn ManagedSandboxBackend>>>,
-    running_sandboxes: AsyncMutex<HashMap<SandboxId, Arc<dyn ManagedSandboxHandle>>>,
-    running_processes: AsyncMutex<HashMap<SandboxProcessId, Arc<RunningSandboxProcess>>>,
+    running_sandboxes: AsyncMutex<HashMap<SandboxKey, Arc<dyn ManagedSandboxHandle>>>,
+    running_processes:
+        AsyncMutex<HashMap<(SandboxOwner, SandboxProcessId), Arc<RunningSandboxProcess>>>,
     secret_cipher: SecretCipher,
 }
 
@@ -1049,11 +1050,26 @@ impl ExoHarness for BasicExoHarness {
     }
 
     async fn delete_agent(&self, id: &AgentId) -> Result<bool> {
-        let _guard = self.inner.write_lock.lock().await;
         let agent_dir = self.agents_dir().join(id.to_string());
         if self.inner.storage.list_keys(&agent_dir).await?.is_empty() {
             return Ok(false);
         }
+        // Provider termination is network I/O. Do it before taking the
+        // harness-wide storage lock; failures leave the owner intact so the
+        // caller can retry the idempotent sweep.
+        terminate_owned_sandboxes(self, &agent_dir, SandboxOwner::Agent(*id)).await?;
+        for (conversation_dir, conversation_id) in
+            conversation_dirs_under_agent(self, &agent_dir).await?
+        {
+            terminate_owned_sandboxes(
+                self,
+                &conversation_dir,
+                SandboxOwner::Conversation(conversation_id),
+            )
+            .await?;
+        }
+
+        let _guard = self.inner.write_lock.lock().await;
         // Release the slug before the record (its source) disappears.
         if let Some(record) = self
             .inner
@@ -1346,7 +1362,6 @@ impl AgentHandle for BasicAgentHandle {
     }
 
     async fn delete_conversation(&self, id: &ConversationId) -> Result<bool> {
-        let _guard = self.harness.inner.write_lock.lock().await;
         let conversation_dir = self.conversations_dir().join(id.to_string());
         if self
             .harness
@@ -1358,6 +1373,15 @@ impl AgentHandle for BasicAgentHandle {
         {
             return Ok(false);
         }
+        // Keep provider round trips outside the harness-wide storage lock.
+        terminate_owned_sandboxes(
+            &self.harness,
+            &conversation_dir,
+            SandboxOwner::Conversation(*id),
+        )
+        .await?;
+
+        let _guard = self.harness.inner.write_lock.lock().await;
         if let Ok(mut record) = self
             .harness
             .inner
@@ -1597,7 +1621,7 @@ fn paginate_conversation_records(
     })
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum SandboxOwner {
     Agent(AgentId),
     Conversation(ConversationId),
@@ -1751,7 +1775,7 @@ impl<'a> BasicScopedSandboxHandle<'a> {
             .running_sandboxes
             .lock()
             .await
-            .remove(&sandbox_id);
+            .remove(&sandbox_key(self.owner, &sandbox_id));
         sandbox.running = false;
         sandbox.attachment = Some(attachment.clone());
         self.harness
@@ -1776,7 +1800,7 @@ impl<'a> BasicScopedSandboxHandle<'a> {
 
     async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
         let (snapshot_id, event) =
-            snapshot_sandbox_side_effect(self.harness, &self.owner_dir, id).await?;
+            snapshot_sandbox_side_effect(self.harness, &self.owner_dir, self.owner, id).await?;
         self.append_events(vec![event]).await?;
         Ok(snapshot_id)
     }
@@ -1800,7 +1824,7 @@ impl<'a> BasicScopedSandboxHandle<'a> {
             .running_sandboxes
             .lock()
             .await
-            .remove(&id);
+            .remove(&sandbox_key(self.owner, &id));
         if let Some(sandbox_handle) = sandbox_handle {
             sandbox_handle.stop().await?;
         }
@@ -1924,12 +1948,7 @@ impl<'a> BasicScopedSandboxHandle<'a> {
         let process = self
             .require_sandbox_process(&request.sandbox_id, &request.process_id)
             .await?;
-        process.stdin.lock().await.take();
-        if let Some(tasks) = process.tasks.lock().await.take() {
-            tasks.stdout.abort();
-            tasks.stderr.abort();
-            tasks.wait.abort();
-        }
+        abort_running_sandbox_process(&process).await;
         push_sandbox_process_event(&process, SandboxProcessEventPayload::Cancelled).await;
         set_sandbox_process_status(&process, SandboxProcessStatus::Cancelled).await;
         Ok(SandboxProcessStatus::Cancelled)
@@ -2033,7 +2052,7 @@ impl<'a> BasicScopedSandboxHandle<'a> {
             .running_sandboxes
             .lock()
             .await
-            .insert(sandbox_id.clone(), sandbox_handle);
+            .insert(sandbox_key(self.owner, &sandbox_id), sandbox_handle);
         let mut events = vec![
             EventData::SandboxCreated {
                 sandbox_id: sandbox_id.clone(),
@@ -2083,7 +2102,7 @@ impl<'a> BasicScopedSandboxHandle<'a> {
             .running_sandboxes
             .lock()
             .await
-            .insert(sandbox_id.clone(), sandbox_handle);
+            .insert(sandbox_key(self.owner, &sandbox_id), sandbox_handle);
         let mut events = vec![EventData::SandboxAttached {
             sandbox_id: sandbox_id.clone(),
             attachment,
@@ -2179,7 +2198,7 @@ impl<'a> BasicScopedSandboxHandle<'a> {
         sandbox_id: &str,
         process_id: &str,
     ) -> Result<Arc<RunningSandboxProcess>> {
-        require_running_sandbox_process(self.harness, sandbox_id, process_id).await
+        require_running_sandbox_process(self.harness, self.owner, sandbox_id, process_id).await
     }
 
     fn process_event_log(&self) -> Option<SandboxProcessEventLog> {
@@ -2508,11 +2527,12 @@ impl ConversationHandle for BasicConversationHandle {
             .storage
             .copy_prefix(self.artifacts_dir(), conversation_dir.join("artifacts"))
             .await?;
-        self.harness
-            .inner
-            .storage
-            .copy_prefix(self.sandboxes_dir(), conversation_dir.join("sandboxes"))
-            .await?;
+        let detached_events = copy_sandbox_records_for_fork(
+            &self.harness.inner.storage,
+            &self.sandboxes_dir(),
+            &conversation_dir.join("sandboxes"),
+        )
+        .await?;
 
         let mut latest_event_id = None;
         for mut event in events {
@@ -2535,6 +2555,11 @@ impl ConversationHandle for BasicConversationHandle {
 
         let mut fork_record = record.clone();
         fork_record.latest_event_id = latest_event_id;
+        let mut fork_events = detached_events;
+        fork_events.push(EventData::ThreadForked {
+            source_thread_id: self.record.id,
+            up_to_inclusive: request.up_to_inclusive,
+        });
         append_events_to_conversation(
             &self.harness.inner,
             &conversation_dir,
@@ -2542,10 +2567,7 @@ impl ConversationHandle for BasicConversationHandle {
             None,
             None,
             fork_record.latest_event_id,
-            vec![EventData::ThreadForked {
-                source_thread_id: self.record.id,
-                up_to_inclusive: request.up_to_inclusive,
-            }],
+            fork_events,
             &mut fork_record,
         )
         .await?;
@@ -2554,6 +2576,14 @@ impl ConversationHandle for BasicConversationHandle {
             .storage
             .put_json(conversation_dir.join("record.json"), &fork_record)
             .await?;
+        drop(_guard);
+        fork_conversation_sandboxes(
+            &self.harness,
+            &self.conversation_dir(),
+            self.record.id,
+            fork_record.id,
+        )
+        .await;
         Ok(Arc::new(BasicConversationHandle {
             harness: self.harness.clone(),
             agent_id: self.agent_id,
@@ -2820,9 +2850,189 @@ impl BasicConversationHandle {
     }
 }
 
+async fn copy_sandbox_records_for_fork(
+    storage: &BasicObjectStore,
+    source_dir: &Path,
+    target_dir: &Path,
+) -> Result<Vec<EventData>> {
+    let mut detached_events = Vec::new();
+    for key in storage.list_keys(source_dir).await? {
+        if !key.ends_with(".json") {
+            continue;
+        }
+        let mut sandbox: StoredSandbox = storage.get_json(Path::new(&key)).await?;
+        if let Some(attachment) = sandbox.attachment.clone()
+            && sandbox.running
+        {
+            sandbox.running = false;
+            detached_events.push(EventData::SandboxDetached {
+                sandbox_id: sandbox.id.clone(),
+                attachment,
+            });
+        }
+        storage
+            .put_json(target_dir.join(format!("{}.json", sandbox.id)), &sandbox)
+            .await?;
+    }
+    Ok(detached_events)
+}
+
+async fn terminate_owned_sandboxes(
+    harness: &BasicExoHarness,
+    owner_dir: &Path,
+    owner: SandboxOwner,
+) -> Result<()> {
+    let sandboxes_dir = owner_dir.join("sandboxes");
+    for key in harness.inner.storage.list_keys(&sandboxes_dir).await? {
+        if !key.ends_with(".json") {
+            continue;
+        }
+        let stored: StoredSandbox = harness.inner.storage.get_json(Path::new(&key)).await?;
+        harness
+            .inner
+            .running_sandboxes
+            .lock()
+            .await
+            .remove(&sandbox_key(owner, &stored.id));
+
+        let processes = {
+            let mut running = harness.inner.running_processes.lock().await;
+            let keys = running
+                .iter()
+                .filter(|((process_owner, _), process)| {
+                    *process_owner == owner && process.sandbox_id == stored.id
+                })
+                .map(|(key, _)| key.clone())
+                .collect::<Vec<_>>();
+            keys.into_iter()
+                .filter_map(|key| running.remove(&key))
+                .collect::<Vec<_>>()
+        };
+        for process in processes {
+            abort_running_sandbox_process(&process).await;
+        }
+
+        // Attachments are borrowed. Deleting their exo owner forgets the
+        // attachment but must not destroy the provider resource itself.
+        if stored.attachment.is_some() {
+            continue;
+        }
+        harness
+            .inner
+            .sandbox_backend_for_provider(stored.provider)
+            .await?
+            .terminate(sandbox_request(owner, &stored.id, &stored, None))
+            .await
+            .with_context(|| {
+                format!(
+                    "terminating {:?} sandbox {} while deleting its owner",
+                    stored.provider, stored.id
+                )
+            })?;
+    }
+    Ok(())
+}
+
+async fn abort_running_sandbox_process(process: &Arc<RunningSandboxProcess>) {
+    process.stdin.lock().await.take();
+    if let Some(tasks) = process.tasks.lock().await.take() {
+        tasks.stdout.abort();
+        tasks.stderr.abort();
+        tasks.wait.abort();
+    }
+}
+
+async fn fork_conversation_sandboxes(
+    harness: &BasicExoHarness,
+    source_dir: &Path,
+    source_conversation_id: ConversationId,
+    target_conversation_id: ConversationId,
+) {
+    let keys = match harness
+        .inner
+        .storage
+        .list_keys(source_dir.join("sandboxes"))
+        .await
+    {
+        Ok(keys) => keys,
+        Err(error) => {
+            tracing::warn!(%error, "cannot list sandboxes to copy into conversation fork");
+            return;
+        }
+    };
+    for key in keys {
+        if !key.ends_with(".json") {
+            continue;
+        }
+        let stored: StoredSandbox = match harness.inner.storage.get_json(Path::new(&key)).await {
+            Ok(stored) => stored,
+            Err(error) => {
+                tracing::warn!(%key, %error, "skipping unreadable sandbox record while forking");
+                continue;
+            }
+        };
+        if !stored.running || stored.attachment.is_some() {
+            continue;
+        }
+        let provider = stored.provider;
+        let source = sandbox_request(
+            SandboxOwner::Conversation(source_conversation_id),
+            &stored.id,
+            &stored,
+            None,
+        );
+        let target = sandbox_request(
+            SandboxOwner::Conversation(target_conversation_id),
+            &stored.id,
+            &stored,
+            None,
+        );
+        let result = match harness.inner.sandbox_backend_for_provider(provider).await {
+            Ok(backend) => backend.fork_sandbox(source, target).await,
+            Err(error) => Err(error),
+        };
+        if let Err(error) = result {
+            tracing::warn!(
+                sandbox_id = %stored.id,
+                %provider,
+                error = format!("{error:#}"),
+                "failed to copy sandbox into conversation fork; target will start cold"
+            );
+        }
+    }
+}
+
+async fn conversation_dirs_under_agent(
+    harness: &BasicExoHarness,
+    agent_dir: &Path,
+) -> Result<Vec<(PathBuf, ConversationId)>> {
+    let conversations_dir = agent_dir.join("conversations");
+    let mut conversations = Vec::new();
+    for key in harness.inner.storage.list_keys(&conversations_dir).await? {
+        let path = Path::new(&key);
+        if !key.ends_with("/record.json") || path.components().count() != 5 {
+            continue;
+        }
+        let Some(segment) = path
+            .components()
+            .nth(3)
+            .and_then(|component| component.as_os_str().to_str())
+        else {
+            continue;
+        };
+        let Ok(conversation_id) = segment.parse::<ConversationId>() else {
+            tracing::warn!(%key, "skipping conversation directory with an unparseable id");
+            continue;
+        };
+        conversations.push((conversations_dir.join(segment), conversation_id));
+    }
+    Ok(conversations)
+}
+
 async fn snapshot_sandbox_side_effect(
     harness: &BasicExoHarness,
     owner_dir: &Path,
+    owner: SandboxOwner,
     id: SandboxId,
 ) -> Result<(SnapshotId, EventData)> {
     let sandbox = load_stored_sandbox(harness, owner_dir, &id).await?;
@@ -2836,7 +3046,7 @@ async fn snapshot_sandbox_side_effect(
         .running_sandboxes
         .lock()
         .await
-        .get(&id)
+        .get(&sandbox_key(owner, &id))
         .cloned()
         .ok_or_else(|| anyhow!("sandbox {id} is not running; start it before snapshotting"))?;
     let payload = handle.snapshot().await?;
@@ -2948,7 +3158,7 @@ async fn start_sandbox_side_effect(
             .running_sandboxes
             .lock()
             .await
-            .remove(&request.id);
+            .remove(&sandbox_key(owner, &request.id));
         if let Some(previous_handle) = previous_handle
             && let Err(error) = previous_handle.stop().await
         {
@@ -2968,7 +3178,7 @@ async fn start_sandbox_side_effect(
             .running_sandboxes
             .lock()
             .await
-            .remove(&request.id);
+            .remove(&sandbox_key(owner, &request.id));
         if let Some(previous_handle) = previous_handle {
             previous_handle.stop().await?;
         }
@@ -3011,7 +3221,7 @@ async fn start_sandbox_side_effect(
         .running_sandboxes
         .lock()
         .await
-        .insert(request.id.clone(), sandbox_handle);
+        .insert(sandbox_key(owner, &request.id), sandbox_handle);
     Ok(EventData::SandboxStarted {
         sandbox_id: request.id,
         snapshot_id: Some(request.snapshot_id),
@@ -3108,7 +3318,7 @@ async fn active_sandbox_handle(
         .running_sandboxes
         .lock()
         .await
-        .get(sandbox_id)
+        .get(&sandbox_key(owner, sandbox_id))
         .cloned()
     {
         return Ok((handle, None));
@@ -3121,7 +3331,7 @@ async fn active_sandbox_handle(
         .running_sandboxes
         .lock()
         .await
-        .insert(sandbox_id.clone(), Arc::clone(&handle));
+        .insert(sandbox_key(owner, sandbox_id), Arc::clone(&handle));
     Ok((handle, provider_state_event))
 }
 
@@ -3237,6 +3447,7 @@ fn sandbox_provider_state_event(
 
 async fn require_running_sandbox_process(
     harness: &BasicExoHarness,
+    owner: SandboxOwner,
     sandbox_id: &str,
     process_id: &str,
 ) -> Result<Arc<RunningSandboxProcess>> {
@@ -3245,7 +3456,7 @@ async fn require_running_sandbox_process(
         .running_processes
         .lock()
         .await
-        .get(process_id)
+        .get(&(owner, process_id.to_string()))
         .cloned()
         .ok_or_else(|| anyhow!("sandbox process not found: {process_id}"))?;
     if process.sandbox_id != sandbox_id {
@@ -3535,6 +3746,7 @@ async fn prepare_sandbox_process(
     };
     let process = Arc::new(RunningSandboxProcess {
         event_log,
+        owner,
         sandbox_id: sandbox_id.clone(),
         process_id: process_id.clone(),
         stdin: AsyncMutex::new(stdin),
@@ -3586,6 +3798,7 @@ async fn spawn_pending_sandbox_process(
         ..
     } = pending;
     let process_id = record.id.clone();
+    let owner = process.owner;
     let stdout_task = tokio::spawn(record_sandbox_process_output(
         Arc::clone(&process),
         SandboxProcessOutputStream::Stdout,
@@ -3607,12 +3820,13 @@ async fn spawn_pending_sandbox_process(
         .running_processes
         .lock()
         .await
-        .insert(process_id, process);
+        .insert((owner, process_id), process);
     Ok(record)
 }
 
 struct RunningSandboxProcess {
     event_log: Option<SandboxProcessEventLog>,
+    owner: SandboxOwner,
     sandbox_id: SandboxId,
     process_id: SandboxProcessId,
     stdin: AsyncMutex<Option<BoxAsyncWrite>>,
@@ -3920,16 +4134,7 @@ fn sandbox_request(
     provider_state: Option<Value>,
 ) -> SandboxRequest {
     SandboxRequest {
-        key: match owner {
-            SandboxOwner::Agent(agent_id) => SandboxKey::AgentSandbox {
-                agent_id: agent_id.to_string(),
-                sandbox_id: sandbox_id.to_string(),
-            },
-            SandboxOwner::Conversation(conversation_id) => SandboxKey::ConversationSandbox {
-                conversation_id: conversation_id.to_string(),
-                sandbox_id: sandbox_id.to_string(),
-            },
-        },
+        key: sandbox_key(owner, sandbox_id),
         spec: SandboxSpec {
             image: sandbox.image.clone(),
             mounts: sandbox
@@ -3960,6 +4165,19 @@ fn sandbox_request(
             idle_ttl: Some(std::time::Duration::from_secs(sandbox.idle_seconds)),
         },
         provider_state,
+    }
+}
+
+fn sandbox_key(owner: SandboxOwner, sandbox_id: &str) -> SandboxKey {
+    match owner {
+        SandboxOwner::Agent(agent_id) => SandboxKey::AgentSandbox {
+            agent_id: agent_id.to_string(),
+            sandbox_id: sandbox_id.to_string(),
+        },
+        SandboxOwner::Conversation(conversation_id) => SandboxKey::ConversationSandbox {
+            conversation_id: conversation_id.to_string(),
+            sandbox_id: sandbox_id.to_string(),
+        },
     }
 }
 

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -19,15 +19,16 @@ use tokio::time::{sleep, timeout};
 
 use crate::test_support::{local_test_config, local_test_config_with_daytona};
 use crate::{
-    Artifact, ArtifactVersion, BasicExoHarness, BeginTurnRequest, Binding, BoxAsyncRead,
-    BoxAsyncWrite, CloseSandboxProcessInputRequest, CreateSandboxRequest, DurableFileSystem,
-    EventData, EventKind, EventQuery, EventQueryDirection, ExoHarness, FileSystemMountMode,
-    ForkConversationRequest, ManagedSandboxBackend, ManagedSandboxHandle, NewAgentRequest,
-    NewConversationRequest, PutSecretRequest, RunInSandboxRequest, SandboxAttachment,
-    SandboxCommand, SandboxCommandOutput, SandboxKey, SandboxLifecycleConfig, SandboxNetworkPolicy,
-    SandboxProcessEvent, SandboxProcessEventQuery, SandboxProcessParts, SandboxProcessStatus,
-    SandboxProcessStdin, SandboxProvider, SandboxProviderConfig, SandboxRequest, SandboxSpec,
-    Secret, SnapshotKind, SnapshotPayload, StartSandboxProcessRequest, StartSandboxRequest, Uuid7,
+    Artifact, ArtifactVersion, AttachSandboxRequest, BasicExoHarness, BeginTurnRequest, Binding,
+    BoxAsyncRead, BoxAsyncWrite, CloseSandboxProcessInputRequest, CreateSandboxRequest,
+    DurableFileSystem, EventData, EventKind, EventQuery, EventQueryDirection, ExoHarness,
+    FileSystemMountMode, ForkConversationRequest, ManagedSandboxBackend, ManagedSandboxHandle,
+    NewAgentRequest, NewConversationRequest, PutSecretRequest, RunInSandboxRequest,
+    SandboxAttachment, SandboxBackendRegistration, SandboxCommand, SandboxCommandOutput,
+    SandboxKey, SandboxLifecycleConfig, SandboxNetworkPolicy, SandboxProcessEvent,
+    SandboxProcessEventQuery, SandboxProcessParts, SandboxProcessStatus, SandboxProcessStdin,
+    SandboxProvider, SandboxProviderConfig, SandboxRequest, SandboxSpec, Secret, SnapshotKind,
+    SnapshotPayload, StartSandboxProcessRequest, StartSandboxRequest, Uuid7,
     WaitSandboxProcessRequest, WriteArtifactRequest, WriteSandboxProcessInputRequest,
 };
 
@@ -1826,6 +1827,10 @@ impl ManagedSandboxBackend for TestProviderStateBackend {
     ) -> crate::Result<Arc<dyn ManagedSandboxHandle>> {
         bail!("test provider-state backend does not support snapshot restore")
     }
+
+    async fn terminate(&self, _request: SandboxRequest) -> crate::Result<()> {
+        Ok(())
+    }
 }
 
 struct TestProviderStateHandle {
@@ -1900,6 +1905,10 @@ impl ManagedSandboxBackend for TestSandboxBackend {
         _payload: SnapshotPayload,
     ) -> crate::Result<Arc<dyn ManagedSandboxHandle>> {
         bail!("test sandbox backend does not support snapshot restore")
+    }
+
+    async fn terminate(&self, _request: SandboxRequest) -> crate::Result<()> {
+        Ok(())
     }
 }
 
@@ -2115,6 +2124,10 @@ impl ManagedSandboxBackend for RestoreImageTestBackend {
             image: "restored-image".to_string(),
         }))
     }
+
+    async fn terminate(&self, _request: SandboxRequest) -> crate::Result<()> {
+        Ok(())
+    }
 }
 
 struct RestoreImageTestHandle {
@@ -2203,4 +2216,283 @@ async fn daytona_sandbox_binding_drives_provider_config() {
     assert_eq!(config.target.as_deref(), Some("experimental"));
     assert_eq!(config.organization_id.as_deref(), Some("org-1"));
     assert_eq!(config.api_url, crate::DEFAULT_DAYTONA_API_URL);
+}
+
+#[derive(Default)]
+struct LifecycleRecordingBackend {
+    acquired: Arc<AsyncMutex<Vec<String>>>,
+    terminated: Arc<AsyncMutex<Vec<String>>>,
+    forked: Arc<AsyncMutex<Vec<(String, String)>>>,
+}
+
+#[async_trait]
+impl ManagedSandboxBackend for LifecycleRecordingBackend {
+    async fn acquire(
+        &self,
+        request: SandboxRequest,
+    ) -> crate::Result<Arc<dyn ManagedSandboxHandle>> {
+        self.acquired.lock().await.push(request.key.to_string());
+        Ok(Arc::new(LifecycleRecordingHandle))
+    }
+
+    async fn attach(
+        &self,
+        _request: SandboxRequest,
+        _attachment: SandboxAttachment,
+    ) -> crate::Result<Arc<dyn ManagedSandboxHandle>> {
+        Ok(Arc::new(LifecycleRecordingHandle))
+    }
+
+    async fn acquire_from_snapshot(
+        &self,
+        _request: SandboxRequest,
+        _payload: SnapshotPayload,
+    ) -> crate::Result<Arc<dyn ManagedSandboxHandle>> {
+        bail!("lifecycle recording backend does not support snapshot restore")
+    }
+
+    async fn terminate(&self, request: SandboxRequest) -> crate::Result<()> {
+        self.terminated.lock().await.push(request.key.to_string());
+        Ok(())
+    }
+
+    async fn fork_sandbox(
+        &self,
+        source: SandboxRequest,
+        target: SandboxRequest,
+    ) -> crate::Result<bool> {
+        self.forked
+            .lock()
+            .await
+            .push((source.key.to_string(), target.key.to_string()));
+        Ok(true)
+    }
+}
+
+struct LifecycleRecordingHandle;
+
+#[async_trait]
+impl ManagedSandboxHandle for LifecycleRecordingHandle {
+    fn id(&self) -> &str {
+        "lifecycle-recording-sandbox"
+    }
+
+    async fn exec(&self, _command: &SandboxCommand) -> crate::Result<SandboxCommandOutput> {
+        bail!("lifecycle recording handle does not support exec")
+    }
+
+    async fn start_process(&self, _command: &SandboxCommand) -> crate::Result<SandboxProcessParts> {
+        bail!("lifecycle recording handle does not support start_process")
+    }
+
+    async fn stop(&self) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn detach(&self) -> crate::Result<SandboxAttachment> {
+        bail!("lifecycle recording handle does not support detach")
+    }
+
+    async fn snapshot(&self) -> crate::Result<SnapshotPayload> {
+        bail!("lifecycle recording handle does not support snapshots")
+    }
+}
+
+fn lifecycle_sandbox_request(name: Option<&str>) -> CreateSandboxRequest {
+    CreateSandboxRequest {
+        name: name.map(ToOwned::to_owned),
+        provider: SandboxProvider::LocalProcess,
+        image: "test-sandbox".to_string(),
+        default_workdir: Some("/".to_string()),
+        file_system_mounts: None,
+        durable_file_systems: None,
+        enable_networking: Some(true),
+        idle_seconds: Some(60),
+    }
+}
+
+#[tokio::test]
+async fn deleting_a_conversation_terminates_its_sandboxes() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let backend = Arc::new(LifecycleRecordingBackend::default());
+    let harness = BasicExoHarness::new_with_sandbox_backend(
+        local_test_config(tempdir.path()),
+        backend.clone(),
+    )
+    .await
+    .expect("harness");
+    let agent = harness
+        .new_agent(NewAgentRequest {
+            slug: "agent".to_string(),
+            name: "Agent".to_string(),
+        })
+        .await
+        .expect("agent");
+    let conversation = agent
+        .new_conversation(NewConversationRequest::default())
+        .await
+        .expect("conversation");
+    let sandbox_id = conversation
+        .create_sandbox(lifecycle_sandbox_request(None))
+        .await
+        .expect("sandbox");
+    let conversation_id = conversation.record().id;
+
+    assert!(
+        agent
+            .delete_conversation(&conversation_id)
+            .await
+            .expect("delete conversation")
+    );
+    assert_eq!(
+        backend.terminated.lock().await.as_slice(),
+        [format!("conversation:{conversation_id}:{sandbox_id}")]
+    );
+}
+
+#[tokio::test]
+async fn deleting_an_agent_terminates_agent_and_conversation_sandboxes() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let backend = Arc::new(LifecycleRecordingBackend::default());
+    let harness = BasicExoHarness::new_with_sandbox_backend(
+        local_test_config(tempdir.path()),
+        backend.clone(),
+    )
+    .await
+    .expect("harness");
+    let agent = harness
+        .new_agent(NewAgentRequest {
+            slug: "agent".to_string(),
+            name: "Agent".to_string(),
+        })
+        .await
+        .expect("agent");
+    let agent_id = agent.record().id;
+    let agent_sandbox_id = agent
+        .create_sandbox(lifecycle_sandbox_request(None))
+        .await
+        .expect("agent sandbox");
+    let conversation = agent
+        .new_conversation(NewConversationRequest::default())
+        .await
+        .expect("conversation");
+    let conversation_id = conversation.record().id;
+    let conversation_sandbox_id = conversation
+        .create_sandbox(lifecycle_sandbox_request(None))
+        .await
+        .expect("conversation sandbox");
+
+    assert!(harness.delete_agent(&agent_id).await.expect("delete agent"));
+    assert_eq!(
+        backend.terminated.lock().await.as_slice(),
+        [
+            format!("agent:{agent_id}:{agent_sandbox_id}"),
+            format!("conversation:{conversation_id}:{conversation_sandbox_id}"),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn forking_copies_sandboxes_under_the_target_owner_key() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let backend = Arc::new(LifecycleRecordingBackend::default());
+    let harness = BasicExoHarness::new_with_sandbox_backend(
+        local_test_config(tempdir.path()),
+        backend.clone(),
+    )
+    .await
+    .expect("harness");
+    let conversation = test_conversation(&harness).await;
+    let sandbox_id = conversation
+        .create_sandbox(lifecycle_sandbox_request(Some("shared")))
+        .await
+        .expect("sandbox");
+    let source_id = conversation.record().id;
+
+    let fork = conversation
+        .fork(ForkConversationRequest::default())
+        .await
+        .expect("fork");
+    let fork_id = fork.record().id;
+    assert_eq!(
+        backend.forked.lock().await.as_slice(),
+        [(
+            format!("conversation:{source_id}:{sandbox_id}"),
+            format!("conversation:{fork_id}:{sandbox_id}"),
+        )]
+    );
+
+    assert_eq!(
+        fork.create_sandbox(lifecycle_sandbox_request(Some("shared")))
+            .await
+            .expect("acquire forked sandbox"),
+        sandbox_id
+    );
+    assert_eq!(
+        backend.acquired.lock().await.as_slice(),
+        [
+            format!("conversation:{source_id}:{sandbox_id}"),
+            format!("conversation:{fork_id}:{sandbox_id}"),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn attached_sandboxes_are_detached_in_forks_and_never_terminated() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let backend = Arc::new(LifecycleRecordingBackend::default());
+    let mut config = local_test_config(tempdir.path());
+    config.sandbox_default = SandboxProvider::Docker;
+    config.sandbox_backends = vec![SandboxBackendRegistration::from_backend(
+        SandboxProvider::Docker,
+        backend.clone(),
+    )];
+    let harness = BasicExoHarness::new(config).await.expect("harness");
+    let agent = harness
+        .new_agent(NewAgentRequest {
+            slug: "agent".to_string(),
+            name: "Agent".to_string(),
+        })
+        .await
+        .expect("agent");
+    let conversation = agent
+        .new_conversation(NewConversationRequest::default())
+        .await
+        .expect("conversation");
+    let attachment = SandboxAttachment::DockerContainer {
+        container_id: "borrowed-container".to_string(),
+    };
+    let sandbox_id = conversation
+        .attach_sandbox(AttachSandboxRequest {
+            attachment: attachment.clone(),
+            default_workdir: Some("/workspace".to_string()),
+        })
+        .await
+        .expect("attach sandbox");
+    let source_id = conversation.record().id;
+    let fork = conversation
+        .fork(ForkConversationRequest::default())
+        .await
+        .expect("fork");
+
+    assert_eq!(
+        fork.detach_sandbox(sandbox_id)
+            .await
+            .expect("forked attachment should already be detached"),
+        attachment
+    );
+    assert!(backend.forked.lock().await.is_empty());
+    assert!(
+        agent
+            .delete_conversation(&source_id)
+            .await
+            .expect("delete source")
+    );
+    assert!(
+        agent
+            .delete_conversation(&fork.record().id)
+            .await
+            .expect("delete fork")
+    );
+    assert!(backend.terminated.lock().await.is_empty());
 }

--- a/crates/exoharness/src/http_tests.rs
+++ b/crates/exoharness/src/http_tests.rs
@@ -449,6 +449,10 @@ impl ManagedSandboxBackend for SnapshotTestSandboxBackend {
         assert_eq!(payload.bytes, Bytes::from_static(b"snapshot"));
         Ok(Arc::new(SnapshotTestSandboxHandle))
     }
+
+    async fn terminate(&self, _request: SandboxRequest) -> crate::Result<()> {
+        Ok(())
+    }
 }
 
 struct SnapshotTestSandboxHandle;

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -138,6 +138,9 @@ pub enum SnapshotKind {
     /// Reference to a Sprites checkpoint id on a named sprite. Payload bytes are
     /// a small JSON manifest; restoring is `POST .../checkpoints/{id}/restore`.
     SpritesSnapshot,
+    /// Reference to a Tensorlake platform snapshot id. Payload bytes are a small
+    /// JSON manifest; restoring is `POST /sandboxes { snapshot_id: <id> }`.
+    TensorlakeSnapshot,
 }
 
 #[async_trait]
@@ -601,6 +604,10 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
             (_, SnapshotKind::SpritesSnapshot) => bail!(
                 "SpritesSnapshot payloads can only be restored by the Sprites sandbox provider; \
                  select provider sprites to rewind this snapshot"
+            ),
+            (_, SnapshotKind::TensorlakeSnapshot) => bail!(
+                "TensorlakeSnapshot payloads can only be restored by the Tensorlake sandbox \
+                 provider; select provider tensorlake to rewind this snapshot"
             ),
         }
 

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -193,6 +193,23 @@ pub trait ManagedSandboxBackend: Send + Sync {
         request: SandboxRequest,
         payload: SnapshotPayload,
     ) -> Result<Arc<dyn ManagedSandboxHandle>>;
+
+    /// Permanently destroy the sandbox addressed by `request`.
+    ///
+    /// Unlike [`ManagedSandboxHandle::stop`], which may preserve a sandbox for
+    /// a later acquire, termination gives up the provider resource and all of
+    /// its retained state. Implementations must be idempotent and must not
+    /// create or resume a sandbox while looking for it.
+    async fn terminate(&self, request: SandboxRequest) -> Result<()>;
+
+    /// Copy the sandbox addressed by `source` to the identity described by
+    /// `target`, leaving the source untouched.
+    ///
+    /// `false` means the source did not exist or this provider does not support
+    /// copying. The caller may then let the target start cold from its image.
+    async fn fork_sandbox(&self, _source: SandboxRequest, _target: SandboxRequest) -> Result<bool> {
+        Ok(false)
+    }
 }
 
 pub const DEFAULT_SANDBOX_IMAGE: &str = crate::sandbox_provider::DEFAULT_DOCKER_IMAGE;
@@ -652,6 +669,23 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
             warm_sandboxes: Arc::clone(&self.warm_sandboxes),
         }))
     }
+
+    async fn terminate(&self, request: SandboxRequest) -> Result<()> {
+        let cached = self.warm_sandboxes.lock().await.remove(&request.key);
+        if let Some(entry) = cached {
+            cleanup_named_container(&self.container_bin, self.cli, &entry.name).await?;
+            return Ok(());
+        }
+        if request.lifecycle.idle_ttl.is_none() {
+            return Ok(());
+        }
+        if let Some(name) =
+            find_running_warm_sandbox(&self.container_bin, self.cli, &request).await?
+        {
+            cleanup_named_container(&self.container_bin, self.cli, &name).await?;
+        }
+        Ok(())
+    }
 }
 
 struct BorrowedDockerSandboxHandle {
@@ -881,6 +915,10 @@ impl ManagedSandboxBackend for LocalProcessSandboxBackend {
         _payload: SnapshotPayload,
     ) -> Result<Arc<dyn ManagedSandboxHandle>> {
         bail!("restore-from-snapshot is not supported by the local-process sandbox backend")
+    }
+
+    async fn terminate(&self, _request: SandboxRequest) -> Result<()> {
+        Ok(())
     }
 }
 

--- a/crates/exoharness/src/sandbox_provider/aws_agentcore.rs
+++ b/crates/exoharness/src/sandbox_provider/aws_agentcore.rs
@@ -124,6 +124,21 @@ impl ManagedSandboxBackend for AwsAgentCoreSandboxBackend {
     ) -> Result<Arc<dyn ManagedSandboxHandle>> {
         bail!("restoring an AgentCore sandbox from a snapshot is not implemented yet");
     }
+
+    async fn terminate(&self, request: SandboxRequest) -> Result<()> {
+        let spec_hash = sandbox_spec_hash(&request.spec);
+        let runtime_session_id = agentcore_runtime_session_id(&request, &spec_hash);
+        stop_runtime_session(
+            &AwsAgentCoreBackendHandle {
+                client: self.client.clone(),
+                runtime_arn: self.runtime_arn.clone(),
+                invoke_target: self.invoke_target.clone(),
+                qualifier: self.qualifier.clone(),
+            },
+            &runtime_session_id,
+        )
+        .await
+    }
 }
 
 #[derive(Clone)]
@@ -174,22 +189,7 @@ impl ManagedSandboxHandle for AwsAgentCoreSandboxHandle {
     }
 
     async fn stop(&self) -> Result<()> {
-        let mut request = self
-            .backend
-            .client
-            .stop_runtime_session()
-            .agent_runtime_arn(self.backend.runtime_arn.clone())
-            .runtime_session_id(self.runtime_session_id.clone());
-        if let Some(qualifier) = &self.backend.qualifier {
-            request = request.qualifier(qualifier.clone());
-        }
-        request.send().await.with_context(|| {
-            format!(
-                "stopping AgentCore runtime session {}",
-                self.runtime_session_id
-            )
-        })?;
-        Ok(())
+        stop_runtime_session(&self.backend, &self.runtime_session_id).await
     }
 
     async fn detach(&self) -> Result<SandboxAttachment> {
@@ -198,6 +198,32 @@ impl ManagedSandboxHandle for AwsAgentCoreSandboxHandle {
 
     async fn snapshot(&self) -> Result<SnapshotPayload> {
         bail!("AgentCore sandbox snapshots are not implemented yet");
+    }
+}
+
+async fn stop_runtime_session(
+    backend: &AwsAgentCoreBackendHandle,
+    runtime_session_id: &str,
+) -> Result<()> {
+    let mut request = backend
+        .client
+        .stop_runtime_session()
+        .agent_runtime_arn(backend.runtime_arn.clone())
+        .runtime_session_id(runtime_session_id.to_string());
+    if let Some(qualifier) = &backend.qualifier {
+        request = request.qualifier(qualifier.clone());
+    }
+    match request.send().await {
+        Ok(_) => Ok(()),
+        Err(error)
+            if error
+                .as_service_error()
+                .is_some_and(|error| error.is_resource_not_found_exception()) =>
+        {
+            Ok(())
+        }
+        Err(error) => Err(error)
+            .with_context(|| format!("stopping AgentCore runtime session {runtime_session_id}")),
     }
 }
 

--- a/crates/exoharness/src/sandbox_provider/daytona.rs
+++ b/crates/exoharness/src/sandbox_provider/daytona.rs
@@ -298,7 +298,9 @@ impl ManagedSandboxBackend for DaytonaSandboxBackend {
             SnapshotKind::DockerImageTar => {
                 import_docker_image_tar(&self.handle_backend(), &payload.bytes).await?
             }
-            SnapshotKind::E2bSnapshot | SnapshotKind::SpritesSnapshot => bail!(
+            SnapshotKind::E2bSnapshot
+            | SnapshotKind::SpritesSnapshot
+            | SnapshotKind::TensorlakeSnapshot => bail!(
                 "the Daytona backend cannot restore a {:?} payload; \
                  select the provider that produced the snapshot",
                 payload.kind

--- a/crates/exoharness/src/sandbox_provider/daytona.rs
+++ b/crates/exoharness/src/sandbox_provider/daytona.rs
@@ -318,6 +318,28 @@ impl ManagedSandboxBackend for DaytonaSandboxBackend {
             backend: self.handle_backend(),
         }))
     }
+
+    async fn terminate(&self, request: SandboxRequest) -> Result<()> {
+        let spec_hash = sandbox_spec_hash(&request.spec);
+        let Some(sandbox) = self
+            .find_sandbox_by_labels(&request.key.to_string(), &spec_hash)
+            .await?
+        else {
+            return Ok(());
+        };
+        let response = self
+            .client
+            .delete(self.api_endpoint(&format!("/sandbox/{}", sandbox.id)))
+            .send()
+            .await
+            .with_context(|| format!("deleting Daytona sandbox {}", sandbox.id))?;
+        if response.status().is_success() || response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(());
+        }
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        bail!("Daytona delete-sandbox failed ({status}): {text}")
+    }
 }
 
 impl DaytonaSandboxBackend {

--- a/crates/exoharness/src/sandbox_provider/e2b.rs
+++ b/crates/exoharness/src/sandbox_provider/e2b.rs
@@ -291,6 +291,28 @@ impl ManagedSandboxBackend for E2bSandboxBackend {
             backend: self.handle_backend(),
         }))
     }
+
+    async fn terminate(&self, request: SandboxRequest) -> Result<()> {
+        let spec_hash = sandbox_spec_hash(&request.spec);
+        let Some(sandbox) = self
+            .find_sandbox_by_metadata(&request.key.to_string(), &spec_hash)
+            .await?
+        else {
+            return Ok(());
+        };
+        let response = self
+            .client
+            .delete(self.api_endpoint(&format!("/sandboxes/{}", sandbox.sandbox_id)))
+            .send()
+            .await
+            .with_context(|| format!("deleting E2B sandbox {}", sandbox.sandbox_id))?;
+        if response.status().is_success() || response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(());
+        }
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        bail!("E2B delete-sandbox failed ({status}): {text}")
+    }
 }
 
 #[derive(Clone)]

--- a/crates/exoharness/src/sandbox_provider/mod.rs
+++ b/crates/exoharness/src/sandbox_provider/mod.rs
@@ -33,6 +33,14 @@ pub mod process_bridge;
 #[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
 mod sprites;
 #[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
+mod tensorlake;
+#[cfg(not(all(not(target_arch = "wasm32"), feature = "basic-backend")))]
+mod tensorlake {
+    pub fn default_tensorlake_image() -> String {
+        "tensorlake/ubuntu-minimal".to_string()
+    }
+}
+#[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
 mod vercel;
 #[cfg(not(all(not(target_arch = "wasm32"), feature = "basic-backend")))]
 mod vercel {
@@ -60,6 +68,12 @@ pub use docker::default_docker_image;
 pub use e2b::{DEFAULT_E2B_API_URL, DEFAULT_E2B_ENVD_PORT, E2bConfig, E2bSandboxBackend};
 #[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
 pub use sprites::{DEFAULT_SPRITES_API_URL, SpritesConfig, SpritesSandboxBackend};
+pub use tensorlake::default_tensorlake_image;
+#[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
+pub use tensorlake::{
+    DEFAULT_TENSORLAKE_API_URL, DEFAULT_TENSORLAKE_IMAGE, TensorlakeConfig,
+    TensorlakeSandboxBackend,
+};
 pub use vercel::default_vercel_image;
 #[cfg(all(not(target_arch = "wasm32"), feature = "basic-backend"))]
 pub use vercel::{DEFAULT_VERCEL_API_URL, VercelConfig, VercelSandboxBackend};

--- a/crates/exoharness/src/sandbox_provider/sprites.rs
+++ b/crates/exoharness/src/sandbox_provider/sprites.rs
@@ -225,6 +225,22 @@ impl ManagedSandboxBackend for SpritesSandboxBackend {
             backend: self.handle_backend(),
         }))
     }
+
+    async fn terminate(&self, request: SandboxRequest) -> Result<()> {
+        let sprite_name = sprite_name_for_request(&request);
+        let response = self
+            .client
+            .delete(self.api_endpoint(&format!("/v1/sprites/{sprite_name}")))
+            .send()
+            .await
+            .with_context(|| format!("deleting Sprites sprite {sprite_name}"))?;
+        if response.status().is_success() || response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(());
+        }
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        bail!("Sprites delete-sprite failed ({status}): {text}")
+    }
 }
 
 #[derive(Clone)]

--- a/crates/exoharness/src/sandbox_provider/tensorlake.rs
+++ b/crates/exoharness/src/sandbox_provider/tensorlake.rs
@@ -19,7 +19,6 @@ use std::collections::HashMap;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -35,6 +34,7 @@ use tokio::task::JoinHandle;
 use tokio::time;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
+use crate::SandboxAttachment;
 use crate::sandbox::{
     ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand, SandboxCommandOutput,
     SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotKind, SnapshotPayload,
@@ -57,6 +57,9 @@ const PROCESS_WAIT_POLL_INTERVAL: Duration = Duration::from_millis(250);
 const PROCESS_OUTPUT_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 /// Client-side backstop on top of the server-side `timeout` for one-shot exec.
 const EXEC_TIMEOUT_GRACE: Duration = Duration::from_secs(10);
+/// A snapshot is accepted before it is restorable; how long to wait for it.
+const SNAPSHOT_READY_TIMEOUT: Duration = Duration::from_secs(300);
+const SNAPSHOT_READY_POLL_INTERVAL: Duration = Duration::from_secs(1);
 /// A just-terminated name can linger briefly before it is free to reuse.
 const NAME_CONFLICT_RETRIES: usize = 5;
 const NAME_CONFLICT_RETRY_DELAY: Duration = Duration::from_secs(1);
@@ -203,6 +206,18 @@ impl ManagedSandboxBackend for TensorlakeSandboxBackend {
         let backend = self.handle_backend();
         let name = sandbox_name_for_request(&request);
 
+        // Restoring one sandbox's filesystem under another's identity would
+        // silently hand the caller someone else's state, so refuse when the
+        // manifest was captured from a different sandbox.
+        if let (Some(captured_from), Some(name)) = (&manifest.sandbox_name, &name)
+            && captured_from != name
+        {
+            bail!(
+                "Tensorlake snapshot was taken from sandbox {captured_from}, \
+                 but this sandbox key maps to {name}"
+            );
+        }
+
         // A restored sandbox must boot from the snapshot, so any sandbox already
         // holding this name is terminated first — mirrors the Docker backend
         // evicting its warm container before restoring an image.
@@ -224,6 +239,16 @@ impl ManagedSandboxBackend for TensorlakeSandboxBackend {
             request,
             backend,
         )))
+    }
+
+    async fn attach(
+        &self,
+        _request: SandboxRequest,
+        _attachment: SandboxAttachment,
+    ) -> Result<Arc<dyn ManagedSandboxHandle>> {
+        // An attachment carries a provider-native handle to an already-running
+        // sandbox; there is no Tensorlake variant to accept yet.
+        bail!("Tensorlake sandbox backend does not support external attachments")
     }
 }
 
@@ -454,17 +479,66 @@ impl TensorlakeBackendHandle {
             .with_context(|| format!("snapshotting Tensorlake sandbox {sandbox_id}"))?;
         let snapshot: SnapshotSandboxResponse =
             decode_json_response(response, "Tensorlake snapshot-sandbox").await?;
+        self.wait_until_snapshot_restorable(&snapshot.snapshot_id)
+            .await?;
         Ok(snapshot.snapshot_id)
     }
+
+    /// `POST /sandboxes/{id}/snapshot` returns `202` with the snapshot still
+    /// being written, so the id alone does not mean it can be restored. Persist
+    /// it only once the platform says otherwise: a caller who snapshots and
+    /// immediately rewinds would otherwise hand back an id that create rejects.
+    async fn wait_until_snapshot_restorable(&self, snapshot_id: &str) -> Result<()> {
+        let deadline = time::Instant::now() + SNAPSHOT_READY_TIMEOUT;
+        loop {
+            let response = self
+                .client
+                .get(self.api_endpoint(&format!("/snapshots/{snapshot_id}")))
+                .send()
+                .await
+                .with_context(|| format!("polling Tensorlake snapshot {snapshot_id}"))?;
+            let info: SnapshotInfo =
+                decode_json_response(response, "Tensorlake get-snapshot").await?;
+            match info.status.as_str() {
+                // Local and replicating are both restorable; waiting for full
+                // durability would stall a rewind for no benefit.
+                "completed" | "local_ready" | "replicating" => return Ok(()),
+                "failed" => bail!(
+                    "Tensorlake snapshot {snapshot_id} failed{}",
+                    info.error
+                        .as_deref()
+                        .map(|error| format!(": {error}"))
+                        .unwrap_or_default()
+                ),
+                "deleting" => bail!("Tensorlake snapshot {snapshot_id} is being deleted"),
+                _ => {}
+            }
+            if time::Instant::now() >= deadline {
+                bail!(
+                    "Tensorlake snapshot {snapshot_id} was still {} after {}s",
+                    info.status,
+                    SNAPSHOT_READY_TIMEOUT.as_secs()
+                );
+            }
+            time::sleep(SNAPSHOT_READY_POLL_INTERVAL).await;
+        }
+    }
+}
+
+/// A resolved proxy target and whether the last call to it succeeded.
+struct ProxyTarget {
+    target: TensorlakeSandboxTarget,
+    live: bool,
 }
 
 struct TensorlakeSandboxHandle {
     id: String,
     /// `Some` for named (resumable) sandboxes, `None` for ephemeral ones.
     name: Option<String>,
-    target: Mutex<TensorlakeSandboxTarget>,
-    /// Cleared when a proxy call fails so the next call re-checks placement.
-    target_is_live: AtomicBool,
+    /// The proxy target plus whether it is still believed reachable. One
+    /// mutex rather than a separate flag: the two are only ever read and
+    /// written together.
+    target: Mutex<ProxyTarget>,
     request: SandboxRequest,
     backend: TensorlakeBackendHandle,
 }
@@ -480,8 +554,7 @@ impl TensorlakeSandboxHandle {
         Self {
             id,
             name,
-            target: Mutex::new(target),
-            target_is_live: AtomicBool::new(true),
+            target: Mutex::new(ProxyTarget { target, live: true }),
             request,
             backend,
         }
@@ -490,26 +563,26 @@ impl TensorlakeSandboxHandle {
     /// The proxy target for the next command, re-resolving (and resuming) when a
     /// previous call found the sandbox gone — named sandboxes suspend on idle.
     async fn running_target(&self) -> Result<TensorlakeSandboxTarget> {
-        let mut target = self.target.lock().await;
-        if self.target_is_live.load(Ordering::Acquire) {
-            return Ok(target.clone());
+        let mut state = self.target.lock().await;
+        if state.live {
+            return Ok(state.target.clone());
         }
         let identifier = self
             .name
             .clone()
-            .unwrap_or_else(|| target.sandbox_id.clone());
+            .unwrap_or_else(|| state.target.sandbox_id.clone());
         let info = self
             .backend
             .get_sandbox(&identifier)
             .await?
             .ok_or_else(|| anyhow!("Tensorlake sandbox {identifier} no longer exists"))?;
-        *target = self.backend.drive_to_running(info).await?;
-        self.target_is_live.store(true, Ordering::Release);
-        Ok(target.clone())
+        state.target = self.backend.drive_to_running(info).await?;
+        state.live = true;
+        Ok(state.target.clone())
     }
 
-    fn mark_unreachable(&self) {
-        self.target_is_live.store(false, Ordering::Release);
+    async fn mark_unreachable(&self) {
+        self.target.lock().await.live = false;
     }
 
     /// Runs a proxy call, retrying once against a freshly resolved target when
@@ -525,7 +598,7 @@ impl TensorlakeSandboxHandle {
             match call(target.base_url).await {
                 Ok(value) => return Ok(value),
                 Err(ProxyCallError::Unavailable(error)) => {
-                    self.mark_unreachable();
+                    self.mark_unreachable().await;
                     last_unavailable = Some(error);
                 }
                 Err(ProxyCallError::Failed(error)) => return Err(error),
@@ -572,13 +645,22 @@ impl ManagedSandboxHandle for TensorlakeSandboxHandle {
     }
 
     async fn stop(&self) -> Result<()> {
-        let target = self.target.lock().await.clone();
         match &self.name {
             // Named sandboxes keep their filesystem across sessions; the next
             // `acquire` resumes this same sandbox by name.
             Some(name) => self.backend.suspend_sandbox(name).await,
-            None => self.backend.delete_sandbox(&target.sandbox_id).await,
+            None => {
+                let sandbox_id = self.target.lock().await.target.sandbox_id.clone();
+                self.backend.delete_sandbox(&sandbox_id).await
+            }
         }
+    }
+
+    async fn detach(&self) -> Result<SandboxAttachment> {
+        // Detach hands lifecycle ownership to someone else without stopping the
+        // sandbox. Exo owns a Tensorlake sandbox through its derived name, and
+        // there is no descriptor to hand over.
+        bail!("Tensorlake sandboxes cannot be detached")
     }
 
     async fn snapshot(&self) -> Result<SnapshotPayload> {
@@ -1154,6 +1236,13 @@ struct SnapshotSandboxBody {
 #[derive(Debug, Deserialize)]
 struct SnapshotSandboxResponse {
     snapshot_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct SnapshotInfo {
+    status: String,
+    #[serde(default)]
+    error: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/exoharness/src/sandbox_provider/tensorlake.rs
+++ b/crates/exoharness/src/sandbox_provider/tensorlake.rs
@@ -250,6 +250,34 @@ impl ManagedSandboxBackend for TensorlakeSandboxBackend {
         // sandbox; there is no Tensorlake variant to accept yet.
         bail!("Tensorlake sandbox backend does not support external attachments")
     }
+
+    async fn terminate(&self, request: SandboxRequest) -> Result<()> {
+        // Ephemeral sandboxes are addressable only through the handle that
+        // created them, so there is nothing a request-keyed lookup can reclaim.
+        let Some(name) = sandbox_name_for_request(&request) else {
+            return Ok(());
+        };
+        self.handle_backend().delete_sandbox(&name).await
+    }
+
+    async fn fork_sandbox(&self, source: SandboxRequest, target: SandboxRequest) -> Result<bool> {
+        reject_unsupported_mounts(&target)?;
+        // Both sides must be resumable for a copy to be useful. Ephemeral
+        // sandboxes have no stable name to copy from or resume under.
+        let (Some(source_name), Some(target_name)) = (
+            sandbox_name_for_request(&source),
+            sandbox_name_for_request(&target),
+        ) else {
+            return Ok(false);
+        };
+
+        let backend = self.handle_backend();
+        if backend.get_sandbox(&source_name).await?.is_none() {
+            return Ok(false);
+        }
+        backend.copy_sandbox(&source_name, &target_name).await?;
+        Ok(true)
+    }
 }
 
 /// A sandbox that is running and reachable: its platform id plus the proxy base
@@ -462,6 +490,32 @@ impl TensorlakeBackendHandle {
             sandbox_id: info.id.clone(),
             base_url,
         })
+    }
+
+    async fn copy_sandbox(&self, source_name: &str, target_name: &str) -> Result<String> {
+        let response = self
+            .client
+            .post(self.api_endpoint(&format!("/sandboxes/{source_name}/copy")))
+            .query(&[("times", "1"), ("name", target_name)])
+            .send()
+            .await
+            .with_context(|| format!("copying Tensorlake sandbox {source_name}"))?;
+        let copied: CopySandboxResponse =
+            decode_json_response(response, "Tensorlake copy-sandbox").await?;
+        let copy = copied.sandboxes.into_iter().next().ok_or_else(|| {
+            anyhow!("Tensorlake copy-sandbox returned no sandboxes for {source_name}")
+        })?;
+        if !matches!(copy.status, SandboxStatus::Running) {
+            bail!(
+                "Tensorlake copy of {source_name} did not come up: {:?}{}",
+                copy.status,
+                copy.pending_reason
+                    .as_deref()
+                    .map(|reason| format!(" ({reason})"))
+                    .unwrap_or_default()
+            );
+        }
+        Ok(copy.sandbox_id)
     }
 
     async fn snapshot_sandbox(&self, sandbox_id: &str) -> Result<String> {
@@ -1248,6 +1302,19 @@ struct SnapshotInfo {
 #[derive(Debug, Deserialize)]
 struct CreateSandboxResponse {
     sandbox_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct CopySandboxResponse {
+    sandboxes: Vec<CopiedSandbox>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CopiedSandbox {
+    sandbox_id: String,
+    status: SandboxStatus,
+    #[serde(default)]
+    pending_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]

--- a/crates/exoharness/src/sandbox_provider/tensorlake.rs
+++ b/crates/exoharness/src/sandbox_provider/tensorlake.rs
@@ -1,0 +1,1261 @@
+//! Tensorlake remote sandbox backend.
+//!
+//! Lifecycle goes through the Tensorlake platform API (`api.tensorlake.ai`):
+//! create, get, suspend, resume, delete, snapshot. Commands run against the
+//! per-sandbox proxy (`sandbox_url`, e.g. `https://<id>.sandbox.tensorlake.ai`)
+//! using the sandbox process API — `/api/v1/processes/run` for one-shot exec and
+//! `/api/v1/processes` + stdin/follow endpoints for streaming processes.
+//!
+//! Cross-process resume uses a deterministic *named* sandbox derived from
+//! [`SandboxKey`](crate::SandboxKey) + spec hash (same role as Docker labels /
+//! E2B metadata); Tensorlake creates have no label field, and only named
+//! sandboxes support suspend/resume. A request with no `idle_ttl` gets an
+//! ephemeral sandbox instead, terminated on `stop`.
+//!
+//! Snapshots are bytes-by-reference via [`SnapshotKind::TensorlakeSnapshot`]
+//! manifests pointing at a platform snapshot id.
+
+use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow, bail};
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::future::BoxFuture;
+use futures::{Stream, StreamExt};
+use reqwest::header::{AUTHORIZATION, CONTENT_TYPE, HeaderMap, HeaderValue};
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use tokio::time;
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+
+use crate::sandbox::{
+    ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand, SandboxCommandOutput,
+    SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotKind, SnapshotPayload,
+    sandbox_spec_hash,
+};
+
+pub const DEFAULT_TENSORLAKE_API_URL: &str = "https://api.tensorlake.ai";
+pub const DEFAULT_TENSORLAKE_IMAGE: &str = "tensorlake/ubuntu-minimal";
+
+pub fn default_tensorlake_image() -> String {
+    DEFAULT_TENSORLAKE_IMAGE.to_string()
+}
+
+const PROCESS_PIPE_BUFFER_SIZE: usize = 64 * 1024;
+/// How long to wait for a created/resumed sandbox to reach `running`.
+const SANDBOX_READY_TIMEOUT: Duration = Duration::from_secs(180);
+const SANDBOX_READY_POLL_INTERVAL: Duration = Duration::from_millis(500);
+const PROCESS_WAIT_POLL_INTERVAL: Duration = Duration::from_millis(250);
+/// Grace period for the output followers to drain after the process exits.
+const PROCESS_OUTPUT_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
+/// Client-side backstop on top of the server-side `timeout` for one-shot exec.
+const EXEC_TIMEOUT_GRACE: Duration = Duration::from_secs(10);
+/// A just-terminated name can linger briefly before it is free to reuse.
+const NAME_CONFLICT_RETRIES: usize = 5;
+const NAME_CONFLICT_RETRY_DELAY: Duration = Duration::from_secs(1);
+
+#[derive(Debug, Clone)]
+pub struct TensorlakeConfig {
+    pub api_key: String,
+    pub api_url: String,
+    /// Base image for sandboxes whose spec doesn't request one.
+    pub default_image: String,
+    /// CPU cores per sandbox. `None` uses the Tensorlake default.
+    pub cpus: Option<f64>,
+    /// Memory per sandbox in MiB. `None` uses the Tensorlake default.
+    pub memory_mb: Option<u64>,
+    /// When set (tests), sandbox proxy requests go here instead of the
+    /// `sandbox_url` the platform reports.
+    pub sandbox_base_url: Option<String>,
+}
+
+/// JSON persisted for [`SnapshotKind::TensorlakeSnapshot`]. Filesystem state lives
+/// in Tensorlake; we only store the snapshot id returned by
+/// `POST /sandboxes/{id}/snapshot`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct TensorlakeSnapshotManifest {
+    snapshot_id: String,
+    /// The named sandbox the snapshot was taken from, when it wasn't ephemeral.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    sandbox_name: Option<String>,
+}
+
+pub struct TensorlakeSandboxBackend {
+    client: reqwest::Client,
+    api_url: String,
+    default_image: String,
+    cpus: Option<f64>,
+    memory_mb: Option<u64>,
+    sandbox_base_url: Option<String>,
+}
+
+impl TensorlakeSandboxBackend {
+    pub fn new(config: TensorlakeConfig) -> Result<Self> {
+        let mut headers = HeaderMap::new();
+        let mut auth = HeaderValue::from_str(&format!("Bearer {}", config.api_key)).context(
+            "TENSORLAKE_API_KEY contains characters that aren't valid in an HTTP header",
+        )?;
+        auth.set_sensitive(true);
+        headers.insert(AUTHORIZATION, auth);
+        let client = reqwest::Client::builder()
+            .default_headers(headers)
+            .build()
+            .context("building Tensorlake HTTP client")?;
+        Ok(Self {
+            client,
+            api_url: config.api_url.trim_end_matches('/').to_string(),
+            default_image: config.default_image,
+            cpus: config.cpus,
+            memory_mb: config.memory_mb,
+            sandbox_base_url: config
+                .sandbox_base_url
+                .map(|url| url.trim_end_matches('/').to_string()),
+        })
+    }
+
+    fn handle_backend(&self) -> TensorlakeBackendHandle {
+        TensorlakeBackendHandle {
+            client: self.client.clone(),
+            api_url: self.api_url.clone(),
+            sandbox_base_url: self.sandbox_base_url.clone(),
+        }
+    }
+
+    fn create_body(&self, request: &SandboxRequest, name: Option<&str>) -> CreateSandboxBody {
+        CreateSandboxBody {
+            name: name.map(ToOwned::to_owned),
+            image: Some(resolve_image(&request.spec, &self.default_image)),
+            snapshot_id: None,
+            resources: self.resource_overrides(),
+            // Named sandboxes suspend at the idle timeout and resume on the next
+            // `acquire`; ephemeral ones get the plan default and are deleted on stop.
+            timeout_secs: request.lifecycle.idle_ttl.map(|ttl| ttl.as_secs().max(1)),
+            network: Some(SandboxNetworkAccessControl {
+                allow_internet_access: matches!(
+                    request.spec.network,
+                    SandboxNetworkPolicy::Enabled
+                ),
+            }),
+        }
+    }
+
+    fn resource_overrides(&self) -> Option<SandboxResourceOverrides> {
+        (self.cpus.is_some() || self.memory_mb.is_some()).then_some(SandboxResourceOverrides {
+            cpus: self.cpus,
+            memory_mb: self.memory_mb,
+        })
+    }
+}
+
+#[async_trait]
+impl ManagedSandboxBackend for TensorlakeSandboxBackend {
+    async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
+        reject_unsupported_mounts(&request)?;
+        let backend = self.handle_backend();
+        let name = sandbox_name_for_request(&request);
+
+        let target = match &name {
+            Some(name) => match backend.get_sandbox(name).await? {
+                Some(info) => backend.drive_to_running(info).await?,
+                None => {
+                    let body = self.create_body(&request, Some(name));
+                    backend.create_and_wait(body).await?
+                }
+            },
+            None => {
+                let body = self.create_body(&request, None);
+                backend.create_and_wait(body).await?
+            }
+        };
+
+        Ok(Arc::new(TensorlakeSandboxHandle::new(
+            format!("tensorlake:{}", request.key),
+            name,
+            target,
+            request,
+            backend,
+        )))
+    }
+
+    async fn acquire_from_snapshot(
+        &self,
+        request: SandboxRequest,
+        payload: SnapshotPayload,
+    ) -> Result<Arc<dyn ManagedSandboxHandle>> {
+        reject_unsupported_mounts(&request)?;
+        if !matches!(payload.kind, SnapshotKind::TensorlakeSnapshot) {
+            bail!(
+                "Tensorlake sandbox backend can only restore from \
+                 SnapshotKind::TensorlakeSnapshot, got {:?}",
+                payload.kind
+            );
+        }
+        let manifest: TensorlakeSnapshotManifest = serde_json::from_slice(&payload.bytes)
+            .context("decoding TensorlakeSnapshot manifest")?;
+
+        let backend = self.handle_backend();
+        let name = sandbox_name_for_request(&request);
+
+        // A restored sandbox must boot from the snapshot, so any sandbox already
+        // holding this name is terminated first — mirrors the Docker backend
+        // evicting its warm container before restoring an image.
+        if let Some(name) = &name
+            && backend.get_sandbox(name).await?.is_some()
+        {
+            backend.delete_sandbox(name).await?;
+        }
+
+        let mut body = self.create_body(&request, name.as_deref());
+        body.image = None;
+        body.snapshot_id = Some(manifest.snapshot_id);
+        let target = backend.create_and_wait(body).await?;
+
+        Ok(Arc::new(TensorlakeSandboxHandle::new(
+            format!("tensorlake-restored:{}", request.key),
+            name,
+            target,
+            request,
+            backend,
+        )))
+    }
+}
+
+/// A sandbox that is running and reachable: its platform id plus the proxy base
+/// URL its commands go to.
+#[derive(Debug, Clone)]
+struct TensorlakeSandboxTarget {
+    sandbox_id: String,
+    base_url: String,
+}
+
+#[derive(Clone)]
+struct TensorlakeBackendHandle {
+    client: reqwest::Client,
+    api_url: String,
+    sandbox_base_url: Option<String>,
+}
+
+impl TensorlakeBackendHandle {
+    fn api_endpoint(&self, path: &str) -> String {
+        format!("{}{}", self.api_url, path)
+    }
+
+    async fn get_sandbox(&self, identifier: &str) -> Result<Option<SandboxInfo>> {
+        let response = self
+            .client
+            .get(self.api_endpoint(&format!("/sandboxes/{identifier}")))
+            .send()
+            .await
+            .with_context(|| format!("fetching Tensorlake sandbox {identifier}"))?;
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        let info: SandboxInfo = decode_json_response(response, "Tensorlake get-sandbox").await?;
+        // A terminated sandbox is a tombstone: the name is free to recreate.
+        if matches!(info.status, SandboxStatus::Terminated) {
+            return Ok(None);
+        }
+        Ok(Some(info))
+    }
+
+    async fn create_and_wait(&self, body: CreateSandboxBody) -> Result<TensorlakeSandboxTarget> {
+        let created = self.create_sandbox(&body).await?;
+        self.wait_until_running(&created.sandbox_id).await
+    }
+
+    async fn create_sandbox(&self, body: &CreateSandboxBody) -> Result<CreateSandboxResponse> {
+        let mut last_conflict = None;
+        for attempt in 0..NAME_CONFLICT_RETRIES {
+            let response = self
+                .client
+                .post(self.api_endpoint("/sandboxes"))
+                .json(body)
+                .send()
+                .await
+                .context("creating Tensorlake sandbox")?;
+            if response.status() != reqwest::StatusCode::CONFLICT {
+                return decode_json_response(response, "Tensorlake create-sandbox").await;
+            }
+            last_conflict = Some(response.text().await.unwrap_or_default());
+            if attempt + 1 < NAME_CONFLICT_RETRIES {
+                time::sleep(NAME_CONFLICT_RETRY_DELAY).await;
+            }
+        }
+        bail!(
+            "Tensorlake create-sandbox kept reporting a name conflict for {:?}: {}",
+            body.name,
+            last_conflict.unwrap_or_default()
+        )
+    }
+
+    async fn delete_sandbox(&self, identifier: &str) -> Result<()> {
+        let response = self
+            .client
+            .delete(self.api_endpoint(&format!("/sandboxes/{identifier}")))
+            .send()
+            .await
+            .with_context(|| format!("deleting Tensorlake sandbox {identifier}"))?;
+        if response.status().is_success() || response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(());
+        }
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        bail!("Tensorlake delete-sandbox failed ({status}): {text}")
+    }
+
+    async fn suspend_sandbox(&self, identifier: &str) -> Result<()> {
+        let response = self
+            .client
+            .post(self.api_endpoint(&format!("/sandboxes/{identifier}/suspend")))
+            .send()
+            .await
+            .with_context(|| format!("suspending Tensorlake sandbox {identifier}"))?;
+        if response.status().is_success() {
+            return Ok(());
+        }
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        bail!("Tensorlake suspend-sandbox failed ({status}): {text}")
+    }
+
+    async fn resume_sandbox(&self, identifier: &str) -> Result<()> {
+        let response = self
+            .client
+            .post(self.api_endpoint(&format!("/sandboxes/{identifier}/resume")))
+            .send()
+            .await
+            .with_context(|| format!("resuming Tensorlake sandbox {identifier}"))?;
+        if response.status().is_success() {
+            return Ok(());
+        }
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        bail!("Tensorlake resume-sandbox failed ({status}): {text}")
+    }
+
+    /// Bring an existing sandbox back to `running`, resuming it if it suspended.
+    async fn drive_to_running(&self, info: SandboxInfo) -> Result<TensorlakeSandboxTarget> {
+        match info.status {
+            SandboxStatus::Running => self.target_for(&info),
+            SandboxStatus::Suspended => self.resume_and_wait(&info.id).await,
+            // A resume is rejected while a suspend is still in flight, so
+            // `suspending` waits like any other transitional state; the poll
+            // loop fires the resume once it settles.
+            SandboxStatus::Suspending | SandboxStatus::Pending | SandboxStatus::Snapshotting => {
+                self.wait_until_running(&info.id).await
+            }
+            SandboxStatus::Terminated => bail!(
+                "Tensorlake sandbox {} is terminated and cannot be reused",
+                info.id
+            ),
+        }
+    }
+
+    async fn wait_until_running(&self, sandbox_id: &str) -> Result<TensorlakeSandboxTarget> {
+        self.poll_until_running(sandbox_id, false).await
+    }
+
+    async fn resume_and_wait(&self, sandbox_id: &str) -> Result<TensorlakeSandboxTarget> {
+        self.resume_sandbox(sandbox_id).await?;
+        self.poll_until_running(sandbox_id, true).await
+    }
+
+    /// Polls until the sandbox reports `running`. A sandbox that settles into
+    /// `suspended` along the way is resumed exactly once — resume is not
+    /// idempotent enough to re-send on every tick, and the API rejects it
+    /// outright in the intermediate states.
+    async fn poll_until_running(
+        &self,
+        sandbox_id: &str,
+        mut resumed: bool,
+    ) -> Result<TensorlakeSandboxTarget> {
+        let deadline = time::Instant::now() + SANDBOX_READY_TIMEOUT;
+        loop {
+            let response = self
+                .client
+                .get(self.api_endpoint(&format!("/sandboxes/{sandbox_id}")))
+                .send()
+                .await
+                .with_context(|| format!("polling Tensorlake sandbox {sandbox_id}"))?;
+            let info: SandboxInfo =
+                decode_json_response(response, "Tensorlake get-sandbox").await?;
+            match info.status {
+                SandboxStatus::Running => return self.target_for(&info),
+                SandboxStatus::Terminated => bail!(
+                    "Tensorlake sandbox {sandbox_id} terminated while starting{}",
+                    info.outcome
+                        .as_deref()
+                        .map(|outcome| format!(": {outcome}"))
+                        .unwrap_or_default()
+                ),
+                SandboxStatus::Suspended if !resumed => {
+                    resumed = true;
+                    self.resume_sandbox(sandbox_id).await?;
+                }
+                SandboxStatus::Suspended
+                | SandboxStatus::Suspending
+                | SandboxStatus::Pending
+                | SandboxStatus::Snapshotting => {}
+            }
+            if time::Instant::now() >= deadline {
+                bail!(
+                    "Tensorlake sandbox {sandbox_id} was still {:?} after {}s{}",
+                    info.status,
+                    SANDBOX_READY_TIMEOUT.as_secs(),
+                    info.pending_reason
+                        .as_deref()
+                        .map(|reason| format!(" ({reason})"))
+                        .unwrap_or_default()
+                );
+            }
+            time::sleep(SANDBOX_READY_POLL_INTERVAL).await;
+        }
+    }
+
+    fn target_for(&self, info: &SandboxInfo) -> Result<TensorlakeSandboxTarget> {
+        let base_url = match &self.sandbox_base_url {
+            Some(base_url) => base_url.clone(),
+            None => info
+                .sandbox_url
+                .as_deref()
+                .map(|url| url.trim_end_matches('/').to_string())
+                .ok_or_else(|| {
+                    anyhow!(
+                        "Tensorlake sandbox {} is running but reported no sandbox_url",
+                        info.id
+                    )
+                })?,
+        };
+        Ok(TensorlakeSandboxTarget {
+            sandbox_id: info.id.clone(),
+            base_url,
+        })
+    }
+
+    async fn snapshot_sandbox(&self, sandbox_id: &str) -> Result<String> {
+        let body = SnapshotSandboxBody {
+            // Filesystem snapshots match what every other exo backend captures
+            // (Docker image tar, Daytona/E2B filesystem snapshots).
+            snapshot_type: "filesystem",
+        };
+        let response = self
+            .client
+            .post(self.api_endpoint(&format!("/sandboxes/{sandbox_id}/snapshot")))
+            .json(&body)
+            .send()
+            .await
+            .with_context(|| format!("snapshotting Tensorlake sandbox {sandbox_id}"))?;
+        let snapshot: SnapshotSandboxResponse =
+            decode_json_response(response, "Tensorlake snapshot-sandbox").await?;
+        Ok(snapshot.snapshot_id)
+    }
+}
+
+struct TensorlakeSandboxHandle {
+    id: String,
+    /// `Some` for named (resumable) sandboxes, `None` for ephemeral ones.
+    name: Option<String>,
+    target: Mutex<TensorlakeSandboxTarget>,
+    /// Cleared when a proxy call fails so the next call re-checks placement.
+    target_is_live: AtomicBool,
+    request: SandboxRequest,
+    backend: TensorlakeBackendHandle,
+}
+
+impl TensorlakeSandboxHandle {
+    fn new(
+        id: String,
+        name: Option<String>,
+        target: TensorlakeSandboxTarget,
+        request: SandboxRequest,
+        backend: TensorlakeBackendHandle,
+    ) -> Self {
+        Self {
+            id,
+            name,
+            target: Mutex::new(target),
+            target_is_live: AtomicBool::new(true),
+            request,
+            backend,
+        }
+    }
+
+    /// The proxy target for the next command, re-resolving (and resuming) when a
+    /// previous call found the sandbox gone — named sandboxes suspend on idle.
+    async fn running_target(&self) -> Result<TensorlakeSandboxTarget> {
+        let mut target = self.target.lock().await;
+        if self.target_is_live.load(Ordering::Acquire) {
+            return Ok(target.clone());
+        }
+        let identifier = self
+            .name
+            .clone()
+            .unwrap_or_else(|| target.sandbox_id.clone());
+        let info = self
+            .backend
+            .get_sandbox(&identifier)
+            .await?
+            .ok_or_else(|| anyhow!("Tensorlake sandbox {identifier} no longer exists"))?;
+        *target = self.backend.drive_to_running(info).await?;
+        self.target_is_live.store(true, Ordering::Release);
+        Ok(target.clone())
+    }
+
+    fn mark_unreachable(&self) {
+        self.target_is_live.store(false, Ordering::Release);
+    }
+
+    /// Runs a proxy call, retrying once against a freshly resolved target when
+    /// the first attempt says the sandbox isn't reachable.
+    async fn with_proxy_retry<T, Fut, F>(&self, call: F) -> Result<T>
+    where
+        F: Fn(String) -> Fut,
+        Fut: std::future::Future<Output = std::result::Result<T, ProxyCallError>>,
+    {
+        let mut last_unavailable = None;
+        for _ in 0..2 {
+            let target = self.running_target().await?;
+            match call(target.base_url).await {
+                Ok(value) => return Ok(value),
+                Err(ProxyCallError::Unavailable(error)) => {
+                    self.mark_unreachable();
+                    last_unavailable = Some(error);
+                }
+                Err(ProxyCallError::Failed(error)) => return Err(error),
+            }
+        }
+        Err(last_unavailable.expect("unavailable error recorded before the retry budget ran out"))
+    }
+}
+
+#[async_trait]
+impl ManagedSandboxHandle for TensorlakeSandboxHandle {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    async fn exec(&self, command: &SandboxCommand) -> Result<SandboxCommandOutput> {
+        if command.argv.is_empty() {
+            bail!("sandbox command requires at least one argv entry");
+        }
+        let cwd = command
+            .cwd
+            .clone()
+            .unwrap_or_else(|| self.request.spec.default_workdir.clone());
+        self.with_proxy_retry(|base_url| {
+            let cwd = cwd.clone();
+            async move { run_process(&self.backend, &base_url, cwd, command).await }
+        })
+        .await
+    }
+
+    async fn start_process(&self, command: &SandboxCommand) -> Result<crate::SandboxProcessParts> {
+        if command.argv.is_empty() {
+            bail!("sandbox command requires at least one argv entry");
+        }
+        let cwd = command
+            .cwd
+            .clone()
+            .unwrap_or_else(|| self.request.spec.default_workdir.clone());
+        self.with_proxy_retry(|base_url| {
+            let cwd = cwd.clone();
+            async move { start_process(&self.backend, &base_url, cwd, command).await }
+        })
+        .await
+    }
+
+    async fn stop(&self) -> Result<()> {
+        let target = self.target.lock().await.clone();
+        match &self.name {
+            // Named sandboxes keep their filesystem across sessions; the next
+            // `acquire` resumes this same sandbox by name.
+            Some(name) => self.backend.suspend_sandbox(name).await,
+            None => self.backend.delete_sandbox(&target.sandbox_id).await,
+        }
+    }
+
+    async fn snapshot(&self) -> Result<SnapshotPayload> {
+        let target = self.running_target().await?;
+        let snapshot_id = self.backend.snapshot_sandbox(&target.sandbox_id).await?;
+        let manifest = TensorlakeSnapshotManifest {
+            snapshot_id,
+            sandbox_name: self.name.clone(),
+        };
+        let bytes =
+            serde_json::to_vec(&manifest).context("serializing Tensorlake snapshot manifest")?;
+        Ok(SnapshotPayload {
+            kind: SnapshotKind::TensorlakeSnapshot,
+            bytes: Bytes::from(bytes),
+        })
+    }
+}
+
+/// Distinguishes "the sandbox proxy isn't reachable" (worth re-resolving the
+/// sandbox and retrying) from a real command/API failure.
+#[derive(Debug, thiserror::Error)]
+enum ProxyCallError {
+    #[error("{0}")]
+    Unavailable(#[source] anyhow::Error),
+    #[error("{0}")]
+    Failed(#[from] anyhow::Error),
+}
+
+fn classify_proxy_status(status: reqwest::StatusCode, context: &str, body: &str) -> ProxyCallError {
+    let error = anyhow!("{context} failed ({status}): {body}");
+    if matches!(
+        status,
+        reqwest::StatusCode::NOT_FOUND
+            | reqwest::StatusCode::BAD_GATEWAY
+            | reqwest::StatusCode::SERVICE_UNAVAILABLE
+            | reqwest::StatusCode::GATEWAY_TIMEOUT
+    ) {
+        ProxyCallError::Unavailable(error)
+    } else {
+        ProxyCallError::Failed(error)
+    }
+}
+
+fn classify_transport_error(error: reqwest::Error, context: &str) -> ProxyCallError {
+    ProxyCallError::Unavailable(anyhow::Error::new(error).context(context.to_string()))
+}
+
+/// One-shot exec: `POST /api/v1/processes/run` streams captured output over SSE
+/// and ends with an exit event.
+async fn run_process(
+    backend: &TensorlakeBackendHandle,
+    base_url: &str,
+    cwd: String,
+    command: &SandboxCommand,
+) -> std::result::Result<SandboxCommandOutput, ProxyCallError> {
+    let body = RunProcessBody {
+        command: command.argv[0].clone(),
+        args: command.argv[1..].to_vec(),
+        env: command.env.clone(),
+        working_dir: (!cwd.is_empty()).then(|| cwd.clone()),
+        timeout: command.timeout.map(|timeout| timeout.as_secs_f64()),
+    };
+
+    let response = backend
+        .client
+        .post(format!("{base_url}/api/v1/processes/run"))
+        .json(&body)
+        .send()
+        .await
+        .map_err(|error| classify_transport_error(error, "Tensorlake run-process"))?;
+    let status = response.status();
+    if !status.is_success() {
+        let text = response.text().await.unwrap_or_default();
+        return Err(classify_proxy_status(
+            status,
+            "Tensorlake run-process",
+            &text,
+        ));
+    }
+
+    // Past this point the command is already running in the sandbox, so every
+    // failure is terminal: a retry would execute it a second time. Only the
+    // send/status failures above are safe to classify as `Unavailable`.
+    let collect = collect_run_events(response);
+    let (exit_code, stdout, stderr) = match command.timeout {
+        Some(timeout) => time::timeout(timeout + EXEC_TIMEOUT_GRACE, collect)
+            .await
+            .map_err(|_| {
+                anyhow!(
+                    "sandbox command timed out after {}s: {}",
+                    timeout.as_secs(),
+                    command
+                        .display_argv
+                        .as_ref()
+                        .unwrap_or(&command.argv)
+                        .join(" ")
+                )
+            })??,
+        None => collect.await?,
+    };
+
+    Ok(SandboxCommandOutput {
+        ok: exit_code == Some(0),
+        exit_code,
+        stdout,
+        stderr,
+        command: command
+            .display_argv
+            .clone()
+            .unwrap_or_else(|| command.argv.clone()),
+        cwd,
+    })
+}
+
+/// Drains the run stream. Every error here is reported as-is rather than as a
+/// retryable one: the command has already run, so replaying it is not an option.
+async fn collect_run_events(response: reqwest::Response) -> Result<(Option<i32>, String, String)> {
+    let mut events = SseReader::new(response.bytes_stream());
+    let mut stdout = OutputLines::default();
+    let mut stderr = OutputLines::default();
+    let mut exit_code = None;
+    let mut saw_exit = false;
+
+    while let Some(event) = events
+        .next_event()
+        .await
+        .context("Tensorlake run-process")?
+    {
+        if event.data.is_empty() {
+            continue;
+        }
+        let payload: RunProcessEvent = serde_json::from_str(&event.data)
+            .with_context(|| format!("decoding Tensorlake run-process event: {}", event.data))?;
+        match payload.line {
+            Some(line) => match payload.stream {
+                Some(ProcessOutputStream::Stderr) => stderr.push(line),
+                Some(ProcessOutputStream::Stdout) | None => stdout.push(line),
+            },
+            // The started event carries the pid; nothing to collect from it.
+            None if payload.started_at.is_some() => {}
+            None => {
+                saw_exit = true;
+                exit_code = resolve_exit_code(payload.exit_code, payload.signal);
+            }
+        }
+    }
+
+    if !saw_exit {
+        bail!(
+            "Tensorlake run-process stream ended without an exit event; \
+             the command may have run without its result being reported"
+        );
+    }
+    Ok((exit_code, stdout.into_text(), stderr.into_text()))
+}
+
+/// Streaming process: start it in `pipe` stdin mode, then bridge stdin over
+/// `/stdin`, stdout/stderr over the SSE follow endpoints, and exit status over
+/// polled process metadata.
+///
+/// Tensorlake's process API frames output as lines, so a partial line (a prompt
+/// with no trailing newline) only reaches the reader once the process emits a
+/// newline or exits.
+async fn start_process(
+    backend: &TensorlakeBackendHandle,
+    base_url: &str,
+    cwd: String,
+    command: &SandboxCommand,
+) -> std::result::Result<crate::SandboxProcessParts, ProxyCallError> {
+    let body = StartProcessBody {
+        command: command.argv[0].clone(),
+        args: command.argv[1..].to_vec(),
+        env: command.env.clone(),
+        working_dir: (!cwd.is_empty()).then_some(cwd),
+        stdin_mode: "pipe",
+        stdout_mode: "capture",
+        stderr_mode: "capture",
+    };
+
+    let response = backend
+        .client
+        .post(format!("{base_url}/api/v1/processes"))
+        .json(&body)
+        .send()
+        .await
+        .map_err(|error| classify_transport_error(error, "Tensorlake start-process"))?;
+    let status = response.status();
+    if !status.is_success() {
+        let text = response.text().await.unwrap_or_default();
+        return Err(classify_proxy_status(
+            status,
+            "Tensorlake start-process",
+            &text,
+        ));
+    }
+    let process: ProcessInfo = response
+        .json()
+        .await
+        .context("decoding Tensorlake start-process response")
+        .map_err(ProxyCallError::Failed)?;
+
+    let (stdout_reader, stdout_writer) = tokio::io::duplex(PROCESS_PIPE_BUFFER_SIZE);
+    let (stderr_reader, stderr_writer) = tokio::io::duplex(PROCESS_PIPE_BUFFER_SIZE);
+    let (stdin_reader, stdin_writer) = tokio::io::duplex(PROCESS_PIPE_BUFFER_SIZE);
+
+    let stdout_task = spawn_output_follower(
+        backend.clone(),
+        format!("{base_url}/api/v1/processes/{}/stdout/follow", process.pid),
+        stdout_writer,
+    );
+    let stderr_task = spawn_output_follower(
+        backend.clone(),
+        format!("{base_url}/api/v1/processes/{}/stderr/follow", process.pid),
+        stderr_writer,
+    );
+    spawn_stdin_forwarder(
+        backend.clone(),
+        format!("{base_url}/api/v1/processes/{}", process.pid),
+        stdin_reader,
+    );
+
+    let backend_for_wait = backend.clone();
+    let process_url = format!("{base_url}/api/v1/processes/{}", process.pid);
+    let wait: BoxFuture<'static, crate::Result<i32>> = Box::pin(async move {
+        let exit_code = wait_for_process_exit(&backend_for_wait, &process_url).await?;
+        // Let the followers drain whatever the process emitted before exiting.
+        for task in [stdout_task, stderr_task] {
+            if time::timeout(PROCESS_OUTPUT_DRAIN_TIMEOUT, task)
+                .await
+                .is_err()
+            {
+                tracing::debug!(%process_url, "Tensorlake output follower did not finish draining");
+            }
+        }
+        Ok(exit_code)
+    });
+
+    Ok(crate::SandboxProcessParts {
+        stdout: Box::pin(stdout_reader.compat()),
+        stderr: Box::pin(stderr_reader.compat()),
+        stdin: Box::pin(stdin_writer.compat_write()),
+        wait,
+    })
+}
+
+fn spawn_output_follower(
+    backend: TensorlakeBackendHandle,
+    url: String,
+    mut writer: tokio::io::DuplexStream,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        if let Err(error) = follow_output(&backend, &url, &mut writer).await {
+            tracing::debug!(%url, %error, "Tensorlake output follower stopped");
+        }
+    })
+}
+
+async fn follow_output(
+    backend: &TensorlakeBackendHandle,
+    url: &str,
+    writer: &mut tokio::io::DuplexStream,
+) -> Result<()> {
+    let response = backend
+        .client
+        .get(url)
+        .send()
+        .await
+        .with_context(|| format!("following Tensorlake process output at {url}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        let text = response.text().await.unwrap_or_default();
+        bail!("Tensorlake follow-output failed ({status}): {text}");
+    }
+
+    let mut events = SseReader::new(response.bytes_stream());
+    while let Some(event) = events.next_event().await? {
+        if event.event == "eof" {
+            break;
+        }
+        if event.data.is_empty() {
+            continue;
+        }
+        let payload: ProcessOutputEvent = serde_json::from_str(&event.data)
+            .with_context(|| format!("decoding Tensorlake output event: {}", event.data))?;
+        let Some(line) = payload.line else {
+            continue;
+        };
+        writer
+            .write_all(line.as_bytes())
+            .await
+            .context("writing Tensorlake process output pipe")?;
+        writer
+            .write_all(b"\n")
+            .await
+            .context("writing Tensorlake process output pipe")?;
+    }
+    Ok(())
+}
+
+fn spawn_stdin_forwarder(
+    backend: TensorlakeBackendHandle,
+    process_url: String,
+    mut reader: tokio::io::DuplexStream,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut buffer = vec![0u8; PROCESS_PIPE_BUFFER_SIZE];
+        loop {
+            let bytes_read = match reader.read(&mut buffer).await {
+                Ok(bytes_read) => bytes_read,
+                Err(error) => {
+                    tracing::debug!(%process_url, %error, "Tensorlake stdin pipe read failed");
+                    break;
+                }
+            };
+            if bytes_read == 0 {
+                break;
+            }
+            let response = backend
+                .client
+                .post(format!("{process_url}/stdin"))
+                .header(CONTENT_TYPE, "application/octet-stream")
+                .body(buffer[..bytes_read].to_vec())
+                .send()
+                .await;
+            match response {
+                Ok(response) if response.status().is_success() => {}
+                Ok(response) => {
+                    tracing::debug!(
+                        %process_url,
+                        status = %response.status(),
+                        "Tensorlake stdin write rejected"
+                    );
+                    break;
+                }
+                Err(error) => {
+                    tracing::debug!(%process_url, %error, "Tensorlake stdin write failed");
+                    break;
+                }
+            }
+        }
+
+        if let Err(error) = backend
+            .client
+            .post(format!("{process_url}/stdin/close"))
+            .send()
+            .await
+        {
+            tracing::debug!(%process_url, %error, "Tensorlake stdin close failed");
+        }
+    })
+}
+
+async fn wait_for_process_exit(
+    backend: &TensorlakeBackendHandle,
+    process_url: &str,
+) -> crate::Result<i32> {
+    loop {
+        let response = backend
+            .client
+            .get(process_url)
+            .send()
+            .await
+            .with_context(|| format!("polling Tensorlake process at {process_url}"))?;
+        let process: ProcessInfo = decode_json_response(response, "Tensorlake get-process").await?;
+        if !matches!(process.status, ProcessStatus::Running) {
+            return Ok(resolve_exit_code(process.exit_code, process.signal).unwrap_or_default());
+        }
+        time::sleep(PROCESS_WAIT_POLL_INTERVAL).await;
+    }
+}
+
+/// Shells report a signalled death as `128 + signum`; mirror that so callers see
+/// a conventional non-zero code instead of a missing one.
+fn resolve_exit_code(exit_code: Option<i32>, signal: Option<i32>) -> Option<i32> {
+    exit_code.or_else(|| signal.map(|signal| 128 + signal))
+}
+
+/// Accumulates line-framed output and rebuilds it as text.
+#[derive(Debug, Default)]
+struct OutputLines {
+    lines: Vec<String>,
+}
+
+impl OutputLines {
+    fn push(&mut self, line: String) {
+        self.lines.push(line);
+    }
+
+    fn into_text(self) -> String {
+        if self.lines.is_empty() {
+            return String::new();
+        }
+        let mut text = self.lines.join("\n");
+        text.push('\n');
+        text
+    }
+}
+
+#[derive(Debug)]
+struct SseEvent {
+    event: String,
+    data: String,
+}
+
+/// Minimal `text/event-stream` reader: accumulates `event:`/`data:` field lines
+/// and yields one event per blank-line dispatch.
+struct SseReader<S> {
+    stream: S,
+    buffer: Vec<u8>,
+    finished: bool,
+    event: String,
+    data: String,
+}
+
+impl<S> SseReader<S>
+where
+    S: Stream<Item = reqwest::Result<Bytes>> + Unpin,
+{
+    fn new(stream: S) -> Self {
+        Self {
+            stream,
+            buffer: Vec::new(),
+            finished: false,
+            event: String::new(),
+            data: String::new(),
+        }
+    }
+
+    async fn next_event(&mut self) -> Result<Option<SseEvent>> {
+        loop {
+            while let Some(line) = self.take_line() {
+                if let Some(event) = self.consume_line(&line) {
+                    return Ok(Some(event));
+                }
+            }
+            if self.finished {
+                // A stream that ends mid-event still owes us that event.
+                return Ok(self.take_pending_event());
+            }
+            match self.stream.next().await {
+                Some(chunk) => {
+                    let chunk = chunk.context("reading Tensorlake event stream")?;
+                    self.buffer.extend_from_slice(&chunk);
+                }
+                None => self.finished = true,
+            }
+        }
+    }
+
+    fn take_line(&mut self) -> Option<String> {
+        let newline = self.buffer.iter().position(|byte| *byte == b'\n')?;
+        let line = self.buffer.drain(..=newline).collect::<Vec<_>>();
+        Some(
+            String::from_utf8_lossy(&line)
+                .trim_end_matches(['\n', '\r'])
+                .to_string(),
+        )
+    }
+
+    fn consume_line(&mut self, line: &str) -> Option<SseEvent> {
+        if line.is_empty() {
+            return self.take_pending_event();
+        }
+        if let Some(value) = line.strip_prefix("event:") {
+            self.event = value.trim().to_string();
+        } else if let Some(value) = line.strip_prefix("data:") {
+            if !self.data.is_empty() {
+                self.data.push('\n');
+            }
+            self.data.push_str(value.strip_prefix(' ').unwrap_or(value));
+        }
+        // Comments (`:` lines) and unknown fields are ignored per the SSE spec.
+        None
+    }
+
+    fn take_pending_event(&mut self) -> Option<SseEvent> {
+        if self.event.is_empty() && self.data.is_empty() {
+            return None;
+        }
+        Some(SseEvent {
+            event: std::mem::take(&mut self.event),
+            data: std::mem::take(&mut self.data),
+        })
+    }
+}
+
+async fn decode_json_response<T: serde::de::DeserializeOwned>(
+    response: reqwest::Response,
+    context: &str,
+) -> Result<T> {
+    let status = response.status();
+    let body = response
+        .text()
+        .await
+        .with_context(|| format!("reading {context} response body"))?;
+    if !status.is_success() {
+        bail!("{context} failed ({status}): {body}");
+    }
+    serde_json::from_str(&body).with_context(|| format!("decoding {context} response: {body}"))
+}
+
+/// Deterministic sandbox name for a resumable sandbox key + spec. Tensorlake has
+/// no label/metadata field on create, so the name is the only resume handle;
+/// hashing the key and spec keeps it stable across processes and forces a new
+/// sandbox whenever the spec changes. Ephemeral requests (no `idle_ttl`) get
+/// `None` — only named sandboxes can suspend and resume.
+fn sandbox_name_for_request(request: &SandboxRequest) -> Option<String> {
+    request.lifecycle.idle_ttl?;
+    let spec_hash = sandbox_spec_hash(&request.spec);
+    let mut hasher = DefaultHasher::new();
+    request.key.hash(&mut hasher);
+    spec_hash.hash(&mut hasher);
+    Some(format!("exo-{:016x}", hasher.finish()))
+}
+
+fn resolve_image(spec: &SandboxSpec, default_image: &str) -> String {
+    if !spec.image.trim().is_empty() {
+        return spec.image.clone();
+    }
+    if !default_image.trim().is_empty() {
+        return default_image.to_string();
+    }
+    default_tensorlake_image()
+}
+
+fn reject_unsupported_mounts(request: &SandboxRequest) -> Result<()> {
+    if !request.spec.mounts.is_empty() {
+        bail!(
+            "Tensorlake sandbox backend does not support host bind-mounts; \
+             remove conversation mounts or use a local sandbox provider"
+        );
+    }
+    if !request.spec.durable_file_systems.is_empty() {
+        bail!("Tensorlake sandbox backend does not support durable file systems");
+    }
+    Ok(())
+}
+
+#[derive(Debug, Serialize)]
+struct CreateSandboxBody {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    image: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    snapshot_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    resources: Option<SandboxResourceOverrides>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    timeout_secs: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    network: Option<SandboxNetworkAccessControl>,
+}
+
+#[derive(Debug, Serialize)]
+struct SandboxResourceOverrides {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cpus: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    memory_mb: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+struct SandboxNetworkAccessControl {
+    allow_internet_access: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct SnapshotSandboxBody {
+    snapshot_type: &'static str,
+}
+
+#[derive(Debug, Deserialize)]
+struct SnapshotSandboxResponse {
+    snapshot_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateSandboxResponse {
+    sandbox_id: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum SandboxStatus {
+    Pending,
+    Running,
+    Snapshotting,
+    Suspending,
+    Suspended,
+    Terminated,
+}
+
+#[derive(Debug, Deserialize)]
+struct SandboxInfo {
+    id: String,
+    status: SandboxStatus,
+    #[serde(default)]
+    pending_reason: Option<String>,
+    #[serde(default)]
+    outcome: Option<String>,
+    #[serde(default)]
+    sandbox_url: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct RunProcessBody {
+    command: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    args: Vec<String>,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    env: HashMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    working_dir: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    timeout: Option<f64>,
+}
+
+#[derive(Debug, Serialize)]
+struct StartProcessBody {
+    command: String,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    args: Vec<String>,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    env: HashMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    working_dir: Option<String>,
+    stdin_mode: &'static str,
+    stdout_mode: &'static str,
+    stderr_mode: &'static str,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ProcessOutputStream {
+    Stdout,
+    Stderr,
+}
+
+/// One `data:` frame from `/api/v1/processes/run`. The endpoint emits three
+/// shapes on the same stream — started, output, exited — distinguished by which
+/// fields are present.
+#[derive(Debug, Deserialize)]
+struct RunProcessEvent {
+    #[serde(default)]
+    started_at: Option<i64>,
+    #[serde(default)]
+    line: Option<String>,
+    #[serde(default)]
+    stream: Option<ProcessOutputStream>,
+    #[serde(default)]
+    exit_code: Option<i32>,
+    #[serde(default)]
+    signal: Option<i32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProcessOutputEvent {
+    #[serde(default)]
+    line: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ProcessStatus {
+    Running,
+    Exited,
+    Signaled,
+    OomKilled,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProcessInfo {
+    pid: i32,
+    status: ProcessStatus,
+    #[serde(default)]
+    exit_code: Option<i32>,
+    #[serde(default)]
+    signal: Option<i32>,
+}

--- a/crates/exoharness/src/sandbox_provider/vercel.rs
+++ b/crates/exoharness/src/sandbox_provider/vercel.rs
@@ -187,6 +187,29 @@ impl ManagedSandboxBackend for VercelSandboxBackend {
     ) -> Result<Arc<dyn ManagedSandboxHandle>> {
         bail!("restoring a Vercel sandbox from a snapshot is not implemented yet");
     }
+
+    async fn terminate(&self, request: SandboxRequest) -> Result<()> {
+        let spec_hash = sandbox_spec_hash(&request.spec);
+        let sandbox_name = vercel_sandbox_name(&request, &spec_hash);
+        let response = self
+            .client
+            .delete(self.api_endpoint(&format!("/v2/sandboxes/{sandbox_name}")))
+            .query(&[
+                ("teamId", self.team_id.as_str()),
+                ("projectId", self.project_id.as_str()),
+            ])
+            .send()
+            .await
+            .with_context(|| format!("deleting Vercel sandbox {sandbox_name}"))?;
+        if response.status().is_success()
+            || matches!(response.status(), StatusCode::NOT_FOUND | StatusCode::GONE)
+        {
+            return Ok(());
+        }
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        bail!("Vercel delete-sandbox failed ({status}): {text}")
+    }
 }
 
 impl VercelSandboxBackend {

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -654,6 +654,7 @@ pub enum SandboxProvider {
     Daytona,
     E2b,
     Sprites,
+    Tensorlake,
     Vercel,
     #[serde(rename = "aws_agentcore", alias = "aws-agentcore")]
     AwsAgentCore,
@@ -677,6 +678,7 @@ impl SandboxProvider {
             Self::Daytona => "daytona",
             Self::E2b => "e2b",
             Self::Sprites => "sprites",
+            Self::Tensorlake => "tensorlake",
             Self::Vercel => "vercel",
             Self::AwsAgentCore => "aws-agentcore",
             Self::AppleContainer => "apple-container",
@@ -701,6 +703,7 @@ impl FromStr for SandboxProvider {
             "daytona" => Ok(Self::Daytona),
             "e2b" => Ok(Self::E2b),
             "sprites" => Ok(Self::Sprites),
+            "tensorlake" => Ok(Self::Tensorlake),
             "vercel" => Ok(Self::Vercel),
             "aws-agentcore" | "aws_agentcore" => Ok(Self::AwsAgentCore),
             "apple-container" | "apple_container" => Ok(Self::AppleContainer),
@@ -1000,6 +1003,19 @@ pub enum SandboxProviderConfig {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         labels: Vec<String>,
     },
+    Tensorlake {
+        api_key_secret_id: SecretId,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        api_url: Option<String>,
+        #[serde(default = "crate::sandbox_provider::default_tensorlake_image")]
+        default_image: String,
+        /// Whole CPU cores per sandbox. Unset uses the Tensorlake default.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cpus: Option<u32>,
+        /// Memory per sandbox in MiB. Unset uses the Tensorlake default.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        memory_mb: Option<u64>,
+    },
     #[serde(rename = "aws_agentcore", alias = "aws-agentcore")]
     AwsAgentCore {
         runtime_arn: String,
@@ -1025,6 +1041,7 @@ impl SandboxProviderConfig {
             Self::Daytona { .. } => SandboxProvider::Daytona,
             Self::E2b { .. } => SandboxProvider::E2b,
             Self::Sprites { .. } => SandboxProvider::Sprites,
+            Self::Tensorlake { .. } => SandboxProvider::Tensorlake,
             Self::Vercel { .. } => SandboxProvider::Vercel,
             Self::Docker { .. } => SandboxProvider::Docker,
             Self::AwsAgentCore { .. } => SandboxProvider::AwsAgentCore,
@@ -1038,6 +1055,7 @@ impl SandboxProviderConfig {
             | Self::Vercel { default_image, .. }
             | Self::Docker { default_image, .. }
             | Self::E2b { default_image, .. }
+            | Self::Tensorlake { default_image, .. }
             | Self::AwsAgentCore { default_image, .. } => Some(default_image),
             Self::Sprites { .. } => None,
         }

--- a/docs/sandbox-snapshots.md
+++ b/docs/sandbox-snapshots.md
@@ -1,8 +1,8 @@
 # Sandbox Snapshots
 
-Status: implemented for the Docker, E2B, Sprites, and Daytona sandbox
-backends; stubs in place for the others. Daytona can additionally restore a
-Docker snapshot (the cross-provider "teleport" bridge).
+Status: implemented for the Docker, E2B, Sprites, Tensorlake, and Daytona
+sandbox backends; stubs in place for the others. Daytona can additionally
+restore a Docker snapshot (the cross-provider "teleport" bridge).
 
 ## Summary
 

--- a/website/docs-src/concepts/sandboxes.md
+++ b/website/docs-src/concepts/sandboxes.md
@@ -20,6 +20,7 @@ plus arbitrary command execution inside them.
 | `daytona` | Remote | [daytona.io](https://www.daytona.io) |
 | `e2b` | Remote | [e2b.dev](https://e2b.dev) |
 | `sprites` | Remote | [sprites.dev](https://sprites.dev) |
+| `tensorlake` | Remote | [Tensorlake Sandboxes](https://docs.tensorlake.ai/sandboxes/introduction) |
 | `vercel` | Remote | [Vercel Sandbox](https://vercel.com/docs/vercel-sandbox) |
 | `aws-agentcore` | Remote | [Amazon Bedrock AgentCore](https://aws.amazon.com/bedrock/agentcore/) |
 

--- a/website/docs-src/getting-started/sandboxed-conversation.md
+++ b/website/docs-src/getting-started/sandboxed-conversation.md
@@ -36,7 +36,8 @@ Local backends are selected with `--sandbox-backend` (or
   Use it only when you trust the agent and the task.
 :::
 
-Remote sandbox providers (Daytona, E2B, Vercel, Sprites, AWS AgentCore) are
+Remote sandbox providers (Daytona, E2B, Vercel, Sprites, Tensorlake, AWS
+AgentCore) are
 configured as *provider bindings*:
 
 ```bash


### PR DESCRIPTION
Adds `tensorlake` alongside Daytona, E2B, Sprites, Vercel, and AgentCore. Tensorlake sandboxes are Firecracker MicroVMs that can suspend and resume with their filesystem intact, which lines up with how Exo conversation sandboxes behave across sessions.

## Trying it

Point Exo at a Tensorlake key and configure the provider:

```console
exo secret set TENSORLAKE_API_KEY --env TENSORLAKE_API_KEY
exo provider configure --provider tensorlake --secret TENSORLAKE_API_KEY
exo agent create tl-demo --model gpt --sandbox-provider tensorlake --networking enabled
exo conversation create tl-demo demo
```

Nothing is provisioned until something first needs the sandbox. A quick test without a model call:

```console
exo conversation sandbox run tl-demo demo "cat /etc/os-release | head -2; uname -m; nproc"
exo conversation sandbox run tl-demo demo "echo 'state survives across processes' > /tmp/note.txt"
exo conversation sandbox run tl-demo demo "cat /tmp/note.txt"
```

Streaming processes work too, so `--shell-program /bin/bash` in the REPL behaves as it does on other providers.

## Lifecycle

This PR now builds on the attach/detach lifecycle from #161:

- `ManagedSandboxBackend` gains idempotent `terminate` and optional `fork_sandbox` APIs.
- Deleting a conversation permanently terminates its provider-owned sandboxes; deleting an agent also sweeps its agent-scoped sandbox and every owned conversation sandbox.
- Forking a conversation asks the provider to copy each live sandbox under the fork's owner key. Tensorlake implements this with its sandbox copy API; unsupported providers retain the existing cold-start behavior.
- Externally attached sandboxes remain borrowed: a fork records them as detached, and owner deletion never terminates the external resource.
- In-memory sandbox and process registries are owner-scoped, so a parent and fork cannot accidentally share a live handle merely because their persisted sandbox IDs match.

Every existing backend implements termination. Remote providers use their permanent delete/stop APIs, container backends remove their Exo-owned container, and local-process termination is a no-op.

## How Tensorlake resume and fork work

Tensorlake creates have no label or metadata field, and only named sandboxes can suspend and resume. Each sandbox therefore gets a deterministic `exo-<hash>` name derived from its `SandboxKey` and spec hash. Agent-scoped and conversation-scoped sandboxes hash differently; changing the image or mounts yields a different name.

`stop` suspends named sandboxes so filesystem state survives. Snapshots are stored by reference and are not persisted until Tensorlake reports them as restorable. Conversation forks copy a live named sandbox directly to the deterministic name derived for the target conversation, leaving the parent untouched.

Configuration lives on the binding, including optional `--cpus` and `--memory-mb`. Credentials resolve lazily from `TENSORLAKE_API_KEY`, so the provider can be registered before a key is set.

## Validation

- `cargo test -p exo --test tensorlake_backend` — 28 passed
- `cargo test -p exoharness --features basic-backend -- --test-threads=1` — 67 passed, 7 real-provider tests ignored
- `cargo check --workspace --all-targets`
- `cargo fmt --all -- --check`

## Known gaps

- Tensorlake rejects host bind mounts and durable filesystems; use a local provider when those are required.
- Tensorlake's process API frames output as lines, so a trailing partial line arrives only after a newline or process exit, and `exec` output always ends with one.
