### PR TITLE
discord: give every message create an enforced nonce

### DIFF
--- a/examples/exo/adapters/discord/discord.test.ts
+++ b/examples/exo/adapters/discord/discord.test.ts
@@ -4,11 +4,67 @@ import {
   attachmentKindForContentType,
   createResilienceHandlers,
   describeCloseCode,
+  discordMessagePayloads,
+  discordNonce,
   errorMessage,
   inboundAttachments,
   splitDiscordContent,
   startConnectionWatchdog,
 } from "./discord";
+
+describe("discordNonce", () => {
+  const commandId = "0198c4f1-7b2a-7c3d-8e4f-5a6b7c8d9e0f";
+
+  it("is deterministic across restarts", () => {
+    // A retry after a crash must derive the same nonce as the attempt that
+    // crashed, or Discord sees an unrelated message.
+    expect(discordNonce(commandId, 0)).toBe(discordNonce(commandId, 0));
+  });
+
+  it("fits inside Discord's 25 character limit", () => {
+    for (const part of [0, 1, 42, 1000]) {
+      expect(discordNonce(commandId, part).length).toBe(25);
+    }
+  });
+
+  it("differs per chunk so a long message is not swallowed", () => {
+    const nonces = [0, 1, 2].map((part) => discordNonce(commandId, part));
+    expect(new Set(nonces).size).toBe(3);
+  });
+
+  it("differs per command", () => {
+    expect(discordNonce("command-a", 0)).not.toBe(discordNonce("command-b", 0));
+  });
+
+  it("does not collide across the id/part boundary", () => {
+    expect(discordNonce("a-1", 0)).not.toBe(discordNonce("a", 10));
+  });
+});
+
+describe("discordMessagePayloads", () => {
+  it("puts an enforced nonce on every chunk", () => {
+    const payloads = discordMessagePayloads("cmd-1", ["one", "two"], []);
+    expect(payloads.map((payload) => payload.content)).toEqual(["one", "two"]);
+    for (const payload of payloads) {
+      expect(payload.enforceNonce).toBe(true);
+    }
+    expect(payloads[0]?.nonce).toBe(discordNonce("cmd-1", 0));
+    expect(payloads[1]?.nonce).toBe(discordNonce("cmd-1", 1));
+    expect(payloads[0]?.nonce).not.toBe(payloads[1]?.nonce);
+  });
+
+  it("attaches files to the first chunk only", () => {
+    const payloads = discordMessagePayloads("cmd-1", ["one", "two"], ["file"]);
+    expect(payloads[0]?.files).toEqual(["file"]);
+    expect(payloads[1]?.files).toEqual([]);
+  });
+
+  it("derives the same payloads on a retry of the same command", () => {
+    expect(discordMessagePayloads("cmd-1", ["one"], [])).toEqual(
+      discordMessagePayloads("cmd-1", ["one"], []),
+    );
+  });
+});
 
 describe("attachmentKindForContentType", () => {
   it("classifies media mime types", () => {

--- a/examples/exo/adapters/discord/discord.ts
+++ b/examples/exo/adapters/discord/discord.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import type { AdapterAttachment, WorkerInboundEvent } from "../protocol";
 
 export type DiscordAttachmentLike = {
@@ -7,6 +9,43 @@ export type DiscordAttachmentLike = {
 };
 
 const DISCORD_CONTENT_LIMIT = 2_000;
+// Discord rejects a nonce longer than this.
+const DISCORD_NONCE_LIMIT = 25;
+
+// Discord's idempotency key: with `enforceNonce`, a repeat inside its window
+// returns the existing message rather than posting a second one. Hashing fits a
+// UUIDv7 command id under the limit and keeps the nonce deterministic, so a
+// retry presents the same key as the attempt that crashed.
+export function discordNonce(commandId: string, part: number): string {
+  return createHash("sha256")
+    .update(commandId)
+    .update("\0")
+    .update(String(part))
+    .digest("hex")
+    .slice(0, DISCORD_NONCE_LIMIT);
+}
+
+export type DiscordMessagePayload<File> = {
+  content: string;
+  files: readonly File[];
+  nonce: string;
+  enforceNonce: true;
+};
+
+// One create per content chunk, keyed per chunk: they are separate messages
+// that each have to survive, so a shared nonce would swallow all but the first.
+export function discordMessagePayloads<File>(
+  commandId: string,
+  chunks: string[],
+  files: readonly File[],
+): DiscordMessagePayload<File>[] {
+  return chunks.map((content, index) => ({
+    content,
+    files: index === 0 ? files : [],
+    nonce: discordNonce(commandId, index),
+    enforceNonce: true,
+  }));
+}
 
 export function splitDiscordContent(
   text: string,

--- a/examples/exo/adapters/discord/worker.ts
+++ b/examples/exo/adapters/discord/worker.ts
@@ -20,6 +20,7 @@ import {
 } from "../protocol";
 import {
   createResilienceHandlers,
+  discordMessagePayloads,
   inboundAttachments,
   splitDiscordContent,
   startConnectionWatchdog,
@@ -180,11 +181,15 @@ try {
       });
       const files = await discordAttachmentFiles(command.attachments);
       const contentChunks = splitDiscordContent(command.text);
-      for (const [index, content] of contentChunks.entries()) {
-        await sendDiscordMessage(target, {
-          content,
-          files: index === 0 ? files : [],
-        });
+      // Under `enforceNonce` a repeat of a send Discord already accepted comes
+      // back as the existing message, so it lands here as an ordinary success
+      // and is acked like any other send.
+      for (const payload of discordMessagePayloads(
+        command.id,
+        contentChunks,
+        files,
+      )) {
+        await sendDiscordMessage(target, payload);
       }
       // If this target has an active voice session, also speak the reply. The
       // text send above doubles as the inspectable transcript of the voice turn.


### PR DESCRIPTION
Redelivery after a worker restart re-sends anything un-acked, including sends that already landed. On Discord this is closable platform-correctly, so this PR does exactly that and nothing else.

## Change

Every message create carries Discord's idempotency key: `nonce` — a truncated hash of the command id and the chunk index — with `enforceNonce: true`. A redelivered command reuses its id, derives the same nonce, and Discord returns the existing message instead of posting a second one; it lands as an ordinary success and is acked like any other send. The nonce is per chunk because a long reply is several creates that must each survive — a shared nonce would swallow every chunk after the first. Attachments ride the first chunk, as they always have.

The worker's ack/nack behavior is untouched; the only change is how create payloads are constructed.

## Tests

138 → 146 on `pnpm check`. The nonce is deterministic across restarts, exactly 25 characters, distinct per chunk and per command, collision-free across the id/part boundary, and enforced on every payload; files land on chunk one.

Caveat: Discord documents the enforcement window only as "the past few minutes" — this is a replay cache, not a durable idempotency key. It cleanly covers the common case (a restarted worker replays its inflight within seconds); a retry delayed toward the runtime's five-minute backoff ceiling may land outside the window and duplicate. Deduplication is keyed on author + nonce and is server-side state, so it survives reconnects and new sessions; a deduplicated create returns the prior message as an ordinary success.
