### PR TITLE
docs: link ExoWorker from the main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,17 +51,6 @@ For a more complete description of the architectural philosophy read
 
 <!-- ![Exo playinb pokemon go](docs/images/exo_playing.gif) -->
 
-## Human-created Exos
-
-- [ExoWorker](https://github.com/exoharness/exo/tree/exo-worker/examples/exo-worker)
-  is a long-running autonomous worker with task-tree planning, durable memory,
-  adapters, scheduling, and host-injected tools.
-- [Gameboy Agent](examples/gameboy-agent/) gives Exo an emulator sidecar and
-  tools for playing Game Boy games.
-
-Building your own Exo? Share it with us on
-[Discord](https://discord.gg/8x23hdBJU6).
-
 ## Quick Start
 
 Exo was designed to be incredibly simple to use. With just a few commands you
@@ -198,6 +187,19 @@ There are a number of prompt files that Exo uses during runtime. You can edit th
 
 After changing prompt files, ask Exo to rebuild/restart itself for them to go in
 use.
+
+## Human-created Exos
+Exo can be extended manually with explicit capabilities as desired, as in these examples:
+Beyond built-in capabilities, Exo also supports human-authored extensions that add explicit, task-specific functionality, as shown in these examples:
+
+- [ExoWorker](https://github.com/exoharness/exo/tree/exo-worker/examples/exo-worker)
+  is a long-running autonomous worker with task-tree planning, durable memory,
+  adapters, scheduling, and host-injected tools.
+- [Gameboy Agent](examples/gameboy-agent/) gives Exo an emulator sidecar and
+  tools for playing Game Boy games.
+
+Building your own Exo? Share it with us on
+[Discord](https://discord.gg/8x23hdBJU6).
 
 ## Ongoing Work
 

--- a/README.md
+++ b/README.md
@@ -189,8 +189,9 @@ After changing prompt files, ask Exo to rebuild/restart itself for them to go in
 use.
 
 ## Human-created Exos
-Exo can be extended manually with explicit capabilities as desired, as in these examples:
-Beyond built-in capabilities, Exo also supports human-authored extensions that add explicit, task-specific functionality, as shown in these examples:
+
+Beyond built-in capabilities, Exo also supports human-authored extensions that
+add explicit, task-specific functionality, as shown in these examples:
 
 - [ExoWorker](https://github.com/exoharness/exo/tree/exo-worker/examples/exo-worker)
   is a long-running autonomous worker with task-tree planning, durable memory,

--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ For a more complete description of the architectural philosophy read
 
 <!-- ![Exo playinb pokemon go](docs/images/exo_playing.gif) -->
 
+## Human-created Exos
+
+- [ExoWorker](https://github.com/exoharness/exo/tree/exo-worker/examples/exo-worker)
+  is a long-running autonomous worker with task-tree planning, durable memory,
+  adapters, scheduling, and host-injected tools.
+- [Gameboy Agent](examples/gameboy-agent/) gives Exo an emulator sidecar and
+  tools for playing Game Boy games.
+
+Building your own Exo? Share it with us on
+[Discord](https://discord.gg/8x23hdBJU6).
+
 ## Quick Start
 
 Exo was designed to be incredibly simple to use. With just a few commands you


### PR DESCRIPTION
## Summary
- add a concise “Human-created Exos” section to the main README
- link ExoWorker on the dedicated official `exo-worker` branch
- highlight the existing Gameboy Agent and invite community submissions through Discord

## Test plan
- [x] `pnpm check` (12 test files, 121 tests)
- [x] Verify the ExoWorker branch URL and local Gameboy Agent link

Made with [Cursor](https://cursor.com)