### PR TITLE
Generalize external sandbox providers

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2367,14 +2367,22 @@ async fn instantiate_exoharness(
     bearer_token: Option<String>,
 ) -> Result<Arc<dyn ExoHarness>> {
     if let Some(http_url) = http_url {
+        let local_sandbox_providers = exo_config
+            .sandbox_backends
+            .iter()
+            .filter(|backend| backend.is_local())
+            .map(SandboxBackendRegistration::provider)
+            .collect::<Vec<_>>();
         let mut harness = HttpExoHarness::new(http_url)?;
         if let Some(bearer_token) = bearer_token {
             harness = harness.with_bearer_token(bearer_token);
         }
         let remote: Arc<dyn ExoHarness> = Arc::new(harness);
         let local: Arc<dyn ExoHarness> = Arc::new(BasicExoHarness::new(exo_config.clone()).await?);
-        return Ok(Arc::new(LocalSandboxExoHarness::new_with_force_local(
-            remote, local, false,
+        return Ok(Arc::new(LocalSandboxExoHarness::new_with_local_providers(
+            remote,
+            local,
+            local_sandbox_providers,
         )));
     }
     Ok(Arc::new(BasicExoHarness::new(exo_config.clone()).await?))

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1423,7 +1423,7 @@ async fn main() -> Result<()> {
                 );
                 println!(
                     "sandbox_provider: {}",
-                    format_sandbox_provider(config.sandbox.provider)
+                    format_sandbox_provider(&config.sandbox.provider)
                 );
                 println!(
                     "sandbox_scope: {}",
@@ -1738,14 +1738,16 @@ async fn main() -> Result<()> {
                     external_id,
                     default_workdir,
                 } => {
-                    let attachment = match SandboxProvider::from(provider) {
-                        SandboxProvider::Docker => SandboxAttachment::DockerContainer {
+                    let provider = SandboxProvider::from(provider);
+                    let attachment = if provider == SandboxProvider::Docker {
+                        SandboxAttachment::DockerContainer {
                             container_id: external_id,
-                        },
-                        provider => bail!(
+                        }
+                    } else {
+                        bail!(
                             "sandbox provider {} does not support external attachments",
                             provider.as_str()
-                        ),
+                        )
                     };
                     let conversation =
                         must_get_conversation(harness.as_ref(), &agent, &conversation).await?;
@@ -1864,12 +1866,13 @@ async fn main() -> Result<()> {
                     "sandbox_provider: {}",
                     config
                         .sandbox_provider
+                        .as_ref()
                         .map(format_sandbox_provider)
                         .unwrap_or("inherit")
                 );
                 println!(
                     "effective_sandbox_provider: {}",
-                    format_sandbox_provider(config.effective_sandbox_provider(&agent_config))
+                    format_sandbox_provider(&config.effective_sandbox_provider(&agent_config))
                 );
                 println!(
                     "model_override: {}",
@@ -2443,7 +2446,7 @@ fn format_harness_kind(kind: AgentHarnessKind) -> &'static str {
     }
 }
 
-fn format_sandbox_provider(provider: SandboxProvider) -> &'static str {
+fn format_sandbox_provider(provider: &SandboxProvider) -> &str {
     provider.as_str()
 }
 

--- a/crates/cli/src/tui.rs
+++ b/crates/cli/src/tui.rs
@@ -556,7 +556,7 @@ impl ChatRepl {
                 id: sandbox_id.clone(),
                 snapshot_id,
                 idle_seconds: None,
-                provider: Some(provider),
+                provider: Some(provider.clone()),
             })
             .await?;
         Ok((sandbox_id, provider))
@@ -1066,7 +1066,7 @@ async fn teleport_sandbox(
             id: sandbox_id.clone(),
             snapshot_id,
             idle_seconds: None,
-            provider: Some(provider),
+            provider: Some(provider.clone()),
         })
         .await?;
     Ok((sandbox_id, provider))

--- a/crates/executor/src/agent_sandbox.rs
+++ b/crates/executor/src/agent_sandbox.rs
@@ -37,7 +37,7 @@ struct AgentSandboxRecord {
 impl AgentSandboxRecord {
     fn spec(&self) -> ConversationSandboxSpec {
         ConversationSandboxSpec {
-            provider: self.provider,
+            provider: self.provider.clone(),
             image: self.image.clone(),
             default_workdir: self.default_workdir.clone(),
             file_system_mounts: self.file_system_mounts.clone(),
@@ -50,7 +50,7 @@ impl AgentSandboxRecord {
     fn new(sandbox_name: String, spec: ConversationSandboxSpec) -> Self {
         Self {
             sandbox_name,
-            provider: spec.provider,
+            provider: spec.provider.clone(),
             image: spec.image,
             default_workdir: spec.default_workdir,
             file_system_mounts: spec.file_system_mounts,
@@ -112,7 +112,7 @@ async fn attach_agent_sandbox(
     let sandbox_id = agent
         .create_sandbox(CreateSandboxRequest {
             name: Some(sandbox_name),
-            provider: spec.provider,
+            provider: spec.provider.clone(),
             image: spec.image.clone(),
             default_workdir: Some(spec.default_workdir.clone()),
             file_system_mounts: Some(spec.file_system_mounts.clone()),

--- a/crates/executor/src/conversation_sandbox.rs
+++ b/crates/executor/src/conversation_sandbox.rs
@@ -206,7 +206,7 @@ pub(crate) async fn conversation_sandboxes(
 // config alone.
 pub(crate) fn agent_sandbox_spec(agent_config: &AgentConfig) -> ConversationSandboxSpec {
     ConversationSandboxSpec {
-        provider: agent_config.sandbox.provider,
+        provider: agent_config.sandbox.provider.clone(),
         image: agent_config
             .sandbox
             .image

--- a/crates/executor/src/executor_types.rs
+++ b/crates/executor/src/executor_types.rs
@@ -145,7 +145,8 @@ impl ConversationConfig {
 
     pub fn effective_sandbox_provider(&self, agent_config: &AgentConfig) -> SandboxProvider {
         self.sandbox_provider
-            .unwrap_or(agent_config.sandbox.provider)
+            .clone()
+            .unwrap_or_else(|| agent_config.sandbox.provider.clone())
     }
 }
 

--- a/crates/executor/src/harness_basic_tests.rs
+++ b/crates/executor/src/harness_basic_tests.rs
@@ -849,11 +849,11 @@ async fn send_executes_shell_tool_when_enabled() {
     assert!(matches!(
         &sandbox_events[0].data,
         EventData::SandboxCreated {
-            provider: SandboxProvider::LocalProcess,
+            provider,
             image,
             enable_networking: true,
             ..
-        } if image == "conversation-image"
+        } if provider == &SandboxProvider::LocalProcess && image == "conversation-image"
     ));
 }
 

--- a/crates/executor/src/harness_tool.rs
+++ b/crates/executor/src/harness_tool.rs
@@ -972,7 +972,7 @@ pub(crate) async fn ensure_shell_sandbox(
     let desired_image = requested_image.map(str::to_string).unwrap_or_default();
     let desired_enable_networking = agent_config.sandbox.enable_networking;
 
-    if let Some(sandbox) = latest_shell_sandbox(conversation, desired_provider).await? {
+    if let Some(sandbox) = latest_shell_sandbox(conversation, &desired_provider).await? {
         // When no image was requested, the stored sandbox holds the provider's
         // resolved default — don't treat that as a mismatch.
         let image_matches = requested_image.is_none_or(|img| sandbox.image == img);
@@ -1043,13 +1043,13 @@ struct ShellSandboxInfo {
 
 async fn latest_shell_sandbox(
     conversation: &dyn ConversationHandle,
-    desired_provider: SandboxProvider,
+    desired_provider: &SandboxProvider,
 ) -> Result<Option<ShellSandboxInfo>> {
     let Some(sandbox) = conversation_sandboxes(conversation)
         .await?
         .into_iter()
         .rev()
-        .find(|sandbox| sandbox.provider == desired_provider)
+        .find(|sandbox| &sandbox.provider == desired_provider)
     else {
         return Ok(None);
     };

--- a/crates/executor/src/local_sandbox.rs
+++ b/crates/executor/src/local_sandbox.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ops::Bound;
 use std::sync::Arc;
 
@@ -11,9 +11,10 @@ use exoharness::{
     GetEventsResult, ListConversationsRequest, ListConversationsResult, NewAgentRequest,
     NewConversationRequest, PutSecretRequest, ReadArtifactRequest, Result, RunInSandboxRequest,
     SandboxAttachment, SandboxHandle, SandboxId, SandboxProcess, SandboxProcessEventQuery,
-    SandboxProcessRecord, SandboxProcessStatus, Secret, SecretId, SecretMetadata, SnapshotHandle,
-    SnapshotId, StartSandboxProcessRequest, StartSandboxRequest, TurnHandle, TurnRecord, Uuid7,
-    WaitSandboxProcessRequest, WriteArtifactRequest, WriteSandboxProcessInputRequest,
+    SandboxProcessRecord, SandboxProcessStatus, SandboxProvider, Secret, SecretId, SecretMetadata,
+    SnapshotHandle, SnapshotId, StartSandboxProcessRequest, StartSandboxRequest, TurnHandle,
+    TurnRecord, Uuid7, WaitSandboxProcessRequest, WriteArtifactRequest,
+    WriteSandboxProcessInputRequest,
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
@@ -41,17 +42,27 @@ struct LocalSandboxState {
     sandboxes: Mutex<HashMap<SandboxId, SandboxId>>,
     detached_sandboxes: Mutex<HashMap<SandboxId, SandboxAttachment>>,
     force_local: bool,
+    local_providers: HashSet<SandboxProvider>,
 }
 
 impl LocalSandboxExoHarness {
     pub fn new(remote: Arc<dyn ExoHarness>, local: Arc<dyn ExoHarness>) -> Self {
-        Self::new_with_force_local(remote, local, true)
+        Self::new_with_routing(remote, local, true, HashSet::new())
     }
 
-    pub fn new_with_force_local(
+    pub fn new_with_local_providers(
+        remote: Arc<dyn ExoHarness>,
+        local: Arc<dyn ExoHarness>,
+        local_providers: impl IntoIterator<Item = SandboxProvider>,
+    ) -> Self {
+        Self::new_with_routing(remote, local, false, local_providers.into_iter().collect())
+    }
+
+    fn new_with_routing(
         remote: Arc<dyn ExoHarness>,
         local: Arc<dyn ExoHarness>,
         force_local: bool,
+        local_providers: HashSet<SandboxProvider>,
     ) -> Self {
         Self {
             state: Arc::new(LocalSandboxState {
@@ -63,6 +74,7 @@ impl LocalSandboxExoHarness {
                 sandboxes: Mutex::new(HashMap::new()),
                 detached_sandboxes: Mutex::new(HashMap::new()),
                 force_local,
+                local_providers,
             }),
         }
     }
@@ -181,7 +193,7 @@ impl LocalSandboxAgent {
     }
 
     fn wants_local_sandbox(&self, request: &CreateSandboxRequest) -> bool {
-        self.state.force_local || request.provider.is_local()
+        self.state.force_local || self.state.local_providers.contains(&request.provider)
     }
 
     async fn local_sandbox_id(&self, sandbox_id: &SandboxId) -> Result<Option<SandboxId>> {
@@ -645,7 +657,7 @@ impl LocalSandboxConversation {
     }
 
     fn wants_local_sandbox(&self, request: &CreateSandboxRequest) -> bool {
-        self.state.force_local || request.provider.is_local()
+        self.state.force_local || self.state.local_providers.contains(&request.provider)
     }
 
     async fn local_sandbox_id(&self, sandbox_id: &SandboxId) -> Result<Option<SandboxId>> {
@@ -1067,7 +1079,11 @@ mod tests {
         );
         let remote_harness: Arc<dyn ExoHarness> = remote.clone();
         let local_harness: Arc<dyn ExoHarness> = local;
-        let wrapper = LocalSandboxExoHarness::new(remote_harness, local_harness);
+        let wrapper = LocalSandboxExoHarness::new_with_local_providers(
+            remote_harness,
+            local_harness,
+            [SandboxProvider::LocalProcess],
+        );
 
         let agent = wrapper
             .new_agent(NewAgentRequest {

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -90,6 +90,22 @@ pub struct SandboxBackendRegistration {
 }
 
 impl SandboxBackendRegistration {
+    pub fn from_builtin_provider(provider: SandboxProvider) -> Result<Self> {
+        match provider.as_str() {
+            "apple_container" => Ok(Self::apple_container()),
+            "aws_agentcore" => Ok(Self::aws_agentcore()),
+            "daytona" => Ok(Self::daytona(
+                DaytonaBackendSpec::with_conventional_secrets(),
+            )),
+            "docker" => Ok(Self::docker()),
+            "e2b" => Ok(Self::e2b(E2bBackendSpec::default())),
+            "local_process" => Ok(Self::local_process()),
+            "sprites" => Ok(Self::sprites(SpritesBackendSpec::default())),
+            "vercel" => Ok(Self::vercel(VercelBackendSpec::with_conventional_secrets())),
+            _ => bail!("sandbox provider {provider} is not built into exoharness"),
+        }
+    }
+
     pub fn from_backend(
         provider: SandboxProvider,
         backend: Arc<dyn ManagedSandboxBackend>,

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -207,7 +207,7 @@ impl SandboxBackendRegistration {
     }
 
     pub fn provider(&self) -> SandboxProvider {
-        self.provider
+        self.provider.clone()
     }
 
     fn from_factory<F>(provider: SandboxProvider, factory: F) -> Self
@@ -804,7 +804,7 @@ impl BasicExoHarness {
         let mut registry = HashMap::new();
         for choice in sandbox_backends {
             let provider = choice.provider();
-            if registry.insert(provider, choice).is_some() {
+            if registry.insert(provider.clone(), choice).is_some() {
                 bail!("duplicate sandbox provider {provider:?} in sandbox_backends");
             }
         }
@@ -814,7 +814,7 @@ impl BasicExoHarness {
 
         let mut cache = HashMap::new();
         if let Some(backend) = seed {
-            cache.insert(sandbox_default, backend);
+            cache.insert(sandbox_default.clone(), backend);
         }
 
         let storage = BasicObjectStore::local_filesystem(&root).await?;
@@ -2820,7 +2820,7 @@ async fn start_sandbox_side_effect(
     // teleport a Docker snapshot up to Daytona). Set before routing so the
     // restore targets the new backend and the new provider is persisted;
     // unsupported providers / snapshot kinds error in the calls below.
-    let previous_provider = sandbox.provider;
+    let previous_provider = sandbox.provider.clone();
     if let Some(provider) = request.provider {
         sandbox.provider = provider;
     }
@@ -2839,7 +2839,7 @@ async fn start_sandbox_side_effect(
     let sandbox_handle = if cross_provider {
         let sandbox_handle = harness
             .inner
-            .sandbox_backend_for_provider(sandbox.provider)
+            .sandbox_backend_for_provider(sandbox.provider.clone())
             .await?
             .acquire_from_snapshot(sandbox_request(owner, &request.id, &sandbox, None), payload)
             .await?;
@@ -2874,7 +2874,7 @@ async fn start_sandbox_side_effect(
         }
         harness
             .inner
-            .sandbox_backend_for_provider(sandbox.provider)
+            .sandbox_backend_for_provider(sandbox.provider.clone())
             .await?
             .acquire_from_snapshot(sandbox_request(owner, &request.id, &sandbox, None), payload)
             .await?
@@ -2938,7 +2938,7 @@ async fn prepare_sandbox_request(
         request.image.clone()
     } else if let Some(default) = harness
         .inner
-        .binding_default_image(request.provider)
+        .binding_default_image(request.provider.clone())
         .await?
     {
         default
@@ -3038,13 +3038,13 @@ async fn create_sandbox_handle(
         owner_dir,
         owner,
         sandbox_id,
-        sandbox.provider,
+        sandbox.provider.clone(),
         &state_key,
     )
     .await?;
     let backend = harness
         .inner
-        .sandbox_backend_for_provider(sandbox.provider)
+        .sandbox_backend_for_provider(sandbox.provider.clone())
         .await?;
     let request = sandbox_request(owner, sandbox_id, sandbox, previous_state.clone());
     let handle = match &sandbox.attachment {
@@ -3053,7 +3053,7 @@ async fn create_sandbox_handle(
     };
     let provider_state_event = sandbox_provider_state_event(
         sandbox_id,
-        sandbox.provider,
+        sandbox.provider.clone(),
         state_key,
         previous_state,
         &handle,
@@ -3360,7 +3360,7 @@ impl PreparedSandboxRequest {
         StoredSandbox {
             id,
             name: self.name.clone(),
-            provider: self.provider,
+            provider: self.provider.clone(),
             image: self.image.clone(),
             requested_image: None,
             default_workdir: self.default_workdir.clone(),

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -85,6 +85,7 @@ type SandboxBackendFactory = Arc<
 #[derive(Clone)]
 pub struct SandboxBackendRegistration {
     provider: SandboxProvider,
+    is_local: bool,
     factory: SandboxBackendFactory,
 }
 
@@ -93,40 +94,36 @@ impl SandboxBackendRegistration {
         provider: SandboxProvider,
         backend: Arc<dyn ManagedSandboxBackend>,
     ) -> Self {
-        Self::from_factory(provider, move |_| {
+        let is_local = backend.is_local();
+        Self::from_factory(provider, is_local, move |_| {
             let backend = Arc::clone(&backend);
             Box::pin(async move { Ok(backend) })
         })
     }
 
     pub fn apple_container() -> Self {
-        Self::from_factory(SandboxProvider::AppleContainer, |_| {
-            Box::pin(async {
-                Ok(Arc::new(CliContainerSandboxBackend::apple_container())
-                    as Arc<dyn ManagedSandboxBackend>)
-            })
-        })
+        Self::from_backend(
+            SandboxProvider::AppleContainer,
+            Arc::new(CliContainerSandboxBackend::apple_container()),
+        )
     }
 
     pub fn docker() -> Self {
-        Self::from_factory(SandboxProvider::Docker, |_| {
-            Box::pin(async {
-                Ok(Arc::new(CliContainerSandboxBackend::docker())
-                    as Arc<dyn ManagedSandboxBackend>)
-            })
-        })
+        Self::from_backend(
+            SandboxProvider::Docker,
+            Arc::new(CliContainerSandboxBackend::docker()),
+        )
     }
 
     pub fn local_process() -> Self {
-        Self::from_factory(SandboxProvider::LocalProcess, |_| {
-            Box::pin(async {
-                Ok(Arc::new(LocalProcessSandboxBackend::new()) as Arc<dyn ManagedSandboxBackend>)
-            })
-        })
+        Self::from_backend(
+            SandboxProvider::LocalProcess,
+            Arc::new(LocalProcessSandboxBackend::new()),
+        )
     }
 
     pub fn daytona(spec: DaytonaBackendSpec) -> Self {
-        Self::from_factory(SandboxProvider::Daytona, move |inner| {
+        Self::from_factory(SandboxProvider::Daytona, false, move |inner| {
             let spec = spec.clone();
             Box::pin(async move {
                 let config = match inner.daytona_config_from_binding().await? {
@@ -140,7 +137,7 @@ impl SandboxBackendRegistration {
     }
 
     pub fn e2b(spec: E2bBackendSpec) -> Self {
-        Self::from_factory(SandboxProvider::E2b, move |inner| {
+        Self::from_factory(SandboxProvider::E2b, false, move |inner| {
             let spec = spec.clone();
             Box::pin(async move {
                 let config = match inner.e2b_config_from_binding().await? {
@@ -154,7 +151,7 @@ impl SandboxBackendRegistration {
     }
 
     pub fn sprites(spec: SpritesBackendSpec) -> Self {
-        Self::from_factory(SandboxProvider::Sprites, move |inner| {
+        Self::from_factory(SandboxProvider::Sprites, false, move |inner| {
             let spec = spec.clone();
             Box::pin(async move {
                 let config = match inner.sprites_config_from_binding().await? {
@@ -168,7 +165,7 @@ impl SandboxBackendRegistration {
     }
 
     pub fn vercel(spec: VercelBackendSpec) -> Self {
-        Self::from_factory(SandboxProvider::Vercel, move |inner| {
+        Self::from_factory(SandboxProvider::Vercel, false, move |inner| {
             let spec = spec.clone();
             Box::pin(async move {
                 let config = match inner.vercel_config_from_binding().await? {
@@ -182,7 +179,7 @@ impl SandboxBackendRegistration {
     }
 
     pub fn aws_agentcore() -> Self {
-        Self::from_factory(SandboxProvider::AwsAgentCore, |_inner| {
+        Self::from_factory(SandboxProvider::AwsAgentCore, false, |_inner| {
             Box::pin(async move {
                 #[cfg(feature = "aws-agentcore")]
                 {
@@ -210,7 +207,11 @@ impl SandboxBackendRegistration {
         self.provider.clone()
     }
 
-    fn from_factory<F>(provider: SandboxProvider, factory: F) -> Self
+    pub fn is_local(&self) -> bool {
+        self.is_local
+    }
+
+    fn from_factory<F>(provider: SandboxProvider, is_local: bool, factory: F) -> Self
     where
         F: for<'a> Fn(
                 &'a BasicExoHarnessInner,
@@ -221,6 +222,7 @@ impl SandboxBackendRegistration {
     {
         Self {
             provider,
+            is_local,
             factory: Arc::new(factory),
         }
     }

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -44,6 +44,29 @@ fn sandbox_backend_registration_uses_backend_locality() {
     assert!(!SandboxBackendRegistration::daytona(crate::DaytonaBackendSpec::default()).is_local());
 }
 
+#[test]
+fn sandbox_backend_registration_resolves_builtin_providers() {
+    for provider in [
+        SandboxProvider::AppleContainer,
+        SandboxProvider::AwsAgentCore,
+        SandboxProvider::Daytona,
+        SandboxProvider::Docker,
+        SandboxProvider::E2b,
+        SandboxProvider::LocalProcess,
+        SandboxProvider::Sprites,
+        SandboxProvider::Vercel,
+    ] {
+        let registration =
+            SandboxBackendRegistration::from_builtin_provider(provider.clone()).unwrap();
+        assert_eq!(registration.provider(), provider);
+    }
+
+    assert!(
+        SandboxBackendRegistration::from_builtin_provider(SandboxProvider::from_static("custom"))
+            .is_err()
+    );
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn basic_backend_supports_agent_and_conversation_crud() {
     let tempdir = TempDir::new().expect("tempdir");

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -24,16 +24,25 @@ use crate::{
     EventData, EventKind, EventQuery, EventQueryDirection, ExoHarness, FileSystemMountMode,
     ForkConversationRequest, ManagedSandboxBackend, ManagedSandboxHandle, NewAgentRequest,
     NewConversationRequest, PutSecretRequest, RunInSandboxRequest, SandboxAttachment,
-    SandboxCommand, SandboxCommandOutput, SandboxKey, SandboxLifecycleConfig, SandboxNetworkPolicy,
-    SandboxProcessEvent, SandboxProcessEventQuery, SandboxProcessParts, SandboxProcessStatus,
-    SandboxProcessStdin, SandboxProvider, SandboxProviderConfig, SandboxRequest, SandboxSpec,
-    Secret, SnapshotKind, SnapshotPayload, StartSandboxProcessRequest, StartSandboxRequest, Uuid7,
-    WaitSandboxProcessRequest, WriteArtifactRequest, WriteSandboxProcessInputRequest,
+    SandboxBackendRegistration, SandboxCommand, SandboxCommandOutput, SandboxKey,
+    SandboxLifecycleConfig, SandboxNetworkPolicy, SandboxProcessEvent, SandboxProcessEventQuery,
+    SandboxProcessParts, SandboxProcessStatus, SandboxProcessStdin, SandboxProvider,
+    SandboxProviderConfig, SandboxRequest, SandboxSpec, Secret, SnapshotKind, SnapshotPayload,
+    StartSandboxProcessRequest, StartSandboxRequest, Uuid7, WaitSandboxProcessRequest,
+    WriteArtifactRequest, WriteSandboxProcessInputRequest,
 };
 
 const DEFAULT_DURABLE_CONTRACT_MOUNT_PATH: &str = "/home/exo/workspace";
 #[cfg(feature = "aws-agentcore")]
 const DEFAULT_AGENTCORE_DURABLE_CONTRACT_MOUNT_PATH: &str = "/mnt/workspace";
+
+#[test]
+fn sandbox_backend_registration_uses_backend_locality() {
+    assert!(SandboxBackendRegistration::apple_container().is_local());
+    assert!(SandboxBackendRegistration::docker().is_local());
+    assert!(SandboxBackendRegistration::local_process().is_local());
+    assert!(!SandboxBackendRegistration::daytona(crate::DaytonaBackendSpec::default()).is_local());
+}
 
 #[tokio::test(flavor = "current_thread")]
 async fn basic_backend_supports_agent_and_conversation_crud() {
@@ -1801,6 +1810,10 @@ impl TestProviderStateBackend {
 
 #[async_trait]
 impl ManagedSandboxBackend for TestProviderStateBackend {
+    fn is_local(&self) -> bool {
+        false
+    }
+
     async fn acquire(
         &self,
         request: SandboxRequest,
@@ -1877,6 +1890,10 @@ impl TestSandboxBackend {
 
 #[async_trait]
 impl ManagedSandboxBackend for TestSandboxBackend {
+    fn is_local(&self) -> bool {
+        false
+    }
+
     async fn acquire(
         &self,
         _request: SandboxRequest,
@@ -2083,6 +2100,10 @@ struct RestoreImageTestBackend {
 
 #[async_trait]
 impl ManagedSandboxBackend for RestoreImageTestBackend {
+    fn is_local(&self) -> bool {
+        false
+    }
+
     async fn acquire(
         &self,
         request: SandboxRequest,

--- a/crates/exoharness/src/http_tests.rs
+++ b/crates/exoharness/src/http_tests.rs
@@ -426,6 +426,10 @@ struct SnapshotTestSandboxBackend;
 
 #[async_trait]
 impl ManagedSandboxBackend for SnapshotTestSandboxBackend {
+    fn is_local(&self) -> bool {
+        false
+    }
+
     async fn acquire(
         &self,
         _request: SandboxRequest,

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -173,6 +173,8 @@ pub trait ManagedSandboxHandle: Send + Sync {
 
 #[async_trait]
 pub trait ManagedSandboxBackend: Send + Sync {
+    fn is_local(&self) -> bool;
+
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>>;
     async fn attach(
         &self,
@@ -493,6 +495,10 @@ impl Drop for CliContainerSandboxBackend {
 
 #[async_trait]
 impl ManagedSandboxBackend for CliContainerSandboxBackend {
+    fn is_local(&self) -> bool {
+        true
+    }
+
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
         let request = self.prepare_request(request).await?;
 
@@ -850,6 +856,10 @@ impl LocalProcessSandboxBackend {
 
 #[async_trait]
 impl ManagedSandboxBackend for LocalProcessSandboxBackend {
+    fn is_local(&self) -> bool {
+        true
+    }
+
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
         if !request.spec.durable_file_systems.is_empty() {
             bail!("local-process sandbox backend does not support durable file systems");

--- a/crates/exoharness/src/sandbox_provider/aws_agentcore.rs
+++ b/crates/exoharness/src/sandbox_provider/aws_agentcore.rs
@@ -92,6 +92,10 @@ impl AwsAgentCoreSandboxBackend {
 
 #[async_trait]
 impl ManagedSandboxBackend for AwsAgentCoreSandboxBackend {
+    fn is_local(&self) -> bool {
+        false
+    }
+
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
         reject_unsupported_request(&request, self.session_storage_mount_path.as_deref())?;
         let spec_hash = sandbox_spec_hash(&request.spec);

--- a/crates/exoharness/src/sandbox_provider/daytona.rs
+++ b/crates/exoharness/src/sandbox_provider/daytona.rs
@@ -245,6 +245,10 @@ impl DaytonaSandboxBackend {
 
 #[async_trait]
 impl ManagedSandboxBackend for DaytonaSandboxBackend {
+    fn is_local(&self) -> bool {
+        false
+    }
+
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
         reject_unsupported_mounts(&request)?;
         let spec_hash = sandbox_spec_hash(&request.spec);

--- a/crates/exoharness/src/sandbox_provider/e2b.rs
+++ b/crates/exoharness/src/sandbox_provider/e2b.rs
@@ -218,6 +218,10 @@ impl E2bSandboxBackend {
 
 #[async_trait]
 impl ManagedSandboxBackend for E2bSandboxBackend {
+    fn is_local(&self) -> bool {
+        false
+    }
+
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
         reject_host_mounts(&request)?;
         let spec_hash = sandbox_spec_hash(&request.spec);

--- a/crates/exoharness/src/sandbox_provider/sprites.rs
+++ b/crates/exoharness/src/sandbox_provider/sprites.rs
@@ -168,6 +168,10 @@ impl SpritesSandboxBackend {
 
 #[async_trait]
 impl ManagedSandboxBackend for SpritesSandboxBackend {
+    fn is_local(&self) -> bool {
+        false
+    }
+
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
         reject_host_mounts(&request)?;
         let sprite_name = sprite_name_for_request(&request);

--- a/crates/exoharness/src/sandbox_provider/vercel.rs
+++ b/crates/exoharness/src/sandbox_provider/vercel.rs
@@ -151,6 +151,10 @@ impl VercelSandboxBackend {
 
 #[async_trait]
 impl ManagedSandboxBackend for VercelSandboxBackend {
+    fn is_local(&self) -> bool {
+        false
+    }
+
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
         reject_unsupported_mounts(&request)?;
         let spec_hash = sandbox_spec_hash(&request.spec);

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -647,42 +647,45 @@ impl SandboxAttachment {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[serde(rename_all = "snake_case")]
-pub enum SandboxProvider {
-    #[default]
-    Daytona,
-    E2b,
-    Sprites,
-    Vercel,
-    #[serde(rename = "aws_agentcore", alias = "aws-agentcore")]
-    AwsAgentCore,
-    AppleContainer,
-    Docker,
-    External,
-    #[serde(alias = "local")]
-    LocalProcess,
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(try_from = "String", into = "String")]
+pub struct SandboxProvider(Cow<'static, str>);
+
+impl Default for SandboxProvider {
+    fn default() -> Self {
+        Self::Daytona
+    }
 }
 
+#[allow(non_upper_case_globals)]
 impl SandboxProvider {
-    pub fn is_local(self) -> bool {
-        matches!(
-            self,
-            Self::AppleContainer | Self::Docker | Self::LocalProcess
-        )
+    pub const Daytona: Self = Self::from_static("daytona");
+    pub const E2b: Self = Self::from_static("e2b");
+    pub const Sprites: Self = Self::from_static("sprites");
+    pub const Vercel: Self = Self::from_static("vercel");
+    pub const AwsAgentCore: Self = Self::from_static("aws-agentcore");
+    pub const AppleContainer: Self = Self::from_static("apple-container");
+    pub const Docker: Self = Self::from_static("docker");
+    pub const LocalProcess: Self = Self::from_static("local-process");
+
+    pub const fn from_static(provider: &'static str) -> Self {
+        Self(Cow::Borrowed(provider))
     }
 
-    pub fn as_str(self) -> &'static str {
-        match self {
-            Self::Daytona => "daytona",
-            Self::E2b => "e2b",
-            Self::Sprites => "sprites",
-            Self::Vercel => "vercel",
-            Self::AwsAgentCore => "aws-agentcore",
-            Self::AppleContainer => "apple-container",
-            Self::Docker => "docker",
-            Self::External => "external",
-            Self::LocalProcess => "local-process",
+    pub fn is_local(&self) -> bool {
+        self == &Self::AppleContainer || self == &Self::Docker || self == &Self::LocalProcess
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_ref()
+    }
+
+    fn serialized_name(&self) -> &str {
+        match self.as_str() {
+            "aws-agentcore" => "aws_agentcore",
+            "apple-container" => "apple_container",
+            "local-process" => "local_process",
+            provider => provider,
         }
     }
 }
@@ -697,18 +700,35 @@ impl FromStr for SandboxProvider {
     type Err = crate::Error;
 
     fn from_str(value: &str) -> Result<Self> {
-        match value.trim() {
-            "daytona" => Ok(Self::Daytona),
-            "e2b" => Ok(Self::E2b),
-            "sprites" => Ok(Self::Sprites),
-            "vercel" => Ok(Self::Vercel),
-            "aws-agentcore" | "aws_agentcore" => Ok(Self::AwsAgentCore),
-            "apple-container" | "apple_container" => Ok(Self::AppleContainer),
-            "docker" => Ok(Self::Docker),
-            "external" => Ok(Self::External),
-            "local" | "local-process" | "local_process" => Ok(Self::LocalProcess),
-            provider => Err(anyhow::anyhow!("unsupported sandbox provider: {provider}")),
+        let provider = value.trim().replace('_', "-").to_ascii_lowercase();
+        let provider = match provider.as_str() {
+            "local" => "local-process".to_string(),
+            _ => provider,
+        };
+        if provider.is_empty()
+            || provider.starts_with('-')
+            || provider.ends_with('-')
+            || !provider
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+        {
+            return Err(anyhow::anyhow!("invalid sandbox provider: {value}"));
         }
+        Ok(Self(Cow::Owned(provider)))
+    }
+}
+
+impl TryFrom<String> for SandboxProvider {
+    type Error = crate::Error;
+
+    fn try_from(provider: String) -> Result<Self> {
+        provider.parse()
+    }
+}
+
+impl From<SandboxProvider> for String {
+    fn from(provider: SandboxProvider) -> Self {
+        provider.serialized_name().to_string()
     }
 }
 
@@ -1254,7 +1274,11 @@ mod tests {
             "vercel".parse::<SandboxProvider>().unwrap(),
             SandboxProvider::Vercel
         );
-        assert!("agentcore".parse::<SandboxProvider>().is_err());
+        assert_eq!(
+            "smolvm".parse::<SandboxProvider>().unwrap().as_str(),
+            "smolvm"
+        );
+        assert!("bad provider".parse::<SandboxProvider>().is_err());
         assert_eq!(
             SandboxProvider::AppleContainer.to_string(),
             "apple-container"
@@ -1262,5 +1286,15 @@ mod tests {
         assert_eq!(SandboxProvider::Vercel.to_string(), "vercel");
         assert_eq!(SandboxProvider::AwsAgentCore.to_string(), "aws-agentcore");
         assert_eq!(SandboxProvider::LocalProcess.to_string(), "local-process");
+        assert_eq!(
+            serde_json::to_value(SandboxProvider::AppleContainer).unwrap(),
+            Value::String("apple_container".to_string())
+        );
+        assert_eq!(
+            serde_json::from_value::<SandboxProvider>(Value::String("smolvm".to_string()))
+                .unwrap()
+                .as_str(),
+            "smolvm"
+        );
     }
 }

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -648,14 +648,8 @@ impl SandboxAttachment {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
-#[serde(try_from = "String", into = "String")]
+#[serde(transparent)]
 pub struct SandboxProvider(Cow<'static, str>);
-
-impl Default for SandboxProvider {
-    fn default() -> Self {
-        Self::Daytona
-    }
-}
 
 #[allow(non_upper_case_globals)]
 impl SandboxProvider {
@@ -663,30 +657,17 @@ impl SandboxProvider {
     pub const E2b: Self = Self::from_static("e2b");
     pub const Sprites: Self = Self::from_static("sprites");
     pub const Vercel: Self = Self::from_static("vercel");
-    pub const AwsAgentCore: Self = Self::from_static("aws-agentcore");
-    pub const AppleContainer: Self = Self::from_static("apple-container");
+    pub const AwsAgentCore: Self = Self::from_static("aws_agentcore");
+    pub const AppleContainer: Self = Self::from_static("apple_container");
     pub const Docker: Self = Self::from_static("docker");
-    pub const LocalProcess: Self = Self::from_static("local-process");
+    pub const LocalProcess: Self = Self::from_static("local_process");
 
     pub const fn from_static(provider: &'static str) -> Self {
         Self(Cow::Borrowed(provider))
     }
 
-    pub fn is_local(&self) -> bool {
-        self == &Self::AppleContainer || self == &Self::Docker || self == &Self::LocalProcess
-    }
-
     pub fn as_str(&self) -> &str {
         self.0.as_ref()
-    }
-
-    fn serialized_name(&self) -> &str {
-        match self.as_str() {
-            "aws-agentcore" => "aws_agentcore",
-            "apple-container" => "apple_container",
-            "local-process" => "local_process",
-            provider => provider,
-        }
     }
 }
 
@@ -700,35 +681,7 @@ impl FromStr for SandboxProvider {
     type Err = crate::Error;
 
     fn from_str(value: &str) -> Result<Self> {
-        let provider = value.trim().replace('_', "-").to_ascii_lowercase();
-        let provider = match provider.as_str() {
-            "local" => "local-process".to_string(),
-            _ => provider,
-        };
-        if provider.is_empty()
-            || provider.starts_with('-')
-            || provider.ends_with('-')
-            || !provider
-                .bytes()
-                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
-        {
-            return Err(anyhow::anyhow!("invalid sandbox provider: {value}"));
-        }
-        Ok(Self(Cow::Owned(provider)))
-    }
-}
-
-impl TryFrom<String> for SandboxProvider {
-    type Error = crate::Error;
-
-    fn try_from(provider: String) -> Result<Self> {
-        provider.parse()
-    }
-}
-
-impl From<SandboxProvider> for String {
-    fn from(provider: SandboxProvider) -> Self {
-        provider.serialized_name().to_string()
+        Ok(Self(Cow::Owned(value.to_string())))
     }
 }
 
@@ -1257,35 +1210,33 @@ mod tests {
     }
 
     #[test]
-    fn parses_and_formats_sandbox_providers() {
-        assert_eq!(
-            "apple-container".parse::<SandboxProvider>().unwrap(),
-            SandboxProvider::AppleContainer
-        );
+    fn preserves_sandbox_provider_names() {
         assert_eq!(
             "apple_container".parse::<SandboxProvider>().unwrap(),
             SandboxProvider::AppleContainer
         );
         assert_eq!(
-            "local".parse::<SandboxProvider>().unwrap(),
-            SandboxProvider::LocalProcess
-        );
-        assert_eq!(
-            "vercel".parse::<SandboxProvider>().unwrap(),
-            SandboxProvider::Vercel
-        );
-        assert_eq!(
-            "smolvm".parse::<SandboxProvider>().unwrap().as_str(),
-            "smolvm"
-        );
-        assert!("bad provider".parse::<SandboxProvider>().is_err());
-        assert_eq!(
-            SandboxProvider::AppleContainer.to_string(),
+            "apple-container"
+                .parse::<SandboxProvider>()
+                .unwrap()
+                .as_str(),
             "apple-container"
         );
+        assert_eq!(
+            "local".parse::<SandboxProvider>().unwrap().as_str(),
+            "local"
+        );
+        assert_eq!(
+            "Bad Provider".parse::<SandboxProvider>().unwrap().as_str(),
+            "Bad Provider"
+        );
+        assert_eq!(
+            SandboxProvider::AppleContainer.to_string(),
+            "apple_container"
+        );
         assert_eq!(SandboxProvider::Vercel.to_string(), "vercel");
-        assert_eq!(SandboxProvider::AwsAgentCore.to_string(), "aws-agentcore");
-        assert_eq!(SandboxProvider::LocalProcess.to_string(), "local-process");
+        assert_eq!(SandboxProvider::AwsAgentCore.to_string(), "aws_agentcore");
+        assert_eq!(SandboxProvider::LocalProcess.to_string(), "local_process");
         assert_eq!(
             serde_json::to_value(SandboxProvider::AppleContainer).unwrap(),
             Value::String("apple_container".to_string())


### PR DESCRIPTION
Remove the SandboxProvider enum so that users can create their own sandbox integrations without committing them in exo