### PR TITLE
exo: file edit tools chosen per model family

### DIFF
--- a/examples/exo/edit-tools.test.ts
+++ b/examples/exo/edit-tools.test.ts
@@ -1,0 +1,820 @@
+import { describe, expect, it } from "vitest";
+
+import type { SandboxProcess } from "@exo/harness";
+
+import {
+  applyHunks,
+  applyStrReplace,
+  createEditToolInstances,
+  editToolsForFamily,
+  parseApplyPatch,
+  readSandboxFile,
+  validatePath,
+  writeSandboxFile,
+} from "./edit-tools";
+
+describe("editToolsForFamily", () => {
+  it("gives each family the shape it was post-trained on", () => {
+    expect(editToolsForFamily("anthropic")).toBe("str_replace");
+    expect(editToolsForFamily("openai")).toBe("apply_patch");
+  });
+
+  it("defaults unknown families to str_replace", () => {
+    expect(editToolsForFamily("unknown")).toBe("str_replace");
+  });
+});
+
+describe("applyStrReplace", () => {
+  it("replaces a unique match", () => {
+    const result = applyStrReplace("a\nb\nc\n", "b", "B");
+    expect(result).toEqual({ ok: true, contents: "a\nB\nc\n" });
+  });
+
+  it("preserves surrounding bytes exactly", () => {
+    const result = applyStrReplace("  indented(  )\n", "(  )", "(x)");
+    expect(result).toEqual({ ok: true, contents: "  indented(x)\n" });
+  });
+
+  it("rejects a missing match rather than writing nothing silently", () => {
+    const result = applyStrReplace("a\nb\n", "zzz", "x");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("not found");
+    }
+  });
+
+  it("rejects an ambiguous match and reports the count", () => {
+    // This is the case sed gets wrong: it would edit the first, or all.
+    const result = applyStrReplace("x\nx\nx\n", "x", "y");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("3 places");
+    }
+  });
+
+  it("rejects an empty old_string", () => {
+    expect(applyStrReplace("a", "", "b").ok).toBe(false);
+  });
+
+  it("rejects a no-op replacement", () => {
+    expect(applyStrReplace("a", "a", "a").ok).toBe(false);
+  });
+
+  it("allows deleting text", () => {
+    expect(applyStrReplace("keep drop", " drop", "")).toEqual({
+      ok: true,
+      contents: "keep",
+    });
+  });
+});
+
+describe("validatePath", () => {
+  it("accepts absolute paths", () => {
+    expect(validatePath("/workspace/exo/examples/exo/harness.ts")).toBeNull();
+  });
+
+  it("rejects relative paths so the process cwd never matters", () => {
+    expect(validatePath("examples/exo/harness.ts")).toContain("absolute");
+  });
+
+  it("rejects traversal segments", () => {
+    expect(validatePath("/workspace/exo/../etc/passwd")).toContain("..");
+  });
+
+  it("rejects an empty path", () => {
+    expect(validatePath("")).toContain("empty");
+  });
+});
+
+describe("parseApplyPatch", () => {
+  it("parses an update with context", () => {
+    const parsed = parseApplyPatch(
+      [
+        "*** Begin Patch",
+        "*** Update File: /workspace/exo/a.ts",
+        "@@ function f()",
+        " const a = 1;",
+        "-const b = 2;",
+        "+const b = 3;",
+        "*** End Patch",
+      ].join("\n"),
+    );
+    expect(parsed).toEqual({
+      ok: true,
+      ops: [
+        {
+          kind: "update",
+          path: "/workspace/exo/a.ts",
+          moveTo: null,
+          hunks: [
+            {
+              changeContext: "function f()",
+              before: ["const a = 1;", "const b = 2;"],
+              after: ["const a = 1;", "const b = 3;"],
+              endOfFile: false,
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("splits hunks on @@ markers", () => {
+    const parsed = parseApplyPatch(
+      [
+        "*** Begin Patch",
+        "*** Update File: /a",
+        "@@",
+        "-one",
+        "+ONE",
+        "@@",
+        "-two",
+        "+TWO",
+        "*** End Patch",
+      ].join("\n"),
+    );
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok && parsed.ops[0].kind === "update") {
+      expect(parsed.ops[0].hunks).toHaveLength(2);
+    }
+  });
+
+  it("parses add and delete operations", () => {
+    const parsed = parseApplyPatch(
+      [
+        "*** Begin Patch",
+        "*** Add File: /new.ts",
+        "+export const x = 1;",
+        "+",
+        "*** Delete File: /old.ts",
+        "*** End Patch",
+      ].join("\n"),
+    );
+    expect(parsed).toEqual({
+      ok: true,
+      ops: [
+        { kind: "add", path: "/new.ts", contents: "export const x = 1;\n\n" },
+        { kind: "delete", path: "/old.ts" },
+      ],
+    });
+  });
+
+  it("accepts CRLF input", () => {
+    const parsed = parseApplyPatch(
+      "*** Begin Patch\r\n*** Delete File: /a\r\n*** End Patch\r\n",
+    );
+    expect(parsed.ok).toBe(true);
+  });
+
+  it("requires the envelope", () => {
+    expect(parseApplyPatch("*** Update File: /a\n-x\n+y\n").ok).toBe(false);
+    expect(parseApplyPatch("*** Begin Patch\n*** Delete File: /a\n").ok).toBe(
+      false,
+    );
+  });
+
+  it("rejects relative paths inside the patch", () => {
+    const parsed = parseApplyPatch(
+      "*** Begin Patch\n*** Delete File: relative.ts\n*** End Patch",
+    );
+    expect(parsed.ok).toBe(false);
+  });
+
+  it("rejects unprefixed body lines", () => {
+    const parsed = parseApplyPatch(
+      "*** Begin Patch\n*** Update File: /a\nbare line\n*** End Patch",
+    );
+    expect(parsed.ok).toBe(false);
+  });
+
+  // Real codex directives; failing to parse them would reject valid patches.
+  it('parses "*** End of File" as an anchor rather than rejecting', () => {
+    const parsed = parseApplyPatch(
+      [
+        "*** Begin Patch",
+        "*** Update File: /a",
+        "-last",
+        "+LAST",
+        "*** End of File",
+        "*** End Patch",
+      ].join("\n"),
+    );
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok && parsed.ops[0].kind === "update") {
+      expect(parsed.ops[0].hunks[0].endOfFile).toBe(true);
+    }
+  });
+
+  it('parses "*** Move to:" as a rename', () => {
+    const parsed = parseApplyPatch(
+      [
+        "*** Begin Patch",
+        "*** Update File: /old.ts",
+        "*** Move to: /new.ts",
+        "-x",
+        "+y",
+        "*** End Patch",
+      ].join("\n"),
+    );
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok && parsed.ops[0].kind === "update") {
+      expect(parsed.ops[0].moveTo).toBe("/new.ts");
+    }
+  });
+
+  it("rejects an empty patch", () => {
+    expect(parseApplyPatch("*** Begin Patch\n*** End Patch").ok).toBe(false);
+  });
+
+  // codex keeps a trailing blank as context; apply time retries without it.
+  it("keeps a trailing blank line as context", () => {
+    const parsed = parseApplyPatch(
+      [
+        "*** Begin Patch",
+        "*** Update File: /a",
+        "-one",
+        "+ONE",
+        "",
+        "*** End Patch",
+      ].join("\n"),
+    );
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok && parsed.ops[0].kind === "update") {
+      expect(parsed.ops[0].hunks[0].before).toEqual(["one", ""]);
+    }
+  });
+
+  it("records the text after @@ as the chunk's context", () => {
+    const parsed = parseApplyPatch(
+      [
+        "*** Begin Patch",
+        "*** Update File: /a",
+        "@@ def f():",
+        "-x",
+        "+y",
+        "*** End Patch",
+      ].join("\n"),
+    );
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok && parsed.ops[0].kind === "update") {
+      expect(parsed.ops[0].hunks[0].changeContext).toBe("def f():");
+    }
+  });
+
+  // Add File body lines must carry "+"; a bare blank is an error.
+  it("rejects a bare blank line in an Add File body", () => {
+    const parsed = parseApplyPatch(
+      [
+        "*** Begin Patch",
+        "*** Add File: /new.ts",
+        "+x",
+        "",
+        "*** End Patch",
+      ].join("\n"),
+    );
+    expect(parsed.ok).toBe(false);
+  });
+
+  // " " is context and "+" an added blank; only bare "" is a separator.
+  it("keeps deliberately marked blank lines", () => {
+    const parsed = parseApplyPatch(
+      [
+        "*** Begin Patch",
+        "*** Update File: /a",
+        " one",
+        " ",
+        "-two",
+        "+TWO",
+        "*** End Patch",
+      ].join("\n"),
+    );
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok && parsed.ops[0].kind === "update") {
+      expect(parsed.ops[0].hunks[0].before).toEqual(["one", "", "two"]);
+    }
+  });
+
+  it("keeps interior blank lines as context", () => {
+    const parsed = parseApplyPatch(
+      [
+        "*** Begin Patch",
+        "*** Update File: /a",
+        " one",
+        "",
+        "-two",
+        "+TWO",
+        "*** End Patch",
+      ].join("\n"),
+    );
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok && parsed.ops[0].kind === "update") {
+      expect(parsed.ops[0].hunks[0].before).toEqual(["one", "", "two"]);
+    }
+  });
+
+  it("tolerates trailing whitespace on the envelope markers", () => {
+    const parsed = parseApplyPatch(
+      "*** Begin Patch  \n*** Delete File: /a\n*** End Patch  ",
+    );
+    expect(parsed.ok).toBe(true);
+  });
+
+  // Leading whitespace is content: " *** x" is not a directive.
+  it("does not treat an indented directive-like line as a directive", () => {
+    const parsed = parseApplyPatch(
+      [
+        "*** Begin Patch",
+        "*** Update File: /a",
+        " *** not a directive",
+        "-x",
+        "+y",
+        "*** End Patch",
+      ].join("\n"),
+    );
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok && parsed.ops[0].kind === "update") {
+      expect(parsed.ops[0].hunks[0].before).toEqual([
+        "*** not a directive",
+        "x",
+      ]);
+    }
+  });
+});
+
+describe("applyHunks", () => {
+  it("applies a unique hunk", () => {
+    const result = applyHunks("one\ntwo\nthree\n", [
+      {
+        changeContext: null,
+        before: ["two"],
+        after: ["TWO"],
+        endOfFile: false,
+      },
+    ]);
+    expect(result).toEqual({ ok: true, contents: "one\nTWO\nthree\n" });
+  });
+
+  it("applies several hunks in order", () => {
+    const result = applyHunks("a\nb\nc\n", [
+      { changeContext: null, before: ["a"], after: ["A"], endOfFile: false },
+      { changeContext: null, before: ["c"], after: ["C"], endOfFile: false },
+    ]);
+    expect(result).toEqual({ ok: true, contents: "A\nb\nC\n" });
+  });
+
+  it("applies to the first match, as apply_patch is positional", () => {
+    expect(
+      applyHunks("x\ny\nx\n", [
+        { changeContext: null, before: ["x"], after: ["z"], endOfFile: false },
+      ]),
+    ).toEqual({
+      ok: true,
+      contents: "z\ny\nx\n",
+    });
+  });
+
+  it("rejects a hunk whose context is absent", () => {
+    const result = applyHunks("a\n", [
+      { changeContext: null, before: ["nope"], after: ["x"], endOfFile: false },
+    ]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("not found");
+    }
+  });
+
+  it("appends a chunk that has no context lines", () => {
+    // codex treats empty old_lines as a pure addition at end of file.
+    expect(
+      applyHunks("a\n", [
+        { changeContext: null, before: [], after: ["added"], endOfFile: false },
+      ]),
+    ).toEqual({ ok: true, contents: "a\nadded\n" });
+  });
+
+  it("seeks past @@ context before matching", () => {
+    // "x" appears in both functions; the context picks the second.
+    expect(
+      applyHunks("function a() {\nx\n}\nfunction b() {\nx\n}\n", [
+        {
+          changeContext: "function b() {",
+          before: ["x"],
+          after: ["FOUND"],
+          endOfFile: false,
+        },
+      ]),
+    ).toEqual({
+      ok: true,
+      contents: "function a() {\nx\n}\nfunction b() {\nFOUND\n}\n",
+    });
+  });
+
+  it("retries without a trailing empty context line", () => {
+    // Direct search fails on the trailing ""; the retry without it succeeds.
+    expect(
+      applyHunks("a\nb\n", [
+        {
+          changeContext: null,
+          before: ["b", ""],
+          after: ["B", ""],
+          endOfFile: false,
+        },
+      ]),
+    ).toEqual({ ok: true, contents: "a\nB\n" });
+  });
+
+  it("can delete lines", () => {
+    expect(
+      applyHunks("a\nb\nc\n", [
+        { changeContext: null, before: ["b"], after: [], endOfFile: false },
+      ]),
+    ).toEqual({
+      ok: true,
+      contents: "a\nc\n",
+    });
+  });
+
+  // A hunk can open on a blank, so quoting before[0] would say `not found: ""`.
+  it("quotes the first line with content when context is missing", () => {
+    const result = applyHunks("a\n", [
+      {
+        changeContext: null,
+        before: ["", "missing line"],
+        after: ["x"],
+        endOfFile: false,
+      },
+    ]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("missing line");
+    }
+  });
+
+  it("matches when the patch differs only in trailing whitespace", () => {
+    expect(
+      applyHunks("const a = 1;   \nconst b = 2;\n", [
+        {
+          changeContext: null,
+          before: ["const a = 1;"],
+          after: ["const a = 9;"],
+          endOfFile: false,
+        },
+      ]),
+    ).toEqual({ ok: true, contents: "const a = 9;\nconst b = 2;\n" });
+  });
+
+  it("matches when the patch differs only in indentation", () => {
+    expect(
+      applyHunks("    indented();\n", [
+        {
+          changeContext: null,
+          before: ["indented();"],
+          after: ["  moved();"],
+          endOfFile: false,
+        },
+      ]),
+    ).toEqual({ ok: true, contents: "  moved();\n" });
+  });
+
+  // A model writes an EN DASH where the file has a plain hyphen.
+  it("matches across typographic punctuation", () => {
+    expect(
+      applyHunks("// a - b\n", [
+        {
+          changeContext: null,
+          before: ["// a \u2013 b"],
+          after: ["// a + b"],
+          endOfFile: false,
+        },
+      ]),
+    ).toEqual({ ok: true, contents: "// a + b\n" });
+  });
+
+  it("matches across curly quotes", () => {
+    expect(
+      applyHunks('const s = "hi";\n', [
+        {
+          changeContext: null,
+          before: ["const s = \u201chi\u201d;"],
+          after: ['const s = "bye";'],
+          endOfFile: false,
+        },
+      ]),
+    ).toEqual({ ok: true, contents: 'const s = "bye";\n' });
+  });
+
+  it("prefers an exact match over a relaxed one", () => {
+    // The exact pass wins before any relaxation is considered.
+    expect(
+      applyHunks("x\n  x\n", [
+        {
+          changeContext: null,
+          before: ["x"],
+          after: ["EXACT"],
+          endOfFile: false,
+        },
+      ]),
+    ).toEqual({ ok: true, contents: "EXACT\n  x\n" });
+  });
+
+  it("edits two identical lines in sequence", () => {
+    // Editing the same text in two places is normal; uniqueness would reject it.
+    expect(
+      applyHunks("x\nx\n", [
+        { changeContext: null, before: ["x"], after: ["A"], endOfFile: false },
+        { changeContext: null, before: ["x"], after: ["B"], endOfFile: false },
+      ]),
+    ).toEqual({ ok: true, contents: "A\nB\n" });
+  });
+
+  it("anchors an end-of-file hunk at the tail", () => {
+    // "x" appears twice; the anchor picks the last one rather than the first.
+    expect(
+      applyHunks("x\ny\nx\n", [
+        {
+          changeContext: null,
+          before: ["x"],
+          after: ["LAST"],
+          endOfFile: true,
+        },
+      ]),
+    ).toEqual({ ok: true, contents: "x\ny\nLAST\n" });
+  });
+
+  it("tolerates a trailing newline when anchoring at the tail", () => {
+    // "a\nb\n" splits with a trailing ""; the last content line sits before it.
+    expect(
+      applyHunks("a\nb\n", [
+        { changeContext: null, before: ["b"], after: ["B"], endOfFile: true },
+      ]),
+    ).toEqual({ ok: true, contents: "a\nB\n" });
+  });
+
+  it("never matches behind the cursor", () => {
+    // An out-of-order patch is refused, not silently misapplied.
+    const result = applyHunks("first\nsecond\n", [
+      {
+        changeContext: null,
+        before: ["second"],
+        after: ["SECOND"],
+        endOfFile: false,
+      },
+      {
+        changeContext: null,
+        before: ["first"],
+        after: ["FIRST"],
+        endOfFile: false,
+      },
+    ]);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain("first");
+    }
+  });
+});
+
+// In-memory sandbox fake; records commands so tests can assert on invocation.
+function streamOf(text: string): ReadableStream<string> {
+  return new ReadableStream<string>({
+    start(controller) {
+      if (text.length > 0) {
+        controller.enqueue(text);
+      }
+      controller.close();
+    },
+  });
+}
+
+interface FakeRun {
+  stdout?: string;
+  stderr?: string;
+  exitCode: number | null;
+}
+
+class FakeSandbox {
+  readonly commands: string[][] = [];
+  readonly stdin: string[] = [];
+  closed = 0;
+
+  constructor(private readonly run: (command: string[]) => FakeRun) {}
+
+  startSandboxProcess = async (request: {
+    command: string[];
+  }): Promise<SandboxProcess> => {
+    this.commands.push(request.command);
+    const result = this.run(request.command);
+    const stdin = this.stdin;
+    const markClosed = (): void => {
+      this.closed += 1;
+    };
+    return {
+      reused: false,
+      stdout: streamOf(result.stdout ?? ""),
+      stderr: streamOf(result.stderr ?? ""),
+      async writeStdin(data: string) {
+        stdin.push(data);
+      },
+      async closeStdin() {},
+      async close() {
+        markClosed();
+      },
+      async wait() {
+        return result.exitCode;
+      },
+    };
+  };
+}
+
+describe("readSandboxFile", () => {
+  it("returns file contents on success", async () => {
+    const sandbox = new FakeSandbox(() => ({
+      stdout: "hello\nworld\n",
+      exitCode: 0,
+    }));
+    await expect(readSandboxFile(sandbox, "/a.ts")).resolves.toEqual({
+      exists: true,
+      contents: "hello\nworld\n",
+    });
+  });
+
+  it("reports a missing file without throwing", async () => {
+    const sandbox = new FakeSandbox(() => ({ exitCode: 66 }));
+    await expect(readSandboxFile(sandbox, "/gone.ts")).resolves.toEqual({
+      exists: false,
+      contents: "",
+    });
+  });
+
+  it("throws with stderr text on an unexpected failure", async () => {
+    const sandbox = new FakeSandbox(() => ({
+      stderr: "is a directory\n",
+      exitCode: 1,
+    }));
+    await expect(readSandboxFile(sandbox, "/dir")).rejects.toThrow(
+      "is a directory",
+    );
+  });
+
+  it("treats a null exit code as failure", async () => {
+    const sandbox = new FakeSandbox(() => ({ exitCode: null }));
+    await expect(readSandboxFile(sandbox, "/a")).rejects.toThrow(
+      "failed to read",
+    );
+  });
+
+  it("refuses binary files", async () => {
+    const sandbox = new FakeSandbox(() => ({
+      stdout: "text\0binary",
+      exitCode: 0,
+    }));
+    await expect(readSandboxFile(sandbox, "/a.png")).rejects.toThrow("binary");
+  });
+
+  it("refuses a file over the size cap", async () => {
+    const sandbox = new FakeSandbox(() => ({
+      stdout: "x".repeat(2_000_001),
+      exitCode: 0,
+    }));
+    await expect(readSandboxFile(sandbox, "/big")).rejects.toThrow("exceeds");
+    expect(sandbox.closed).toBe(1);
+  });
+
+  it("closes the process even when it throws", async () => {
+    const sandbox = new FakeSandbox(() => ({
+      stdout: "\0",
+      exitCode: 0,
+    }));
+    await expect(readSandboxFile(sandbox, "/a")).rejects.toThrow();
+    expect(sandbox.closed).toBe(1);
+  });
+
+  // The path is a positional "$1", never spliced into the script text.
+  it("passes the path as a positional argument, not interpolated", async () => {
+    const sandbox = new FakeSandbox(() => ({ exitCode: 66 }));
+    const nasty = '/tmp/a";rm -rf /;"';
+    await readSandboxFile(sandbox, nasty);
+    const command = sandbox.commands[0];
+    expect(command[0]).toBe("sh");
+    expect(command[1]).toBe("-c");
+    expect(command[2]).not.toContain("rm -rf");
+    expect(command[command.length - 1]).toBe(nasty);
+  });
+});
+
+describe("writeSandboxFile", () => {
+  it("sends the contents on stdin and succeeds on exit 0", async () => {
+    const sandbox = new FakeSandbox(() => ({ exitCode: 0 }));
+    await writeSandboxFile(sandbox, "/a.ts", "new contents\n");
+    expect(sandbox.stdin).toEqual(["new contents\n"]);
+    expect(sandbox.closed).toBe(1);
+  });
+
+  it("writes via a temp file and renames", async () => {
+    const sandbox = new FakeSandbox(() => ({ exitCode: 0 }));
+    await writeSandboxFile(sandbox, "/a.ts", "x");
+    const script = sandbox.commands[0][2];
+    expect(script).toContain(".exo-edit-tmp");
+    expect(script).toContain("mv --");
+    // The temp file must be cleaned up on failure.
+    expect(script).toContain("rm -f --");
+  });
+
+  it("throws with stderr text on failure", async () => {
+    const sandbox = new FakeSandbox(() => ({
+      stderr: "no space left on device",
+      exitCode: 1,
+    }));
+    await expect(writeSandboxFile(sandbox, "/a.ts", "x")).rejects.toThrow(
+      "no space left on device",
+    );
+    expect(sandbox.closed).toBe(1);
+  });
+});
+
+describe("apply_patch handler", () => {
+  function applyPatchHandler() {
+    const [tool] = createEditToolInstances("openai");
+    return tool;
+  }
+
+  it("is the only tool registered for the OpenAI family", () => {
+    expect(applyPatchHandler().definition.name).toBe("apply_patch");
+  });
+
+  it("composes two blocks that touch the same file", () => {
+    // A second block on one file sees the first block's result.
+    const sandbox = new FakeSandbox((command) =>
+      command[2].includes("cat >")
+        ? { exitCode: 0 }
+        : { stdout: "one\ntwo\n", exitCode: 0 },
+    );
+    return applyPatchHandler()
+      .handler.execute(
+        {
+          patch: [
+            "*** Begin Patch",
+            "*** Update File: /a",
+            "-one",
+            "+ONE",
+            "*** Update File: /a",
+            "-two",
+            "+TWO",
+            "*** End Patch",
+          ].join("\n"),
+        },
+        { context: sandbox as never },
+      )
+      .then((result) => {
+        expect(result).toEqual({ ok: true, files_changed: 1 });
+        expect(sandbox.stdin).toEqual(["ONE\nTWO\n"]);
+      });
+  });
+
+  it("writes nothing when one hunk in a multi-file patch fails", async () => {
+    const sandbox = new FakeSandbox((command) => {
+      const path = command[command.length - 1];
+      return path === "/a"
+        ? { stdout: "one\n", exitCode: 0 }
+        : { stdout: "nope\n", exitCode: 0 };
+    });
+    const result = await applyPatchHandler().handler.execute(
+      {
+        patch: [
+          "*** Begin Patch",
+          "*** Update File: /a",
+          "-one",
+          "+ONE",
+          "*** Update File: /b",
+          "-missing",
+          "+x",
+          "*** End Patch",
+        ].join("\n"),
+      },
+      { context: sandbox as never },
+    );
+    expect(result).toMatchObject({ ok: false });
+    expect(sandbox.stdin).toEqual([]);
+  });
+
+  it("applies a valid single-file patch", async () => {
+    const sandbox = new FakeSandbox((command) =>
+      command[2].includes("cat >")
+        ? { exitCode: 0 }
+        : { stdout: "one\ntwo\n", exitCode: 0 },
+    );
+    const result = await applyPatchHandler().handler.execute(
+      {
+        patch: [
+          "*** Begin Patch",
+          "*** Update File: /a",
+          "-one",
+          "+ONE",
+          "*** End Patch",
+        ].join("\n"),
+      },
+      { context: sandbox as never },
+    );
+    expect(result).toEqual({ ok: true, files_changed: 1 });
+    expect(sandbox.stdin).toEqual(["ONE\ntwo\n"]);
+  });
+});

--- a/examples/exo/edit-tools.ts
+++ b/examples/exo/edit-tools.ts
@@ -1,0 +1,813 @@
+import type {
+  HarnessToolRegistry,
+  JsonObject,
+  ToolInstance,
+  ToolResult,
+  TurnContext,
+} from "@exo/harness";
+
+import { modelFamily, type ModelFamily } from "../typescript/model-family";
+
+// File editing tools, shape picked per model family: str_replace demands a
+// unique match, apply_patch takes the first match from a moving cursor as
+// codex does. Matching is host-side pure functions; the sandbox moves bytes.
+
+// Cap reads to protect host memory; tools return a confirmation, not the file.
+const MAX_FILE_CHARS = 2_000_000;
+// EX_NOINPUT: "missing" is distinguishable from "unreadable" without stderr parsing.
+const READ_MISSING_EXIT_CODE = 66;
+
+export type EditFamilyTools = "str_replace" | "apply_patch";
+
+// "unknown" (router aliases, self-hosted models) gets str_replace: a bad
+// match fails loudly, a bad patch envelope doesn't.
+export function editToolsForFamily(family: ModelFamily): EditFamilyTools {
+  return family === "openai" ? "apply_patch" : "str_replace";
+}
+
+export type EditOutcome =
+  | { ok: true; contents: string }
+  | { ok: false; error: string };
+
+export function applyStrReplace(
+  contents: string,
+  oldString: string,
+  newString: string,
+): EditOutcome {
+  if (oldString.length === 0) {
+    return { ok: false, error: "old_string must not be empty" };
+  }
+  if (oldString === newString) {
+    return { ok: false, error: "old_string and new_string are identical" };
+  }
+  const first = contents.indexOf(oldString);
+  if (first === -1) {
+    return {
+      ok: false,
+      error:
+        "old_string was not found in the file; read the file first and copy the exact text, including indentation",
+    };
+  }
+  if (contents.indexOf(oldString, first + oldString.length) !== -1) {
+    const count = countOccurrences(contents, oldString);
+    return {
+      ok: false,
+      error: `old_string matches ${count} places; include more surrounding context so it matches exactly one`,
+    };
+  }
+  return {
+    ok: true,
+    contents:
+      contents.slice(0, first) +
+      newString +
+      contents.slice(first + oldString.length),
+  };
+}
+
+function countOccurrences(haystack: string, needle: string): number {
+  let count = 0;
+  let index = haystack.indexOf(needle);
+  while (index !== -1) {
+    count += 1;
+    index = haystack.indexOf(needle, index + needle.length);
+  }
+  return count;
+}
+
+// One contiguous block and its replacement: context+removed lines in
+// `before`, context+added lines in `after`.
+export interface PatchHunk {
+  // Text after "@@" (codex's change_context), sought before matching `before`.
+  changeContext: string | null;
+  before: string[];
+  after: string[];
+  // Set by "*** End of File": `before` must sit at the end of the file.
+  endOfFile: boolean;
+}
+
+export type PatchOp =
+  | { kind: "add"; path: string; contents: string }
+  | { kind: "delete"; path: string }
+  | {
+      kind: "update";
+      path: string;
+      // "*** Move to: <path>": written there, the original removed.
+      moveTo: string | null;
+      hunks: PatchHunk[];
+    };
+
+export type PatchParse =
+  | { ok: true; ops: PatchOp[] }
+  | { ok: false; error: string };
+
+const BEGIN_PATCH = "*** Begin Patch";
+const END_PATCH = "*** End Patch";
+const ADD_FILE = "*** Add File: ";
+const DELETE_FILE = "*** Delete File: ";
+const UPDATE_FILE = "*** Update File: ";
+const MOVE_TO = "*** Move to: ";
+const CHANGE_CONTEXT = "@@ ";
+const CHANGE_CONTEXT_EMPTY = "@@";
+const END_OF_FILE = "*** End of File";
+
+// Codex's apply_patch envelope, ported from codex-rs/apply-patch. An
+// unrecognised directive rejects the whole patch.
+export function parseApplyPatch(patch: string): PatchParse {
+  const lines = patch.replace(/\r\n/g, "\n").split("\n");
+  let index = 0;
+  while (index < lines.length && lines[index].trim().length === 0) {
+    index += 1;
+  }
+  // Trailing whitespace on markers is tolerated; leading is not (" *** x" is content).
+  if ((lines[index] ?? "").trim() !== BEGIN_PATCH) {
+    return { ok: false, error: `patch must start with "${BEGIN_PATCH}"` };
+  }
+  index += 1;
+
+  const ops: PatchOp[] = [];
+  let sawEnd = false;
+  while (index < lines.length) {
+    const line = lines[index];
+    if (line.trimEnd() === END_PATCH) {
+      sawEnd = true;
+      index += 1;
+      break;
+    }
+    if (line.trim().length === 0) {
+      index += 1;
+      continue;
+    }
+    if (line.startsWith(ADD_FILE)) {
+      const path = line.slice(ADD_FILE.length).trim();
+      const raw: string[] = [];
+      index += 1;
+      while (index < lines.length && !isDirective(lines[index])) {
+        raw.push(lines[index]);
+        index += 1;
+      }
+      const pathError = validatePath(path);
+      if (pathError !== null) {
+        return { ok: false, error: pathError };
+      }
+      let contents = "";
+      for (const bodyLine of raw) {
+        if (!bodyLine.startsWith("+")) {
+          return {
+            ok: false,
+            error: `Add File body lines must start with "+" (got ${JSON.stringify(bodyLine)})`,
+          };
+        }
+        // codex appends a newline per body line.
+        contents += `${bodyLine.slice(1)}\n`;
+      }
+      ops.push({ kind: "add", path, contents });
+      continue;
+    }
+    if (line.startsWith(DELETE_FILE)) {
+      const path = line.slice(DELETE_FILE.length).trim();
+      const pathError = validatePath(path);
+      if (pathError !== null) {
+        return { ok: false, error: pathError };
+      }
+      ops.push({ kind: "delete", path });
+      index += 1;
+      continue;
+    }
+    if (line.startsWith(UPDATE_FILE)) {
+      const path = line.slice(UPDATE_FILE.length).trim();
+      const pathError = validatePath(path);
+      if (pathError !== null) {
+        return { ok: false, error: pathError };
+      }
+      index += 1;
+      let moveTo: string | null = null;
+      if ((lines[index] ?? "").startsWith(MOVE_TO)) {
+        moveTo = lines[index].slice(MOVE_TO.length).trim();
+        const moveError = validatePath(moveTo);
+        if (moveError !== null) {
+          return { ok: false, error: moveError };
+        }
+        index += 1;
+      }
+      const hunks: PatchHunk[] = [];
+      const openChunk = (changeContext: string | null): PatchHunk => {
+        const chunk: PatchHunk = {
+          changeContext,
+          before: [],
+          after: [],
+          endOfFile: false,
+        };
+        hunks.push(chunk);
+        return chunk;
+      };
+      while (index < lines.length && !isDirective(lines[index])) {
+        const hunkLine = lines[index];
+        index += 1;
+        // "@@" opens a chunk; "@@ text" opens one anchored on that context.
+        if (hunkLine === CHANGE_CONTEXT_EMPTY) {
+          openChunk(null);
+          continue;
+        }
+        if (hunkLine.startsWith(CHANGE_CONTEXT)) {
+          openChunk(hunkLine.slice(CHANGE_CONTEXT.length));
+          continue;
+        }
+        const chunk = hunks[hunks.length - 1] ?? openChunk(null);
+        if (hunkLine.startsWith("+")) {
+          chunk.after.push(hunkLine.slice(1));
+          continue;
+        }
+        if (hunkLine.startsWith("-")) {
+          chunk.before.push(hunkLine.slice(1));
+          continue;
+        }
+        if (hunkLine.startsWith(" ") || hunkLine.length === 0) {
+          // A bare empty line is context; a trailing one is handled at apply time.
+          const text = hunkLine.length === 0 ? "" : hunkLine.slice(1);
+          chunk.before.push(text);
+          chunk.after.push(text);
+          continue;
+        }
+        return {
+          ok: false,
+          error: `Update File lines must start with " ", "+", "-", or "@@" (got ${JSON.stringify(hunkLine)})`,
+        };
+      }
+      if ((lines[index] ?? "").trimEnd() === END_OF_FILE) {
+        index += 1;
+        if (hunks.length > 0) {
+          hunks[hunks.length - 1].endOfFile = true;
+        }
+        // codex ignores blank lines after the marker.
+        while (index < lines.length && lines[index].length === 0) {
+          index += 1;
+        }
+      }
+      if (hunks.length === 0) {
+        return { ok: false, error: `Update File ${path} has no hunks` };
+      }
+      ops.push({ kind: "update", path, moveTo, hunks });
+      continue;
+    }
+    return {
+      ok: false,
+      error: `unrecognised patch directive: ${JSON.stringify(line)}`,
+    };
+  }
+  if (!sawEnd) {
+    return { ok: false, error: `patch must end with "${END_PATCH}"` };
+  }
+  if (ops.length === 0) {
+    return { ok: false, error: "patch contains no file operations" };
+  }
+  return { ok: true, ops };
+}
+
+function isDirective(line: string): boolean {
+  return line.startsWith("*** ");
+}
+
+// Models emit these where the file has the plain ASCII character.
+const TYPOGRAPHIC: Record<string, string> = {
+  // Dashes and the minus sign.
+  "\u2010": "-",
+  "\u2011": "-",
+  "\u2012": "-",
+  "\u2013": "-",
+  "\u2014": "-",
+  "\u2015": "-",
+  "\u2212": "-",
+  // Single quotes.
+  "\u2018": "'",
+  "\u2019": "'",
+  "\u201a": "'",
+  "\u201b": "'",
+  // Double quotes.
+  "\u201c": '"',
+  "\u201d": '"',
+  "\u201e": '"',
+  "\u201f": '"',
+  // Spaces.
+  "\u00a0": " ",
+  "\u2002": " ",
+  "\u2003": " ",
+  "\u2004": " ",
+  "\u2005": " ",
+  "\u2006": " ",
+  "\u2007": " ",
+  "\u2008": " ",
+  "\u2009": " ",
+  "\u200a": " ",
+  "\u202f": " ",
+  "\u205f": " ",
+  "\u3000": " ",
+};
+
+function normalizeTypography(line: string): string {
+  let out = "";
+  for (const char of line) {
+    out += TYPOGRAPHIC[char] ?? char;
+  }
+  return out;
+}
+
+// The relaxation ladder from codex's seek_sequence.
+const MATCH_PASSES: ((a: string, b: string) => boolean)[] = [
+  (a, b) => a === b,
+  (a, b) => a.trimEnd() === b.trimEnd(),
+  (a, b) => a.trim() === b.trim(),
+  (a, b) => normalizeTypography(a.trim()) === normalizeTypography(b.trim()),
+];
+
+function matchesAt(
+  lines: string[],
+  block: string[],
+  start: number,
+  equal: (a: string, b: string) => boolean,
+): boolean {
+  for (let offset = 0; offset < block.length; offset += 1) {
+    if (!equal(lines[start + offset], block[offset])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Port of codex's seek_sequence: first match at or after `from` (first, not
+// unique — hunks apply from an advancing cursor), each pass scanning the whole
+// range before relaxing. endOfFile anchors the search to the tail, no fallback.
+export function seekSequence(
+  lines: string[],
+  block: string[],
+  from: number,
+  endOfFile = false,
+): number | null {
+  if (block.length === 0) {
+    return from;
+  }
+  if (block.length > lines.length) {
+    return null;
+  }
+  const searchStart = endOfFile ? lines.length - block.length : from;
+  for (const equal of MATCH_PASSES) {
+    for (
+      let start = searchStart;
+      start + block.length <= lines.length;
+      start += 1
+    ) {
+      if (matchesAt(lines, block, start, equal)) {
+        return start;
+      }
+    }
+  }
+  return null;
+}
+
+interface Replacement {
+  at: number;
+  remove: number;
+  insert: string[];
+}
+
+// Port of codex's compute_replacements: resolve all hunks against the
+// original lines, then apply.
+export function applyHunks(contents: string, hunks: PatchHunk[]): EditOutcome {
+  const original = contents.split("\n");
+  // Drop the final newline's empty element; restored on the way out.
+  if (original[original.length - 1] === "") {
+    original.pop();
+  }
+  const replacements: Replacement[] = [];
+  let lineIndex = 0;
+  for (const hunk of hunks) {
+    if (hunk.changeContext !== null) {
+      const found = seekSequence(
+        original,
+        [hunk.changeContext],
+        lineIndex,
+        false,
+      );
+      if (found === null) {
+        return {
+          ok: false,
+          error: `could not find context ${JSON.stringify(hunk.changeContext)}`,
+        };
+      }
+      lineIndex = found + 1;
+    }
+    if (hunk.before.length === 0) {
+      // No context and no removals: a pure addition at end of file.
+      replacements.push({
+        at: original.length,
+        remove: 0,
+        insert: hunk.after,
+      });
+      continue;
+    }
+    let before = hunk.before;
+    let after = hunk.after;
+    let found = seekSequence(original, before, lineIndex, hunk.endOfFile);
+    if (found === null && before[before.length - 1] === "") {
+      // A trailing empty stands for the popped final newline; retry without it.
+      before = before.slice(0, -1);
+      if (after[after.length - 1] === "") {
+        after = after.slice(0, -1);
+      }
+      found = seekSequence(original, before, lineIndex, hunk.endOfFile);
+    }
+    if (found === null) {
+      const quoted = hunk.before.find((line) => line.trim().length > 0);
+      return {
+        ok: false,
+        error: `hunk context was not found: ${JSON.stringify(quoted ?? hunk.before[0])}`,
+      };
+    }
+    replacements.push({ at: found, remove: before.length, insert: after });
+    lineIndex = found + before.length;
+  }
+  replacements.sort((left, right) => left.at - right.at);
+  const out: string[] = [];
+  let copied = 0;
+  for (const replacement of replacements) {
+    out.push(...original.slice(copied, replacement.at));
+    out.push(...replacement.insert);
+    copied = replacement.at + replacement.remove;
+  }
+  out.push(...original.slice(copied));
+  // codex always terminates the file with a newline.
+  if (out[out.length - 1] !== "") {
+    out.push("");
+  }
+  return { ok: true, contents: out.join("\n") };
+}
+
+// Absolute paths only, so the process cwd never matters.
+export function validatePath(path: string): string | null {
+  if (path.length === 0) {
+    return "path must not be empty";
+  }
+  if (!path.startsWith("/")) {
+    return `path must be absolute (got ${JSON.stringify(path)})`;
+  }
+  if (path.split("/").includes("..")) {
+    return "path must not contain '..' segments";
+  }
+  return null;
+}
+
+// The TurnContext subset these helpers need, so tests can fake it.
+export type SandboxHandle = Pick<TurnContext, "startSandboxProcess">;
+
+async function drain(stream: ReadableStream<string>): Promise<string> {
+  const reader = stream.getReader();
+  const chunks: string[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (typeof value !== "string") {
+        continue;
+      }
+      total += value.length;
+      if (total > MAX_FILE_CHARS) {
+        throw new Error(
+          `file exceeds ${MAX_FILE_CHARS} characters; edit it with shell instead`,
+        );
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  return chunks.join("");
+}
+
+export interface ReadResult {
+  exists: boolean;
+  contents: string;
+}
+
+export async function readSandboxFile(
+  sandbox: SandboxHandle,
+  path: string,
+): Promise<ReadResult> {
+  // A dedicated exit code distinguishes "missing" from "unreadable".
+  const process = await sandbox.startSandboxProcess({
+    command: [
+      "sh",
+      "-c",
+      // A directory is a real error, not a missing file.
+      `if [ -d "$1" ]; then echo "is a directory" >&2; exit 1; fi; [ -f "$1" ] || exit ${READ_MISSING_EXIT_CODE}; cat -- "$1"`,
+      "exo-edit-read",
+      path,
+    ],
+  });
+  // close() in a finally: drain() can throw mid-stream.
+  try {
+    const [contents, errorText, exitCode] = await Promise.all([
+      drain(process.stdout),
+      drain(process.stderr),
+      process.wait(),
+    ]);
+    if (exitCode === READ_MISSING_EXIT_CODE) {
+      return { exists: false, contents: "" };
+    }
+    if (exitCode !== 0) {
+      throw new Error(
+        `failed to read ${path}: ${errorText.trim() || `exit code ${String(exitCode)}`}`,
+      );
+    }
+    if (contents.includes("\0")) {
+      throw new Error(`${path} looks binary; these tools only edit text files`);
+    }
+    return { exists: true, contents };
+  } finally {
+    await process.close();
+  }
+}
+
+export async function writeSandboxFile(
+  sandbox: SandboxHandle,
+  path: string,
+  contents: string,
+): Promise<void> {
+  // Sibling temp then rename: same filesystem, nothing left behind on failure.
+  const process = await sandbox.startSandboxProcess({
+    command: [
+      "sh",
+      "-c",
+      'tmp="$1.exo-edit-tmp"; if cat > "$tmp" && mv -- "$tmp" "$1"; then exit 0; fi; rm -f -- "$tmp"; exit 1',
+      "exo-edit-write",
+      path,
+    ],
+  });
+  try {
+    const stdout = drain(process.stdout);
+    const stderr = drain(process.stderr);
+    await process.writeStdin(contents);
+    await process.closeStdin();
+    const [, errorText, exitCode] = await Promise.all([
+      stdout,
+      stderr,
+      process.wait(),
+    ]);
+    if (exitCode !== 0) {
+      throw new Error(
+        `failed to write ${path}: ${errorText.trim() || `exit code ${String(exitCode)}`}`,
+      );
+    }
+  } finally {
+    await process.close();
+  }
+}
+
+async function deleteSandboxFile(
+  sandbox: SandboxHandle,
+  path: string,
+): Promise<void> {
+  const process = await sandbox.startSandboxProcess({
+    command: ["sh", "-c", 'rm -f -- "$1"', "exo-edit-delete", path],
+  });
+  try {
+    const [, errorText, exitCode] = await Promise.all([
+      drain(process.stdout),
+      drain(process.stderr),
+      process.wait(),
+    ]);
+    if (exitCode !== 0) {
+      throw new Error(
+        `failed to delete ${path}: ${errorText.trim() || `exit code ${String(exitCode)}`}`,
+      );
+    }
+  } finally {
+    await process.close();
+  }
+}
+
+function stringArg(args: JsonObject, name: string): string | null {
+  const value = args[name];
+  return typeof value === "string" ? value : null;
+}
+
+function strReplaceTool(): ToolInstance {
+  return {
+    source: "built_in",
+    definition: {
+      name: "str_replace",
+      description:
+        "Replace an exact string in a file in the sandbox. old_string must appear EXACTLY ONCE in the file: if it matches zero or several places the edit is rejected and nothing is written, so include enough surrounding context (including indentation) to be unambiguous. Prefer this over editing with shell/sed, which cannot tell you whether it changed what you intended. Paths must be absolute; Exo's own source tree is mounted at /workspace/exo.",
+      parameters: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          path: {
+            type: "string",
+            description: "Absolute path of the file to edit.",
+          },
+          old_string: {
+            type: "string",
+            description:
+              "The exact text to replace, copied from the file including indentation.",
+          },
+          new_string: {
+            type: "string",
+            description: "The replacement text.",
+          },
+        },
+        required: ["path", "old_string", "new_string"],
+      },
+    },
+    handler: {
+      async execute(args, execution): Promise<ToolResult> {
+        const path = stringArg(args, "path");
+        const oldString = stringArg(args, "old_string");
+        const newString = stringArg(args, "new_string");
+        if (path === null || oldString === null || newString === null) {
+          return {
+            ok: false,
+            error: "path, old_string, and new_string must all be strings",
+          };
+        }
+        const pathError = validatePath(path);
+        if (pathError !== null) {
+          return { ok: false, error: pathError };
+        }
+        const file = await readSandboxFile(execution.context, path);
+        if (!file.exists) {
+          return { ok: false, error: `${path} does not exist` };
+        }
+        const outcome = applyStrReplace(file.contents, oldString, newString);
+        if (!outcome.ok) {
+          return { ok: false, error: outcome.error };
+        }
+        await writeSandboxFile(execution.context, path, outcome.contents);
+        return { ok: true, path, replaced: 1 };
+      },
+    },
+  };
+}
+
+function createFileTool(): ToolInstance {
+  return {
+    source: "built_in",
+    definition: {
+      name: "create_file",
+      description:
+        "Create a new file in the sandbox with the given contents. Fails if the file already exists — use str_replace to modify an existing file. Paths must be absolute.",
+      parameters: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          path: {
+            type: "string",
+            description: "Absolute path of the file to create.",
+          },
+          contents: {
+            type: "string",
+            description: "Full contents of the new file.",
+          },
+        },
+        required: ["path", "contents"],
+      },
+    },
+    handler: {
+      async execute(args, execution): Promise<ToolResult> {
+        const path = stringArg(args, "path");
+        const contents = stringArg(args, "contents");
+        if (path === null || contents === null) {
+          return { ok: false, error: "path and contents must both be strings" };
+        }
+        const pathError = validatePath(path);
+        if (pathError !== null) {
+          return { ok: false, error: pathError };
+        }
+        const existing = await readSandboxFile(execution.context, path);
+        if (existing.exists) {
+          return {
+            ok: false,
+            error: `${path} already exists; use str_replace to modify it`,
+          };
+        }
+        await writeSandboxFile(execution.context, path, contents);
+        return { ok: true, path, bytes: contents.length };
+      },
+    },
+  };
+}
+
+function applyPatchTool(): ToolInstance {
+  return {
+    source: "built_in",
+    definition: {
+      name: "apply_patch",
+      description:
+        'Apply a patch to files in the sandbox. The patch is an envelope: "*** Begin Patch", then one or more of "*** Add File: <path>" (body lines prefixed "+"), "*** Delete File: <path>", or "*** Update File: <path>" (optionally "*** Move to: <path>" to rename it, then hunks of " " context, "-" removed and "+" added lines, separated by "@@" and closed by "*** End of File" if the hunk ends the file), then "*** End Patch". Hunks apply in order, each located at or after the previous one, so list them in the order they appear in the file. Context matching tolerates differing whitespace and typographic punctuation. The whole patch is resolved before anything is written: if any hunk cannot be located, nothing is written at all. Paths must be absolute; Exo\'s own source tree is mounted at /workspace/exo.',
+      parameters: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          patch: {
+            type: "string",
+            description: "The full patch envelope.",
+          },
+        },
+        required: ["patch"],
+      },
+    },
+    handler: {
+      async execute(args, execution): Promise<ToolResult> {
+        const patch = stringArg(args, "patch");
+        if (patch === null) {
+          return { ok: false, error: "patch must be a string" };
+        }
+        const parsed = parseApplyPatch(patch);
+        if (!parsed.ok) {
+          return { ok: false, error: parsed.error };
+        }
+        // Resolve everything against an in-memory working copy first: a
+        // failing patch writes nothing, and ops on one file compose.
+        const working = new Map<string, string | null>();
+        const load = async (path: string): Promise<string | null> => {
+          const cached = working.get(path);
+          if (cached !== undefined) {
+            return cached;
+          }
+          const file = await readSandboxFile(execution.context, path);
+          const contents = file.exists ? file.contents : null;
+          working.set(path, contents);
+          return contents;
+        };
+        for (const op of parsed.ops) {
+          const current = await load(op.path);
+          if (op.kind === "add") {
+            if (current !== null) {
+              return {
+                ok: false,
+                error: `${op.path} already exists; use "*** Update File" instead of "*** Add File"`,
+              };
+            }
+            working.set(op.path, op.contents);
+            continue;
+          }
+          if (op.kind === "delete") {
+            if (current === null) {
+              return { ok: false, error: `${op.path} does not exist` };
+            }
+            working.set(op.path, null);
+            continue;
+          }
+          if (current === null) {
+            return { ok: false, error: `${op.path} does not exist` };
+          }
+          const outcome = applyHunks(current, op.hunks);
+          if (!outcome.ok) {
+            return { ok: false, error: `${op.path}: ${outcome.error}` };
+          }
+          if (op.moveTo === null) {
+            working.set(op.path, outcome.contents);
+            continue;
+          }
+          // "*** Move to": write the destination, delete the original.
+          if ((await load(op.moveTo)) !== null && op.moveTo !== op.path) {
+            return { ok: false, error: `${op.moveTo} already exists` };
+          }
+          working.set(op.path, null);
+          working.set(op.moveTo, outcome.contents);
+        }
+        const touched = new Set(working.keys());
+        for (const path of touched) {
+          const contents = working.get(path) ?? null;
+          if (contents === null) {
+            await deleteSandboxFile(execution.context, path);
+            continue;
+          }
+          await writeSandboxFile(execution.context, path, contents);
+        }
+        return {
+          ok: true,
+          files_changed: touched.size,
+        };
+      },
+    },
+  };
+}
+
+// Exported separately from registration so tests can exercise the handlers.
+export function createEditToolInstances(family: ModelFamily): ToolInstance[] {
+  return editToolsForFamily(family) === "apply_patch"
+    ? [applyPatchTool()]
+    : [strReplaceTool(), createFileTool()];
+}
+
+// `model` is the upstream id from the resolved binding, not the binding name.
+export function registerEditTools(
+  registry: HarnessToolRegistry,
+  model: string,
+): void {
+  for (const tool of createEditToolInstances(modelFamily(model))) {
+    registry.register(tool);
+  }
+}

--- a/examples/exo/harness.ts
+++ b/examples/exo/harness.ts
@@ -14,6 +14,7 @@ import {
   type TurnContext,
 } from "@exo/harness";
 
+import { registerEditTools } from "./edit-tools";
 import { registerSchedulerTools } from "./scheduler-tools";
 import { registerSandboxTools } from "./sandbox-tools";
 import { registerGuardianTools } from "./guardian-tools";
@@ -54,8 +55,10 @@ export default defineHarness({
 export async function registerExoTools(
   tools: HarnessToolRegistry,
   context: TurnContext,
+  model: string,
 ): Promise<void> {
   registerBuiltInTools(tools, context, builtInToolNames(context));
+  registerEditTools(tools, model);
   registerSchedulerTools(tools);
   registerAdapterTools(tools);
   registerIntrospectionTools(tools);

--- a/examples/typescript/model-family.test.ts
+++ b/examples/typescript/model-family.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { modelFamily } from "./model-family";
+
+describe("modelFamily", () => {
+  it("recognises Anthropic model ids", () => {
+    expect(modelFamily("claude-sonnet-4-6")).toBe("anthropic");
+    expect(modelFamily("claude-opus-4-1-20250805")).toBe("anthropic");
+  });
+
+  it("recognises Anthropic ids behind provider prefixes", () => {
+    expect(modelFamily("anthropic/claude-sonnet-4-6")).toBe("anthropic");
+    expect(modelFamily("us.anthropic.claude-sonnet-4-6-v1:0")).toBe(
+      "anthropic",
+    );
+    expect(modelFamily("publishers/anthropic/models/claude-opus-4-1")).toBe(
+      "anthropic",
+    );
+  });
+
+  it("recognises OpenAI model ids", () => {
+    expect(modelFamily("gpt-5.4")).toBe("openai");
+    expect(modelFamily("gpt-5.6-terra")).toBe("openai");
+    expect(modelFamily("codex-mini-latest")).toBe("openai");
+    expect(modelFamily("openai/gpt-5.5")).toBe("openai");
+  });
+
+  it("is case and whitespace insensitive", () => {
+    expect(modelFamily("  Claude-Sonnet-4-6 ")).toBe("anthropic");
+    expect(modelFamily("GPT-5.4")).toBe("openai");
+  });
+
+  it("reports unknown for router aliases and unrecognised models", () => {
+    // `exo model register auto` is a real configuration (see
+    // scripts/agent-harness-e2e.ts): the family genuinely is not statically
+    // knowable, and callers must handle that rather than guess.
+    expect(modelFamily("auto")).toBe("unknown");
+    expect(modelFamily("llama-3.1-70b")).toBe("unknown");
+    expect(modelFamily("gemini-2.5-pro")).toBe("unknown");
+    expect(modelFamily("")).toBe("unknown");
+  });
+
+  it("does not match models that merely contain the substring", () => {
+    expect(modelFamily("claudette-7b")).toBe("unknown");
+  });
+});

--- a/examples/typescript/model-family.ts
+++ b/examples/typescript/model-family.ts
@@ -1,0 +1,28 @@
+// Post-training family of a model, used to pick the edit-tool shape. Keys off
+// the upstream model id, not the arbitrary local binding name.
+export type ModelFamily = "anthropic" | "openai" | "unknown";
+
+// Exact token membership, not substring: "claudette-7b" is not Claude.
+const ANTHROPIC_TOKENS = new Set(["claude", "anthropic"]);
+const OPENAI_TOKENS = new Set(["gpt", "codex", "openai"]);
+
+function tokens(modelId: string): string[] {
+  return modelId
+    .split("/")
+    .flatMap((part) => part.split("."))
+    .flatMap((part) => part.split("-"))
+    .filter((part) => part.length > 0);
+}
+
+// Router aliases ("auto") and self-hosted models have no static family;
+// "unknown" is a real state, not an error.
+export function modelFamily(upstreamModel: string): ModelFamily {
+  const parts = tokens(upstreamModel.trim().toLowerCase());
+  if (parts.some((part) => ANTHROPIC_TOKENS.has(part))) {
+    return "anthropic";
+  }
+  if (parts.some((part) => OPENAI_TOKENS.has(part))) {
+    return "openai";
+  }
+  return "unknown";
+}

--- a/examples/typescript/turn-loop.ts
+++ b/examples/typescript/turn-loop.ts
@@ -25,9 +25,12 @@ import { resolveLlmBinding } from "./shared";
 
 export interface ResponsesTurnLoopOptions {
   instructions?: (context: TurnContext) => Message[] | Promise<Message[]>;
+  // registerTools receives the upstream model id from the resolved llm
+  // binding, not the local binding name.
   registerTools?: (
     tools: HarnessToolRegistry,
     context: TurnContext,
+    model: string,
   ) => Promise<void> | void;
 }
 
@@ -113,7 +116,7 @@ async function runResponsesTurnLoop(
       ? createToolRegistry(context)
       : await createDefaultToolRegistry(context);
     if (options.registerTools) {
-      await options.registerTools(tools, context);
+      await options.registerTools(tools, context, model);
     }
     const messages = await materializePromptMessages(
       conversation,

--- a/website/docs-src/tutorials/game-emulator-integration.md
+++ b/website/docs-src/tutorials/game-emulator-integration.md
@@ -398,8 +398,12 @@ export default defineHarness({
   async runTurn(context) {
     await runResponsesHarnessTurn(context, {
       // Exo's tools + the game tools, one registry.
-      async registerTools(tools: HarnessToolRegistry, ctx: TurnContext) {
-        await registerExoTools(tools, ctx);
+      async registerTools(
+        tools: HarnessToolRegistry,
+        ctx: TurnContext,
+        model: string,
+      ) {
+        await registerExoTools(tools, ctx, model);
         await registerLibraryTools(tools, ctx, gameboyTools(emulator));
       },
 


### PR DESCRIPTION
This adds edit tools, str_replace/create_file and apply_patch, registered per model family.

- `examples/exo/edit-tools.ts` (+test): Adding the three tools. Matching runs host-side as pure functions (the sandbox only moves bytes), and writes are temp-file+rename with nothing written unless the whole patch resolves; a failed edit can't half-write a source file. Tests fake the sandbox - no docker in my current env :(
- `examples/typescript/model-family.ts` (+test): resolves the model family from upstream model id. Router aliases resolve to `unknown`, which gets str_replace.
- `examples/typescript/turn-loop.ts`:  threads the resolved model id into the `registerTools` hook, so family resolution costs no extra round trip.
- `examples/exo/harness.ts`: registers the tools; tool descriptions and error messages carry usage guidance.
- `website/docs-src/tutorials/game-emulator-integration.md`: updates the caller of the exported `registerExoTools`, which gained a required `model` param.

`pnpm check` green: lint 0 warnings, typecheck clean, 190 tests (69 new).
