### PR TITLE
cost: record why a usage record has no cost, instead of omitting the field

### DIFF
--- a/typescript/model-runtime/cost.test.ts
+++ b/typescript/model-runtime/cost.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { computeCostUsd, lookup, parseTable } from "./cost";
+import { computeCostUsd, lookup, parseTable, priceUsage } from "./cost";
 
 const FIXTURE = `{
   "sample_spec": { "comment": "ignored" },
@@ -71,5 +71,52 @@ describe("cost", () => {
     expect(
       computeCostUsd(table, "acme-llm-9000", { prompt: 100, completion: 50 }),
     ).toBeNull();
+  });
+});
+
+const UNPRICED = parseTable(`{
+  "listed-but-unpriced": { "litellm_provider": "openai" },
+  "openrouter/xiaomi/mimo-v2.5-pro": {
+    "litellm_provider": "openrouter", "input_cost_per_token": 1e-07,
+    "output_cost_per_token": 4e-07
+  }
+}`);
+
+describe("priceUsage", () => {
+  const tokens = { prompt: 100, completion: 50 };
+
+  it("prices a known model", () => {
+    const priced = priceUsage(table, "gpt-4o-mini", tokens);
+    expect(priced.status).toBe("priced");
+    expect(priced.costUsd).toBeGreaterThan(0);
+  });
+
+  it("reports an unavailable table separately from a miss", () => {
+    expect(priceUsage(null, "gpt-4o-mini", tokens)).toEqual({
+      costUsd: null,
+      status: "table_unavailable",
+    });
+    expect(priceUsage(table, "acme-llm-9000", tokens)).toEqual({
+      costUsd: null,
+      status: "model_not_found",
+    });
+  });
+
+  it("reports a listed model with no input rate", () => {
+    expect(priceUsage(UNPRICED, "listed-but-unpriced", tokens)).toEqual({
+      costUsd: null,
+      status: "model_not_priced",
+    });
+  });
+
+  it("does not match a bare name against a provider-qualified key", () => {
+    // lookup is prefix-based, so a locally registered alias never resolves to
+    // the provider-qualified entry that actually carries the rate.
+    expect(priceUsage(UNPRICED, "mimo-v2.5-pro", tokens).status).toBe(
+      "model_not_found",
+    );
+    expect(
+      priceUsage(UNPRICED, "openrouter/xiaomi/mimo-v2.5-pro", tokens).status,
+    ).toBe("priced");
   });
 });

--- a/typescript/model-runtime/cost.ts
+++ b/typescript/model-runtime/cost.ts
@@ -86,6 +86,39 @@ export function computeCostUsd(
   );
 }
 
+// Why a usage record does or does not carry a cost. Recorded alongside the
+// usage so an absent `cost_usd` is diagnosable: without it, "the table never
+// loaded", "the model is not in the table", and "this call was free" all look
+// identical after the fact.
+export type CostStatus =
+  | "priced"
+  | "table_unavailable"
+  | "model_not_found"
+  | "model_not_priced";
+
+export interface PricedUsage {
+  costUsd: number | null;
+  status: CostStatus;
+}
+
+export function priceUsage(
+  table: PricingTable | null,
+  model: string,
+  tokens: TokenCounts,
+): PricedUsage {
+  if (!table) {
+    return { costUsd: null, status: "table_unavailable" };
+  }
+  const entry = lookup(table, model);
+  if (!entry) {
+    return { costUsd: null, status: "model_not_found" };
+  }
+  const costUsd = computeCostUsd(table, model, tokens);
+  return costUsd == null
+    ? { costUsd: null, status: "model_not_priced" }
+    : { costUsd, status: "priced" };
+}
+
 function isAdditive(provider?: string): boolean {
   return (
     provider != null &&

--- a/typescript/model-runtime/responses.ts
+++ b/typescript/model-runtime/responses.ts
@@ -36,7 +36,7 @@ import {
   type ToolDefinition,
   type TurnContext,
 } from "../harness";
-import { computeCostUsd, getTable } from "./cost";
+import { getTable, priceUsage } from "./cost";
 import type {
   ChatCompletion,
   ChatCompletionChunk,
@@ -1170,7 +1170,7 @@ export function responseToLinguaEvents(response: Response): EventData[] {
 }
 
 // Policy: attach raw usage + cost to the messages event. cost_usd is filled from
-// the shared price cache; left unset if the cache is unavailable.
+// the shared price cache; cost_status always records why it is or is not there.
 function usageRecord(response: Response): JsonObject | undefined {
   const usage = response.usage;
   if (!usage) return undefined;
@@ -1178,17 +1178,19 @@ function usageRecord(response: Response): JsonObject | undefined {
   const completion = usage.output_tokens;
   const cached = usage.input_tokens_details?.cached_tokens;
   const reasoning = usage.output_tokens_details?.reasoning_tokens;
-  const table = getTable();
-  const cost = table
-    ? computeCostUsd(table, response.model, { prompt, completion, cached })
-    : null;
+  const { costUsd, status } = priceUsage(getTable(), response.model, {
+    prompt,
+    completion,
+    cached,
+  });
 
   const record: JsonObject = { model: response.model };
   if (prompt != null) record.prompt_tokens = prompt;
   if (completion != null) record.completion_tokens = completion;
   if (cached != null) record.prompt_cached_tokens = cached;
   if (reasoning != null) record.completion_reasoning_tokens = reasoning;
-  if (cost != null) record.cost_usd = cost;
+  if (costUsd != null) record.cost_usd = costUsd;
+  record.cost_status = status;
   return record;
 }
 


### PR DESCRIPTION
Follow-up to the cost thread in Discord. This is only the "say why" half — it doesn't touch lookup or the fetch path, both of which need a decision I didn't want to make unilaterally.

## Problem

`usageRecord` wrote `cost_usd` only when a price came back:

```ts
if (cost != null) record.cost_usd = cost;
```

So a missing field means one of three things — the table never loaded, nothing matched the model, or the call was genuinely free — and there's no way to tell which after the fact. I ran an agent for two weeks and concluded cost tracking wasn't implemented, because every usage record had tokens and no cost.

The miss that actually bit me is worth spelling out, because it isn't rare. Cost is looked up by the model id the provider echoes back (`completion.model` → `response.model`). Most LiteLLM keys are route-qualified — 2421 of 2983 entries have a `/` in them — so a model reached directly from its vendor's own OpenAI-compatible endpoint echoes a bare id that simply isn't a key. Running `lookup` against a freshly pulled table with the ids exactly as they appear in my records:

```
mimo-v2.5-pro            miss
k3                       miss
MiniMax-M3               miss
gpt-4o-mini-2024-07-18   exact
claude-sonnet-4-6        exact
```

`mimo-v2.5-pro` has entries under `openrouter/xiaomi/mimo-v2.5-pro` and `novita/xiaomimimo/...`, but those are other routes at other rates — I reach it through Xiaomi directly, so neither price is mine. That's why I don't think this is fixable by making `lookup` fuzzier: a name-based match here would attach a rate I'm not paying.

## Change

`priceUsage(table, model, tokens)` returns the cost together with a status, and `usageRecord` always writes `cost_status`:

- `priced` — rate found, `cost_usd` present
- `table_unavailable` — `getTable()` returned null
- `model_not_found` — table loaded, nothing matched
- `model_not_priced` — entry exists but carries no `input_cost_per_token`

`computeCostUsd` is unchanged, so its behaviour and existing tests are untouched.

## Not in scope

Whether a model binding should carry its own pricing key or rates, which seems like the real fix for the route problem and overlaps #175. Also the Rust path in `crates/executor/src/basic.rs`, which omits on miss the same way — happy to mirror this there if the shape looks right.

With `cost_status` recorded, both of those become measurable instead of guessed.

## Test plan

- [x] `pnpm check` — lint, typecheck, 125 tests including 4 new `priceUsage` cases
