### PR TITLE
Codex and Claude Code as executors for the exo agent

### DIFF
--- a/examples/exo/coding-executor-harness.test.ts
+++ b/examples/exo/coding-executor-harness.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { createToolRegistry, type TurnContext } from "@exo/harness";
+
+import {
+  executorForFamily,
+  registerCodingExecutorTools,
+} from "./coding-executor-harness";
+
+function fakeContext(enableAgentToolCreation = false): TurnContext {
+  return {
+    agentConfig: { typescript: undefined, enableAgentToolCreation },
+    conversationConfig: {},
+  } as unknown as TurnContext;
+}
+
+describe("executorForFamily", () => {
+  it("routes each family to its executor", () => {
+    expect(executorForFamily("anthropic")).toBe("claude-code");
+    expect(executorForFamily("openai")).toBe("codex");
+    expect(executorForFamily("unknown")).toBeNull();
+  });
+});
+
+describe("registerCodingExecutorTools", () => {
+  it("registers the exo agent tools but not shell", async () => {
+    const context = fakeContext();
+    const tools = createToolRegistry(context);
+    await registerCodingExecutorTools(tools, context);
+    expect(tools.get("shell")).toBeUndefined();
+    for (const name of [
+      "remember",
+      "todowrite",
+      "web_search",
+      "rewind_sandbox",
+      "rebuild_and_restart_exo",
+      "manage_tool",
+    ]) {
+      expect(tools.get(name), name).toBeDefined();
+    }
+  });
+
+  it("includes the agent-tool-creation built-ins when enabled", async () => {
+    const context = fakeContext(true);
+    const tools = createToolRegistry(context);
+    await registerCodingExecutorTools(tools, context);
+    expect(tools.get("install_agent_tool")).toBeDefined();
+    expect(tools.get("shell")).toBeUndefined();
+  });
+});

--- a/examples/exo/coding-executor-harness.ts
+++ b/examples/exo/coding-executor-harness.ts
@@ -1,0 +1,75 @@
+import {
+  defineHarness,
+  registerBuiltInTools,
+  registerLibraryToolModulePath,
+  type HarnessToolRegistry,
+  type TurnContext,
+} from "@exo/harness";
+
+import { runClaudeCodeHarnessTurn } from "../typescript/claude-code-harness";
+import { runCodexHarnessTurn } from "../typescript/codex-harness";
+import { modelFamily, type ModelFamily } from "../typescript/model-family";
+import { resolveLlmBinding } from "../typescript/shared";
+import { registerConfiguredAgentTools } from "../typescript/turn-loop";
+import { exoInstructions } from "./harness";
+import { resolveExoProfile } from "./profiles";
+
+// The exo agent on a coding-agent executor, picked by model family: Anthropic
+// models run on Claude Code, OpenAI models on codex. Exo's tools reach the
+// executor through the registry bridge; shell stays native to the executor.
+//
+// Select with `--harness examples/exo/coding-executor-harness.ts` plus the
+// executor's sandbox image (exo-claude-code-sandbox / exo-codex-sandbox) and
+// networking enabled.
+
+export function executorForFamily(
+  family: ModelFamily,
+): "claude-code" | "codex" | null {
+  if (family === "anthropic") {
+    return "claude-code";
+  }
+  if (family === "openai") {
+    return "codex";
+  }
+  return null;
+}
+
+export default defineHarness({
+  async runTurn(context) {
+    const binding = await resolveLlmBinding(context);
+    const executor = executorForFamily(modelFamily(binding.model));
+    if (executor === null) {
+      throw new Error(
+        `no coding executor for model ${binding.model}: its family is unknown. Register the model under its upstream id, or use the default exo harness.`,
+      );
+    }
+    const options = {
+      instructions: exoInstructions,
+      registerTools: registerCodingExecutorTools,
+    };
+    if (executor === "claude-code") {
+      await runClaudeCodeHarnessTurn(context, options);
+      return;
+    }
+    await runCodexHarnessTurn(context, options);
+  },
+});
+
+// registerExoTools minus the shell built-in: the executor brings its own.
+export async function registerCodingExecutorTools(
+  tools: HarnessToolRegistry,
+  context: TurnContext,
+): Promise<void> {
+  const profile = resolveExoProfile();
+  registerBuiltInTools(
+    tools,
+    context,
+    profile.builtInToolNames(context).filter((name) => name !== "shell"),
+  );
+  await profile.registerTools(tools, context);
+  for (const modulePath of context.agentConfig.typescript?.toolModulePaths ??
+    []) {
+    await registerLibraryToolModulePath(tools, context, modulePath);
+  }
+  await registerConfiguredAgentTools(tools, context);
+}

--- a/examples/exo/coding-executor-harness.ts
+++ b/examples/exo/coding-executor-harness.ts
@@ -46,6 +46,9 @@ export default defineHarness({
     const options = {
       instructions: exoInstructions,
       registerTools: registerCodingExecutorTools,
+      // The sandbox boundary is the containment; decisions land in the
+      // event log.
+      approvals: "auto" as const,
     };
     if (executor === "claude-code") {
       await runClaudeCodeHarnessTurn(context, options);

--- a/examples/typescript/claude-code-harness.ts
+++ b/examples/typescript/claude-code-harness.ts
@@ -50,6 +50,10 @@ import {
   type ResolvedLlmBinding,
 } from "./shared";
 import { injectedToolRegistry, registryMcpServer } from "./registry-tools";
+import {
+  claudePermissionResult,
+  type CodingApprovalPolicy,
+} from "./executor-approvals";
 
 const DEFAULT_CLAUDE_CODE_SANDBOX_EXECUTABLE = "/usr/local/bin/claude-code";
 const CLAUDE_RESULT_GRACE_MS = 5_000;
@@ -143,6 +147,7 @@ async function runClaudeCodeTurn(
               state.systemPrompt,
               modelBinding,
               registry,
+              options.approvals ?? "auto",
             ),
           }),
           context,
@@ -306,6 +311,7 @@ function claudeOptions(
   systemPrompt: string | null,
   modelBinding: ResolvedLlmBinding,
   registry: HarnessToolRegistry,
+  approvals: CodingApprovalPolicy,
 ): Options {
   const options: Options = {
     model: modelBinding.model,
@@ -316,6 +322,27 @@ function claudeOptions(
     pathToClaudeCodeExecutable: claudeSandboxExecutable(),
     spawnClaudeCodeProcess: (options) =>
       new SandboxClaudeCodeProcess(context, options),
+    // Without a handler a permission prompt stalls the CLI until the startup
+    // timeout. Denies are recorded; allows are already visible as observed
+    // tool events.
+    permissionMode: "default",
+    canUseTool: async (toolName, _input, { toolUseID }) => {
+      const result = claudePermissionResult(approvals, toolName);
+      if (result.behavior === "deny") {
+        await appendCustomEvent(
+          context.exoharness.current.turn,
+          "claude_tool_permission",
+          {
+            metadata: turnMetadata(context),
+            tool: toolName,
+            tool_use_id: toolUseID,
+            policy: approvals,
+            decision: result.behavior,
+          },
+        );
+      }
+      return result;
+    },
   };
   if (registry.definitions().length > 0) {
     // The MCP server runs in this host process, so registry tools execute on

--- a/examples/typescript/claude-code-harness.ts
+++ b/examples/typescript/claude-code-harness.ts
@@ -39,16 +39,17 @@ import {
   appendEvents,
   appendAndTraceObservedToolEvents,
   asRecord,
+  instructionsText,
   markFirstTextDelta,
   pickEnv,
   pickEnvFrom,
   projectAnthropicMessageToolEvents,
   resolveLlmBinding,
   sandboxCwd,
+  type CodingExecutorTurnOptions,
   type ResolvedLlmBinding,
 } from "./shared";
-import { registryMcpServer } from "./registry-tools";
-import { createDefaultToolRegistry } from "./turn-loop";
+import { injectedToolRegistry, registryMcpServer } from "./registry-tools";
 
 const DEFAULT_CLAUDE_CODE_SANDBOX_EXECUTABLE = "/usr/local/bin/claude-code";
 const CLAUDE_RESULT_GRACE_MS = 5_000;
@@ -71,26 +72,36 @@ interface ClaudeTraceState {
 
 export default defineHarness({
   async runTurn(context) {
-    const modelBinding = await resolveLlmBinding(context);
-    const runtime = ResponsesRuntime.fromModelBinding(
-      context.agentConfig,
-      modelBinding,
-    );
-    await runtime.runTurn(context, (turnParent) =>
-      runClaudeCodeTurn(context, turnParent, modelBinding),
-    );
+    await runClaudeCodeHarnessTurn(context);
   },
 });
+
+// Exported so other harnesses can run the Claude Code executor with their own
+// instructions and tools (see coding-executor-harness).
+export async function runClaudeCodeHarnessTurn(
+  context: TurnContext,
+  options: CodingExecutorTurnOptions = {},
+): Promise<void> {
+  const modelBinding = await resolveLlmBinding(context);
+  const runtime = ResponsesRuntime.fromModelBinding(
+    context.agentConfig,
+    modelBinding,
+  );
+  await runtime.runTurn(context, (turnParent) =>
+    runClaudeCodeTurn(context, turnParent, modelBinding, options),
+  );
+}
 
 async function runClaudeCodeTurn(
   context: TurnContext,
   turnParent: TraceParent,
   modelBinding: ResolvedLlmBinding,
+  options: CodingExecutorTurnOptions,
 ): Promise<string | null> {
-  const systemPrompt = claudeSystemPrompt(context);
-  // No built-ins: Claude Code brings its own shell and edit tools. The
-  // registry carries tool-module and agent-created tools, exposed over MCP.
-  const registry = await createDefaultToolRegistry(context, []);
+  const systemPrompt = options.instructions
+    ? instructionsText(await options.instructions(context)) || null
+    : claudeSystemPrompt(context);
+  const registry = await injectedToolRegistry(context, options.registerTools);
   const state: ClaudeTraceState = {
     startedAt: Date.now(),
     finalText: "",

--- a/examples/typescript/claude-code-harness.ts
+++ b/examples/typescript/claude-code-harness.ts
@@ -22,6 +22,7 @@ import {
   systemTextMessage,
   toJsonValue,
   turnMetadata,
+  type HarnessToolRegistry,
   type JsonValue,
   type Message,
   type PendingToolCall,
@@ -46,6 +47,8 @@ import {
   sandboxCwd,
   type ResolvedLlmBinding,
 } from "./shared";
+import { registryMcpServer } from "./registry-tools";
+import { createDefaultToolRegistry } from "./turn-loop";
 
 const DEFAULT_CLAUDE_CODE_SANDBOX_EXECUTABLE = "/usr/local/bin/claude-code";
 const CLAUDE_RESULT_GRACE_MS = 5_000;
@@ -85,6 +88,9 @@ async function runClaudeCodeTurn(
   modelBinding: ResolvedLlmBinding,
 ): Promise<string | null> {
   const systemPrompt = claudeSystemPrompt(context);
+  // No built-ins: Claude Code brings its own shell and edit tools. The
+  // registry carries tool-module and agent-created tools, exposed over MCP.
+  const registry = await createDefaultToolRegistry(context, []);
   const state: ClaudeTraceState = {
     startedAt: Date.now(),
     finalText: "",
@@ -121,7 +127,12 @@ async function runClaudeCodeTurn(
         await consumeClaudeQuery(
           query({
             prompt: claudePromptInput(claudePrompt(state.promptMessages)),
-            options: claudeOptions(context, state.systemPrompt, modelBinding),
+            options: claudeOptions(
+              context,
+              state.systemPrompt,
+              modelBinding,
+              registry,
+            ),
           }),
           context,
           turnParent,
@@ -283,6 +294,7 @@ function claudeOptions(
   context: TurnContext,
   systemPrompt: string | null,
   modelBinding: ResolvedLlmBinding,
+  registry: HarnessToolRegistry,
 ): Options {
   const options: Options = {
     model: modelBinding.model,
@@ -294,6 +306,13 @@ function claudeOptions(
     spawnClaudeCodeProcess: (options) =>
       new SandboxClaudeCodeProcess(context, options),
   };
+  if (registry.definitions().length > 0) {
+    // The MCP server runs in this host process, so registry tools execute on
+    // the host while the CLI runs in the sandbox.
+    options.mcpServers = {
+      exo: { type: "sdk", name: "exo", instance: registryMcpServer(registry) },
+    };
+  }
   if (systemPrompt) {
     return { ...options, systemPrompt };
   }

--- a/examples/typescript/codex-harness.test.ts
+++ b/examples/typescript/codex-harness.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import type { Conversation, EventQuery } from "@exo/harness";
+
+import { latestSandboxStartedEventId } from "./codex-harness";
+
+function conversationWith(ids: string[]): {
+  handle: Pick<Conversation, "getEvents">;
+  queries: EventQuery[];
+} {
+  const queries: EventQuery[] = [];
+  const handle = {
+    getEvents: async (query: EventQuery) => {
+      queries.push(query);
+      return { events: ids.map((id) => ({ id })) };
+    },
+  } as unknown as Pick<Conversation, "getEvents">;
+  return { handle, queries };
+}
+
+describe("latestSandboxStartedEventId", () => {
+  it("returns the newest sandbox_started event id", async () => {
+    const { handle, queries } = conversationWith(["evt-9", "evt-3"]);
+    await expect(latestSandboxStartedEventId(handle)).resolves.toBe("evt-9");
+    expect(queries[0].types).toEqual(["sandbox_started"]);
+    expect(queries[0].direction).toBe("desc");
+  });
+
+  it("returns null when the sandbox was never started", async () => {
+    const { handle } = conversationWith([]);
+    await expect(latestSandboxStartedEventId(handle)).resolves.toBeNull();
+  });
+});

--- a/examples/typescript/codex-harness.ts
+++ b/examples/typescript/codex-harness.ts
@@ -9,6 +9,7 @@ import {
   toolRequestedEvent,
   toolResultEvent,
   turnMetadata,
+  type Conversation,
   type EventData,
   type HarnessToolRegistry,
   type JsonObject,
@@ -127,6 +128,10 @@ class CodexWarmSession {
     readonly process: SandboxProcess,
     initialScope: CodexWarmTurnScope,
     threadId: string | null,
+    // The newest sandbox_started event id when this session was created; a
+    // later one means the sandbox was rewound and this session's process is
+    // dead.
+    readonly sandboxEpoch: string | null,
   ) {
     this.current = initialScope;
     this.threadId = threadId;
@@ -136,6 +141,7 @@ class CodexWarmSession {
     scope: CodexWarmTurnScope,
     modelBinding: ResolvedLlmBinding,
     sessionKey: string,
+    sandboxEpoch: string | null,
   ): Promise<CodexWarmSession> {
     let session: CodexWarmSession | null = null;
     const pendingProtocol: CodexProtocolLogEntry[] = [];
@@ -167,6 +173,7 @@ class CodexWarmSession {
       process,
       scope,
       process.reused ? (warmRecord?.threadId ?? null) : null,
+      sandboxEpoch,
     );
     for (const entry of pendingProtocol) {
       session.recordProtocol(entry);
@@ -257,6 +264,16 @@ async function runCodexTurn(
   };
   const sessionKey = codexWarmSessionKey(context, modelBinding);
   const sandboxRuntime = codexSandboxRuntimeKey(context);
+  // A rewind restarts the sandbox and kills every process in it, which the
+  // warm cache cannot see; a cached session would fail mid-turn. Compare
+  // against the newest sandbox_started event and start fresh when it moved.
+  // (A rewind from another conversation is invisible here; the error path
+  // below still recovers on the following turn.)
+  const sandboxEpoch = await latestSandboxStartedEventId(
+    context.exoharness.current.conversation,
+  );
+  const startSession = () =>
+    CodexWarmSession.start(scope, modelBinding, sessionKey, sandboxEpoch);
   const { resource: session, reused: appServerReused } = await traceCodexTask(
     turnParent,
     "codex_app_server_ready",
@@ -266,10 +283,20 @@ async function runCodexTurn(
       sandbox_runtime: sandboxRuntime,
       warm_session_key: sessionKey,
     },
-    () =>
-      codexSessions.get(sessionKey, () =>
-        CodexWarmSession.start(scope, modelBinding, sessionKey),
-      ),
+    async () => {
+      const cached = await codexSessions.get(sessionKey, startSession);
+      if (cached.resource.sandboxEpoch === sandboxEpoch) {
+        return cached;
+      }
+      await appendCustomEvent(turn, "codex_warm_session_invalidated", {
+        metadata: turnMetadata(context),
+        warm_session_key: sessionKey,
+        stale_epoch: cached.resource.sandboxEpoch,
+        sandbox_epoch: sandboxEpoch,
+      });
+      codexSessions.delete(sessionKey, (stale) => stale.close());
+      return codexSessions.get(sessionKey, startSession);
+    },
   );
   session.setTurnScope(scope);
 
@@ -567,6 +594,18 @@ async function startCodexThread(
     throw new Error("codex thread/start response did not include thread.id");
   }
   return thread.id;
+}
+
+// Exported for tests.
+export async function latestSandboxStartedEventId(
+  conversation: Pick<Conversation, "getEvents">,
+): Promise<string | null> {
+  const result = await conversation.getEvents({
+    direction: "desc",
+    limit: 1,
+    types: ["sandbox_started"],
+  });
+  return result.events[0]?.id ?? null;
 }
 
 async function latestCodexWarmSession(

--- a/examples/typescript/codex-harness.ts
+++ b/examples/typescript/codex-harness.ts
@@ -50,10 +50,14 @@ import {
   traceExoharnessToolCall,
   traceObservedToolCall,
   WarmResourceCache,
+  type CodingExecutorTurnOptions,
   type ResolvedLlmBinding,
 } from "./shared";
-import { callRegistryTool, injectedToolDefinitions } from "./registry-tools";
-import { createDefaultToolRegistry } from "./turn-loop";
+import {
+  callRegistryTool,
+  injectedToolDefinitions,
+  injectedToolRegistry,
+} from "./registry-tools";
 
 const CODEX_SHELL_TOOL = "codex.shell";
 const CODEX_WEB_SEARCH_TOOL = "codex.web_search";
@@ -203,29 +207,41 @@ const codexSessions = new WarmResourceCache<CodexWarmSession>();
 
 export default defineHarness({
   async runTurn(context) {
-    const modelBinding = await resolveLlmBinding(context);
-    const runtime = ResponsesRuntime.fromModelBinding(
-      context.agentConfig,
-      modelBinding,
-    );
-    await runtime.runTurn(context, (turnParent) =>
-      runCodexTurn(context, turnParent, modelBinding),
-    );
+    await runCodexHarnessTurn(context);
   },
 });
+
+// Exported so other harnesses can run the codex executor with their own
+// instructions and tools (see coding-executor-harness). A reused warm thread
+// keeps the instructions and dynamic tools it was started with.
+export async function runCodexHarnessTurn(
+  context: TurnContext,
+  options: CodingExecutorTurnOptions = {},
+): Promise<void> {
+  const modelBinding = await resolveLlmBinding(context);
+  const runtime = ResponsesRuntime.fromModelBinding(
+    context.agentConfig,
+    modelBinding,
+  );
+  await runtime.runTurn(context, (turnParent) =>
+    runCodexTurn(context, turnParent, modelBinding, options),
+  );
+}
 
 async function runCodexTurn(
   context: TurnContext,
   turnParent: TraceParent,
   modelBinding: ResolvedLlmBinding,
+  options: CodingExecutorTurnOptions,
 ): Promise<string | null> {
   await requireCodexSandboxNetworking(context);
 
   const { turn } = context.exoharness.current;
   const protocolLog = new CodexProtocolEventBuffer(context);
-  // No built-ins: codex brings its own shell. The registry carries tool-module
-  // and agent-created tools, exposed to codex as dynamic tools.
-  const registry = await createDefaultToolRegistry(context, []);
+  const registry = await injectedToolRegistry(context, options.registerTools);
+  const developerInstructions = options.instructions
+    ? instructionsText(await options.instructions(context)) || null
+    : codexDeveloperInstructions(context);
   const scope: CodexWarmTurnScope = {
     context,
     protocolLog,
@@ -272,7 +288,14 @@ async function runCodexTurn(
           cwd: codexAppServerCwd(context),
           external_sandbox: useCodexExternalSandbox(),
         },
-        () => startCodexThread(session.server, context, modelBinding, registry),
+        () =>
+          startCodexThread(
+            session.server,
+            context,
+            modelBinding,
+            registry,
+            developerInstructions,
+          ),
       ));
     session.threadId = threadId;
     await recordCodexWarmSession(
@@ -515,8 +538,8 @@ async function startCodexThread(
   context: TurnContext,
   modelBinding: ResolvedLlmBinding,
   registry: HarnessToolRegistry,
+  developerInstructions: string | null,
 ): Promise<string> {
-  const developerInstructions = codexDeveloperInstructions(context);
   const request: JsonObject = {
     model: modelBinding.model,
     modelProvider: "openai",

--- a/examples/typescript/codex-harness.ts
+++ b/examples/typescript/codex-harness.ts
@@ -58,6 +58,10 @@ import {
   injectedToolDefinitions,
   injectedToolRegistry,
 } from "./registry-tools";
+import {
+  codexApprovalDecision,
+  type CodingApprovalPolicy,
+} from "./executor-approvals";
 
 const CODEX_SHELL_TOOL = "codex.shell";
 const CODEX_WEB_SEARCH_TOOL = "codex.web_search";
@@ -90,6 +94,7 @@ interface CodexWarmTurnScope {
   protocolLog: CodexProtocolEventBuffer;
   turnParent: TraceParent;
   registry: HarnessToolRegistry;
+  approvals: CodingApprovalPolicy;
 }
 
 interface PriorResponseItems {
@@ -198,6 +203,7 @@ class CodexWarmSession {
       current.context,
       current.turnParent,
       current.registry,
+      current.approvals,
       request,
     );
   }
@@ -247,6 +253,7 @@ async function runCodexTurn(
     protocolLog,
     turnParent,
     registry,
+    approvals: options.approvals ?? "auto",
   };
   const sessionKey = codexWarmSessionKey(context, modelBinding);
   const sandboxRuntime = codexSandboxRuntimeKey(context);
@@ -637,13 +644,19 @@ async function handleCodexServerRequest(
   context: TurnContext,
   turnParent: TraceParent,
   registry: HarnessToolRegistry,
+  approvals: CodingApprovalPolicy,
   request: CodexServerRequest,
 ): Promise<JsonValue | undefined> {
-  if (
-    useCodexExternalSandbox() &&
-    request.method === "item/commandExecution/requestApproval"
-  ) {
-    return { decision: "accept" };
+  const decision = codexApprovalDecision(approvals, request.method);
+  if (decision !== undefined) {
+    await appendCustomEvent(context.exoharness.current.turn, "codex_approval", {
+      metadata: turnMetadata(context),
+      method: request.method,
+      params: toJsonValue(request.params ?? null),
+      policy: approvals,
+      response: decision,
+    });
+    return decision;
   }
   if (request.method !== "item/tool/call") {
     return undefined;

--- a/examples/typescript/codex-harness.ts
+++ b/examples/typescript/codex-harness.ts
@@ -10,6 +10,7 @@ import {
   toolResultEvent,
   turnMetadata,
   type EventData,
+  type HarnessToolRegistry,
   type JsonObject,
   type JsonValue,
   type Message,
@@ -51,6 +52,8 @@ import {
   WarmResourceCache,
   type ResolvedLlmBinding,
 } from "./shared";
+import { callRegistryTool, injectedToolDefinitions } from "./registry-tools";
+import { createDefaultToolRegistry } from "./turn-loop";
 
 const CODEX_SHELL_TOOL = "codex.shell";
 const CODEX_WEB_SEARCH_TOOL = "codex.web_search";
@@ -82,6 +85,7 @@ interface CodexWarmTurnScope {
   context: TurnContext;
   protocolLog: CodexProtocolEventBuffer;
   turnParent: TraceParent;
+  registry: HarnessToolRegistry;
 }
 
 interface PriorResponseItems {
@@ -189,6 +193,7 @@ class CodexWarmSession {
     return handleCodexServerRequest(
       current.context,
       current.turnParent,
+      current.registry,
       request,
     );
   }
@@ -218,7 +223,15 @@ async function runCodexTurn(
 
   const { turn } = context.exoharness.current;
   const protocolLog = new CodexProtocolEventBuffer(context);
-  const scope: CodexWarmTurnScope = { context, protocolLog, turnParent };
+  // No built-ins: codex brings its own shell. The registry carries tool-module
+  // and agent-created tools, exposed to codex as dynamic tools.
+  const registry = await createDefaultToolRegistry(context, []);
+  const scope: CodexWarmTurnScope = {
+    context,
+    protocolLog,
+    turnParent,
+    registry,
+  };
   const sessionKey = codexWarmSessionKey(context, modelBinding);
   const sandboxRuntime = codexSandboxRuntimeKey(context);
   const { resource: session, reused: appServerReused } = await traceCodexTask(
@@ -259,7 +272,7 @@ async function runCodexTurn(
           cwd: codexAppServerCwd(context),
           external_sandbox: useCodexExternalSandbox(),
         },
-        () => startCodexThread(session.server, context, modelBinding),
+        () => startCodexThread(session.server, context, modelBinding, registry),
       ));
     session.threadId = threadId;
     await recordCodexWarmSession(
@@ -501,6 +514,7 @@ async function startCodexThread(
   codex: CodexAppServer,
   context: TurnContext,
   modelBinding: ResolvedLlmBinding,
+  registry: HarnessToolRegistry,
 ): Promise<string> {
   const developerInstructions = codexDeveloperInstructions(context);
   const request: JsonObject = {
@@ -509,7 +523,7 @@ async function startCodexThread(
     cwd: codexAppServerCwd(context),
     approvalPolicy: "on-request",
     sandbox: "read-only",
-    dynamicTools: buildCodexDynamicTools(context),
+    dynamicTools: buildCodexDynamicTools(context, registry),
     ephemeral: true,
     experimentalRawEvents: true,
     persistFullHistory: true,
@@ -599,6 +613,7 @@ function codexWarmSessionRecord(
 async function handleCodexServerRequest(
   context: TurnContext,
   turnParent: TraceParent,
+  registry: HarnessToolRegistry,
   request: CodexServerRequest,
 ): Promise<JsonValue | undefined> {
   if (
@@ -610,18 +625,31 @@ async function handleCodexServerRequest(
   if (request.method !== "item/tool/call") {
     return undefined;
   }
-  return executeDynamicToolCall(context, turnParent, asRecord(request.params));
+  return executeDynamicToolCall(
+    context,
+    turnParent,
+    registry,
+    asRecord(request.params),
+  );
 }
 
 async function executeDynamicToolCall(
   context: TurnContext,
   turnParent: TraceParent,
+  registry: HarnessToolRegistry,
   params: Record<string, unknown>,
 ): Promise<JsonValue> {
   const callId = stringOrNull(params.callId) ?? "dynamic-tool-call";
   const toolName = stringOrNull(params.tool);
   if (toolName !== EXO_SHELL_DYNAMIC_TOOL) {
-    return dynamicToolErrorResponse(`unsupported dynamic tool: ${toolName}`);
+    return executeRegistryDynamicToolCall(
+      context,
+      turnParent,
+      registry,
+      callId,
+      toolName,
+      asRecord(params.arguments),
+    );
   }
 
   const args = asRecord(params.arguments);
@@ -657,6 +685,37 @@ async function executeDynamicToolCall(
     ]);
     return dynamicToolErrorResponse(message);
   }
+}
+
+async function executeRegistryDynamicToolCall(
+  context: TurnContext,
+  turnParent: TraceParent,
+  registry: HarnessToolRegistry,
+  callId: string,
+  toolName: string | null,
+  args: Record<string, unknown>,
+): Promise<JsonValue> {
+  if (!toolName || !registry.get(toolName)) {
+    return dynamicToolErrorResponse(`unsupported dynamic tool: ${toolName}`);
+  }
+  const toolCall: PendingToolCall = {
+    toolCallId: callId,
+    request: {
+      functionName: toolName,
+      arguments: objectArgs(args),
+    },
+  };
+  await appendEvents(context, [toolRequestedEvent(toolCall)]);
+  const { result, ok, events } = await callRegistryTool(registry, toolCall);
+  await appendEvents(context, events);
+  await traceObservedToolCall(
+    context,
+    turnParent,
+    toolCall,
+    result,
+    "codex_dynamic_tool",
+  );
+  return dynamicToolResultResponse(stringifyValue(result), { success: ok });
 }
 
 async function handleCodexNotification(
@@ -995,14 +1054,21 @@ function codexDeveloperInstructions(context: TurnContext): string | null {
   return instructionsText(context.agentConfig.instructions) || null;
 }
 
-function buildCodexDynamicTools(context: TurnContext): JsonValue[] {
+function buildCodexDynamicTools(
+  context: TurnContext,
+  registry: HarnessToolRegistry,
+): JsonValue[] {
+  const registryTools = injectedToolDefinitions(registry).map((definition) =>
+    toJsonValue({ ...definition }),
+  );
   if (useCodexExternalSandbox()) {
-    return [];
+    return registryTools;
   }
   if (!context.conversationConfig.shellProgram) {
-    return [];
+    return registryTools;
   }
   return [
+    ...registryTools,
     {
       name: EXO_SHELL_DYNAMIC_TOOL,
       description: `Run a shell command through the exoharness sandbox. Commands execute from ${sandboxCwd(context)}. Use this for command execution in exo conversations.`,

--- a/examples/typescript/executor-approvals.test.ts
+++ b/examples/typescript/executor-approvals.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  claudePermissionResult,
+  codexApprovalDecision,
+} from "./executor-approvals";
+
+describe("codexApprovalDecision", () => {
+  it("answers command and file-change approvals by policy", () => {
+    for (const method of [
+      "item/commandExecution/requestApproval",
+      "item/fileChange/requestApproval",
+    ]) {
+      expect(codexApprovalDecision("auto", method)).toEqual({
+        decision: "accept",
+      });
+      expect(codexApprovalDecision("deny", method)).toEqual({
+        decision: "decline",
+      });
+    }
+  });
+
+  it("grants no permissions under either policy", () => {
+    expect(
+      codexApprovalDecision("auto", "item/permissions/requestApproval"),
+    ).toEqual({ scope: "turn", permissions: {} });
+  });
+
+  it("leaves non-approval methods to the caller", () => {
+    expect(codexApprovalDecision("auto", "item/tool/call")).toBeUndefined();
+    expect(codexApprovalDecision("deny", "thread/start")).toBeUndefined();
+  });
+});
+
+describe("claudePermissionResult", () => {
+  it("allows under auto", () => {
+    expect(claudePermissionResult("auto", "Bash")).toEqual({
+      behavior: "allow",
+    });
+  });
+
+  it("denies with the tool named", () => {
+    const result = claudePermissionResult("deny", "Bash");
+    expect(result.behavior).toBe("deny");
+    if (result.behavior === "deny") {
+      expect(result.message).toContain("Bash");
+    }
+  });
+});

--- a/examples/typescript/executor-approvals.ts
+++ b/examples/typescript/executor-approvals.ts
@@ -1,0 +1,44 @@
+import type { PermissionResult } from "@anthropic-ai/claude-agent-sdk";
+
+import type { JsonValue } from "@exo/harness";
+
+// Approval policy for the coding-agent executors. "auto" approves inside the
+// sandbox boundary (the containment the presets already rely on); "deny"
+// refuses anything the runtime asks about. There is no interactive path yet:
+// TurnContext has no ask-the-user channel, so a real approval UX needs
+// substrate support first. Callers record every decision as an event.
+export type CodingApprovalPolicy = "auto" | "deny";
+
+const CODEX_APPROVAL_METHODS = new Set([
+  "item/commandExecution/requestApproval",
+  "item/fileChange/requestApproval",
+]);
+
+// The answer to a codex approval request, or undefined for non-approval
+// methods. Permission requests grant nothing either way; without this the
+// app-server defaults silently declined fileChange even in "auto".
+export function codexApprovalDecision(
+  policy: CodingApprovalPolicy,
+  method: string,
+): JsonValue | undefined {
+  if (CODEX_APPROVAL_METHODS.has(method)) {
+    return { decision: policy === "deny" ? "decline" : "accept" };
+  }
+  if (method === "item/permissions/requestApproval") {
+    return { scope: "turn", permissions: {} };
+  }
+  return undefined;
+}
+
+// Claude Code asks per tool use; without a handler a prompt stalls the CLI.
+export function claudePermissionResult(
+  policy: CodingApprovalPolicy,
+  toolName: string,
+): PermissionResult {
+  return policy === "deny"
+    ? {
+        behavior: "deny",
+        message: `${toolName} denied by the harness approval policy`,
+      }
+    : { behavior: "allow" };
+}

--- a/examples/typescript/model-family.test.ts
+++ b/examples/typescript/model-family.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+
+import { modelFamily } from "./model-family";
+
+describe("modelFamily", () => {
+  it("recognises Anthropic model ids", () => {
+    expect(modelFamily("claude-sonnet-4-6")).toBe("anthropic");
+    expect(modelFamily("claude-opus-4-1-20250805")).toBe("anthropic");
+  });
+
+  it("recognises Anthropic ids behind provider prefixes", () => {
+    expect(modelFamily("anthropic/claude-sonnet-4-6")).toBe("anthropic");
+    expect(modelFamily("us.anthropic.claude-sonnet-4-6-v1:0")).toBe(
+      "anthropic",
+    );
+    expect(modelFamily("publishers/anthropic/models/claude-opus-4-1")).toBe(
+      "anthropic",
+    );
+  });
+
+  it("recognises OpenAI model ids", () => {
+    expect(modelFamily("gpt-5.4")).toBe("openai");
+    expect(modelFamily("gpt-5.6-terra")).toBe("openai");
+    expect(modelFamily("codex-mini-latest")).toBe("openai");
+    expect(modelFamily("openai/gpt-5.5")).toBe("openai");
+  });
+
+  it("is case and whitespace insensitive", () => {
+    expect(modelFamily("  Claude-Sonnet-4-6 ")).toBe("anthropic");
+    expect(modelFamily("GPT-5.4")).toBe("openai");
+  });
+
+  it("reports unknown for router aliases and unrecognised models", () => {
+    // `exo model register auto` is a real configuration (see
+    // scripts/agent-harness-e2e.ts): the family genuinely is not statically
+    // knowable, and callers must handle that rather than guess.
+    expect(modelFamily("auto")).toBe("unknown");
+    expect(modelFamily("llama-3.1-70b")).toBe("unknown");
+    expect(modelFamily("gemini-2.5-pro")).toBe("unknown");
+    expect(modelFamily("")).toBe("unknown");
+  });
+
+  it("does not match models that merely contain the substring", () => {
+    expect(modelFamily("claudette-7b")).toBe("unknown");
+  });
+});

--- a/examples/typescript/model-family.ts
+++ b/examples/typescript/model-family.ts
@@ -1,0 +1,28 @@
+// Post-training family of a model, used to pick the edit-tool shape. Keys off
+// the upstream model id, not the arbitrary local binding name.
+export type ModelFamily = "anthropic" | "openai" | "unknown";
+
+// Exact token membership, not substring: "claudette-7b" is not Claude.
+const ANTHROPIC_TOKENS = new Set(["claude", "anthropic"]);
+const OPENAI_TOKENS = new Set(["gpt", "codex", "openai"]);
+
+function tokens(modelId: string): string[] {
+  return modelId
+    .split("/")
+    .flatMap((part) => part.split("."))
+    .flatMap((part) => part.split("-"))
+    .filter((part) => part.length > 0);
+}
+
+// Router aliases ("auto") and self-hosted models have no static family;
+// "unknown" is a real state, not an error.
+export function modelFamily(upstreamModel: string): ModelFamily {
+  const parts = tokens(upstreamModel.trim().toLowerCase());
+  if (parts.some((part) => ANTHROPIC_TOKENS.has(part))) {
+    return "anthropic";
+  }
+  if (parts.some((part) => OPENAI_TOKENS.has(part))) {
+    return "openai";
+  }
+  return "unknown";
+}

--- a/examples/typescript/registry-tools.test.ts
+++ b/examples/typescript/registry-tools.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+import type {
+  EventData,
+  JsonObject,
+  PendingToolCall,
+  ToolInstance,
+  ToolResult,
+} from "@exo/harness";
+
+import {
+  callRegistryTool,
+  injectedToolDefinitions,
+  registryMcpServer,
+  toolResultOk,
+  type ToolRegistryHandle,
+} from "./registry-tools";
+
+const GREET_SCHEMA = {
+  type: "object",
+  additionalProperties: false,
+  properties: { name: { type: "string", description: "Who to greet." } },
+  required: ["name"],
+};
+
+// In-memory registry fake; records calls so tests can assert on dispatch.
+class FakeRegistry implements ToolRegistryHandle {
+  readonly calls: PendingToolCall[] = [];
+
+  constructor(
+    private readonly tools: Record<string, (args: JsonObject) => ToolResult>,
+  ) {}
+
+  definitions() {
+    return Object.keys(this.tools).map((name) => ({
+      name,
+      description: `${name} tool`,
+      parameters: GREET_SCHEMA,
+    }));
+  }
+
+  get(name: string): ToolInstance | undefined {
+    const run = this.tools[name];
+    if (!run) {
+      return undefined;
+    }
+    return {
+      source: "library",
+      definition: {
+        name,
+        description: `${name} tool`,
+        parameters: GREET_SCHEMA,
+      },
+      handler: { execute: async (args) => run(args) },
+    };
+  }
+
+  async executePending(toolCalls: PendingToolCall[]): Promise<EventData[]> {
+    const events: EventData[] = [];
+    for (const toolCall of toolCalls) {
+      this.calls.push(toolCall);
+      const run = this.tools[toolCall.request.functionName];
+      const result = run
+        ? run(toolCall.request.arguments)
+        : { ok: false, error: "not registered" };
+      events.push({
+        type: "tool_result",
+        tool_call_id: toolCall.toolCallId,
+        result,
+      });
+    }
+    return events;
+  }
+}
+
+function pendingCall(name: string, args: JsonObject = {}): PendingToolCall {
+  return {
+    toolCallId: "call-1",
+    request: { functionName: name, arguments: args },
+  };
+}
+
+describe("injectedToolDefinitions", () => {
+  it("passes the JSON schema through verbatim", () => {
+    const registry = new FakeRegistry({ greet: () => ({ ok: true }) });
+    expect(injectedToolDefinitions(registry)).toEqual([
+      { name: "greet", description: "greet tool", inputSchema: GREET_SCHEMA },
+    ]);
+  });
+});
+
+describe("toolResultOk", () => {
+  it("treats ok: false as failure and everything else as success", () => {
+    expect(toolResultOk({ ok: false, error: "nope" })).toBe(false);
+    expect(toolResultOk({ ok: true })).toBe(true);
+    expect(toolResultOk({ files_changed: 2 })).toBe(true);
+    expect(toolResultOk("plain text")).toBe(true);
+    expect(toolResultOk(null)).toBe(true);
+  });
+});
+
+describe("callRegistryTool", () => {
+  it("executes the tool and returns its result with events", async () => {
+    const registry = new FakeRegistry({
+      greet: (args) => ({ ok: true, greeting: `hi ${String(args.name)}` }),
+    });
+    const outcome = await callRegistryTool(
+      registry,
+      pendingCall("greet", { name: "exo" }),
+    );
+    expect(outcome.result).toEqual({ ok: true, greeting: "hi exo" });
+    expect(outcome.ok).toBe(true);
+    expect(outcome.events).toHaveLength(1);
+    expect(registry.calls).toHaveLength(1);
+  });
+
+  it("reports a failing tool as not ok", async () => {
+    const registry = new FakeRegistry({
+      greet: () => ({ ok: false, error: "bad mood" }),
+    });
+    const outcome = await callRegistryTool(registry, pendingCall("greet"));
+    expect(outcome.ok).toBe(false);
+  });
+
+  it("rejects an unknown tool without executing anything", async () => {
+    const registry = new FakeRegistry({ greet: () => ({ ok: true }) });
+    const outcome = await callRegistryTool(registry, pendingCall("missing"));
+    expect(outcome.ok).toBe(false);
+    expect(JSON.stringify(outcome.result)).toContain("missing");
+    expect(registry.calls).toHaveLength(0);
+    expect(outcome.events).toHaveLength(0);
+  });
+});
+
+describe("registryMcpServer", () => {
+  async function connect(registry: ToolRegistryHandle): Promise<Client> {
+    const server = registryMcpServer(registry);
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "test", version: "0.0.0" });
+    await Promise.all([
+      server.connect(serverTransport),
+      client.connect(clientTransport),
+    ]);
+    return client;
+  }
+
+  it("lists registry tools with their schemas", async () => {
+    const client = await connect(
+      new FakeRegistry({ greet: () => ({ ok: true }) }),
+    );
+    const listed = await client.listTools();
+    expect(listed.tools).toHaveLength(1);
+    expect(listed.tools[0].name).toBe("greet");
+    expect(listed.tools[0].inputSchema).toEqual(GREET_SCHEMA);
+  });
+
+  it("routes a tool call to the registry and returns the result", async () => {
+    const registry = new FakeRegistry({
+      greet: (args) => ({ ok: true, greeting: `hi ${String(args.name)}` }),
+    });
+    const client = await connect(registry);
+    const result = await client.callTool({
+      name: "greet",
+      arguments: { name: "exo" },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toEqual([
+      { type: "text", text: JSON.stringify({ ok: true, greeting: "hi exo" }) },
+    ]);
+  });
+
+  it("marks a failing tool call as an error", async () => {
+    const client = await connect(
+      new FakeRegistry({ greet: () => ({ ok: false, error: "bad mood" }) }),
+    );
+    const result = await client.callTool({ name: "greet", arguments: {} });
+    expect(result.isError).toBe(true);
+  });
+
+  it("marks an unknown tool as an error instead of throwing", async () => {
+    const client = await connect(new FakeRegistry({}));
+    const result = await client.callTool({ name: "nope", arguments: {} });
+    expect(result.isError).toBe(true);
+  });
+});

--- a/examples/typescript/registry-tools.ts
+++ b/examples/typescript/registry-tools.ts
@@ -6,13 +6,17 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 
-import type {
-  EventData,
-  HarnessToolRegistry,
-  JsonObject,
-  PendingToolCall,
-  ToolResult,
+import {
+  createToolRegistry,
+  type EventData,
+  type HarnessToolRegistry,
+  type JsonObject,
+  type PendingToolCall,
+  type ToolResult,
+  type TurnContext,
 } from "@exo/harness";
+
+import { createDefaultToolRegistry } from "./turn-loop";
 
 // Exposes harness registry tools inside the native coding-agent runtimes:
 // codex takes them as dynamic tools, Claude Code as an in-process MCP server.
@@ -24,6 +28,24 @@ export type ToolRegistryHandle = Pick<
   HarnessToolRegistry,
   "definitions" | "get" | "executePending"
 >;
+
+// The registry a coding harness injects: the given hook's registrations, or
+// by default the tool modules + agent-created tools (no built-ins — the
+// native runtimes bring their own shell).
+export async function injectedToolRegistry(
+  context: TurnContext,
+  registerTools?: (
+    tools: HarnessToolRegistry,
+    context: TurnContext,
+  ) => Promise<void> | void,
+): Promise<HarnessToolRegistry> {
+  if (!registerTools) {
+    return createDefaultToolRegistry(context, []);
+  }
+  const tools = createToolRegistry(context);
+  await registerTools(tools, context);
+  return tools;
+}
 
 export interface InjectedToolDefinition {
   name: string;

--- a/examples/typescript/registry-tools.ts
+++ b/examples/typescript/registry-tools.ts
@@ -1,0 +1,116 @@
+import { randomUUID } from "node:crypto";
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+import type {
+  EventData,
+  HarnessToolRegistry,
+  JsonObject,
+  PendingToolCall,
+  ToolResult,
+} from "@exo/harness";
+
+// Exposes harness registry tools inside the native coding-agent runtimes:
+// codex takes them as dynamic tools, Claude Code as an in-process MCP server.
+// Built-ins are not injected; the native runtimes bring their own shell and
+// file tools. Execution stays on the host, where the registry lives.
+
+// The registry subset the bridge needs, so tests can fake it.
+export type ToolRegistryHandle = Pick<
+  HarnessToolRegistry,
+  "definitions" | "get" | "executePending"
+>;
+
+export interface InjectedToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: JsonObject;
+}
+
+export function injectedToolDefinitions(
+  registry: ToolRegistryHandle,
+): InjectedToolDefinition[] {
+  return registry.definitions().map((definition) => ({
+    name: definition.name,
+    description: definition.description,
+    // ToolDefinition.parameters is already a JSON schema object; both
+    // runtimes take it verbatim, so nothing is lost in translation.
+    inputSchema: definition.parameters as JsonObject,
+  }));
+}
+
+export interface RegistryToolOutcome {
+  result: ToolResult;
+  ok: boolean;
+  events: EventData[];
+}
+
+// Tools report failure as { ok: false }; anything else counts as success.
+export function toolResultOk(result: ToolResult): boolean {
+  return !(
+    typeof result === "object" &&
+    result !== null &&
+    !Array.isArray(result) &&
+    result.ok === false
+  );
+}
+
+export async function callRegistryTool(
+  registry: ToolRegistryHandle,
+  toolCall: PendingToolCall,
+): Promise<RegistryToolOutcome> {
+  if (!registry.get(toolCall.request.functionName)) {
+    const result: ToolResult = {
+      ok: false,
+      error: `unknown tool: ${toolCall.request.functionName}`,
+    };
+    return { result, ok: false, events: [] };
+  }
+  const events = await registry.executePending([toolCall]);
+  const resultEvent = events.find((event) => event.type === "tool_result");
+  const result = (resultEvent?.result ?? {
+    ok: false,
+    error: "tool produced no result",
+  }) as ToolResult;
+  return { result, ok: toolResultOk(result), events };
+}
+
+// The instance goes into claude-agent-sdk options as
+// { type: "sdk", name, instance }; the SDK runs it in this process, so calls
+// land on the registry without leaving the host. Raw request handlers rather
+// than registerTool, which would force the JSON schemas through zod.
+export function registryMcpServer(registry: ToolRegistryHandle): McpServer {
+  const server = new McpServer(
+    { name: "exo", version: "0.0.0" },
+    { capabilities: { tools: {} } },
+  );
+  server.server.setRequestHandler(ListToolsRequestSchema, () => ({
+    tools: injectedToolDefinitions(registry).map((definition) => ({
+      ...definition,
+      inputSchema: definition.inputSchema as { [key: string]: unknown } & {
+        type: "object";
+      },
+    })),
+  }));
+  server.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const toolCall: PendingToolCall = {
+      toolCallId: `injected-${randomUUID()}`,
+      request: {
+        functionName: request.params.name,
+        arguments: (request.params.arguments ?? {}) as JsonObject,
+      },
+    };
+    // No events appended here: the Claude message observer already records
+    // MCP tool calls and results from the SDK message stream.
+    const { result, ok } = await callRegistryTool(registry, toolCall);
+    return {
+      content: [{ type: "text" as const, text: JSON.stringify(result) }],
+      isError: !ok,
+    };
+  });
+  return server;
+}

--- a/examples/typescript/shared.ts
+++ b/examples/typescript/shared.ts
@@ -24,13 +24,14 @@ export { projectAnthropicMessageToolEvents } from "@exo/harness";
 // Options for the coding-agent harness entry points. `instructions` replaces
 // agentConfig.instructions as the executor's system/developer prompt;
 // `registerTools` replaces the default tool-module registry. Codex warm
-// threads snapshot both at thread start.
+// threads snapshot both at thread start. `approvals` defaults to "auto".
 export interface CodingExecutorTurnOptions {
   instructions?: (context: TurnContext) => Message[] | Promise<Message[]>;
   registerTools?: (
     tools: HarnessToolRegistry,
     context: TurnContext,
   ) => Promise<void> | void;
+  approvals?: import("./executor-approvals").CodingApprovalPolicy;
 }
 
 export interface TextDeltaTraceState {

--- a/examples/typescript/shared.ts
+++ b/examples/typescript/shared.ts
@@ -5,6 +5,7 @@ import {
   toJsonValue,
   turnMetadata,
   type EventData,
+  type HarnessToolRegistry,
   type JsonObject,
   type JsonValue,
   type Message,
@@ -19,6 +20,18 @@ import {
 } from "@exo/model-runtime/responses";
 
 export { projectAnthropicMessageToolEvents } from "@exo/harness";
+
+// Options for the coding-agent harness entry points. `instructions` replaces
+// agentConfig.instructions as the executor's system/developer prompt;
+// `registerTools` replaces the default tool-module registry. Codex warm
+// threads snapshot both at thread start.
+export interface CodingExecutorTurnOptions {
+  instructions?: (context: TurnContext) => Message[] | Promise<Message[]>;
+  registerTools?: (
+    tools: HarnessToolRegistry,
+    context: TurnContext,
+  ) => Promise<void> | void;
+}
 
 export interface TextDeltaTraceState {
   startedAt: number;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@braintrust/lingua-wasm": "^0.1.0",
     "@cursor/sdk": "^1.0.12",
     "@discordjs/voice": "^0.19.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@mozilla/readability": "^0.6.0",
     "@shadcn/react": "^0.1.0",
     "@whiskeysockets/baileys": "7.0.0-rc13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@discordjs/voice':
         specifier: ^0.19.0
         version: 0.19.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(opusscript@0.1.1)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
       '@mozilla/readability':
         specifier: ^0.6.0
         version: 0.6.0

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,12 @@ export default defineConfig({
       "@exo/model-runtime/responses": fileURLToPath(
         new URL("./typescript/model-runtime/responses.ts", import.meta.url),
       ),
+      "@exo/model-runtime/cost": fileURLToPath(
+        new URL("./typescript/model-runtime/cost.ts", import.meta.url),
+      ),
+      "@exo/codex/app-server": fileURLToPath(
+        new URL("./typescript/codex/app-server.ts", import.meta.url),
+      ),
     },
   },
 });


### PR DESCRIPTION
This makes Claude Code and Codex usable as executors for the Exo agent on the exoharness substrate. The PR is split into four independently reviewable commits.

1. Expose registry tools inside each native runtime

Codex receives registry tools through its dynamic-tools channel, the same mechanism originally built for the gated exo_shell bridge. exo_shell remains gated, and shell execution stays native to Codex inside the external sandbox.

Claude Code receives the tools through an in-process MCP server.

In both cases:

* Registry JSON schemas pass through unchanged.
* Tool execution remains on the host, where the registry lives.
* An empty registry preserves the existing preset behavior.

This adds @modelcontextprotocol/sdk, which is already present in the lockfile through claude-agent-sdk, so it does not introduce a new download.

2. Add the composition harness

The new harness routes:

* Anthropic models to Claude Code
* OpenAI models to Codex

The executor is selected from the upstream model ID. Unknown model families fail explicitly rather than falling back silently.

Exo-provided tools, memory, scheduler, adapters, guardian, todos, skills, and web, are passed through the bridge. Shell execution remains native to the selected executor.

No Rust changes are required. The harness already runs with:

--harness examples/exo/coding-executor-harness.ts

using the executor sandbox image with networking enabled.

3. Make approval behavior explicit

Executor options now accept:

approvals: "auto" | "deny"

The default is "auto", treating the external sandbox as the containment boundary, consistent with the existing executor presets.

This also fixes two silent failure modes:

* Codex fileChange approval requests were falling through to the unhandled-request fallback and being declined.
* Claude Code had no permission handler, so permission prompts stalled the CLI until the startup timeout.

Codex approval decisions are emitted as codex_approval events.

Claude Code denials are emitted as claude_tool_permission events. Allowed tool calls are already visible through the existing observed-tool events.

4. Make Codex warm sessions rewind-safe

Each warm Codex session records the newest sandbox_started event ID when it is created.

Before reuse, the session checks that epoch. If a rewind has moved the sandbox to a different epoch, the session invalidates itself instead of passing the next turn to a dead process.

### Open questions

**Should fileChange be accepted under "auto"?**

Previously, fileChange requests were silently declined.

Because command execution is already accepted inside the external sandbox, declining file changes does not add meaningful protection. I treated the previous behavior as an accidental consequence of the fallback handler.

Please flag this if the decline was intentional.

**Should Claude Code use canUseTool or bypassPermissions?**

bypassPermissions would be simpler and would align with:

* Codex auto-accepting approvals
* The Claude SDK sandbox being disabled in favor of the external sandbox

I used canUseTool because the first commit changes the trust boundary: injected mcp__exo__* tools execute on the host and can perform actions such as guardian_action and send_adapter_message.

The callback therefore remains the only chokepoint between the model and host-side effects. It is also required for "deny" mode and provides the seam for a future interactive approval flow.

Switching "auto" to bypassPermissions would be a three-line change.

### Known limitations

* Codex warm threads retain the instructions and tools they were created with because the protocol does not support per-turn updates.
* A rewind triggered by another conversation on an agent-scoped sandbox is not visible to the current epoch check. That case still follows the existing error-then-recover path. Fixing it requires an agent-scoped event query in the TypeScript API.
* The approval policy currently lives in the harness options. Adding it to AgentConfig and exposing a CLI flag should follow once the policy shape is settled, rather than persisting a premature two-value enum in agent records.

**Validation**

pnpm check passes at every commit:

* Lint: 0 warnings
* Typecheck: clean
* Tests: 146 passing, including 25 new tests

Coverage includes type-level checks, unit tests, and a real MCP client/server exchange over an in-memory transport.

I have not yet run live Claude Code or Codex executions as I am currently afk!