### PR TITLE
setup: reuse existing checkout when run from inside the repo

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -404,7 +404,17 @@ missing_has() {
 
 is_exo_checkout() {
   local dir="$1"
-  [[ -d "$dir/.git" && -f "$dir/exo.sh" ]]
+  # .git is a file (not a directory) in worktrees and submodules.
+  [[ -e "$dir/.git" && -f "$dir/exo.sh" ]]
+}
+
+exo_checkout_root() {
+  # Print the root of the Exo checkout containing $PWD, if any.
+  local toplevel
+  toplevel="$(git rev-parse --show-toplevel 2>/dev/null)" || return 1
+  [[ -n "$toplevel" ]] || return 1
+  is_exo_checkout "$toplevel" || return 1
+  printf '%s' "$toplevel"
 }
 
 prompt_yes_no() {
@@ -628,9 +638,10 @@ trust_mise_config() {
 }
 
 choose_install_dir() {
-  if is_exo_checkout "$PWD"; then
-    echo "Using current Exo checkout: $PWD" >&2
-    printf '%s' "$PWD"
+  local checkout_root
+  if checkout_root="$(exo_checkout_root)"; then
+    echo "Using current Exo checkout: $checkout_root" >&2
+    printf '%s' "$checkout_root"
     return
   fi
   if [[ -n "${EXO_INSTALL_DIR:-}" ]]; then


### PR DESCRIPTION
Running `bash setup.sh` from inside an already-cloned exo repo cloned a fresh copy into a new `exo/` subfolder instead of using the code already there.

Two fixes in `choose_install_dir`'s checkout detection:
- `is_exo_checkout` required `.git` to be a directory, which fails in git worktrees (`.git` is a file there). Now checks `-e`.
- Detection only worked at the repo root. New `exo_checkout_root` uses `git rev-parse --show-toplevel`, so setup run from any subdirectory reuses the containing checkout's root.

The curl-piped install flow outside a checkout is unchanged.