### PR TITLE
Stop detached process bridge pollers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6129,6 +6129,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/crates/exoharness/Cargo.toml
+++ b/crates/exoharness/Cargo.toml
@@ -63,7 +63,7 @@ tokio-tungstenite = { version = "0.26.2", default-features = false, features = [
   "connect",
   "rustls-tls-webpki-roots",
 ], optional = true }
-tokio-util = { workspace = true, optional = true, features = ["compat"] }
+tokio-util = { workspace = true, optional = true, features = ["compat", "rt"] }
 tracing = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
 uuid = { workspace = true, features = ["serde", "v4", "v7", "js"] }

--- a/crates/exoharness/src/sandbox_provider/process_bridge.rs
+++ b/crates/exoharness/src/sandbox_provider/process_bridge.rs
@@ -9,6 +9,7 @@ use futures::future::BoxFuture;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{mpsc, oneshot};
+use tokio::task::JoinHandle;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 const PROCESS_PIPE_BUFFER_SIZE: usize = 64 * 1024;
@@ -326,16 +327,21 @@ pub fn process_parts(client: Arc<dyn Client>) -> crate::SandboxProcessParts {
     let (wait_tx, wait_rx) = oneshot::channel();
     let (error_tx, mut error_rx) = mpsc::unbounded_channel();
 
-    spawn_output_poller(
+    let output_poller = spawn_output_poller(
         Arc::clone(&client),
         stdout_writer,
         stderr_writer,
         wait_tx,
         error_tx.clone(),
     );
-    spawn_stdin_forwarder(client, stdin_reader, error_tx);
+    let stdin_forwarder = spawn_stdin_forwarder(client, stdin_reader, error_tx);
+    let task_owner = ProcessTaskOwner {
+        output_poller,
+        stdin_forwarder,
+    };
 
     let wait: BoxFuture<'static, crate::Result<i32>> = Box::pin(async move {
+        let _task_owner = task_owner;
         tokio::pin!(wait_rx);
         let mut errors_open = true;
         loop {
@@ -362,34 +368,46 @@ pub fn process_parts(client: Arc<dyn Client>) -> crate::SandboxProcessParts {
     }
 }
 
+struct ProcessTaskOwner {
+    output_poller: JoinHandle<()>,
+    stdin_forwarder: JoinHandle<()>,
+}
+
+impl Drop for ProcessTaskOwner {
+    fn drop(&mut self) {
+        self.output_poller.abort();
+        self.stdin_forwarder.abort();
+    }
+}
+
 fn spawn_output_poller(
     client: Arc<dyn Client>,
     stdout_writer: tokio::io::DuplexStream,
     stderr_writer: tokio::io::DuplexStream,
     wait_tx: oneshot::Sender<i32>,
     error_tx: mpsc::UnboundedSender<anyhow::Error>,
-) {
+) -> JoinHandle<()> {
     tokio::spawn(async move {
         if let Err(error) = poll_output(client, stdout_writer, stderr_writer, wait_tx).await
             && error_tx.send(error).is_err()
         {
             tracing::debug!("process bridge waiter stopped before output error could be reported");
         }
-    });
+    })
 }
 
 fn spawn_stdin_forwarder(
     client: Arc<dyn Client>,
     stdin_reader: tokio::io::DuplexStream,
     error_tx: mpsc::UnboundedSender<anyhow::Error>,
-) {
+) -> JoinHandle<()> {
     tokio::spawn(async move {
         if let Err(error) = forward_stdin(client, stdin_reader).await
             && error_tx.send(error).is_err()
         {
             tracing::debug!("process bridge waiter stopped before stdin error could be reported");
         }
-    });
+    })
 }
 
 async fn poll_output(
@@ -487,6 +505,18 @@ mod tests {
         responses: Mutex<VecDeque<Response>>,
     }
 
+    struct BlockingRecvClient {
+        recv_events: mpsc::UnboundedSender<()>,
+    }
+
+    struct DropNotify(mpsc::UnboundedSender<()>);
+
+    impl Drop for DropNotify {
+        fn drop(&mut self) {
+            self.0.send(()).expect("receive recv-drop notification");
+        }
+    }
+
     #[async_trait]
     impl Client for FakeClient {
         async fn request(&self, request: Request) -> Result<Response> {
@@ -505,6 +535,18 @@ mod tests {
                 events: Vec::new(),
                 error: None,
             }))
+        }
+    }
+
+    #[async_trait]
+    impl Client for BlockingRecvClient {
+        async fn request(&self, request: Request) -> Result<Response> {
+            assert_eq!(request.kind, "recv");
+            self.recv_events
+                .send(())
+                .expect("receive recv-start notification");
+            let _drop_notify = DropNotify(self.recv_events.clone());
+            std::future::pending().await
         }
     }
 
@@ -542,6 +584,31 @@ mod tests {
 
         assert_eq!(exit_code, 0);
         assert_eq!(output, "hello world");
+    }
+
+    #[tokio::test]
+    async fn dropping_wait_cancels_output_polling() {
+        let (recv_events_tx, mut recv_events_rx) = mpsc::unbounded_channel();
+        let client = Arc::new(BlockingRecvClient {
+            recv_events: recv_events_tx,
+        });
+        let parts = process_parts(client.clone());
+
+        tokio::time::timeout(Duration::from_secs(1), recv_events_rx.recv())
+            .await
+            .expect("output poll should start")
+            .expect("recv-events channel should remain open");
+        drop(parts.wait);
+        tokio::time::timeout(Duration::from_secs(1), recv_events_rx.recv())
+            .await
+            .expect("in-flight recv should be cancelled")
+            .expect("recv-events channel should remain open");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), recv_events_rx.recv())
+                .await
+                .is_err(),
+            "output poller started another recv request"
+        );
     }
 
     #[tokio::test]

--- a/crates/exoharness/src/sandbox_provider/process_bridge.rs
+++ b/crates/exoharness/src/sandbox_provider/process_bridge.rs
@@ -335,13 +335,10 @@ pub fn process_parts(client: Arc<dyn Client>) -> crate::SandboxProcessParts {
         error_tx.clone(),
     );
     let stdin_forwarder = spawn_stdin_forwarder(client, stdin_reader, error_tx);
-    let task_owner = ProcessTaskOwner {
-        output_poller,
-        stdin_forwarder,
-    };
+    let tasks = AbortOnDrop([output_poller, stdin_forwarder]);
 
     let wait: BoxFuture<'static, crate::Result<i32>> = Box::pin(async move {
-        let _task_owner = task_owner;
+        let _tasks = tasks;
         tokio::pin!(wait_rx);
         let mut errors_open = true;
         loop {
@@ -368,15 +365,13 @@ pub fn process_parts(client: Arc<dyn Client>) -> crate::SandboxProcessParts {
     }
 }
 
-struct ProcessTaskOwner {
-    output_poller: JoinHandle<()>,
-    stdin_forwarder: JoinHandle<()>,
-}
+struct AbortOnDrop([JoinHandle<()>; 2]);
 
-impl Drop for ProcessTaskOwner {
+impl Drop for AbortOnDrop {
     fn drop(&mut self) {
-        self.output_poller.abort();
-        self.stdin_forwarder.abort();
+        for task in &self.0 {
+            task.abort();
+        }
     }
 }
 
@@ -505,16 +500,9 @@ mod tests {
         responses: Mutex<VecDeque<Response>>,
     }
 
-    struct BlockingRecvClient {
-        recv_events: mpsc::UnboundedSender<()>,
-    }
-
-    struct DropNotify(mpsc::UnboundedSender<()>);
-
-    impl Drop for DropNotify {
-        fn drop(&mut self) {
-            self.0.send(()).expect("receive recv-drop notification");
-        }
+    struct BlockingClient {
+        recv_started: mpsc::UnboundedSender<()>,
+        recv_request: Mutex<Option<oneshot::Receiver<()>>>,
     }
 
     #[async_trait]
@@ -539,14 +527,20 @@ mod tests {
     }
 
     #[async_trait]
-    impl Client for BlockingRecvClient {
+    impl Client for BlockingClient {
         async fn request(&self, request: Request) -> Result<Response> {
             assert_eq!(request.kind, "recv");
-            self.recv_events
+            self.recv_started
                 .send(())
                 .expect("receive recv-start notification");
-            let _drop_notify = DropNotify(self.recv_events.clone());
-            std::future::pending().await
+            self.recv_request
+                .lock()
+                .await
+                .take()
+                .expect("recv request should only start once")
+                .await
+                .expect("recv request should remain blocked");
+            unreachable!("recv request unexpectedly completed")
         }
     }
 
@@ -588,23 +582,24 @@ mod tests {
 
     #[tokio::test]
     async fn dropping_wait_cancels_output_polling() {
-        let (recv_events_tx, mut recv_events_rx) = mpsc::unbounded_channel();
-        let client = Arc::new(BlockingRecvClient {
-            recv_events: recv_events_tx,
+        let (recv_started_tx, mut recv_started_rx) = mpsc::unbounded_channel();
+        let (mut recv_request_tx, recv_request_rx) = oneshot::channel();
+        let client = Arc::new(BlockingClient {
+            recv_started: recv_started_tx,
+            recv_request: Mutex::new(Some(recv_request_rx)),
         });
         let parts = process_parts(client.clone());
 
-        tokio::time::timeout(Duration::from_secs(1), recv_events_rx.recv())
+        tokio::time::timeout(Duration::from_secs(1), recv_started_rx.recv())
             .await
             .expect("output poll should start")
-            .expect("recv-events channel should remain open");
+            .expect("recv-start channel should remain open");
         drop(parts.wait);
-        tokio::time::timeout(Duration::from_secs(1), recv_events_rx.recv())
+        tokio::time::timeout(Duration::from_secs(1), recv_request_tx.closed())
             .await
-            .expect("in-flight recv should be cancelled")
-            .expect("recv-events channel should remain open");
+            .expect("in-flight recv should be cancelled");
         assert!(
-            tokio::time::timeout(Duration::from_millis(100), recv_events_rx.recv())
+            tokio::time::timeout(Duration::from_millis(100), recv_started_rx.recv())
                 .await
                 .is_err(),
             "output poller started another recv request"

--- a/crates/exoharness/src/sandbox_provider/process_bridge.rs
+++ b/crates/exoharness/src/sandbox_provider/process_bridge.rs
@@ -11,6 +11,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+use tokio_util::task::AbortOnDropHandle;
 
 const PROCESS_PIPE_BUFFER_SIZE: usize = 64 * 1024;
 pub const PATH: &str = "/tmp/exo-process-bridge.py";
@@ -335,7 +336,7 @@ pub fn process_parts(client: Arc<dyn Client>) -> crate::SandboxProcessParts {
         error_tx.clone(),
     );
     let stdin_forwarder = spawn_stdin_forwarder(client, stdin_reader, error_tx);
-    let tasks = AbortOnDrop([output_poller, stdin_forwarder]);
+    let tasks = [output_poller, stdin_forwarder].map(AbortOnDropHandle::new);
 
     let wait: BoxFuture<'static, crate::Result<i32>> = Box::pin(async move {
         let _tasks = tasks;
@@ -362,16 +363,6 @@ pub fn process_parts(client: Arc<dyn Client>) -> crate::SandboxProcessParts {
         stderr: Box::pin(stderr_reader.compat()),
         stdin: Box::pin(stdin_writer.compat_write()),
         wait,
-    }
-}
-
-struct AbortOnDrop([JoinHandle<()>; 2]);
-
-impl Drop for AbortOnDrop {
-    fn drop(&mut self) {
-        for task in &self.0 {
-            task.abort();
-        }
     }
 }
 


### PR DESCRIPTION
## Context

Dropping a process bridge's wait future detached its output poller, which continued issuing `recv` long polls indefinitely. The output and stdin background tasks should not outlive the returned process.

## Description

- Return both background task handles and own them with a guard captured by the wait future.
- Abort both tasks when the wait future is dropped, completes normally, or returns either task's error.
- Cover cancellation of an in-flight `recv` request and verify that polling does not restart.

## Testing

- `cargo test -p exoharness --features basic-backend process_bridge`
- `cargo fmt --check`
