### PR TITLE
Add trial adapter and Harbor evaluation integration

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1508,13 +1508,9 @@ async fn main() -> Result<()> {
                             .sandbox_provider
                             .map(SandboxProvider::from),
                         shell_program: sandbox_runtime.shell_program,
+                        sandbox_scope: sandbox_scope.map(Into::into),
                     })
                     .await?;
-                if let Some(sandbox_scope) = sandbox_scope {
-                    let mut config = conversation.config().await?;
-                    config.sandbox_scope = Some(sandbox_scope.into());
-                    conversation.put_config(config).await?;
-                }
                 println!(
                     "created conversation {} ({})",
                     conversation.record().slug,

--- a/crates/executor/src/adapter/mod.rs
+++ b/crates/executor/src/adapter/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) mod runtime;
 pub(crate) mod store;
 pub(crate) mod tools;
+mod trial;
 pub(crate) mod types;
 pub(crate) mod worker;
 

--- a/crates/executor/src/adapter/runtime.rs
+++ b/crates/executor/src/adapter/runtime.rs
@@ -15,6 +15,7 @@ use lingua::universal::{TextContentPart, UserContent, UserContentPart};
 
 use super::store::{AdapterStore, stable_target_key};
 use super::tools::download_attachment;
+use super::trial::prepare_trial_run;
 use super::types::{
     AdapterAttachment, AdapterAttachmentKind, AdapterConfig, AdapterDeliveryStatus,
     AdapterEventType, AdapterRecord, AdapterTargetConversationRecord, now_ms,
@@ -585,6 +586,9 @@ async fn handle_worker_event(
                 &metadata,
             )
             .await?;
+            if config.adapter_type == "trial" {
+                prepare_trial_run(conversation.as_ref(), metadata.clone()).await?;
+            }
             handle_worker_message(
                 store,
                 conversation.as_ref(),

--- a/crates/executor/src/adapter/runtime.rs
+++ b/crates/executor/src/adapter/runtime.rs
@@ -15,7 +15,7 @@ use lingua::universal::{TextContentPart, UserContent, UserContentPart};
 
 use super::store::{AdapterStore, stable_target_key};
 use super::tools::download_attachment;
-use super::trial::{prepare_trial_run, trial_started};
+use super::trial::{cancellation_response, phase_started, prepare_trial_message};
 use super::types::{
     AdapterAttachment, AdapterAttachmentKind, AdapterConfig, AdapterDeliveryStatus,
     AdapterEventType, AdapterRecord, AdapterTargetConversationRecord, now_ms,
@@ -449,6 +449,11 @@ async fn run_adapter_loop(
     let event_agent = std::sync::Arc::clone(&agent);
     let event_conversation = std::sync::Arc::clone(&conversation);
     let event_config = config.clone();
+    let control_store = store.clone();
+    let control_adapter = adapter.clone();
+    let control_agent = std::sync::Arc::clone(&agent);
+    let control_conversation = std::sync::Arc::clone(&conversation);
+    let control_config = config.clone();
     let outbound_store = store.clone();
     let outbound_adapter_id = adapter.id.clone();
     let stop_store = store.clone();
@@ -464,6 +469,24 @@ async fn run_adapter_loop(
             let agent = std::sync::Arc::clone(&event_agent);
             let conversation = std::sync::Arc::clone(&event_conversation);
             let config = event_config.clone();
+            async move {
+                handle_worker_event(
+                    &store,
+                    agent.as_ref(),
+                    conversation,
+                    &adapter,
+                    &config,
+                    event,
+                )
+                .await
+            }
+        },
+        move |event| {
+            let store = control_store.clone();
+            let adapter = control_adapter.clone();
+            let agent = std::sync::Arc::clone(&control_agent);
+            let conversation = std::sync::Arc::clone(&control_conversation);
+            let config = control_config.clone();
             async move {
                 handle_worker_event(
                     &store,
@@ -597,9 +620,22 @@ async fn handle_worker_event(
             )
             .await?;
             if config.adapter_type == "trial" {
-                let prepared = prepare_trial_run(conversation.as_ref(), metadata.clone()).await?;
+                let prepared = prepare_trial_message(
+                    store,
+                    &adapter.id,
+                    &target,
+                    conversation.as_ref(),
+                    metadata.clone(),
+                )
+                .await?;
                 let conversation_id = conversation.record().id.to_string();
-                let started = trial_started(&prepared, &target, &conversation_id)?;
+                if let Some(response) = cancellation_response(&prepared) {
+                    queue_adapter_message(store, adapter, response, Some(&target), Vec::new())
+                        .await?;
+                    return Ok(());
+                }
+                let started = phase_started(&prepared, &target, &conversation_id)?
+                    .ok_or_else(|| anyhow!("trial request did not produce a started response"))?;
                 // Publish the conversation id before entering the potentially
                 // long-running wakeup turn so evaluators can retain it on timeout.
                 queue_adapter_message(store, adapter, &started, Some(&target), Vec::new()).await?;
@@ -617,6 +653,31 @@ async fn handle_worker_event(
                 attachments,
             )
             .await
+        }
+        WorkerEvent::Control { target, metadata } => {
+            if config.adapter_type != "trial" {
+                bail!(
+                    "{} adapter does not support control events",
+                    config.adapter_type
+                );
+            }
+            let conversation = resolve_message_conversation(
+                store,
+                agent,
+                root_conversation,
+                adapter,
+                config,
+                &target,
+                &metadata,
+            )
+            .await?;
+            let prepared =
+                prepare_trial_message(store, &adapter.id, &target, conversation.as_ref(), metadata)
+                    .await?;
+            let response = cancellation_response(&prepared)
+                .ok_or_else(|| anyhow!("trial control did not produce a cancellation response"))?;
+            queue_adapter_message(store, adapter, response, Some(&target), Vec::new()).await?;
+            Ok(())
         }
         WorkerEvent::Lifecycle { name, metadata } => {
             record_worker_lifecycle(

--- a/crates/executor/src/adapter/runtime.rs
+++ b/crates/executor/src/adapter/runtime.rs
@@ -15,7 +15,7 @@ use lingua::universal::{TextContentPart, UserContent, UserContentPart};
 
 use super::store::{AdapterStore, stable_target_key};
 use super::tools::download_attachment;
-use super::trial::prepare_trial_run;
+use super::trial::{prepare_trial_run, trial_started};
 use super::types::{
     AdapterAttachment, AdapterAttachmentKind, AdapterConfig, AdapterDeliveryStatus,
     AdapterEventType, AdapterRecord, AdapterTargetConversationRecord, now_ms,
@@ -381,6 +381,16 @@ pub async fn send_adapter_message_with_handles(
     target: Option<&str>,
     attachments: Vec<AdapterAttachment>,
 ) -> Result<String> {
+    queue_adapter_message(store, adapter, text, target, attachments).await
+}
+
+async fn queue_adapter_message(
+    store: &AdapterStore,
+    adapter: &AdapterRecord,
+    text: &str,
+    target: Option<&str>,
+    attachments: Vec<AdapterAttachment>,
+) -> Result<String> {
     if !adapter.enabled {
         bail!("adapter is disabled: {}", adapter.id);
     }
@@ -587,7 +597,12 @@ async fn handle_worker_event(
             )
             .await?;
             if config.adapter_type == "trial" {
-                prepare_trial_run(conversation.as_ref(), metadata.clone()).await?;
+                let prepared = prepare_trial_run(conversation.as_ref(), metadata.clone()).await?;
+                let conversation_id = conversation.record().id.to_string();
+                let started = trial_started(&prepared, &target, &conversation_id)?;
+                // Publish the conversation id before entering the potentially
+                // long-running wakeup turn so evaluators can retain it on timeout.
+                queue_adapter_message(store, adapter, &started, Some(&target), Vec::new()).await?;
             }
             handle_worker_message(
                 store,

--- a/crates/executor/src/adapter/runtime.rs
+++ b/crates/executor/src/adapter/runtime.rs
@@ -25,7 +25,7 @@ use crate::conversation_events::{
     record_host_event,
 };
 use crate::conversation_wakeup::{send_conversation_wakeup, send_conversation_wakeup_content};
-use crate::{CreateConversationRequest, Harness, HarnessAgent, HarnessConversation};
+use crate::{CreateConversationRequest, Harness, HarnessAgent, HarnessConversation, SandboxScope};
 
 const INITIAL_RESTART_DELAY: Duration = Duration::from_secs(5);
 const MAX_RESTART_DELAY: Duration = Duration::from_secs(300);
@@ -708,6 +708,7 @@ async fn resolve_message_conversation(
         .create_conversation(CreateConversationRequest {
             slug: Some(slug.clone()),
             name: Some(name),
+            sandbox_scope: Some(SandboxScope::Conversation),
             ..Default::default()
         })
         .await

--- a/crates/executor/src/adapter/store.rs
+++ b/crates/executor/src/adapter/store.rs
@@ -9,7 +9,7 @@ use tokio::io::AsyncWriteExt;
 use super::types::{
     AdapterAttachment, AdapterDeliveryStatus, AdapterEventRecord, AdapterEventType,
     AdapterInboundMessageRecord, AdapterLifecycleState, AdapterOutboundMessageRecord,
-    AdapterRecord, AdapterTargetConversationRecord, NewAdapter, now_ms,
+    AdapterRecord, AdapterTargetConversationRecord, AdapterTrialRecord, NewAdapter, now_ms,
 };
 
 const MAX_QUEUED_MESSAGES_PER_ADAPTER: usize = 1_000;
@@ -143,6 +143,7 @@ impl AdapterStore {
         remove_dir_if_exists(self.failed_dir(adapter_id)).await?;
         remove_dir_if_exists(self.inbound_seen_dir(adapter_id)).await?;
         remove_dir_if_exists(self.target_conversations_dir(adapter_id)).await?;
+        remove_dir_if_exists(self.trials_dir(adapter_id)).await?;
         Ok(Some(adapter))
     }
 
@@ -472,6 +473,29 @@ impl AdapterStore {
         Ok(records)
     }
 
+    pub async fn get_trial(
+        &self,
+        adapter_id: &str,
+        target: &str,
+    ) -> Result<Option<AdapterTrialRecord>> {
+        let path = self.trial_path(adapter_id, target);
+        match fs::read(&path).await {
+            Ok(bytes) => Ok(Some(serde_json::from_slice::<AdapterTrialRecord>(&bytes)?)),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => Err(error)
+                .with_context(|| format!("failed to read trial record {}", path.display())),
+        }
+    }
+
+    pub async fn put_trial(&self, record: &AdapterTrialRecord) -> Result<()> {
+        let dir = self.trials_dir(&record.adapter_id);
+        fs::create_dir_all(&dir).await?;
+        let path = self.trial_path(&record.adapter_id, &record.target);
+        write_json_file(&path, record)
+            .await
+            .with_context(|| format!("failed to write trial record {}", path.display()))
+    }
+
     pub async fn record_inbound_message_once(
         &self,
         adapter_id: &str,
@@ -590,6 +614,15 @@ impl AdapterStore {
 
     fn target_conversation_path(&self, adapter_id: &str, target: &str) -> PathBuf {
         self.target_conversations_dir(adapter_id)
+            .join(format!("{}.json", stable_target_key(target)))
+    }
+
+    fn trials_dir(&self, adapter_id: &str) -> PathBuf {
+        self.root.join("trials").join(adapter_id)
+    }
+
+    fn trial_path(&self, adapter_id: &str, target: &str) -> PathBuf {
+        self.trials_dir(adapter_id)
             .join(format!("{}.json", stable_target_key(target)))
     }
 

--- a/crates/executor/src/adapter/tools.rs
+++ b/crates/executor/src/adapter/tools.rs
@@ -14,6 +14,7 @@ use tokio::fs;
 
 use super::runtime::send_adapter_message_with_handles;
 use super::store::AdapterStore;
+use super::trial::finalize_trial_completion;
 use super::types::{
     AdapterAttachment, AdapterConfig, AdapterEventType, AdapterSource, NewAdapter,
     WorkerSecretEnvVar,
@@ -100,6 +101,7 @@ enum AdapterCreationConfig {
     Slack(SlackAdapterCreationConfig),
     Exochat(ExochatAdapterCreationConfig),
     AgentCli(AgentCliAdapterCreationConfig),
+    Trial(TrialAdapterCreationConfig),
 }
 
 #[derive(Debug, Deserialize)]
@@ -201,6 +203,21 @@ struct AgentCliAdapterCreationConfig {
     socket_path: Option<String>,
     mount_root: String,
     mount_path: Option<String>,
+}
+
+/// Receives containerized evaluation trials over a local Unix socket.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct TrialAdapterCreationConfig {
+    #[serde(rename = "type")]
+    _adapter_type: TrialAdapterType,
+    socket_path: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum TrialAdapterType {
+    Trial,
 }
 
 #[derive(Debug, Deserialize)]
@@ -324,6 +341,7 @@ impl AdapterCreationConfig {
             Self::Slack(_) => "slack",
             Self::Exochat(_) => "exochat",
             Self::AgentCli(_) => "agent-cli",
+            Self::Trial(_) => "trial",
         }
     }
 
@@ -519,6 +537,22 @@ impl AdapterCreationConfig {
                         "socketPath": config.socket_path,
                         "mountRoot": config.mount_root,
                         "mountPath": mount_path,
+                    }),
+                    state_dir: None,
+                    secret_env: Vec::new(),
+                })
+            }
+            Self::Trial(config) => {
+                require_source(source, AdapterSource::Library, "trial")?;
+                if !config.socket_path.starts_with('/') {
+                    bail!("trial socketPath must be an absolute host path");
+                }
+                Ok(AdapterConfig {
+                    adapter_type: "trial".to_string(),
+                    worker_command: options.worker_command("trial"),
+                    initialization: serde_json::json!({
+                        "socketPath": config.socket_path,
+                        "conversationScope": "target",
                     }),
                     state_dir: None,
                     secret_env: Vec::new(),
@@ -891,6 +925,14 @@ pub async fn execute_send_adapter_message_tool(
         scoped_target.as_deref(),
         args.target.as_deref(),
     )?;
+    let text = if adapter.config.adapter_type == "trial" {
+        let target = target
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("trial completion requires its inbound target"))?;
+        finalize_trial_completion(&args.text, target, &conversation.record().id.to_string())?
+    } else {
+        args.text
+    };
     let attachments = args.attachments.unwrap_or_default();
     if !attachments.is_empty()
         && adapter.config.adapter_type != "whatsapp"
@@ -917,7 +959,7 @@ pub async fn execute_send_adapter_message_tool(
         conversation,
         store,
         &adapter,
-        &args.text,
+        &text,
         target.as_deref(),
         attachments,
     )
@@ -1565,6 +1607,27 @@ mod tests {
             .into_adapter_config(AdapterSource::Library, &test_creation_options())
             .unwrap_err();
         assert!(error.to_string().contains("absolute host path"));
+    }
+
+    #[test]
+    fn trial_config_uses_target_scoped_conversations() {
+        let config: AdapterCreationConfig = serde_json::from_value(serde_json::json!({
+            "type": "trial",
+            "socketPath": "/tmp/trial.sock",
+        }))
+        .unwrap();
+        let adapter_config = config
+            .into_adapter_config(AdapterSource::Library, &test_creation_options())
+            .unwrap();
+        assert_eq!(adapter_config.adapter_type, "trial");
+        assert!(adapter_config.worker_command[2].ends_with("/tmp/exo-adapters/trial/worker.ts"));
+        assert_eq!(
+            adapter_config.initialization,
+            serde_json::json!({
+                "socketPath": "/tmp/trial.sock",
+                "conversationScope": "target",
+            })
+        );
     }
 
     #[test]

--- a/crates/executor/src/adapter/tools.rs
+++ b/crates/executor/src/adapter/tools.rs
@@ -929,7 +929,15 @@ pub async fn execute_send_adapter_message_tool(
         let target = target
             .as_deref()
             .ok_or_else(|| anyhow::anyhow!("trial completion requires its inbound target"))?;
-        finalize_trial_completion(&args.text, target, &conversation.record().id.to_string())?
+        finalize_trial_completion(
+            store,
+            &adapter.id,
+            conversation,
+            &args.text,
+            target,
+            &conversation.record().id.to_string(),
+        )
+        .await?
     } else {
         args.text
     };

--- a/crates/executor/src/adapter/trial.rs
+++ b/crates/executor/src/adapter/trial.rs
@@ -12,6 +12,10 @@ struct TrialRunMetadata {
     container_id: String,
 }
 
+pub(super) struct PreparedTrialRun {
+    request_id: String,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 enum TrialCompletionSignal {
@@ -32,10 +36,19 @@ struct TrialComplete<'a> {
     summary: Option<&'a str>,
 }
 
+#[derive(Debug, Serialize)]
+struct TrialStarted<'a> {
+    #[serde(rename = "type")]
+    message_type: &'static str,
+    request_id: &'a str,
+    target: &'a str,
+    conversation_id: &'a str,
+}
+
 pub(super) async fn prepare_trial_run(
     conversation: &dyn HarnessConversation,
     metadata: serde_json::Value,
-) -> Result<()> {
+) -> Result<PreparedTrialRun> {
     let metadata = serde_json::from_value::<TrialRunMetadata>(metadata)
         .context("trial_run metadata is invalid")?;
     if metadata.request_id.trim().is_empty() {
@@ -52,7 +65,9 @@ pub(super) async fn prepare_trial_run(
         .await?
         .is_some()
     {
-        return Ok(());
+        return Ok(PreparedTrialRun {
+            request_id: metadata.request_id,
+        });
     }
 
     conversation
@@ -64,7 +79,22 @@ pub(super) async fn prepare_trial_run(
             default_workdir: None,
         })
         .await?;
-    Ok(())
+    Ok(PreparedTrialRun {
+        request_id: metadata.request_id,
+    })
+}
+
+pub(super) fn trial_started(
+    prepared: &PreparedTrialRun,
+    target: &str,
+    conversation_id: &str,
+) -> Result<String> {
+    Ok(serde_json::to_string(&TrialStarted {
+        message_type: "trial_started",
+        request_id: &prepared.request_id,
+        target,
+        conversation_id,
+    })?)
 }
 
 pub(super) fn finalize_trial_completion(
@@ -112,6 +142,27 @@ mod tests {
                 "target": "trial-1",
                 "conversation_id": "conversation-1",
                 "summary": "done",
+            })
+        );
+    }
+
+    #[test]
+    fn started_adds_runtime_owned_conversation_id() {
+        let response = trial_started(
+            &PreparedTrialRun {
+                request_id: "request-1".to_string(),
+            },
+            "trial-1",
+            "conversation-1",
+        )
+        .expect("started response");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&response).expect("response JSON"),
+            serde_json::json!({
+                "type": "trial_started",
+                "request_id": "request-1",
+                "target": "trial-1",
+                "conversation_id": "conversation-1",
             })
         );
     }

--- a/crates/executor/src/adapter/trial.rs
+++ b/crates/executor/src/adapter/trial.rs
@@ -1,25 +1,52 @@
 use anyhow::{Context, Result, bail};
-use exoharness::{AttachSandboxRequest, SandboxAttachment};
+use exoharness::{
+    AttachSandboxRequest, ConversationHandle, CreateSandboxFromSnapshotRequest, SandboxAttachment,
+};
 use serde::{Deserialize, Serialize};
 
+use super::store::AdapterStore;
+use super::types::{AdapterTrialRecord, now_ms};
 use crate::HarnessConversation;
 use crate::conversation_sandbox::attached_conversation_sandbox;
 
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "snake_case", deny_unknown_fields)]
-struct TrialRunMetadata {
-    request_id: String,
-    container_id: String,
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+enum TrialMessageMetadata {
+    #[serde(rename = "trial_run")]
+    Run {
+        request_id: String,
+        container_id: String,
+    },
+    #[serde(rename = "trial_feedback")]
+    Feedback { request_id: String },
+    #[serde(rename = "trial_cancel")]
+    Cancel { request_id: String },
 }
 
-pub(super) struct PreparedTrialRun {
-    request_id: String,
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum TrialPhase {
+    Run,
+    Feedback,
+}
+
+pub(super) enum PreparedTrialMessage {
+    Started {
+        phase: TrialPhase,
+        request_id: String,
+        sandbox_id: Option<String>,
+    },
+    Cancelled(String),
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 enum TrialCompletionSignal {
     TrialComplete {
+        request_id: String,
+        #[serde(default)]
+        summary: Option<String>,
+    },
+    FeedbackComplete {
         request_id: String,
         #[serde(default)]
         summary: Option<String>,
@@ -33,137 +60,397 @@ struct TrialComplete<'a> {
     request_id: &'a str,
     target: &'a str,
     conversation_id: &'a str,
+    snapshot_id: &'a str,
     summary: Option<&'a str>,
 }
 
 #[derive(Debug, Serialize)]
-struct TrialStarted<'a> {
+struct PhaseComplete<'a> {
     #[serde(rename = "type")]
     message_type: &'static str,
     request_id: &'a str,
     target: &'a str,
     conversation_id: &'a str,
+    summary: Option<&'a str>,
 }
 
-pub(super) async fn prepare_trial_run(
+#[derive(Debug, Serialize)]
+struct PhaseStarted<'a> {
+    #[serde(rename = "type")]
+    message_type: &'static str,
+    request_id: &'a str,
+    target: &'a str,
+    conversation_id: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    sandbox_id: Option<&'a str>,
+}
+
+#[derive(Debug, Serialize)]
+struct TrialCancelled<'a> {
+    #[serde(rename = "type")]
+    message_type: &'static str,
+    request_id: &'a str,
+    target: &'a str,
+    conversation_id: &'a str,
+    snapshot_id: &'a str,
+}
+
+pub(super) async fn prepare_trial_message(
+    store: &AdapterStore,
+    adapter_id: &str,
+    target: &str,
     conversation: &dyn HarnessConversation,
     metadata: serde_json::Value,
-) -> Result<PreparedTrialRun> {
-    let metadata = serde_json::from_value::<TrialRunMetadata>(metadata)
-        .context("trial_run metadata is invalid")?;
-    if metadata.request_id.trim().is_empty() {
-        bail!("trial_run request_id must not be empty");
+) -> Result<PreparedTrialMessage> {
+    match serde_json::from_value::<TrialMessageMetadata>(metadata)
+        .context("trial adapter message metadata is invalid")?
+    {
+        TrialMessageMetadata::Run {
+            request_id,
+            container_id,
+        } => {
+            prepare_trial_run(
+                store,
+                adapter_id,
+                target,
+                conversation,
+                request_id,
+                container_id,
+            )
+            .await
+        }
+        TrialMessageMetadata::Feedback { request_id } => {
+            prepare_trial_feedback(store, adapter_id, target, conversation, request_id).await
+        }
+        TrialMessageMetadata::Cancel { request_id } => {
+            cancel_trial(store, adapter_id, target, conversation, request_id).await
+        }
     }
-    if metadata.container_id.trim().is_empty() {
-        bail!("trial_run container_id must not be empty");
+}
+
+async fn prepare_trial_run(
+    store: &AdapterStore,
+    adapter_id: &str,
+    target: &str,
+    conversation: &dyn HarnessConversation,
+    request_id: String,
+    container_id: String,
+) -> Result<PreparedTrialMessage> {
+    require_non_empty("trial_run request_id", &request_id)?;
+    require_non_empty("trial_run container_id", &container_id)?;
+    if let Some(trial) = store.get_trial(adapter_id, target).await? {
+        if trial.trial_request_id == request_id {
+            bail!("trial target {target} is already complete");
+        }
+        bail!("trial target {target} was already used by another request");
     }
 
-    // Replayed pending requests arrive after adapter restarts. The target is
-    // mapped to one dedicated conversation, so its existing attachment is the
-    // environment for this same trial and must not be attached a second time.
     if attached_conversation_sandbox(conversation.exoharness_handle().as_ref())
         .await?
-        .is_some()
+        .is_none()
     {
-        return Ok(PreparedTrialRun {
-            request_id: metadata.request_id,
-        });
+        conversation
+            .exoharness_handle()
+            .attach_sandbox(AttachSandboxRequest {
+                attachment: SandboxAttachment::DockerContainer { container_id },
+                default_workdir: None,
+            })
+            .await?;
     }
 
-    conversation
-        .exoharness_handle()
-        .attach_sandbox(AttachSandboxRequest {
-            attachment: SandboxAttachment::DockerContainer {
-                container_id: metadata.container_id,
-            },
-            default_workdir: None,
-        })
-        .await?;
-    Ok(PreparedTrialRun {
-        request_id: metadata.request_id,
+    Ok(PreparedTrialMessage::Started {
+        phase: TrialPhase::Run,
+        request_id,
+        sandbox_id: None,
     })
 }
 
-pub(super) fn trial_started(
-    prepared: &PreparedTrialRun,
+async fn prepare_trial_feedback(
+    store: &AdapterStore,
+    adapter_id: &str,
     target: &str,
-    conversation_id: &str,
-) -> Result<String> {
-    Ok(serde_json::to_string(&TrialStarted {
-        message_type: "trial_started",
-        request_id: &prepared.request_id,
-        target,
-        conversation_id,
-    })?)
+    conversation: &dyn HarnessConversation,
+    request_id: String,
+) -> Result<PreparedTrialMessage> {
+    require_non_empty("trial_feedback request_id", &request_id)?;
+    let mut trial = store
+        .get_trial(adapter_id, target)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("trial target {target} has no completed snapshot"))?;
+    if trial.conversation_id != conversation.record().id.to_string() {
+        bail!("trial target {target} is mapped to a different conversation");
+    }
+    if trial.feedback_completed {
+        bail!("trial target {target} already completed feedback");
+    }
+    if let Some(active_request_id) = &trial.feedback_request_id
+        && active_request_id != &request_id
+    {
+        bail!("trial target {target} already has an active feedback request");
+    }
+
+    let sandbox_id = if let Some(sandbox_id) = &trial.feedback_sandbox_id {
+        sandbox_id.clone()
+    } else {
+        let sandbox_id = conversation
+            .exoharness_handle()
+            .create_sandbox_from_snapshot(CreateSandboxFromSnapshotRequest {
+                snapshot_id: trial.snapshot_id.parse()?,
+                idle_seconds: Some(300),
+                provider: None,
+            })
+            .await?;
+        trial.feedback_request_id = Some(request_id.clone());
+        trial.feedback_sandbox_id = Some(sandbox_id.clone());
+        trial.updated_at_ms = now_ms();
+        store.put_trial(&trial).await?;
+        sandbox_id
+    };
+
+    Ok(PreparedTrialMessage::Started {
+        phase: TrialPhase::Feedback,
+        request_id,
+        sandbox_id: Some(sandbox_id),
+    })
 }
 
-pub(super) fn finalize_trial_completion(
+async fn cancel_trial(
+    store: &AdapterStore,
+    adapter_id: &str,
+    target: &str,
+    conversation: &dyn HarnessConversation,
+    request_id: String,
+) -> Result<PreparedTrialMessage> {
+    require_non_empty("trial_cancel request_id", &request_id)?;
+    let conversation_id = conversation.record().id.to_string();
+    let trial = if let Some(trial) = store.get_trial(adapter_id, target).await? {
+        if trial.trial_request_id != request_id
+            && trial.feedback_request_id.as_deref() != Some(&request_id)
+        {
+            bail!("trial cancellation does not match the active request");
+        }
+        if trial.feedback_request_id.as_deref() == Some(&request_id)
+            && let Some(sandbox_id) = &trial.feedback_sandbox_id
+        {
+            conversation
+                .exoharness_handle()
+                .stop_sandbox(sandbox_id.clone())
+                .await?;
+        }
+        trial
+    } else {
+        let sandbox_id = attached_conversation_sandbox(conversation.exoharness_handle().as_ref())
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("cancelled trial has no attached sandbox"))?;
+        let snapshot_id = conversation
+            .exoharness_handle()
+            .snapshot_sandbox(sandbox_id.clone())
+            .await?;
+        let trial = AdapterTrialRecord {
+            adapter_id: adapter_id.to_string(),
+            target: target.to_string(),
+            trial_request_id: request_id.clone(),
+            conversation_id: conversation_id.clone(),
+            source_sandbox_id: sandbox_id.clone(),
+            snapshot_id: snapshot_id.to_string(),
+            feedback_request_id: None,
+            feedback_sandbox_id: None,
+            feedback_completed: false,
+            updated_at_ms: now_ms(),
+        };
+        store.put_trial(&trial).await?;
+        conversation
+            .exoharness_handle()
+            .detach_sandbox(sandbox_id)
+            .await?;
+        trial
+    };
+    Ok(PreparedTrialMessage::Cancelled(serde_json::to_string(
+        &TrialCancelled {
+            message_type: "trial_cancelled",
+            request_id: &request_id,
+            target,
+            conversation_id: &conversation_id,
+            snapshot_id: &trial.snapshot_id,
+        },
+    )?))
+}
+
+pub(super) fn phase_started(
+    prepared: &PreparedTrialMessage,
+    target: &str,
+    conversation_id: &str,
+) -> Result<Option<String>> {
+    let PreparedTrialMessage::Started {
+        phase,
+        request_id,
+        sandbox_id,
+    } = prepared
+    else {
+        return Ok(None);
+    };
+    Ok(Some(serde_json::to_string(&PhaseStarted {
+        message_type: match phase {
+            TrialPhase::Run => "trial_started",
+            TrialPhase::Feedback => "feedback_started",
+        },
+        request_id,
+        target,
+        conversation_id,
+        sandbox_id: sandbox_id.as_deref(),
+    })?))
+}
+
+pub(super) fn cancellation_response(prepared: &PreparedTrialMessage) -> Option<&str> {
+    match prepared {
+        PreparedTrialMessage::Cancelled(response) => Some(response),
+        PreparedTrialMessage::Started { .. } => None,
+    }
+}
+
+pub(super) async fn finalize_trial_completion(
+    store: &AdapterStore,
+    adapter_id: &str,
+    conversation: &dyn ConversationHandle,
     text: &str,
     target: &str,
     conversation_id: &str,
 ) -> Result<String> {
-    let completion = serde_json::from_str::<TrialCompletionSignal>(text)
-        .context("trial completion must be a JSON object")?;
-    let TrialCompletionSignal::TrialComplete {
-        request_id,
-        summary,
-    } = completion;
+    match serde_json::from_str::<TrialCompletionSignal>(text)
+        .context("trial completion must be a JSON object")?
+    {
+        TrialCompletionSignal::TrialComplete {
+            request_id,
+            summary,
+        } => {
+            let trial = if let Some(trial) = store.get_trial(adapter_id, target).await? {
+                if trial.trial_request_id != request_id {
+                    bail!("trial completion does not match the completed request");
+                }
+                trial
+            } else {
+                let sandbox_id = attached_conversation_sandbox(conversation)
+                    .await?
+                    .ok_or_else(|| anyhow::anyhow!("trial has no attached sandbox to snapshot"))?;
+                let snapshot_id = conversation.snapshot_sandbox(sandbox_id.clone()).await?;
+                let trial = AdapterTrialRecord {
+                    adapter_id: adapter_id.to_string(),
+                    target: target.to_string(),
+                    trial_request_id: request_id.clone(),
+                    conversation_id: conversation_id.to_string(),
+                    source_sandbox_id: sandbox_id,
+                    snapshot_id: snapshot_id.to_string(),
+                    feedback_request_id: None,
+                    feedback_sandbox_id: None,
+                    feedback_completed: false,
+                    updated_at_ms: now_ms(),
+                };
+                store.put_trial(&trial).await?;
+                trial
+            };
+            if attached_conversation_sandbox(conversation)
+                .await?
+                .as_deref()
+                == Some(trial.source_sandbox_id.as_str())
+            {
+                conversation
+                    .detach_sandbox(trial.source_sandbox_id.clone())
+                    .await?;
+            }
+            Ok(serde_json::to_string(&TrialComplete {
+                message_type: "trial_complete",
+                request_id: &request_id,
+                target,
+                conversation_id,
+                snapshot_id: &trial.snapshot_id,
+                summary: summary.as_deref(),
+            })?)
+        }
+        TrialCompletionSignal::FeedbackComplete {
+            request_id,
+            summary,
+        } => {
+            let mut trial = store
+                .get_trial(adapter_id, target)
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("trial target {target} has no feedback state"))?;
+            if trial.feedback_request_id.as_deref() != Some(&request_id) {
+                bail!("feedback completion does not match the active request");
+            }
+            let sandbox_id = trial
+                .feedback_sandbox_id
+                .clone()
+                .ok_or_else(|| anyhow::anyhow!("trial target {target} has no feedback sandbox"))?;
+            conversation.stop_sandbox(sandbox_id).await?;
+            trial.feedback_completed = true;
+            trial.updated_at_ms = now_ms();
+            store.put_trial(&trial).await?;
+            Ok(serde_json::to_string(&PhaseComplete {
+                message_type: "feedback_complete",
+                request_id: &request_id,
+                target,
+                conversation_id,
+                summary: summary.as_deref(),
+            })?)
+        }
+    }
+}
 
-    // TODO(trial-feedback): Before returning this response, snapshot the active
-    // trial container and retain the snapshot with this target. A later
-    // trial_feedback request can then create a new sandbox from that snapshot
-    // and resume this same conversation.
-    Ok(serde_json::to_string(&TrialComplete {
-        message_type: "trial_complete",
-        request_id: &request_id,
-        target,
-        conversation_id,
-        summary: summary.as_deref(),
-    })?)
+fn require_non_empty(name: &str, value: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        bail!("{name} must not be empty");
+    }
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
+    use serde_json::json;
+
     use super::*;
 
     #[test]
-    fn completion_adds_runtime_owned_routing_fields() {
-        let response = finalize_trial_completion(
-            r#"{"type":"trial_complete","request_id":"request-1","summary":"done"}"#,
+    fn feedback_started_includes_restored_sandbox() {
+        let started = phase_started(
+            &PreparedTrialMessage::Started {
+                phase: TrialPhase::Feedback,
+                request_id: "feedback-1".to_string(),
+                sandbox_id: Some("sandbox-2".to_string()),
+            },
             "trial-1",
             "conversation-1",
         )
-        .expect("completion");
+        .unwrap()
+        .unwrap();
+
         assert_eq!(
-            serde_json::from_str::<serde_json::Value>(&response).expect("response JSON"),
-            serde_json::json!({
-                "type": "trial_complete",
-                "request_id": "request-1",
+            serde_json::from_str::<serde_json::Value>(&started).unwrap(),
+            json!({
+                "type": "feedback_started",
+                "request_id": "feedback-1",
                 "target": "trial-1",
                 "conversation_id": "conversation-1",
-                "summary": "done",
+                "sandbox_id": "sandbox-2",
             })
         );
     }
 
     #[test]
-    fn started_adds_runtime_owned_conversation_id() {
-        let response = trial_started(
-            &PreparedTrialRun {
-                request_id: "request-1".to_string(),
-            },
-            "trial-1",
-            "conversation-1",
-        )
-        .expect("started response");
-        assert_eq!(
-            serde_json::from_str::<serde_json::Value>(&response).expect("response JSON"),
-            serde_json::json!({
-                "type": "trial_started",
-                "request_id": "request-1",
-                "target": "trial-1",
-                "conversation_id": "conversation-1",
-            })
+    fn trial_metadata_is_typed_by_phase() {
+        let feedback = serde_json::from_value::<TrialMessageMetadata>(json!({
+            "type": "trial_feedback",
+            "request_id": "feedback-1",
+        }))
+        .unwrap();
+        assert!(matches!(feedback, TrialMessageMetadata::Feedback { .. }));
+
+        assert!(
+            serde_json::from_value::<TrialMessageMetadata>(json!({
+                "type": "trial_feedback",
+                "request_id": "feedback-1",
+                "container_id": "not-allowed",
+            }))
+            .is_err()
         );
     }
 }

--- a/crates/executor/src/adapter/trial.rs
+++ b/crates/executor/src/adapter/trial.rs
@@ -1,0 +1,118 @@
+use anyhow::{Context, Result, bail};
+use exoharness::{AttachSandboxRequest, SandboxAttachment};
+use serde::{Deserialize, Serialize};
+
+use crate::HarnessConversation;
+use crate::conversation_sandbox::attached_conversation_sandbox;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+struct TrialRunMetadata {
+    request_id: String,
+    container_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+enum TrialCompletionSignal {
+    TrialComplete {
+        request_id: String,
+        #[serde(default)]
+        summary: Option<String>,
+    },
+}
+
+#[derive(Debug, Serialize)]
+struct TrialComplete<'a> {
+    #[serde(rename = "type")]
+    message_type: &'static str,
+    request_id: &'a str,
+    target: &'a str,
+    conversation_id: &'a str,
+    summary: Option<&'a str>,
+}
+
+pub(super) async fn prepare_trial_run(
+    conversation: &dyn HarnessConversation,
+    metadata: serde_json::Value,
+) -> Result<()> {
+    let metadata = serde_json::from_value::<TrialRunMetadata>(metadata)
+        .context("trial_run metadata is invalid")?;
+    if metadata.request_id.trim().is_empty() {
+        bail!("trial_run request_id must not be empty");
+    }
+    if metadata.container_id.trim().is_empty() {
+        bail!("trial_run container_id must not be empty");
+    }
+
+    // Replayed pending requests arrive after adapter restarts. The target is
+    // mapped to one dedicated conversation, so its existing attachment is the
+    // environment for this same trial and must not be attached a second time.
+    if attached_conversation_sandbox(conversation.exoharness_handle().as_ref())
+        .await?
+        .is_some()
+    {
+        return Ok(());
+    }
+
+    conversation
+        .exoharness_handle()
+        .attach_sandbox(AttachSandboxRequest {
+            attachment: SandboxAttachment::DockerContainer {
+                container_id: metadata.container_id,
+            },
+            default_workdir: None,
+        })
+        .await?;
+    Ok(())
+}
+
+pub(super) fn finalize_trial_completion(
+    text: &str,
+    target: &str,
+    conversation_id: &str,
+) -> Result<String> {
+    let completion = serde_json::from_str::<TrialCompletionSignal>(text)
+        .context("trial completion must be a JSON object")?;
+    let TrialCompletionSignal::TrialComplete {
+        request_id,
+        summary,
+    } = completion;
+
+    // TODO(trial-feedback): Before returning this response, snapshot the active
+    // trial container and retain the snapshot with this target. A later
+    // trial_feedback request can then create a new sandbox from that snapshot
+    // and resume this same conversation.
+    Ok(serde_json::to_string(&TrialComplete {
+        message_type: "trial_complete",
+        request_id: &request_id,
+        target,
+        conversation_id,
+        summary: summary.as_deref(),
+    })?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn completion_adds_runtime_owned_routing_fields() {
+        let response = finalize_trial_completion(
+            r#"{"type":"trial_complete","request_id":"request-1","summary":"done"}"#,
+            "trial-1",
+            "conversation-1",
+        )
+        .expect("completion");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&response).expect("response JSON"),
+            serde_json::json!({
+                "type": "trial_complete",
+                "request_id": "request-1",
+                "target": "trial-1",
+                "conversation_id": "conversation-1",
+                "summary": "done",
+            })
+        );
+    }
+}

--- a/crates/executor/src/adapter/types.rs
+++ b/crates/executor/src/adapter/types.rs
@@ -161,6 +161,20 @@ pub struct AdapterTargetConversationRecord {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AdapterTrialRecord {
+    pub adapter_id: String,
+    pub target: String,
+    pub trial_request_id: String,
+    pub conversation_id: String,
+    pub source_sandbox_id: String,
+    pub snapshot_id: String,
+    pub feedback_request_id: Option<String>,
+    pub feedback_sandbox_id: Option<String>,
+    pub feedback_completed: bool,
+    pub updated_at_ms: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct AdapterInboundMessageRecord {
     pub adapter_id: String,
     pub target: String,

--- a/crates/executor/src/adapter/worker.rs
+++ b/crates/executor/src/adapter/worker.rs
@@ -46,6 +46,10 @@ pub enum WorkerEvent {
         #[serde(default)]
         attachments: Vec<AdapterAttachment>,
     },
+    Control {
+        target: String,
+        metadata: Value,
+    },
     Lifecycle {
         name: String,
         #[serde(default)]
@@ -67,18 +71,21 @@ pub enum WorkerEvent {
     },
 }
 
-pub async fn run_worker_loop<F, Fut, G, OutFut, S, StopFut>(
+pub async fn run_worker_loop<F, Fut, C, ControlFut, G, OutFut, S, StopFut>(
     adapter_id: &str,
     config: &AdapterConfig,
     secret_env: Vec<(String, String)>,
     outbound_notify: Arc<Notify>,
     on_event: F,
+    mut on_control: C,
     take_outbound_messages: G,
     mut should_stop: S,
 ) -> Result<()>
 where
     F: FnMut(WorkerEvent) -> Fut + Send + 'static,
     Fut: std::future::Future<Output = Result<()>> + Send + 'static,
+    C: FnMut(WorkerEvent) -> ControlFut,
+    ControlFut: std::future::Future<Output = Result<()>>,
     G: FnMut() -> OutFut + Send + 'static,
     OutFut: std::future::Future<Output = Result<Vec<WorkerCommand>>> + Send + 'static,
     S: FnMut() -> StopFut,
@@ -157,6 +164,10 @@ where
                     event = ?event,
                     "adapter worker event"
                 );
+                if matches!(event, WorkerEvent::Control { .. }) {
+                    on_control(event).await?;
+                    continue;
+                }
                 pending_events.fetch_add(1, Ordering::SeqCst);
                 if event_tx.send(event).await.is_err() {
                     break Err(anyhow!("adapter event handler stopped"));
@@ -358,6 +369,7 @@ mod tests {
             Vec::new(),
             outbound_notify,
             |_event| async { Ok(()) },
+            |_event| async { Ok(()) },
             || async { Ok(Vec::new()) },
             || async { Ok(true) },
         )
@@ -397,6 +409,7 @@ mod tests {
                     tokio::time::sleep(Duration::from_millis(100)).await;
                     Ok(())
                 },
+                |_event| async { Ok(()) },
                 || async { Ok(Vec::new()) },
                 move || {
                     let stop_checks = Arc::clone(&stop_checks);
@@ -407,6 +420,52 @@ mod tests {
         .await
         .expect("worker loop did not honor the stop request");
         result.unwrap();
+    }
+
+    #[tokio::test]
+    async fn dispatches_control_while_message_handler_is_busy() {
+        let config = AdapterConfig {
+            adapter_type: "test".to_string(),
+            worker_command: vec![
+                "sh".to_string(),
+                "-c".to_string(),
+                "printf '%s\n' '{\"type\":\"message\",\"target\":\"t\",\"text\":\"work\"}' '{\"type\":\"control\",\"target\":\"t\",\"metadata\":{}}'; sleep 60".to_string(),
+            ],
+            initialization: json!({}),
+            state_dir: None,
+            secret_env: Vec::new(),
+        };
+        let (control_tx, control_rx) = oneshot::channel();
+        let mut control_tx = Some(control_tx);
+
+        let worker = tokio::spawn(async move {
+            run_worker_loop(
+                "adapter",
+                &config,
+                Vec::new(),
+                Arc::new(Notify::new()),
+                |_event| async {
+                    std::future::pending::<()>().await;
+                    Ok(())
+                },
+                move |_event| {
+                    let control_tx = control_tx.take();
+                    async move {
+                        control_tx.unwrap().send(()).unwrap();
+                        Ok(())
+                    }
+                },
+                || async { Ok(Vec::new()) },
+                || async { Ok(false) },
+            )
+            .await
+        });
+
+        tokio::time::timeout(Duration::from_secs(5), control_rx)
+            .await
+            .expect("control event waited behind message handler")
+            .unwrap();
+        worker.abort();
     }
 
     #[tokio::test]
@@ -459,6 +518,7 @@ mod tests {
                         Ok(())
                     }
                 },
+                |_event| async { Ok(()) },
                 move || {
                     let outbound = Arc::clone(&outbound_for_worker);
                     async move {

--- a/crates/executor/src/basic_tests.rs
+++ b/crates/executor/src/basic_tests.rs
@@ -7,14 +7,14 @@ use async_trait::async_trait;
 use exoharness::{
     AddEventsRequest, AddEventsResult, AgentHandle, AgentId, AgentRecord, Artifact,
     ArtifactVersion, AttachSandboxRequest, BeginTurnRequest, Binding, BindingRecord, BindingType,
-    ConversationHandle, ConversationId, ConversationRecord, CreateSandboxRequest, Event, EventData,
-    EventQuery, EventQueryDirection, EventStream, ExoHarness, ForkConversationRequest,
-    GetEventsResult, NewAgentRequest, NewConversationRequest, PutSecretRequest,
-    ReadArtifactRequest, Result, RunInSandboxRequest, SandboxAttachment, SandboxHandle, SandboxId,
-    SandboxProcess, SandboxProcessEventQuery, SandboxProcessParts, SandboxProcessRecord,
-    SandboxProcessStatus, Secret, SecretMetadata, SecretType, SessionId, SnapshotHandle,
-    SnapshotId, StartSandboxProcessRequest, StartSandboxRequest, ToolRequest, ToolResult,
-    TurnHandle, TurnId, TurnRecord, Uuid7, WriteArtifactRequest,
+    ConversationHandle, ConversationId, ConversationRecord, CreateSandboxFromSnapshotRequest,
+    CreateSandboxRequest, Event, EventData, EventQuery, EventQueryDirection, EventStream,
+    ExoHarness, ForkConversationRequest, GetEventsResult, NewAgentRequest, NewConversationRequest,
+    PutSecretRequest, ReadArtifactRequest, Result, RunInSandboxRequest, SandboxAttachment,
+    SandboxHandle, SandboxId, SandboxProcess, SandboxProcessEventQuery, SandboxProcessParts,
+    SandboxProcessRecord, SandboxProcessStatus, Secret, SecretMetadata, SecretType, SessionId,
+    SnapshotHandle, SnapshotId, StartSandboxProcessRequest, StartSandboxRequest, ToolRequest,
+    ToolResult, TurnHandle, TurnId, TurnRecord, Uuid7, WriteArtifactRequest,
 };
 use futures::FutureExt;
 use futures::io::Cursor;
@@ -810,6 +810,13 @@ impl SandboxHandle for FakeAgentHandle {
         Ok("agent-sandbox".to_string())
     }
 
+    async fn create_sandbox_from_snapshot(
+        &self,
+        _request: CreateSandboxFromSnapshotRequest,
+    ) -> Result<SandboxId> {
+        Err(anyhow!("not implemented"))
+    }
+
     async fn attach_sandbox(&self, _request: AttachSandboxRequest) -> Result<SandboxId> {
         Err(anyhow!("not implemented"))
     }
@@ -1087,6 +1094,13 @@ impl SnapshotHandle for FakeConversationHandle {
 #[async_trait]
 impl SandboxHandle for FakeConversationHandle {
     async fn create_sandbox(&self, _request: CreateSandboxRequest) -> Result<SandboxId> {
+        Err(anyhow!("not implemented"))
+    }
+
+    async fn create_sandbox_from_snapshot(
+        &self,
+        _request: CreateSandboxFromSnapshotRequest,
+    ) -> Result<SandboxId> {
         Err(anyhow!("not implemented"))
     }
 

--- a/crates/executor/src/conversation_sandbox.rs
+++ b/crates/executor/src/conversation_sandbox.rs
@@ -61,10 +61,17 @@ pub(crate) async fn ensure_conversation_sandbox(
     {
         match candidate {
             ConversationSandboxCandidate::Attached { id } => return Ok(id),
-            ConversationSandboxCandidate::Created(sandbox) if sandbox.matches_spec(&spec) => {
+            ConversationSandboxCandidate::Created {
+                sandbox,
+                explicitly_started: true,
+            } => return Ok(sandbox.id),
+            ConversationSandboxCandidate::Created {
+                sandbox,
+                explicitly_started: false,
+            } if sandbox.matches_spec(&spec) => {
                 return Ok(sandbox.id);
             }
-            ConversationSandboxCandidate::Created(_) => {}
+            ConversationSandboxCandidate::Created { .. } => {}
         }
     }
 
@@ -81,21 +88,49 @@ pub async fn attached_conversation_sandbox(
             .next_back()
         {
             Some(ConversationSandboxCandidate::Attached { id }) => Some(id),
-            Some(ConversationSandboxCandidate::Created(_)) | None => None,
+            Some(ConversationSandboxCandidate::Created { .. }) | None => None,
+        },
+    )
+}
+
+pub(crate) async fn explicitly_selected_conversation_sandbox(
+    conversation: &dyn ConversationHandle,
+) -> Result<Option<String>> {
+    Ok(
+        match conversation_sandbox_candidates(conversation)
+            .await?
+            .into_iter()
+            .next_back()
+        {
+            Some(ConversationSandboxCandidate::Attached { id })
+            | Some(ConversationSandboxCandidate::Created {
+                sandbox: ConversationSandboxInfo { id, .. },
+                explicitly_started: true,
+            }) => Some(id),
+            Some(ConversationSandboxCandidate::Created {
+                explicitly_started: false,
+                ..
+            })
+            | None => None,
         },
     )
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum ConversationSandboxCandidate {
-    Created(ConversationSandboxInfo),
-    Attached { id: String },
+    Created {
+        sandbox: ConversationSandboxInfo,
+        explicitly_started: bool,
+    },
+    Attached {
+        id: String,
+    },
 }
 
 impl ConversationSandboxCandidate {
     fn id(&self) -> &str {
         match self {
-            Self::Created(sandbox) => &sandbox.id,
+            Self::Created { sandbox, .. } => &sandbox.id,
             Self::Attached { id } => id,
         }
     }
@@ -138,8 +173,8 @@ async fn conversation_sandbox_candidates(
                 idle_seconds,
                 ..
             } => {
-                candidates.push(ConversationSandboxCandidate::Created(
-                    ConversationSandboxInfo {
+                candidates.push(ConversationSandboxCandidate::Created {
+                    sandbox: ConversationSandboxInfo {
                         id: sandbox_id,
                         provider,
                         image,
@@ -149,13 +184,31 @@ async fn conversation_sandbox_candidates(
                         enable_networking,
                         idle_seconds,
                     },
-                ));
+                    explicitly_started: false,
+                });
             }
             EventData::SandboxAttached { sandbox_id, .. } => {
                 candidates.push(ConversationSandboxCandidate::Attached { id: sandbox_id });
             }
-            EventData::SandboxStarted { sandbox_id, .. } => {
+            EventData::SandboxStarted {
+                sandbox_id,
+                snapshot_id,
+            } => {
                 inactive.remove(&sandbox_id);
+                if snapshot_id.is_some()
+                    && let Some(index) = candidates
+                        .iter()
+                        .position(|candidate| candidate.id() == sandbox_id)
+                {
+                    let mut candidate = candidates.remove(index);
+                    if let ConversationSandboxCandidate::Created {
+                        explicitly_started, ..
+                    } = &mut candidate
+                    {
+                        *explicitly_started = true;
+                    }
+                    candidates.push(candidate);
+                }
             }
             EventData::SandboxStopped { sandbox_id }
             | EventData::SandboxDetached { sandbox_id, .. } => {
@@ -195,7 +248,7 @@ pub(crate) async fn conversation_sandboxes(
         .await?
         .into_iter()
         .filter_map(|candidate| match candidate {
-            ConversationSandboxCandidate::Created(sandbox) => Some(sandbox),
+            ConversationSandboxCandidate::Created { sandbox, .. } => Some(sandbox),
             ConversationSandboxCandidate::Attached { .. } => None,
         })
         .collect())

--- a/crates/executor/src/harness_basic_tests.rs
+++ b/crates/executor/src/harness_basic_tests.rs
@@ -1242,6 +1242,29 @@ async fn updating_sandbox_image_recreates_shell_sandbox_without_shell_program() 
         .expect("previous sandbox should be selected after detachment"),
         second_sandbox_id
     );
+
+    conversation
+        .exoharness_handle()
+        .add_events(AddEventsRequest {
+            session_id: None,
+            turn_id: None,
+            data: vec![EventData::SandboxStarted {
+                sandbox_id: first_sandbox_id.clone(),
+                snapshot_id: Some(Uuid7::now()),
+            }],
+        })
+        .await
+        .expect("explicit sandbox start should be recorded");
+    assert_eq!(
+        ensure_shell_sandbox(
+            conversation.exoharness_handle().as_ref(),
+            &agent_config,
+            &conversation_config,
+        )
+        .await
+        .expect("explicitly started sandbox should be selected"),
+        first_sandbox_id
+    );
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/crates/executor/src/harness_facade.rs
+++ b/crates/executor/src/harness_facade.rs
@@ -252,7 +252,9 @@ where
                 .or(default_conversation_config.shell_program),
             mounts: default_conversation_config.mounts,
             durable_file_systems: default_conversation_config.durable_file_systems,
-            sandbox_scope: default_conversation_config.sandbox_scope,
+            sandbox_scope: request
+                .sandbox_scope
+                .or(default_conversation_config.sandbox_scope),
         };
         self.runtime
             .put_conversation_config(conversation.as_ref(), conversation_config)

--- a/crates/executor/src/harness_tool.rs
+++ b/crates/executor/src/harness_tool.rs
@@ -10,7 +10,7 @@ use crate::agent_sandbox::{current_agent_sandbox, ensure_agent_sandbox};
 use crate::conversation_events::execute_list_conversation_events_tool;
 use crate::conversation_sandbox::{
     agent_sandbox_spec, attached_conversation_sandbox, conversation_sandbox_spec,
-    conversation_sandboxes, ensure_conversation_sandbox,
+    conversation_sandboxes, ensure_conversation_sandbox, explicitly_selected_conversation_sandbox,
 };
 use crate::scheduler_store::SchedulerStore;
 use crate::scheduler_types::{
@@ -950,7 +950,7 @@ pub(crate) async fn ensure_shell_sandbox(
     agent_config: &AgentConfig,
     config: &ConversationConfig,
 ) -> Result<String> {
-    if let Some(sandbox_id) = attached_conversation_sandbox(conversation).await? {
+    if let Some(sandbox_id) = explicitly_selected_conversation_sandbox(conversation).await? {
         return Ok(sandbox_id);
     }
     let desired_default_workdir = config

--- a/crates/executor/src/harness_types.rs
+++ b/crates/executor/src/harness_types.rs
@@ -82,4 +82,5 @@ pub struct CreateConversationRequest {
     pub sandbox_image: Option<String>,
     pub sandbox_provider: Option<SandboxProvider>,
     pub shell_program: Option<String>,
+    pub sandbox_scope: Option<SandboxScope>,
 }

--- a/crates/executor/src/local_sandbox.rs
+++ b/crates/executor/src/local_sandbox.rs
@@ -6,8 +6,9 @@ use async_trait::async_trait;
 use exoharness::{
     AddEventsRequest, AddEventsResult, AgentHandle, AgentId, Artifact, ArtifactVersion,
     AttachSandboxRequest, Binding, BindingId, BindingRecord, CancelSandboxProcessRequest,
-    CloseSandboxProcessInputRequest, ConversationHandle, ConversationId, CreateSandboxRequest,
-    Event, EventData, EventId, EventKind, EventStream, ExoHarness, ForkConversationRequest,
+    CloseSandboxProcessInputRequest, ConversationHandle, ConversationId,
+    CreateSandboxFromSnapshotRequest, CreateSandboxRequest, Event, EventData, EventId, EventKind,
+    EventQuery, EventQueryDirection, EventStream, ExoHarness, ForkConversationRequest,
     GetEventsResult, ListConversationsRequest, ListConversationsResult, NewAgentRequest,
     NewConversationRequest, PutSecretRequest, ReadArtifactRequest, Result, RunInSandboxRequest,
     SandboxAttachment, SandboxHandle, SandboxId, SandboxProcess, SandboxProcessEventQuery,
@@ -40,6 +41,7 @@ struct LocalSandboxState {
     conversations: Mutex<HashMap<ConversationId, Arc<dyn ConversationHandle>>>,
     conversation_init: Mutex<()>,
     sandboxes: Mutex<HashMap<SandboxId, SandboxId>>,
+    local_snapshots: Mutex<HashSet<SnapshotId>>,
     detached_sandboxes: Mutex<HashMap<SandboxId, SandboxAttachment>>,
     force_local: bool,
     local_providers: HashSet<SandboxProvider>,
@@ -72,6 +74,7 @@ impl LocalSandboxExoHarness {
                 conversations: Mutex::new(HashMap::new()),
                 conversation_init: Mutex::new(()),
                 sandboxes: Mutex::new(HashMap::new()),
+                local_snapshots: Mutex::new(HashSet::new()),
                 detached_sandboxes: Mutex::new(HashMap::new()),
                 force_local,
                 local_providers,
@@ -296,7 +299,9 @@ impl SnapshotHandle for LocalSandboxAgent {
         let Some(local_id) = self.local_sandbox_id(&id).await? else {
             return self.remote.snapshot_sandbox(id).await;
         };
-        self.local_agent().await?.snapshot_sandbox(local_id).await
+        let snapshot_id = self.local_agent().await?.snapshot_sandbox(local_id).await?;
+        self.state.local_snapshots.lock().await.insert(snapshot_id);
+        Ok(snapshot_id)
     }
 
     async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
@@ -323,6 +328,29 @@ impl SandboxHandle for LocalSandboxAgent {
         }
 
         let local_id = self.local_agent().await?.create_sandbox(request).await?;
+        let remote_id = local_id.clone();
+        self.map_local_sandbox(remote_id.clone(), local_id).await;
+        Ok(remote_id)
+    }
+
+    async fn create_sandbox_from_snapshot(
+        &self,
+        request: CreateSandboxFromSnapshotRequest,
+    ) -> Result<SandboxId> {
+        if !self
+            .state
+            .local_snapshots
+            .lock()
+            .await
+            .contains(&request.snapshot_id)
+        {
+            return self.remote.create_sandbox_from_snapshot(request).await;
+        }
+        let local_id = self
+            .local_agent()
+            .await?
+            .create_sandbox_from_snapshot(request)
+            .await?;
         let remote_id = local_id.clone();
         self.map_local_sandbox(remote_id.clone(), local_id).await;
         Ok(remote_id)
@@ -664,6 +692,33 @@ impl LocalSandboxConversation {
         local_sandbox_id_for(&self.state, self.remote.record().id, sandbox_id).await
     }
 
+    async fn snapshot_is_local(&self, snapshot_id: SnapshotId) -> Result<bool> {
+        let source_id = self
+            .remote
+            .get_events(Some(EventQuery {
+                cursor: None,
+                direction: Some(EventQueryDirection::Desc),
+                limit: None,
+                session_id: None,
+                turn_id: None,
+                types: Some(vec![EventKind::SANDBOX_SNAPSHOTTED]),
+            }))
+            .await?
+            .events
+            .into_iter()
+            .find_map(|event| match event.data {
+                EventData::SandboxSnapshotted {
+                    sandbox_id,
+                    snapshot_id: candidate,
+                } if candidate == snapshot_id => Some(sandbox_id),
+                _ => None,
+            });
+        let Some(source_id) = source_id else {
+            return Ok(false);
+        };
+        Ok(self.local_sandbox_id(&source_id).await?.is_some())
+    }
+
     async fn map_local_sandbox(&self, remote_id: SandboxId, local_id: SandboxId) -> Result<()> {
         self.state
             .sandboxes
@@ -801,6 +856,7 @@ impl SnapshotHandle for LocalSandboxConversation {
             .await?
             .snapshot_sandbox(local_id)
             .await?;
+        self.state.local_snapshots.lock().await.insert(snapshot_id);
         self.append_remote_sandbox_events(vec![EventData::SandboxSnapshotted {
             sandbox_id: id,
             snapshot_id,
@@ -859,6 +915,48 @@ impl SandboxHandle for LocalSandboxConversation {
             EventData::SandboxStarted {
                 sandbox_id: remote_id.clone(),
                 snapshot_id: None,
+            },
+        ])
+        .await?;
+        Ok(remote_id)
+    }
+
+    async fn create_sandbox_from_snapshot(
+        &self,
+        request: CreateSandboxFromSnapshotRequest,
+    ) -> Result<SandboxId> {
+        if !self.snapshot_is_local(request.snapshot_id).await? {
+            return self.remote.create_sandbox_from_snapshot(request).await;
+        }
+
+        let snapshot_id = request.snapshot_id;
+        let local_conversation = self.local_conversation().await?;
+        let local_id = local_conversation
+            .create_sandbox_from_snapshot(request)
+            .await?;
+        let sandbox =
+            crate::conversation_sandbox::conversation_sandboxes(local_conversation.as_ref())
+                .await?
+                .into_iter()
+                .find(|sandbox| sandbox.id == local_id)
+                .ok_or_else(|| anyhow::anyhow!("created local sandbox event was not recorded"))?;
+        let remote_id = format!("sandbox-{}", Uuid7::now());
+        self.map_local_sandbox(remote_id.clone(), local_id).await?;
+        self.append_remote_sandbox_events(vec![
+            EventData::SandboxCreated {
+                sandbox_id: remote_id.clone(),
+                name: None,
+                provider: sandbox.provider,
+                image: sandbox.image,
+                default_workdir: sandbox.default_workdir,
+                file_system_mounts: sandbox.file_system_mounts,
+                durable_file_systems: sandbox.durable_file_systems,
+                enable_networking: sandbox.enable_networking,
+                idle_seconds: sandbox.idle_seconds,
+            },
+            EventData::SandboxStarted {
+                sandbox_id: remote_id.clone(),
+                snapshot_id: Some(snapshot_id),
             },
         ])
         .await?;

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -36,17 +36,17 @@ use crate::{
     ArtifactVersion, AttachSandboxRequest, BeginTurnRequest, Binding, BindingId, BindingRecord,
     BindingType, BoxAsyncRead, BoxAsyncWrite, CancelSandboxProcessRequest,
     CloseSandboxProcessInputRequest, ConversationHandle, ConversationId, ConversationRecord,
-    CreateSandboxRequest, DurableFileSystem, Event, EventData, EventId, EventKind, EventQuery,
-    EventQueryDirection, EventStream, ExoHarness, FileSystemMount, ForkConversationRequest,
-    GetEventsResult, GetSandboxProcessEventsResult, ListConversationsRequest,
-    ListConversationsResult, NewAgentRequest, NewConversationRequest, PutSecretRequest,
-    ReadArtifactRequest, Result, RunInSandboxRequest, SandboxAttachment, SandboxHandle, SandboxId,
-    SandboxProcess, SandboxProcessEvent, SandboxProcessEventQuery, SandboxProcessId,
-    SandboxProcessMode, SandboxProcessParts, SandboxProcessRecord, SandboxProcessStatus,
-    SandboxProcessStdin, SandboxProvider, SandboxProviderConfig, Secret, SecretId, SecretMetadata,
-    SecretType, SessionId, SnapshotHandle, SnapshotId, StartSandboxProcessRequest,
-    StartSandboxRequest, TurnHandle, TurnId, TurnRecord, Uuid7, WaitSandboxProcessRequest,
-    WriteArtifactRequest, WriteSandboxProcessInputRequest,
+    CreateSandboxFromSnapshotRequest, CreateSandboxRequest, DurableFileSystem, Event, EventData,
+    EventId, EventKind, EventQuery, EventQueryDirection, EventStream, ExoHarness, FileSystemMount,
+    ForkConversationRequest, GetEventsResult, GetSandboxProcessEventsResult,
+    ListConversationsRequest, ListConversationsResult, NewAgentRequest, NewConversationRequest,
+    PutSecretRequest, ReadArtifactRequest, Result, RunInSandboxRequest, SandboxAttachment,
+    SandboxHandle, SandboxId, SandboxProcess, SandboxProcessEvent, SandboxProcessEventQuery,
+    SandboxProcessId, SandboxProcessMode, SandboxProcessParts, SandboxProcessRecord,
+    SandboxProcessStatus, SandboxProcessStdin, SandboxProvider, SandboxProviderConfig, Secret,
+    SecretId, SecretMetadata, SecretType, SessionId, SnapshotHandle, SnapshotId,
+    StartSandboxProcessRequest, StartSandboxRequest, TurnHandle, TurnId, TurnRecord, Uuid7,
+    WaitSandboxProcessRequest, WriteArtifactRequest, WriteSandboxProcessInputRequest,
 };
 
 const SANDBOX_PROVIDER_STATE_EVENT: &str = "sandbox_provider_state";
@@ -1091,6 +1091,15 @@ where
         self.sandbox_handle().create_sandbox(request).await
     }
 
+    async fn create_sandbox_from_snapshot(
+        &self,
+        request: CreateSandboxFromSnapshotRequest,
+    ) -> Result<SandboxId> {
+        self.sandbox_handle()
+            .create_sandbox_from_snapshot(request)
+            .await
+    }
+
     async fn attach_sandbox(&self, request: AttachSandboxRequest) -> Result<SandboxId> {
         self.sandbox_handle().attach_sandbox(request).await
     }
@@ -1613,6 +1622,22 @@ impl<'a> BasicScopedSandboxHandle<'a> {
         self.create_new_sandbox_locked(prepared).await
     }
 
+    async fn create_sandbox_from_snapshot(
+        &self,
+        request: CreateSandboxFromSnapshotRequest,
+    ) -> Result<SandboxId> {
+        self.ensure_full_sandbox_scope("create_sandbox_from_snapshot")?;
+        let (sandbox_id, events) = create_sandbox_from_snapshot_side_effect(
+            self.harness,
+            &self.owner_dir,
+            self.owner,
+            request,
+        )
+        .await?;
+        self.append_events(events).await?;
+        Ok(sandbox_id)
+    }
+
     async fn attach_sandbox(&self, request: AttachSandboxRequest) -> Result<SandboxId> {
         self.ensure_full_sandbox_scope("attach_sandbox")?;
         let sandbox_id = format!("sandbox-{}", Uuid7::now());
@@ -1693,9 +1718,9 @@ impl<'a> BasicScopedSandboxHandle<'a> {
     }
 
     async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
-        let (snapshot_id, event) =
-            snapshot_sandbox_side_effect(self.harness, &self.owner_dir, id).await?;
-        self.append_events(vec![event]).await?;
+        let (snapshot_id, events) =
+            snapshot_sandbox_side_effect(self.harness, &self.owner_dir, self.owner, id).await?;
+        self.append_events(events).await?;
         Ok(snapshot_id)
     }
 
@@ -2741,22 +2766,17 @@ impl BasicConversationHandle {
 async fn snapshot_sandbox_side_effect(
     harness: &BasicExoHarness,
     owner_dir: &Path,
+    owner: SandboxOwner,
     id: SandboxId,
-) -> Result<(SnapshotId, EventData)> {
-    let sandbox = load_stored_sandbox(harness, owner_dir, &id).await?;
-    if sandbox.attachment.is_some() {
-        bail!("attached sandboxes cannot be snapshotted");
+) -> Result<(SnapshotId, Vec<EventData>)> {
+    let stored = load_stored_sandbox(harness, owner_dir, &id).await?;
+    if !stored.running {
+        bail!("sandbox is not running: {id}");
     }
     // Capture the payload before taking the write lock. Backends may need to
     // talk to docker or pause the container, which can be slow.
-    let handle = harness
-        .inner
-        .running_sandboxes
-        .lock()
-        .await
-        .get(&id)
-        .cloned()
-        .ok_or_else(|| anyhow!("sandbox {id} is not running; start it before snapshotting"))?;
+    let (handle, provider_state_event) =
+        active_sandbox_handle(harness, owner_dir, owner, &id, &stored).await?;
     let payload = handle.snapshot().await?;
 
     let _guard = harness.inner.write_lock.lock().await;
@@ -2786,13 +2806,15 @@ async fn snapshot_sandbox_side_effect(
             &sandbox,
         )
         .await?;
-    Ok((
+    let mut events = Vec::new();
+    if let Some(event) = provider_state_event {
+        events.push(event);
+    }
+    events.push(EventData::SandboxSnapshotted {
+        sandbox_id: id,
         snapshot_id,
-        EventData::SandboxSnapshotted {
-            sandbox_id: id,
-            snapshot_id,
-        },
-    ))
+    });
+    Ok((snapshot_id, events))
 }
 
 async fn start_sandbox_side_effect(
@@ -2807,26 +2829,7 @@ async fn start_sandbox_side_effect(
     }
     // Load the snapshot payload before acquiring the write lock. It can be
     // large, and we don't want to block writers while we read.
-    let snapshot_dir = owner_dir
-        .join("snapshots")
-        .join(request.snapshot_id.to_string());
-    let storage = &harness.inner.storage;
-    let (manifest_result, payload_result) = tokio::join!(
-        storage.get_json::<StoredSnapshotManifest>(snapshot_dir.join("manifest.json")),
-        storage.get_bytes(snapshot_dir.join("payload.bin")),
-    );
-    let manifest = manifest_result.with_context(|| {
-        format!(
-            "loading snapshot manifest for {} (have you taken a snapshot?)",
-            request.snapshot_id
-        )
-    })?;
-    let payload_bytes = payload_result
-        .with_context(|| format!("loading snapshot payload for {}", request.snapshot_id))?;
-    let payload = SnapshotPayload {
-        kind: manifest.kind,
-        bytes: Bytes::from(payload_bytes),
-    };
+    let (_, payload) = load_snapshot(harness, owner_dir, request.snapshot_id).await?;
 
     let mut sandbox = load_stored_sandbox(harness, owner_dir, &request.id).await?;
     sandbox.running = true;
@@ -2934,6 +2937,105 @@ async fn start_sandbox_side_effect(
         sandbox_id: request.id,
         snapshot_id: Some(request.snapshot_id),
     })
+}
+
+async fn create_sandbox_from_snapshot_side_effect(
+    harness: &BasicExoHarness,
+    owner_dir: &Path,
+    owner: SandboxOwner,
+    request: CreateSandboxFromSnapshotRequest,
+) -> Result<(SandboxId, Vec<EventData>)> {
+    let (manifest, payload) = load_snapshot(harness, owner_dir, request.snapshot_id).await?;
+    let source = load_stored_sandbox(harness, owner_dir, &manifest.sandbox_id).await?;
+    let sandbox_id = format!("sandbox-{}", Uuid7::now());
+    let mut sandbox = StoredSandbox {
+        id: sandbox_id.clone(),
+        name: None,
+        provider: request.provider.unwrap_or(source.provider),
+        image: source.image,
+        requested_image: source.requested_image,
+        default_workdir: source.default_workdir,
+        file_system_mounts: source.file_system_mounts,
+        durable_file_systems: source.durable_file_systems,
+        enable_networking: source.enable_networking,
+        idle_seconds: request.idle_seconds.unwrap_or(source.idle_seconds),
+        running: true,
+        latest_snapshot_id: Some(request.snapshot_id),
+        attachment: None,
+    };
+    let handle = harness
+        .inner
+        .sandbox_backend_for_provider(sandbox.provider.clone())
+        .await?
+        .acquire_from_snapshot(sandbox_request(owner, &sandbox_id, &sandbox, None), payload)
+        .await?;
+    if let Some(effective_image) = handle.effective_image()
+        && effective_image != sandbox.image
+    {
+        sandbox
+            .requested_image
+            .get_or_insert_with(|| sandbox.image.clone());
+        sandbox.image = effective_image;
+    }
+
+    let _guard = harness.inner.write_lock.lock().await;
+    harness
+        .inner
+        .storage
+        .put_json(
+            owner_dir
+                .join("sandboxes")
+                .join(format!("{sandbox_id}.json")),
+            &sandbox,
+        )
+        .await?;
+    harness
+        .inner
+        .running_sandboxes
+        .lock()
+        .await
+        .insert(sandbox_id.clone(), handle);
+    let events = vec![
+        EventData::SandboxCreated {
+            sandbox_id: sandbox_id.clone(),
+            name: None,
+            provider: sandbox.provider,
+            image: sandbox.image,
+            default_workdir: sandbox.default_workdir.unwrap_or_default(),
+            file_system_mounts: sandbox.file_system_mounts,
+            durable_file_systems: sandbox.durable_file_systems,
+            enable_networking: sandbox.enable_networking,
+            idle_seconds: sandbox.idle_seconds,
+        },
+        EventData::SandboxStarted {
+            sandbox_id: sandbox_id.clone(),
+            snapshot_id: Some(request.snapshot_id),
+        },
+    ];
+    Ok((sandbox_id, events))
+}
+
+async fn load_snapshot(
+    harness: &BasicExoHarness,
+    owner_dir: &Path,
+    snapshot_id: SnapshotId,
+) -> Result<(StoredSnapshotManifest, SnapshotPayload)> {
+    let snapshot_dir = owner_dir.join("snapshots").join(snapshot_id.to_string());
+    let storage = &harness.inner.storage;
+    let (manifest_result, payload_result) = tokio::join!(
+        storage.get_json::<StoredSnapshotManifest>(snapshot_dir.join("manifest.json")),
+        storage.get_bytes(snapshot_dir.join("payload.bin")),
+    );
+    let manifest = manifest_result.with_context(|| {
+        format!("loading snapshot manifest for {snapshot_id} (have you taken a snapshot?)")
+    })?;
+    let payload_bytes =
+        payload_result.with_context(|| format!("loading snapshot payload for {snapshot_id}"))?;
+    let payload = SnapshotPayload {
+        kind: manifest.kind,
+        bytes: Bytes::from(payload_bytes),
+    };
+    Ok((manifest, payload))
 }
 
 async fn load_stored_sandbox(

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -19,17 +19,17 @@ use tokio::time::{sleep, timeout};
 
 use crate::test_support::{local_test_config, local_test_config_with_daytona};
 use crate::{
-    Artifact, ArtifactVersion, BasicExoHarness, BeginTurnRequest, Binding, BoxAsyncRead,
-    BoxAsyncWrite, CloseSandboxProcessInputRequest, CreateSandboxRequest, DurableFileSystem,
-    EventData, EventKind, EventQuery, EventQueryDirection, ExoHarness, FileSystemMountMode,
-    ForkConversationRequest, ManagedSandboxBackend, ManagedSandboxHandle, NewAgentRequest,
-    NewConversationRequest, PutSecretRequest, RunInSandboxRequest, SandboxAttachment,
-    SandboxBackendRegistration, SandboxCommand, SandboxCommandOutput, SandboxKey,
-    SandboxLifecycleConfig, SandboxNetworkPolicy, SandboxProcessEvent, SandboxProcessEventQuery,
-    SandboxProcessParts, SandboxProcessStatus, SandboxProcessStdin, SandboxProvider,
-    SandboxProviderConfig, SandboxRequest, SandboxSpec, Secret, SnapshotKind, SnapshotPayload,
-    StartSandboxProcessRequest, StartSandboxRequest, Uuid7, WaitSandboxProcessRequest,
-    WriteArtifactRequest, WriteSandboxProcessInputRequest,
+    Artifact, ArtifactVersion, AttachSandboxRequest, BasicExoHarness, BeginTurnRequest, Binding,
+    BoxAsyncRead, BoxAsyncWrite, CloseSandboxProcessInputRequest, CreateSandboxFromSnapshotRequest,
+    CreateSandboxRequest, DurableFileSystem, EventData, EventKind, EventQuery, EventQueryDirection,
+    ExoHarness, FileSystemMountMode, ForkConversationRequest, ManagedSandboxBackend,
+    ManagedSandboxHandle, NewAgentRequest, NewConversationRequest, PutSecretRequest,
+    RunInSandboxRequest, SandboxAttachment, SandboxBackendRegistration, SandboxCommand,
+    SandboxCommandOutput, SandboxKey, SandboxLifecycleConfig, SandboxNetworkPolicy,
+    SandboxProcessEvent, SandboxProcessEventQuery, SandboxProcessParts, SandboxProcessStatus,
+    SandboxProcessStdin, SandboxProvider, SandboxProviderConfig, SandboxRequest, SandboxSpec,
+    Secret, SnapshotKind, SnapshotPayload, StartSandboxProcessRequest, StartSandboxRequest, Uuid7,
+    WaitSandboxProcessRequest, WriteArtifactRequest, WriteSandboxProcessInputRequest,
 };
 
 const DEFAULT_DURABLE_CONTRACT_MOUNT_PATH: &str = "/home/exo/workspace";
@@ -1631,6 +1631,232 @@ async fn test_conversation(harness: &BasicExoHarness) -> Arc<dyn crate::Conversa
         .new_conversation(NewConversationRequest::default())
         .await
         .expect("conversation")
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn attached_sandbox_snapshot_creates_a_separate_owned_sandbox() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let backend = Arc::new(AttachmentTestBackend::default());
+    backend
+        .external_resource_exists
+        .store(true, std::sync::atomic::Ordering::SeqCst);
+    let harness = BasicExoHarness::new(attachment_test_config(tempdir.path(), backend.clone()))
+        .await
+        .expect("harness should initialize");
+    let agent = harness
+        .new_agent(NewAgentRequest {
+            slug: "agent".to_string(),
+            name: "Agent".to_string(),
+        })
+        .await
+        .expect("agent");
+    let agent_id = agent.record().id;
+    let conversation = agent
+        .new_conversation(NewConversationRequest::default())
+        .await
+        .expect("conversation");
+    let conversation_id = conversation.record().id;
+    let attachment = SandboxAttachment::DockerContainer {
+        container_id: "external-container".to_string(),
+    };
+    let attached_id = conversation
+        .attach_sandbox(AttachSandboxRequest {
+            attachment: attachment.clone(),
+            default_workdir: Some("/workspace".to_string()),
+        })
+        .await
+        .expect("sandbox should attach");
+
+    // Reopen the durable state as a separate process would. Snapshotting must
+    // reacquire the attachment from its descriptor rather than depend on the
+    // process-local handle that performed the original attach.
+    drop(conversation);
+    drop(agent);
+    drop(harness);
+    let reloaded = BasicExoHarness::new(attachment_test_config(tempdir.path(), backend.clone()))
+        .await
+        .expect("reloaded harness should initialize");
+    let reloaded_agent = reloaded
+        .get_agent(&agent_id)
+        .await
+        .expect("agent lookup")
+        .expect("agent should exist");
+    let conversation = reloaded_agent
+        .get_conversation(&conversation_id)
+        .await
+        .expect("conversation lookup")
+        .expect("conversation should exist");
+
+    let snapshot_id = conversation
+        .snapshot_sandbox(attached_id.clone())
+        .await
+        .expect("attached sandbox should snapshot");
+    let restored_id = conversation
+        .create_sandbox_from_snapshot(CreateSandboxFromSnapshotRequest {
+            snapshot_id,
+            idle_seconds: Some(300),
+            provider: None,
+        })
+        .await
+        .expect("snapshot should create an owned sandbox");
+
+    assert_ne!(restored_id, attached_id);
+    assert_eq!(
+        conversation
+            .detach_sandbox(attached_id)
+            .await
+            .expect("the original attachment should remain borrowed"),
+        attachment
+    );
+    conversation
+        .stop_sandbox(restored_id)
+        .await
+        .expect("the restored sandbox should be owned");
+    assert_eq!(
+        backend
+            .restore_calls
+            .load(std::sync::atomic::Ordering::SeqCst),
+        1
+    );
+    assert_eq!(
+        backend.stop_calls.load(std::sync::atomic::Ordering::SeqCst),
+        1
+    );
+}
+
+fn attachment_test_config(
+    root: &std::path::Path,
+    backend: Arc<AttachmentTestBackend>,
+) -> crate::BasicExoHarnessConfig {
+    let mut config = local_test_config(root);
+    config.sandbox_default = SandboxProvider::Docker;
+    config.sandbox_backends = vec![SandboxBackendRegistration::from_backend(
+        SandboxProvider::Docker,
+        backend,
+    )];
+    config
+}
+
+#[derive(Default)]
+struct AttachmentTestBackend {
+    attach_calls: std::sync::atomic::AtomicUsize,
+    restore_calls: Arc<std::sync::atomic::AtomicUsize>,
+    stop_calls: Arc<std::sync::atomic::AtomicUsize>,
+    external_resource_exists: std::sync::atomic::AtomicBool,
+}
+
+#[async_trait]
+impl ManagedSandboxBackend for AttachmentTestBackend {
+    fn is_local(&self) -> bool {
+        false
+    }
+
+    async fn acquire(
+        &self,
+        _request: SandboxRequest,
+    ) -> crate::Result<Arc<dyn ManagedSandboxHandle>> {
+        bail!("attachment test backend only supports attach")
+    }
+
+    async fn attach(
+        &self,
+        _request: SandboxRequest,
+        attachment: SandboxAttachment,
+    ) -> crate::Result<Arc<dyn ManagedSandboxHandle>> {
+        self.attach_calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        if !self
+            .external_resource_exists
+            .load(std::sync::atomic::Ordering::SeqCst)
+        {
+            bail!("external resource is gone")
+        }
+        Ok(Arc::new(AttachmentTestHandle { attachment }))
+    }
+
+    async fn acquire_from_snapshot(
+        &self,
+        _request: SandboxRequest,
+        payload: SnapshotPayload,
+    ) -> crate::Result<Arc<dyn ManagedSandboxHandle>> {
+        assert_eq!(payload.kind, SnapshotKind::DockerImageTar);
+        assert_eq!(payload.bytes.as_ref(), b"submitted state");
+        self.restore_calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Ok(Arc::new(RestoredAttachmentTestHandle {
+            stop_calls: Arc::clone(&self.stop_calls),
+        }))
+    }
+}
+
+struct AttachmentTestHandle {
+    attachment: SandboxAttachment,
+}
+
+#[async_trait]
+impl ManagedSandboxHandle for AttachmentTestHandle {
+    fn id(&self) -> &str {
+        "attachment-test"
+    }
+
+    async fn exec(&self, _command: &SandboxCommand) -> crate::Result<SandboxCommandOutput> {
+        bail!("attachment test handle does not support exec")
+    }
+
+    async fn start_process(&self, _command: &SandboxCommand) -> crate::Result<SandboxProcessParts> {
+        bail!("attachment test handle does not support start_process")
+    }
+
+    async fn stop(&self) -> crate::Result<()> {
+        bail!("attached sandbox must not be stopped")
+    }
+
+    async fn detach(&self) -> crate::Result<SandboxAttachment> {
+        Ok(self.attachment.clone())
+    }
+
+    async fn snapshot(&self) -> crate::Result<SnapshotPayload> {
+        Ok(SnapshotPayload {
+            kind: SnapshotKind::DockerImageTar,
+            bytes: b"submitted state".to_vec().into(),
+        })
+    }
+}
+
+struct RestoredAttachmentTestHandle {
+    stop_calls: Arc<std::sync::atomic::AtomicUsize>,
+}
+
+#[async_trait]
+impl ManagedSandboxHandle for RestoredAttachmentTestHandle {
+    fn id(&self) -> &str {
+        "restored-attachment-test"
+    }
+
+    async fn exec(&self, _command: &SandboxCommand) -> crate::Result<SandboxCommandOutput> {
+        bail!("restored attachment test handle does not support exec")
+    }
+
+    async fn start_process(&self, _command: &SandboxCommand) -> crate::Result<SandboxProcessParts> {
+        bail!("restored attachment test handle does not support start_process")
+    }
+
+    async fn stop(&self) -> crate::Result<()> {
+        self.stop_calls
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn detach(&self) -> crate::Result<SandboxAttachment> {
+        bail!("restored attachment test handle does not support detachment")
+    }
+
+    async fn snapshot(&self) -> crate::Result<SnapshotPayload> {
+        Ok(SnapshotPayload {
+            kind: SnapshotKind::DockerImageTar,
+            bytes: b"restored state".to_vec().into(),
+        })
+    }
 }
 
 async fn test_sandbox(conversation: &Arc<dyn crate::ConversationHandle>) -> String {

--- a/crates/exoharness/src/http/client.rs
+++ b/crates/exoharness/src/http/client.rs
@@ -20,13 +20,13 @@ use crate::{
     AddEventsRequest, AddEventsResult, AgentHandle, AgentId, AgentRecord, Artifact,
     ArtifactVersion, AttachSandboxRequest, BeginTurnRequest, Binding, BindingId, BindingRecord,
     CancelSandboxProcessRequest, CloseSandboxProcessInputRequest, ConversationHandle,
-    ConversationId, ConversationRecord, CreateSandboxRequest, Event, EventData, EventId,
-    EventQuery, EventStream, ExoHarness, ForkConversationRequest, GetEventsResult,
-    GetSandboxProcessEventsResult, ListConversationsRequest, ListConversationsResult,
-    NewAgentRequest, NewConversationRequest, PutSecretRequest, ReadArtifactRequest, Result,
-    RunInSandboxRequest, SandboxAttachment, SandboxHandle, SandboxId, SandboxProcess,
-    SandboxProcessEventQuery, SandboxProcessParts, SandboxProcessRecord, SandboxProcessStatus,
-    Secret, SecretId, SecretMetadata, SessionId, SnapshotHandle, SnapshotId,
+    ConversationId, ConversationRecord, CreateSandboxFromSnapshotRequest, CreateSandboxRequest,
+    Event, EventData, EventId, EventQuery, EventStream, ExoHarness, ForkConversationRequest,
+    GetEventsResult, GetSandboxProcessEventsResult, ListConversationsRequest,
+    ListConversationsResult, NewAgentRequest, NewConversationRequest, PutSecretRequest,
+    ReadArtifactRequest, Result, RunInSandboxRequest, SandboxAttachment, SandboxHandle, SandboxId,
+    SandboxProcess, SandboxProcessEventQuery, SandboxProcessParts, SandboxProcessRecord,
+    SandboxProcessStatus, Secret, SecretId, SecretMetadata, SessionId, SnapshotHandle, SnapshotId,
     StartSandboxProcessRequest, StartSandboxRequest, TurnHandle, TurnRecord,
     WaitSandboxProcessRequest, WriteArtifactRequest, WriteSandboxProcessInputRequest,
 };
@@ -209,6 +209,20 @@ async fn http_create_sandbox(
 ) -> Result<SandboxId> {
     match harness
         .request(Request::CreateSandbox { scope, request })
+        .await?
+    {
+        Response::SandboxId { sandbox_id } => Ok(sandbox_id),
+        response => unexpected_response(response, "sandbox_id"),
+    }
+}
+
+async fn http_create_sandbox_from_snapshot(
+    harness: &HttpExoHarness,
+    scope: SandboxScope,
+    request: CreateSandboxFromSnapshotRequest,
+) -> Result<SandboxId> {
+    match harness
+        .request(Request::CreateSandboxFromSnapshot { scope, request })
         .await?
     {
         Response::SandboxId { sandbox_id } => Ok(sandbox_id),
@@ -669,6 +683,13 @@ impl SandboxHandle for HttpAgentHandle {
         http_create_sandbox(&self.harness, self.sandbox_scope(), request).await
     }
 
+    async fn create_sandbox_from_snapshot(
+        &self,
+        request: CreateSandboxFromSnapshotRequest,
+    ) -> Result<SandboxId> {
+        http_create_sandbox_from_snapshot(&self.harness, self.sandbox_scope(), request).await
+    }
+
     async fn attach_sandbox(&self, request: AttachSandboxRequest) -> Result<SandboxId> {
         http_attach_sandbox(&self.harness, self.sandbox_scope(), request).await
     }
@@ -1043,6 +1064,13 @@ impl SnapshotHandle for HttpConversationHandle {
 impl SandboxHandle for HttpConversationHandle {
     async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId> {
         http_create_sandbox(&self.harness, self.sandbox_scope(), request).await
+    }
+
+    async fn create_sandbox_from_snapshot(
+        &self,
+        request: CreateSandboxFromSnapshotRequest,
+    ) -> Result<SandboxId> {
+        http_create_sandbox_from_snapshot(&self.harness, self.sandbox_scope(), request).await
     }
 
     async fn attach_sandbox(&self, request: AttachSandboxRequest) -> Result<SandboxId> {

--- a/crates/exoharness/src/protocol.rs
+++ b/crates/exoharness/src/protocol.rs
@@ -4,10 +4,10 @@ use crate::{
     AddEventsRequest, AddEventsResult, AgentId, AgentRecord, Artifact, ArtifactVersion,
     AttachSandboxRequest, BeginTurnRequest, Binding, BindingId, BindingRecord,
     CancelSandboxProcessRequest, CloseSandboxProcessInputRequest, ConversationId,
-    CreateSandboxRequest, Event, EventData, EventId, EventQuery, ForkConversationRequest,
-    GetEventsResult, GetSandboxProcessEventsResult, ListConversationsRequest,
-    ListConversationsResult, NewAgentRequest, NewConversationRequest, PutSecretRequest,
-    ReadArtifactRequest, SandboxAttachment, SandboxId, SandboxProcessEventQuery,
+    CreateSandboxFromSnapshotRequest, CreateSandboxRequest, Event, EventData, EventId, EventQuery,
+    ForkConversationRequest, GetEventsResult, GetSandboxProcessEventsResult,
+    ListConversationsRequest, ListConversationsResult, NewAgentRequest, NewConversationRequest,
+    PutSecretRequest, ReadArtifactRequest, SandboxAttachment, SandboxId, SandboxProcessEventQuery,
     SandboxProcessRecord, SandboxProcessStatus, Secret, SecretId, SecretMetadata, SessionId,
     SnapshotId, StartSandboxProcessRequest, StartSandboxRequest, ThreadRecord, TurnId, TurnRecord,
     WaitSandboxProcessRequest, WriteArtifactRequest, WriteSandboxProcessInputRequest,
@@ -130,6 +130,10 @@ pub enum Request {
     CreateSandbox {
         scope: SandboxScope,
         request: CreateSandboxRequest,
+    },
+    CreateSandboxFromSnapshot {
+        scope: SandboxScope,
+        request: CreateSandboxFromSnapshotRequest,
     },
     AttachSandbox {
         scope: SandboxScope,
@@ -316,6 +320,7 @@ impl Request {
             Self::AgentReadArtifact { .. } => "agent_read_artifact",
             Self::AgentWriteArtifact { .. } => "agent_write_artifact",
             Self::CreateSandbox { .. } => "create_sandbox",
+            Self::CreateSandboxFromSnapshot { .. } => "create_sandbox_from_snapshot",
             Self::AttachSandbox { .. } => "attach_sandbox",
             Self::DetachSandbox { .. } => "detach_sandbox",
             Self::SnapshotSandbox { .. } => "snapshot_sandbox",

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -683,7 +683,7 @@ impl ManagedSandboxHandle for BorrowedDockerSandboxHandle {
     }
 
     async fn snapshot(&self) -> Result<SnapshotPayload> {
-        bail!("borrowed Docker containers cannot be snapshotted")
+        docker_snapshot_container(&self.container_bin, &self.container_id).await
     }
 }
 
@@ -2325,7 +2325,7 @@ esac
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn borrowed_docker_sandbox_execs_without_taking_container_ownership() {
+    async fn borrowed_docker_sandbox_execs_and_snapshots_without_taking_ownership() {
         use std::fs;
         use std::os::unix::fs::PermissionsExt;
 
@@ -2346,6 +2346,9 @@ case "$1" in
     ;;
   exec)
     printf 'borrowed output'
+    ;;
+  save)
+    printf 'snapshot payload'
     ;;
 esac
 "#,
@@ -2410,11 +2413,20 @@ esac
                 container_id: "canonical-id".to_string(),
             }
         );
+        let snapshot = handle
+            .snapshot()
+            .await
+            .expect("snapshot borrowed container");
+        assert_eq!(snapshot.kind, SnapshotKind::DockerImageTar);
+        assert_eq!(snapshot.bytes.as_ref(), b"snapshot payload");
 
         let args = fs::read_to_string(&args_path).expect("read fake docker args");
         assert!(args.contains("inspect\nharbor-task\n---"));
         assert!(args.contains("exec\n--workdir\n/task\ncanonical-id"));
-        assert!(!args.lines().any(|arg| arg == "rm"));
+        assert!(args.contains("commit\n-p\ncanonical-id\nexo-snap-"));
+        assert!(args.contains("save\nexo-snap-"));
+        assert!(args.contains("image\nrm\nexo-snap-"));
+        assert!(!args.contains("rm\ncanonical-id"));
         assert!(!args.lines().any(|arg| arg == "stop"));
         assert!(!args.lines().any(|arg| arg == "kill"));
     }

--- a/crates/exoharness/src/server.rs
+++ b/crates/exoharness/src/server.rs
@@ -8,10 +8,11 @@ use crate::protocol::{
 };
 use crate::{
     AgentHandle, AgentId, AttachSandboxRequest, CancelSandboxProcessRequest,
-    CloseSandboxProcessInputRequest, ConversationHandle, ConversationId, CreateSandboxRequest,
-    ExoHarness, GetSandboxProcessEventsResult, ListConversationsResult, Result, SandboxAttachment,
-    SandboxId, SandboxProcessEventQuery, SandboxProcessRecord, SandboxProcessStatus, SessionId,
-    SnapshotId, StartSandboxProcessRequest, StartSandboxRequest, TurnHandle, TurnId, TurnRecord,
+    CloseSandboxProcessInputRequest, ConversationHandle, ConversationId,
+    CreateSandboxFromSnapshotRequest, CreateSandboxRequest, ExoHarness,
+    GetSandboxProcessEventsResult, ListConversationsResult, Result, SandboxAttachment, SandboxId,
+    SandboxProcessEventQuery, SandboxProcessRecord, SandboxProcessStatus, SessionId, SnapshotId,
+    StartSandboxProcessRequest, StartSandboxRequest, TurnHandle, TurnId, TurnRecord,
     WaitSandboxProcessRequest, WriteSandboxProcessInputRequest,
 };
 
@@ -139,6 +140,9 @@ impl ExoHarnessServer {
             }
             Request::CreateSandbox { scope, request } => Ok(Response::SandboxId {
                 sandbox_id: self.create_sandbox(scope, request).await?,
+            }),
+            Request::CreateSandboxFromSnapshot { scope, request } => Ok(Response::SandboxId {
+                sandbox_id: self.create_sandbox_from_snapshot(scope, request).await?,
             }),
             Request::AttachSandbox { scope, request } => Ok(Response::SandboxId {
                 sandbox_id: self.attach_sandbox(scope, request).await?,
@@ -518,6 +522,33 @@ impl ExoHarnessServer {
             SandboxScope::Turn { .. } => {
                 Err(anyhow!("attach_sandbox is not supported on a turn scope"))
             }
+        }
+    }
+
+    async fn create_sandbox_from_snapshot(
+        &self,
+        scope: SandboxScope,
+        request: CreateSandboxFromSnapshotRequest,
+    ) -> Result<SandboxId> {
+        match scope {
+            SandboxScope::Agent { agent_id } => {
+                self.require_agent(&agent_id)
+                    .await?
+                    .create_sandbox_from_snapshot(request)
+                    .await
+            }
+            SandboxScope::Conversation {
+                agent_id,
+                conversation_id,
+            } => {
+                self.require_conversation(agent_id, conversation_id)
+                    .await?
+                    .create_sandbox_from_snapshot(request)
+                    .await
+            }
+            SandboxScope::Turn { .. } => Err(anyhow!(
+                "create_sandbox_from_snapshot is not supported on a turn scope"
+            )),
         }
     }
 

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -42,6 +42,10 @@ pub trait SnapshotHandle: Send + Sync {
 #[async_trait]
 pub trait SandboxHandle: SnapshotHandle {
     async fn create_sandbox(&self, request: CreateSandboxRequest) -> Result<SandboxId>;
+    async fn create_sandbox_from_snapshot(
+        &self,
+        request: CreateSandboxFromSnapshotRequest,
+    ) -> Result<SandboxId>;
     async fn attach_sandbox(&self, request: AttachSandboxRequest) -> Result<SandboxId>;
     async fn detach_sandbox(&self, id: SandboxId) -> Result<SandboxAttachment>;
     async fn stop_sandbox(&self, id: SandboxId) -> Result<()>;
@@ -693,6 +697,14 @@ pub struct StartSandboxRequest {
     // If unspecified, starts sandbox where it was last run. If specified, will attempt to
     // start the sandbox on the specified provider, if supported. If successful, the
     // sandbox will start there going forward.
+    #[serde(default)]
+    pub provider: Option<SandboxProvider>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CreateSandboxFromSnapshotRequest {
+    pub snapshot_id: SnapshotId,
+    pub idle_seconds: Option<u64>,
     #[serde(default)]
     pub provider: Option<SandboxProvider>,
 }

--- a/eval/harbor/.gitignore
+++ b/eval/harbor/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+*.egg-info/
+.venv/

--- a/eval/harbor/README.md
+++ b/eval/harbor/README.md
@@ -1,0 +1,126 @@
+# Exo agent for Harbor
+
+Runs Exo as a Harbor external agent so it can be evaluated over Harbor's
+benchmark catalog. The Exo-side adapter that handles waking Exo's
+conversation and waiting on a response lives in the generic
+[`exo/adapters/trial`](../../exo/adapters/trial) adapter.
+
+## The split
+
+Harbor has two lifecycle planes relevant to Exo:
+
+1. `BaseAgent`, which is constructed fresh for each trial and controls what
+   happens during the trail.
+2. `Plugin`, which lives for the duration of a full job and exposes hooks for
+   initial agent setup, per-trial completions, and final Exo tear-down.
+
+|                                                            | Owns                                                                |
+| ---------------------------------------------------------- | ------------------------------------------------------------------- |
+| [`plugin.py`](src/exo_harbor/plugin.py) `ExoSessionPlugin` | Exo's lifetime and the adapter runner. Job-scoped.                  |
+| [`agent.py`](src/exo_harbor/agent.py) `ExoAgent`           | One task: resolve the container, submit it, and wait. Trial-scoped. |
+
+Thus the end-to-end lifecycle looks like this:
+
+```
+attach_job_plugins(job)
+  on_job_start(job)          start Exo, create adapter (fixed slug + socket)
+  job.run()
+    Trial.create()           new ExoAgent
+      setup(env)             resolve Harbor's container     [once per trial]
+      run(instruction)       trial_run -> trial_complete    [once per step]
+      <verifier runs>
+      TrialEvent.END         record accumulated agent state
+    ... next trial ...
+```
+
+Nit: run() is called per-_step_, which is a construct that exists for some
+types of tasks where there are intermediate checkpoints to specify. For most
+common task-sets, such as terminal-bench, there is only one default step.
+
+## Responsibilities
+
+Harbor constructs the agent and plugin independently:
+
+- The plugin creates the persistent Exo agent and trial adapter, then starts
+  the adapter runner.
+- Each Harbor agent resolves its task container, submits it through the shared
+  socket, and uses the returned conversation id to export its trajectory.
+
+The plugin recovers `exo_root` from `job.config.agents[0].kwargs` rather than
+taking its own `--pk` copy, so the path is written down once.
+
+Because nothing is handed over, `setup()` instead probes the adapter socket as
+a preflight. That is what catches a run launched with `--agent` but no
+`--plugin`: every convention would still resolve to something plausible, but
+there would be no worker to accept the trial. A live probe is a stronger check
+than a marker file, which can be stale from an earlier run.
+
+## Running
+
+The usual entry point is deliberately small:
+
+```bash
+cd eval/harbor
+./eval.sh --dataset=terminal-bench
+```
+
+It defaults to GPT-5.5, all tasks in the dataset, and one attempt. Flags can
+limit or override those defaults:
+
+```bash
+./eval.sh --dataset=terminal-bench --model=gpt-5.5 --n-tasks=10 --n-attempts=2
+```
+
+For a quick end-to-end check using the bundled tiny task:
+
+```bash
+./eval.sh --dataset=smoke-test --n-tasks=1
+```
+
+To test self-evolution across trials, run the bundled three-task dataset. Its
+first trial asks Exo to install and use a custom tool; its second trial uses
+the installed tool again from a fresh conversation and container; its third
+trial changes durable agent policy state, rebuilds and restarts Exo, then
+finishes the trial after the adapter reconnects.
+
+```bash
+./eval.sh --dataset=self-evolution-smoke-test
+```
+
+For a short real benchmark run, `terminal-bench-easy` selects three Terminal
+Bench 2 tasks marked easy: `fix-git`, `prove-plus-comm`, and
+`cobol-modernization`.
+
+```bash
+./eval.sh --dataset=terminal-bench-easy
+```
+
+For repeatable runs, copy [`eval.example.toml`](eval.example.toml), edit it,
+and run:
+
+```bash
+./eval.sh --config=my-eval.toml
+```
+
+Command-line flags take precedence over the config file. Harbor datasets can
+also be given as `name@version`. Endless Terminals is not currently in the
+Harbor registry, so pass a local checkout with
+`--dataset=endless-terminals --dataset-path=/path/to/dataset`.
+
+The wrapper creates `.venv` on its first run. The runner builds Exo, starts the
+evaluation, shows Harbor's live task progress, and prints the score and result
+paths when it finishes. Runs are saved under `.local/harbor-evals` at the
+repository root. Harbor also prints a `harbor view ...` command for opening its
+full results UI. Each trial's Trajectory tab shows the Exo rollout, including
+model messages, tool calls and results, token usage, and cost. Each trial gets
+its own target-scoped Exo conversation.
+
+`--n-concurrent 1` is intentionally fixed so each trial deterministically sees
+the persistent agent changes made by all earlier trials.
+
+Feedback and container snapshotting are intentionally deferred. Version one
+ends at `trial_complete`; Harbor then grades and cleans up its original
+container normally.
+
+The package is pinned to `harbor>=0.20,<0.21` because the `JobPlugin` protocol
+and the `TrialEvent.END` payload may move between Harbor minor releases.

--- a/eval/harbor/README.md
+++ b/eval/harbor/README.md
@@ -27,7 +27,8 @@ attach_job_plugins(job)
   job.run()
     Trial.create()           new ExoAgent
       setup(env)             resolve Harbor's container     [once per trial]
-      run(instruction)       trial_run -> trial_complete    [once per step]
+      run(instruction)       trial_run -> trial_started -> trial_complete
+                                                             [once per step]
       <verifier runs>
       TrialEvent.END         record accumulated agent state
     ... next trial ...
@@ -44,7 +45,8 @@ Harbor constructs the agent and plugin independently:
 - The plugin creates the persistent Exo agent and trial adapter, then starts
   the adapter runner.
 - Each Harbor agent resolves its task container, submits it through the shared
-  socket, and uses the returned conversation id to export its trajectory.
+  socket, and retains the conversation id from `trial_started`. It exports the
+  trajectory after completion or timeout.
 
 The plugin recovers `exo_root` from `job.config.agents[0].kwargs` rather than
 taking its own `--pk` copy, so the path is written down once.

--- a/eval/harbor/README.md
+++ b/eval/harbor/README.md
@@ -73,6 +73,17 @@ limit or override those defaults:
 ./eval.sh --dataset=terminal-bench --model=gpt-5.5 --n-tasks=10 --n-attempts=2
 ```
 
+Select particular tasks by repeating `--include-task-name`:
+
+```bash
+./eval.sh --dataset=terminal-bench \
+  --include-task-name=path-tracing \
+  --include-task-name=gpt2-codegolf
+```
+
+The equivalent TOML field is `include_task_names = ["path-tracing",
+"gpt2-codegolf"]`.
+
 For a quick end-to-end check using the bundled tiny task:
 
 ```bash

--- a/eval/harbor/README.md
+++ b/eval/harbor/README.md
@@ -30,7 +30,7 @@ attach_job_plugins(job)
       run(instruction)       trial_run -> trial_started -> trial_complete
                                                              [once per step]
       <verifier runs>
-      TrialEvent.END         record accumulated agent state
+      TrialEvent.END         restore submitted snapshot and reflect on grading
     ... next trial ...
 ```
 
@@ -47,6 +47,12 @@ Harbor constructs the agent and plugin independently:
 - Each Harbor agent resolves its task container, submits it through the shared
   socket, and retains the conversation id from `trial_started`. It exports the
   trajectory after completion or timeout.
+
+After Harbor verifies a completed trial, the plugin sends its rewards,
+exception details, and available verifier logs back to the same conversation.
+Exo reflects inside a new sandbox restored from the submitted snapshot. The
+trajectory is exported again afterward so Harbor shows both the task and its
+reflection.
 
 The plugin recovers `exo_root` from `job.config.agents[0].kwargs` rather than
 taking its own `--pk` copy, so the path is written down once.
@@ -131,9 +137,11 @@ its own target-scoped Exo conversation.
 `--n-concurrent 1` is intentionally fixed so each trial deterministically sees
 the persistent agent changes made by all earlier trials.
 
-Feedback and container snapshotting are intentionally deferred. Version one
-ends at `trial_complete`; Harbor then grades and cleans up its original
-container normally.
+At `trial_complete`, Exo snapshots and detaches from Harbor's original
+container without taking ownership of it. Harbor grades and cleans up that
+container normally. Completed trials receive one feedback phase; trials that
+time out before producing a snapshot skip reflection but retain their partial
+trajectory.
 
 The package is pinned to `harbor>=0.20,<0.21` because the `JobPlugin` protocol
 and the `TrialEvent.END` payload may move between Harbor minor releases.

--- a/eval/harbor/datasets/self-evolution-smoke-test/01-install-tool/environment/Dockerfile
+++ b/eval/harbor/datasets/self-evolution-smoke-test/01-install-tool/environment/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:24.04
+
+WORKDIR /app

--- a/eval/harbor/datasets/self-evolution-smoke-test/01-install-tool/instruction.md
+++ b/eval/harbor/datasets/self-evolution-smoke-test/01-install-tool/instruction.md
@@ -1,0 +1,16 @@
+Create and install an agent tool with module name `evolution-stamp` and tool
+name `evolution_stamp`.
+
+The tool must take one required string parameter named `text` and return an
+object with one string field named `stamped`. Its result must be `EVOLVED:`
+followed by `text` converted to uppercase.
+
+Install it with `install_agent_tool`, then call the newly installed
+`evolution_stamp` tool with `text` set to `first trial`. Use the tool's returned
+value to create `/app/evolution.txt`, containing exactly:
+
+```text
+EVOLVED:FIRST TRIAL
+```
+
+Do not implement the transformation with shell or another existing tool.

--- a/eval/harbor/datasets/self-evolution-smoke-test/01-install-tool/task.toml
+++ b/eval/harbor/datasets/self-evolution-smoke-test/01-install-tool/task.toml
@@ -1,0 +1,30 @@
+schema_version = "1.4"
+
+[task]
+name = "exo/self-evolution-install-tool"
+version = "1.0.0"
+authors = []
+keywords = ["smoke", "self-evolution", "tools"]
+
+[metadata]
+difficulty = "easy"
+category = "testing"
+tags = ["smoke", "self-evolution"]
+
+[verifier]
+timeout_sec = 30.0
+
+[agent]
+timeout_sec = 180.0
+
+[environment]
+build_timeout_sec = 120.0
+cpus = 1
+memory_mb = 512
+storage_mb = 1024
+gpus = 0
+mcp_servers = []
+
+[verifier.env]
+
+[solution.env]

--- a/eval/harbor/datasets/self-evolution-smoke-test/01-install-tool/tests/test.sh
+++ b/eval/harbor/datasets/self-evolution-smoke-test/01-install-tool/tests/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+if [[ -f /app/evolution.txt ]] &&
+  [[ $(cat /app/evolution.txt) == "EVOLVED:FIRST TRIAL" ]]; then
+  echo 1 > /logs/verifier/reward.txt
+else
+  echo 0 > /logs/verifier/reward.txt
+fi

--- a/eval/harbor/datasets/self-evolution-smoke-test/02-reuse-tool/environment/Dockerfile
+++ b/eval/harbor/datasets/self-evolution-smoke-test/02-reuse-tool/environment/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:24.04
+
+WORKDIR /app

--- a/eval/harbor/datasets/self-evolution-smoke-test/02-reuse-tool/instruction.md
+++ b/eval/harbor/datasets/self-evolution-smoke-test/02-reuse-tool/instruction.md
@@ -1,0 +1,12 @@
+The previous trial installed an agent tool named `evolution_stamp`. Do not
+reinstall, replace, or recreate it. Call that existing tool with `text` set to
+`second trial`, then use its returned value to create `/app/evolution.txt`,
+containing exactly:
+
+```text
+EVOLVED:SECOND TRIAL
+```
+
+Do not implement the transformation with shell or another tool. The point of
+this trial is to demonstrate that the tool installed by the earlier trial is
+available in this fresh conversation and container.

--- a/eval/harbor/datasets/self-evolution-smoke-test/02-reuse-tool/task.toml
+++ b/eval/harbor/datasets/self-evolution-smoke-test/02-reuse-tool/task.toml
@@ -1,0 +1,30 @@
+schema_version = "1.4"
+
+[task]
+name = "exo/self-evolution-reuse-tool"
+version = "1.0.0"
+authors = []
+keywords = ["smoke", "self-evolution", "tools"]
+
+[metadata]
+difficulty = "easy"
+category = "testing"
+tags = ["smoke", "self-evolution"]
+
+[verifier]
+timeout_sec = 30.0
+
+[agent]
+timeout_sec = 120.0
+
+[environment]
+build_timeout_sec = 120.0
+cpus = 1
+memory_mb = 512
+storage_mb = 1024
+gpus = 0
+mcp_servers = []
+
+[verifier.env]
+
+[solution.env]

--- a/eval/harbor/datasets/self-evolution-smoke-test/02-reuse-tool/tests/test.sh
+++ b/eval/harbor/datasets/self-evolution-smoke-test/02-reuse-tool/tests/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+if [[ -f /app/evolution.txt ]] &&
+  [[ $(cat /app/evolution.txt) == "EVOLVED:SECOND TRIAL" ]]; then
+  echo 1 > /logs/verifier/reward.txt
+else
+  echo 0 > /logs/verifier/reward.txt
+fi

--- a/eval/harbor/datasets/self-evolution-smoke-test/03-restart-policy/environment/Dockerfile
+++ b/eval/harbor/datasets/self-evolution-smoke-test/03-restart-policy/environment/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:24.04
+
+WORKDIR /app

--- a/eval/harbor/datasets/self-evolution-smoke-test/03-restart-policy/instruction.md
+++ b/eval/harbor/datasets/self-evolution-smoke-test/03-restart-policy/instruction.md
@@ -1,0 +1,23 @@
+This trial tests durable policy state and continuation across an Exo restart.
+Complete it in two distinct phases.
+
+Before the restart:
+
+1. Call `remember` with exactly this standalone policy statement:
+   `Restart smoke policy: after Exo restarts, write RESTARTED:POLICY ACTIVE to /app/restarted.txt.`
+2. Call `rebuild_and_restart_exo` with reason
+   `activate restart smoke policy`.
+3. Once the restart has been queued, end the current model turn immediately.
+   Do not create `/app/restarted.txt` and do not send the trial completion
+   message before the restart.
+
+After the adapter reconnects and wakes this conversation following the host
+restart, follow the durable policy you saved: create `/app/restarted.txt`
+containing exactly:
+
+```text
+RESTARTED:POLICY ACTIVE
+```
+
+Only then complete the trial. Do not call `rebuild_and_restart_exo` a second
+time.

--- a/eval/harbor/datasets/self-evolution-smoke-test/03-restart-policy/task.toml
+++ b/eval/harbor/datasets/self-evolution-smoke-test/03-restart-policy/task.toml
@@ -1,0 +1,30 @@
+schema_version = "1.4"
+
+[task]
+name = "exo/self-evolution-restart-policy"
+version = "1.0.0"
+authors = []
+keywords = ["smoke", "self-evolution", "restart"]
+
+[metadata]
+difficulty = "easy"
+category = "testing"
+tags = ["smoke", "self-evolution", "restart"]
+
+[verifier]
+timeout_sec = 30.0
+
+[agent]
+timeout_sec = 300.0
+
+[environment]
+build_timeout_sec = 120.0
+cpus = 1
+memory_mb = 512
+storage_mb = 1024
+gpus = 0
+mcp_servers = []
+
+[verifier.env]
+
+[solution.env]

--- a/eval/harbor/datasets/self-evolution-smoke-test/03-restart-policy/tests/test.sh
+++ b/eval/harbor/datasets/self-evolution-smoke-test/03-restart-policy/tests/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+if [[ -f /app/restarted.txt ]] &&
+  [[ $(cat /app/restarted.txt) == "RESTARTED:POLICY ACTIVE" ]]; then
+  echo 1 > /logs/verifier/reward.txt
+else
+  echo 0 > /logs/verifier/reward.txt
+fi

--- a/eval/harbor/datasets/self-evolution-smoke-test/04-timeout-trajectory/environment/Dockerfile
+++ b/eval/harbor/datasets/self-evolution-smoke-test/04-timeout-trajectory/environment/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:24.04
+
+WORKDIR /app

--- a/eval/harbor/datasets/self-evolution-smoke-test/04-timeout-trajectory/instruction.md
+++ b/eval/harbor/datasets/self-evolution-smoke-test/04-timeout-trajectory/instruction.md
@@ -1,0 +1,12 @@
+This trial intentionally tests trajectory export when Harbor times out.
+
+Use the shell once to run exactly this foreground command, and wait for it to
+finish:
+
+```bash
+printf 'STARTED\n' > /app/timeout-started.txt && sleep 120 && printf 'FINISHED\n' > /app/timeout-finished.txt
+```
+
+Only after that command finishes, complete the trial normally. Do not shorten,
+background, interrupt, or otherwise avoid the sleep. Harbor will stop waiting
+after 30 seconds, so the trial is not expected to reach completion.

--- a/eval/harbor/datasets/self-evolution-smoke-test/04-timeout-trajectory/task.toml
+++ b/eval/harbor/datasets/self-evolution-smoke-test/04-timeout-trajectory/task.toml
@@ -1,0 +1,30 @@
+schema_version = "1.4"
+
+[task]
+name = "exo/self-evolution-timeout-trajectory"
+version = "1.0.0"
+authors = []
+keywords = ["smoke", "self-evolution", "timeout", "trajectory"]
+
+[metadata]
+difficulty = "easy"
+category = "testing"
+tags = ["smoke", "self-evolution", "timeout", "trajectory"]
+
+[verifier]
+timeout_sec = 30.0
+
+[agent]
+timeout_sec = 30.0
+
+[environment]
+build_timeout_sec = 120.0
+cpus = 1
+memory_mb = 512
+storage_mb = 1024
+gpus = 0
+mcp_servers = []
+
+[verifier.env]
+
+[solution.env]

--- a/eval/harbor/datasets/self-evolution-smoke-test/04-timeout-trajectory/tests/test.sh
+++ b/eval/harbor/datasets/self-evolution-smoke-test/04-timeout-trajectory/tests/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+if [[ $(cat /app/timeout-started.txt 2>/dev/null) == "STARTED" ]] &&
+  [[ ! -e /app/timeout-finished.txt ]]; then
+  echo 1 > /logs/verifier/reward.txt
+else
+  echo 0 > /logs/verifier/reward.txt
+fi

--- a/eval/harbor/datasets/smoke-test/environment/Dockerfile
+++ b/eval/harbor/datasets/smoke-test/environment/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:24.04
+
+WORKDIR /app

--- a/eval/harbor/datasets/smoke-test/instruction.md
+++ b/eval/harbor/datasets/smoke-test/instruction.md
@@ -1,0 +1,1 @@
+Create `/app/done.txt` containing exactly `ready` followed by a newline.

--- a/eval/harbor/datasets/smoke-test/task.toml
+++ b/eval/harbor/datasets/smoke-test/task.toml
@@ -1,0 +1,30 @@
+schema_version = "1.4"
+
+[task]
+name = "exo/harbor-lifecycle-smoke"
+version = "1.0.0"
+authors = []
+keywords = ["smoke"]
+
+[metadata]
+difficulty = "easy"
+category = "testing"
+tags = ["smoke"]
+
+[verifier]
+timeout_sec = 30.0
+
+[agent]
+timeout_sec = 120.0
+
+[environment]
+build_timeout_sec = 120.0
+cpus = 1
+memory_mb = 512
+storage_mb = 1024
+gpus = 0
+mcp_servers = []
+
+[verifier.env]
+
+[solution.env]

--- a/eval/harbor/datasets/smoke-test/tests/test.sh
+++ b/eval/harbor/datasets/smoke-test/tests/test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [[ -f /app/done.txt ]] && [[ $(cat /app/done.txt) == ready ]]; then
+  echo 1 > /logs/verifier/reward.txt
+else
+  echo 0 > /logs/verifier/reward.txt
+fi

--- a/eval/harbor/eval.example.toml
+++ b/eval/harbor/eval.example.toml
@@ -1,0 +1,14 @@
+# Flags passed to eval.sh override this file.
+dataset = "terminal-bench"
+# For a shorter run of three easy tasks, use "terminal-bench-easy".
+model = "gpt-5.5"
+n_tasks = 10
+n_attempts = 1
+
+# "shared" measures learning across tasks. "per_task" isolates task context
+# while retaining agent-level state such as tools, memory, and source changes.
+
+# Endless Terminals is currently a local dataset rather than a Harbor registry
+# entry. To run it, replace dataset above and set its local path.
+# dataset = "endless-terminals"
+# dataset_path = ".local/datasets/endless-terminals"

--- a/eval/harbor/eval.py
+++ b/eval/harbor/eval.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Run Exo on a Harbor dataset and print the result."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+
+DATASETS = {
+    "terminal-bench": "terminal-bench@2.0",
+    "terminal-bench-easy": "terminal-bench@2.0",
+    "terminal-bench-sample": "terminal-bench-sample@2.0",
+    "terminal-bench-pro": "terminal-bench-pro@1.0",
+}
+LOCAL_DATASETS = {
+    "smoke-test": "datasets/smoke-test",
+    "self-evolution-smoke-test": "datasets/self-evolution-smoke-test",
+}
+DATASET_TASKS = {
+    "terminal-bench-easy": (
+        "fix-git",
+        "prove-plus-comm",
+        "cobol-modernization",
+    ),
+}
+CONFIG_FIELDS = {
+    "dataset",
+    "dataset_path",
+    "model",
+    "n_tasks",
+    "n_attempts",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    config_parser = argparse.ArgumentParser(add_help=False)
+    config_parser.add_argument("--config", type=Path)
+    known, _ = config_parser.parse_known_args()
+
+    defaults = {
+        "dataset": "terminal-bench",
+        "dataset_path": None,
+        "model": "gpt-5.5",
+        "n_tasks": None,
+        "n_attempts": 1,
+    }
+    if known.config is not None:
+        with known.config.open("rb") as file:
+            configured = tomllib.load(file)
+        unknown = sorted(set(configured) - CONFIG_FIELDS)
+        if unknown:
+            raise ValueError(f"unknown config fields: {', '.join(unknown)}")
+        defaults.update(configured)
+
+    parser = argparse.ArgumentParser(
+        parents=[config_parser],
+        description="Run Exo on a Harbor dataset.",
+    )
+    parser.set_defaults(**defaults)
+    parser.add_argument(
+        "--dataset",
+        help=(
+            "smoke-test, self-evolution-smoke-test, terminal-bench, "
+            "terminal-bench-easy, terminal-bench-sample, terminal-bench-pro, "
+            "or name@version"
+        ),
+    )
+    parser.add_argument(
+        "--dataset-path",
+        type=Path,
+        help="local dataset directory, for example an Endless Terminals checkout",
+    )
+    parser.add_argument("--model")
+    parser.add_argument("--n-tasks", type=int)
+    parser.add_argument(
+        "--n-attempts", "--number-tries", dest="n_attempts", type=int
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the resolved command without running it",
+    )
+    return parser.parse_args()
+
+
+def dataset_arguments(args: argparse.Namespace) -> list[str]:
+    if args.dataset_path is not None:
+        dataset_path = Path(args.dataset_path).expanduser().resolve()
+        if not dataset_path.is_dir():
+            raise ValueError(f"dataset path is not a directory: {dataset_path}")
+        return ["--path", str(dataset_path)]
+    if local_dataset := LOCAL_DATASETS.get(args.dataset):
+        return ["--path", str(Path(__file__).resolve().parent / local_dataset)]
+    if args.dataset == "endless-terminals":
+        raise ValueError(
+            "Endless Terminals is not in Harbor's registry; pass --dataset-path"
+        )
+    dataset = DATASETS.get(args.dataset, args.dataset)
+    if not re.fullmatch(r"[^@\s]+@[^@\s]+", dataset):
+        raise ValueError(
+            f"unknown dataset {args.dataset!r}; use a built-in name or name@version"
+        )
+    arguments = ["--dataset", dataset]
+    for task in DATASET_TASKS.get(args.dataset, ()):
+        arguments.extend(["--include-task-name", task])
+    return arguments
+
+
+def slug(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-") or "eval"
+
+
+def harbor_command(
+    args: argparse.Namespace,
+    *,
+    harbor: Path | str,
+    repo: Path,
+    exo: Path,
+    run_dir: Path,
+    job_name: str,
+) -> list[str]:
+    task_limit = [] if args.n_tasks is None else ["--n-tasks", str(args.n_tasks)]
+    command = [
+        str(harbor),
+        "run",
+        "--env",
+        "docker",
+        "--n-concurrent",
+        "1",
+        "--n-attempts",
+        str(args.n_attempts),
+        "--agent",
+        "exo_harbor.agent:ExoAgent",
+        "--plugin",
+        "exo_harbor.plugin:ExoSessionPlugin",
+        "--model",
+        args.model,
+        "--ak",
+        f"exo_repo_root={repo}",
+        "--ak",
+        f"exo_root={run_dir / 'exo'}",
+        "--ak",
+        f"exo_bin={exo}",
+        "--ak",
+        f"exo_model={args.model}",
+        "--pk",
+        "adapter_start_timeout_sec=90",
+        "--jobs-dir",
+        str(run_dir / "jobs"),
+        *task_limit,
+        "--job-name",
+        job_name,
+        "--yes",
+        "--debug",
+        *dataset_arguments(args),
+    ]
+    return command
+
+
+def require_command(name: str) -> str:
+    command = shutil.which(name)
+    if command is None:
+        raise ValueError(f"required command is not on PATH: {name}")
+    return command
+
+
+def print_result_paths(run_dir: Path, job_name: str) -> None:
+    job_dir = run_dir / "jobs" / job_name
+    print("\n===Results===")
+    print(f"Harbor results: {job_dir / 'result.json'}")
+    print(f"View: harbor view {run_dir / 'jobs'}")
+
+
+def main() -> int:
+    try:
+        args = parse_args()
+        if (args.n_tasks is not None and args.n_tasks <= 0) or args.n_attempts <= 0:
+            raise ValueError("n_tasks and n_attempts must be positive")
+
+        repo = Path(__file__).resolve().parents[2]
+        exo = repo / "target/debug/exo"
+        timestamp = dt.datetime.now(dt.UTC).strftime("%Y%m%dT%H%M%SZ")
+        # Keep the Unix socket below Linux's 108-byte path limit. Harbor's job
+        # metadata already records the dataset and model.
+        run_dir = repo / ".local/harbor-evals" / timestamp
+        task_count = args.n_tasks if args.n_tasks is not None else "all"
+        job_name = f"{slug(args.dataset)}-{task_count}"
+        harbor = Path(sys.executable).with_name("harbor")
+        if not harbor.is_file():
+            harbor = Path(require_command("harbor"))
+        command = harbor_command(
+            args,
+            harbor=harbor,
+            repo=repo,
+            exo=exo,
+            run_dir=run_dir,
+            job_name=job_name,
+        )
+
+        if args.dry_run:
+            print(shlex.join(command))
+            return 0
+
+        print("\n===Setup===", flush=True)
+        if not os.environ.get("OPENAI_API_KEY"):
+            raise ValueError("OPENAI_API_KEY is not set")
+        for required in ("cargo", "docker", "node", "pnpm"):
+            require_command(required)
+        if subprocess.run(
+            ["docker", "info"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        ).returncode:
+            raise ValueError("Docker is unavailable; run this through ./eval.sh")
+
+        run_dir.mkdir(parents=True)
+        subprocess.run(["cargo", "build", "-p", "exo"], cwd=repo, check=True)
+        subprocess.run(
+            [
+                str(exo),
+                "--root",
+                str(run_dir / "exo"),
+                "secret",
+                "set",
+                "openai",
+                "--env",
+                "OPENAI_API_KEY",
+            ],
+            cwd=repo,
+            check=True,
+        )
+        subprocess.run(
+            [
+                str(exo),
+                "--root",
+                str(run_dir / "exo"),
+                "model",
+                "register",
+                args.model,
+                "--secret",
+                "openai",
+                "--model",
+                args.model,
+            ],
+            cwd=repo,
+            check=True,
+        )
+        print(f"Run directory: {run_dir}")
+        print("\n===Trials===", flush=True)
+        # Let Harbor own the terminal so its built-in live progress UI works.
+        subprocess.run(command, cwd=repo, check=True)
+        print_result_paths(run_dir, job_name)
+        return 0
+    except (OSError, ValueError, subprocess.CalledProcessError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+    except KeyboardInterrupt:
+        print("\nEvaluation stopped.", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/eval/harbor/eval.py
+++ b/eval/harbor/eval.py
@@ -38,6 +38,7 @@ CONFIG_FIELDS = {
     "model",
     "n_tasks",
     "n_attempts",
+    "include_task_names",
 }
 
 
@@ -52,6 +53,7 @@ def parse_args() -> argparse.Namespace:
         "model": "gpt-5.5",
         "n_tasks": None,
         "n_attempts": 1,
+        "include_task_names": [],
     }
     if known.config is not None:
         with known.config.open("rb") as file:
@@ -82,6 +84,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--model")
     parser.add_argument("--n-tasks", type=int)
     parser.add_argument(
+        "--include-task-name",
+        dest="include_task_names",
+        action="append",
+        help="task name to include; may be passed more than once",
+    )
+    parser.add_argument(
         "--n-attempts", "--number-tries", dest="n_attempts", type=int
     )
     parser.add_argument(
@@ -110,7 +118,7 @@ def dataset_arguments(args: argparse.Namespace) -> list[str]:
             f"unknown dataset {args.dataset!r}; use a built-in name or name@version"
         )
     arguments = ["--dataset", dataset]
-    for task in DATASET_TASKS.get(args.dataset, ()):
+    for task in (*DATASET_TASKS.get(args.dataset, ()), *args.include_task_names):
         arguments.extend(["--include-task-name", task])
     return arguments
 

--- a/eval/harbor/eval.sh
+++ b/eval/harbor/eval.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+eval_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "$eval_dir/../.." && pwd)
+venv="$eval_dir/.venv"
+
+if [[ ! -x "$venv/bin/python" ]]; then
+  python3.12 -m venv "$venv"
+fi
+
+if ! "$venv/bin/python" -c 'import harbor, exo_harbor' 2>/dev/null; then
+  "$venv/bin/pip" install -e "$eval_dir"
+fi
+
+command=("$venv/bin/python" "$eval_dir/eval.py" "$@")
+
+# Harbor runs each benchmark task in a Docker container. Most shells can use
+# Docker directly; this workspace needs its configured docker group activated.
+if docker info >/dev/null 2>&1; then
+  cd "$repo_root"
+  exec "${command[@]}"
+fi
+
+if command -v sg >/dev/null 2>&1 && getent group docker >/dev/null 2>&1; then
+  printf -v quoted_command '%q ' "${command[@]}"
+  cd "$repo_root"
+  exec sg docker -c "$quoted_command"
+fi
+
+echo "Docker is unavailable. Start Docker or grant this user Docker access." >&2
+exit 1

--- a/eval/harbor/pyproject.toml
+++ b/eval/harbor/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "exo-harbor"
+version = "0.1.0"
+description = "Run Exo as a Harbor external agent"
+requires-python = ">=3.12"
+dependencies = [
+  # Pinned to the minor. The integration depends on the JobPlugin protocol
+  # and the TrialEvent.END hook payload, both of which are young enough to
+  # move between minors.
+  "harbor>=0.20,<0.21",
+]
+
+[project.entry-points."harbor.plugins"]
+# Lets runs say `--plugin exo-session` instead of the full import path.
+exo-session = "exo_harbor.plugin:ExoSessionPlugin"
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/eval/harbor/src/exo_harbor/__init__.py
+++ b/eval/harbor/src/exo_harbor/__init__.py
@@ -1,0 +1,18 @@
+"""Run Exo as a Harbor external agent.
+
+    harbor run \\
+      --env docker \\
+      --n-concurrent 1 \\
+      --agent exo_harbor.agent:ExoAgent \\
+      --plugin exo_harbor.plugin:ExoSessionPlugin \\
+      --ak exo_root=/path/to/run/exo \\
+      --ak exo_bin=/path/to/target/debug/exo
+
+Both flags are required. The agent alone would run tasks but never receive a
+grade, producing a job that looks scored but measures nothing.
+"""
+
+from exo_harbor.agent import ExoAgent
+from exo_harbor.plugin import ExoSessionPlugin
+
+__all__ = ["ExoAgent", "ExoSessionPlugin"]

--- a/eval/harbor/src/exo_harbor/agent.py
+++ b/eval/harbor/src/exo_harbor/agent.py
@@ -1,0 +1,155 @@
+"""ExoAgent — Harbor's per-trial bridge to the generic Exo trial adapter.
+
+Where this sits in Harbor's trial lifecycle:
+
+    Trial.create()                    <- new ExoAgent instance
+    trial.run()
+      _prepare()
+        _setup_agent_environment()    <- docker compose up --wait
+        run_healthcheck()
+        setup(environment)            <- HERE: resolve the container  [1/trial]
+      _run()
+        run(instruction, ...)         <- HERE: work the task      [1/step]
+        _run_verifier()               <- the grade appears here
+        _stop_agent_environment()
+      _finalize() -> TrialEvent.END   <- plugin records the inventory
+
+Notes:
+ * a fresh instance is constructed for each trial then thrown away, so holds
+no cross-task state. The actual Exo process is managed by ExoSessionPlugin.
+ * setup() is called for each trial, and run()/resume() for each step.
+ * run() returns before the verifier executes. Feedback is intentionally not
+   part of the first version of the trial protocol.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, override
+from uuid import uuid4
+
+from harbor.agents.base import BaseAgent
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+
+from exo_harbor import conventions
+from exo_harbor.docker import resolve_main_container
+from exo_harbor.exo import ExoClient
+from exo_harbor.protocol import TrialRun, send_trial_run
+from exo_harbor.trajectory import export_trial_trajectory
+
+logger = logging.getLogger(__name__)
+
+
+class ExoAgent(BaseAgent):
+    """Submits Harbor's task container to Exo and waits for completion."""
+
+    # Can be enabled for multi-step tasks after resume() support is added.
+    SUPPORTS_RESUME = False
+    SUPPORTS_ATIF = True
+    SUPPORTS_WINDOWS = False
+
+    def __init__(
+        self,
+        *args: Any,
+        # Set by --ak. The plugin reads these same values back off job.config.agents[0].kwargs.
+        exo_root: str | Path,
+        exo_bin: str | Path,
+        exo_repo_root: str | Path,
+        exo_model: str,
+        task_timeout_sec: float | str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._exo_root = Path(exo_root)
+        self._model = exo_model
+        self._task_timeout_sec = (
+            float(task_timeout_sec) if task_timeout_sec is not None else None
+        )
+        self._client = ExoClient(
+            exo_bin=Path(exo_bin),
+            exo_root=Path(exo_root),
+            repo_root=Path(exo_repo_root),
+        )
+
+        self._container_id: str | None = None
+
+    @staticmethod
+    @override
+    def name() -> str:
+        return "exo"
+
+    @override
+    def version(self) -> str | None:
+        # TODO: report the Exo build under test rather than this package's
+        # version — the eval result needs to identify the agent, and "0.1.0"
+        # identifies the wrapper.
+        return None
+
+    # ----------------------------------------------------------------------
+    # Per-trial setup
+    # ----------------------------------------------------------------------
+    @override
+    async def setup(self, environment: BaseEnvironment) -> None:
+        """Resolve the Docker container supplied by Harbor for this trial.
+
+        Runs once per trial, after Harbor has started and health-checked the
+        environment. Everything expensive happened in on_job_start.
+        """
+        socket_path = conventions.socket_path(self._exo_root)
+        if not socket_path.exists():
+            raise RuntimeError(
+                f"no trial adapter socket at {socket_path}. Pass "
+                "--plugin exo_harbor.plugin:ExoSessionPlugin alongside --agent."
+            )
+
+        container = resolve_main_container(environment.session_id)
+        self._container_id = container.container_id
+        logger.info(
+            "resolved Harbor container %s for trial %s",
+            container.container_id[:12],
+            self.context_id,
+        )
+
+    # ----------------------------------------------------------------------
+    # Per-step execution
+    # ----------------------------------------------------------------------
+
+    @override
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        """Hand Exo the task and block until it says it is done."""
+        if self._container_id is None:
+            raise RuntimeError("ExoAgent.run called before setup")
+
+        response = await send_trial_run(
+            conventions.socket_path(self._exo_root),
+            TrialRun(
+                request_id=str(uuid4()),
+                target=str(self.context_id),
+                container_id=self._container_id,
+                instructions=instruction,
+            ),
+            timeout_sec=self._task_timeout_sec,
+        )
+        try:
+            await export_trial_trajectory(
+                self._client,
+                response.conversation_id,
+                str(self.context_id),
+                instruction,
+                self._model,
+                self.logs_dir / "trajectory.json",
+            )
+        except Exception:
+            logger.exception(
+                "failed to export Harbor trajectory for %s", self.context_id
+            )
+
+        if response.summary:
+            logger.info("trial %s complete: %s", self.context_id, response.summary)

--- a/eval/harbor/src/exo_harbor/agent.py
+++ b/eval/harbor/src/exo_harbor/agent.py
@@ -36,7 +36,7 @@ from harbor.models.agent.context import AgentContext
 from exo_harbor import conventions
 from exo_harbor.docker import resolve_main_container
 from exo_harbor.exo import ExoClient
-from exo_harbor.protocol import TrialRun, send_trial_run
+from exo_harbor.protocol import TrialRun, TrialStarted, send_trial_run
 from exo_harbor.trajectory import export_trial_trajectory
 
 logger = logging.getLogger(__name__)
@@ -127,29 +127,45 @@ class ExoAgent(BaseAgent):
         if self._container_id is None:
             raise RuntimeError("ExoAgent.run called before setup")
 
-        response = await send_trial_run(
-            conventions.socket_path(self._exo_root),
-            TrialRun(
-                request_id=str(uuid4()),
-                target=str(self.context_id),
-                container_id=self._container_id,
-                instructions=instruction,
-            ),
-            timeout_sec=self._task_timeout_sec,
-        )
+        conversation_id: str | None = None
+
+        def trial_started(started: TrialStarted) -> None:
+            nonlocal conversation_id
+            conversation_id = started.conversation_id
+            logger.info(
+                "trial %s started in conversation %s",
+                self.context_id,
+                conversation_id,
+            )
+
         try:
-            await export_trial_trajectory(
-                self._client,
-                response.conversation_id,
-                str(self.context_id),
-                instruction,
-                self._model,
-                self.logs_dir / "trajectory.json",
+            response = await send_trial_run(
+                conventions.socket_path(self._exo_root),
+                TrialRun(
+                    request_id=str(uuid4()),
+                    target=str(self.context_id),
+                    container_id=self._container_id,
+                    instructions=instruction,
+                ),
+                timeout_sec=self._task_timeout_sec,
+                on_started=trial_started,
             )
-        except Exception:
-            logger.exception(
-                "failed to export Harbor trajectory for %s", self.context_id
-            )
+            conversation_id = response.conversation_id
+        finally:
+            if conversation_id is not None:
+                try:
+                    await export_trial_trajectory(
+                        self._client,
+                        conversation_id,
+                        str(self.context_id),
+                        instruction,
+                        self._model,
+                        self.logs_dir / "trajectory.json",
+                    )
+                except Exception:
+                    logger.exception(
+                        "failed to export Harbor trajectory for %s", self.context_id
+                    )
 
         if response.summary:
             logger.info("trial %s complete: %s", self.context_id, response.summary)

--- a/eval/harbor/src/exo_harbor/agent.py
+++ b/eval/harbor/src/exo_harbor/agent.py
@@ -36,7 +36,12 @@ from harbor.models.agent.context import AgentContext
 from exo_harbor import conventions
 from exo_harbor.docker import resolve_main_container
 from exo_harbor.exo import ExoClient
-from exo_harbor.protocol import TrialRun, TrialStarted, send_trial_run
+from exo_harbor.protocol import (
+    TrialCancelled,
+    TrialRun,
+    TrialStarted,
+    send_trial_run,
+)
 from exo_harbor.trajectory import export_trial_trajectory
 
 logger = logging.getLogger(__name__)
@@ -132,10 +137,29 @@ class ExoAgent(BaseAgent):
         def trial_started(started: TrialStarted) -> None:
             nonlocal conversation_id
             conversation_id = started.conversation_id
+            context.metadata = {
+                **(context.metadata or {}),
+                "exo_conversation_id": started.conversation_id,
+            }
             logger.info(
                 "trial %s started in conversation %s",
                 self.context_id,
                 conversation_id,
+            )
+
+        def trial_cancelled(cancelled: TrialCancelled) -> None:
+            nonlocal conversation_id
+            conversation_id = cancelled.conversation_id
+            context.metadata = {
+                **(context.metadata or {}),
+                "exo_conversation_id": cancelled.conversation_id,
+                "exo_snapshot_id": cancelled.snapshot_id,
+                "exo_instruction": instruction,
+            }
+            logger.info(
+                "snapshotted cancelled trial %s as %s",
+                self.context_id,
+                cancelled.snapshot_id,
             )
 
         try:
@@ -149,8 +173,15 @@ class ExoAgent(BaseAgent):
                 ),
                 timeout_sec=self._task_timeout_sec,
                 on_started=trial_started,
+                on_cancelled=trial_cancelled,
             )
             conversation_id = response.conversation_id
+            context.metadata = {
+                **(context.metadata or {}),
+                "exo_conversation_id": response.conversation_id,
+                "exo_snapshot_id": response.snapshot_id,
+                "exo_instruction": instruction,
+            }
         finally:
             if conversation_id is not None:
                 try:

--- a/eval/harbor/src/exo_harbor/conventions.py
+++ b/eval/harbor/src/exo_harbor/conventions.py
@@ -1,0 +1,20 @@
+"""Names shared by Harbor's independently constructed plugin and agents."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Fixed slugs are safe because each job has its own exo_root.
+AGENT_SLUG = "harbor-eval"
+
+# Keep adapter setup chatter out of measured trial conversations.
+SETUP_CONVERSATION_SLUG = "harbor-setup"
+
+
+def socket_path(exo_root: Path) -> Path:
+    """Where the trial adapter listens for this job.
+
+    Under exo_root rather than the adapter's ~/.exo/trial.sock default, so
+    concurrent jobs on one host do not fight over one socket.
+    """
+    return exo_root / "trial.sock"

--- a/eval/harbor/src/exo_harbor/docker.py
+++ b/eval/harbor/src/exo_harbor/docker.py
@@ -1,0 +1,103 @@
+"""Host-side resolution of the Docker container Harbor started for a trial.
+
+Harbor's DockerEnvironment brings the task up with Docker Compose under a
+project name derived from the public ``environment.session_id``, with the task
+container as the ``main`` service. We find it by label from the host.
+
+Deliberately not done via ``BaseEnvironment.exec()``: that runs *inside* the
+task container, where recovering the host-side container identity is
+unreliable. This is host work and belongs in the external agent.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+
+MAIN_SERVICE = "main"
+PROJECT_LABEL = "com.docker.compose.project"
+SERVICE_LABEL = "com.docker.compose.service"
+
+
+class DockerResolutionError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class DockerContainer:
+    container_id: str
+    project: str
+
+
+def compose_project_name(session_id: str) -> str:
+    """Reproduce Harbor's Compose project-name normalization.
+
+    1. lowercase
+    2. prefix "0" if the first character is not alphanumeric
+    3. replace anything outside [a-z0-9_-] with "-"
+
+    Mirrors Harbor's own logic, so it must be re-checked on a Harbor bump.
+    """
+    name = session_id.lower()
+    if not name or not name[0].isalnum():
+        name = f"0{name}"
+    return re.sub(r"[^a-z0-9_-]", "-", name)
+
+
+def resolve_main_container(session_id: str) -> DockerContainer:
+    """Find the single running ``main`` container for this trial.
+
+    Zero matches means the environment is gone. More than one is ambiguous.
+    Both raise: submitting an arbitrary container would silently grade the wrong
+    machine, which is worse than failing the trial.
+    """
+    project = compose_project_name(session_id)
+    ids = _docker(
+        "ps",
+        "--filter",
+        f"label={PROJECT_LABEL}={project}",
+        "--filter",
+        f"label={SERVICE_LABEL}={MAIN_SERVICE}",
+        "--format",
+        "{{.ID}}",
+    ).split()
+
+    if not ids:
+        raise DockerResolutionError(
+            f"no running {MAIN_SERVICE} container for Compose project {project!r}"
+        )
+    if len(ids) > 1:
+        raise DockerResolutionError(
+            f"{len(ids)} running {MAIN_SERVICE} containers for Compose project "
+            f"{project!r}; refusing to guess"
+        )
+
+    container_id = ids[0]
+    # Re-read the labels off the chosen container. `docker ps` filtering and
+    # this inspect are separate calls, and the trial is about to be graded on
+    # whatever we submit.
+    labels = _docker(
+        "inspect",
+        "--format",
+        f"{{{{index .Config.Labels \"{PROJECT_LABEL}\"}}}} "
+        f"{{{{index .Config.Labels \"{SERVICE_LABEL}\"}}}}",
+        container_id,
+    ).split()
+    if labels != [project, MAIN_SERVICE]:
+        raise DockerResolutionError(
+            f"container {container_id} no longer matches {project}/{MAIN_SERVICE}"
+        )
+
+    return DockerContainer(container_id=container_id, project=project)
+
+
+def _docker(*args: str) -> str:
+    result = subprocess.run(
+        ["docker", *args], capture_output=True, text=True, check=False
+    )
+    if result.returncode != 0:
+        raise DockerResolutionError(
+            f"docker {' '.join(args)} failed: {result.stderr.strip()}"
+        )
+    return result.stdout.strip()

--- a/eval/harbor/src/exo_harbor/exo.py
+++ b/eval/harbor/src/exo_harbor/exo.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import shutil
 import subprocess
 import threading
 from dataclasses import dataclass
@@ -91,6 +92,17 @@ class ExoClient:
             args.extend(("--turn-id", turn_id))
         args.extend(("--limit", str(limit)))
         return await self._run(*args)
+
+    async def delete_snapshots(self) -> int:
+        """Delete snapshot payloads while preserving the rest of the Exo run."""
+        snapshot_directories = list(
+            (self.exo_root / "exoharness" / "agents").glob(
+                "*/conversations/*/snapshots"
+            )
+        )
+        for directory in snapshot_directories:
+            await asyncio.to_thread(shutil.rmtree, directory)
+        return len(snapshot_directories)
 
     async def _ensure_conversation(self, slug: str) -> None:
         if await self._exists("conversation", "show", conventions.AGENT_SLUG, slug):

--- a/eval/harbor/src/exo_harbor/exo.py
+++ b/eval/harbor/src/exo_harbor/exo.py
@@ -1,0 +1,195 @@
+"""Small CLI client for Exo job setup and trajectory export."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+
+from exo_harbor import conventions
+from exo_harbor.protocol import probe
+
+
+class ExoCommandError(RuntimeError):
+    """An Exo CLI command failed."""
+
+
+@dataclass(frozen=True)
+class ExoClient:
+    exo_bin: Path
+    exo_root: Path
+    repo_root: Path
+
+    async def ensure_agent(self, model: str) -> None:
+        """Create the persistent evaluation agent if it does not exist."""
+        if await self._exists("agent", "show", conventions.AGENT_SLUG):
+            return
+        await self._run(
+            "agent",
+            "create",
+            "Harbor eval",
+            "--slug",
+            conventions.AGENT_SLUG,
+            "--model",
+            model,
+            "--module",
+            str(self.repo_root / "exo/harness.ts"),
+            "--sandbox-provider",
+            "docker",
+            "--sandbox-scope",
+            "agent",
+            "--tool-creation",
+            "enabled",
+        )
+
+    async def ensure_trial_adapter(self, socket_path: Path) -> None:
+        """Create the job's trial adapter if it does not exist."""
+        setup = conventions.SETUP_CONVERSATION_SLUG
+        await self._ensure_conversation(setup)
+        await self._run(
+            "conversation",
+            "send",
+            conventions.AGENT_SLUG,
+            setup,
+            _ADAPTER_SETUP_PROMPT.format(socket_path=socket_path),
+        )
+
+    async def ensure_adapter_runner(
+        self, socket_path: Path, *, timeout_sec: float
+    ) -> None:
+        """Start the adapter supervisor and wait for its socket."""
+        if await probe(socket_path, timeout_sec=0.5):
+            return
+        await asyncio.to_thread(self._spawn_adapter_runner)
+        if not await probe(socket_path, timeout_sec=timeout_sec):
+            raise ExoCommandError(
+                f"trial adapter socket never appeared at {socket_path}; "
+                f"check {self.exo_root / 'exo-adapters.log'}"
+            )
+
+    async def read_conversation_events(
+        self,
+        conversation: str,
+        *,
+        types: list[str],
+        turn_id: str | None = None,
+        limit: int,
+    ) -> str:
+        """Return canonical conversation events as JSON."""
+        args = [
+            "conversation",
+            "events",
+            conventions.AGENT_SLUG,
+            conversation,
+        ]
+        for event_type in types:
+            args.extend(("--type", event_type))
+        if turn_id is not None:
+            args.extend(("--turn-id", turn_id))
+        args.extend(("--limit", str(limit)))
+        return await self._run(*args)
+
+    async def _ensure_conversation(self, slug: str) -> None:
+        if await self._exists("conversation", "show", conventions.AGENT_SLUG, slug):
+            return
+        await self._run(
+            "conversation",
+            "create",
+            conventions.AGENT_SLUG,
+            slug,
+            "--slug",
+            slug,
+            "--sandbox-scope",
+            "agent",
+        )
+
+    def _spawn_adapter_runner(self) -> None:
+        log_path = self.exo_root / "exo-adapters.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("ab") as log:
+            process = subprocess.Popen(  # noqa: S603 - fixed argv, no shell
+                self._argv(
+                    "adapters",
+                    "run",
+                    "--lock-file",
+                    str(self.exo_root / "exo-adapters.lock"),
+                    "--drain-marker",
+                    str(self.exo_root / "exo-adapters.restart"),
+                    "--reboot-notice",
+                    str(self.exo_root / "exo-reboot-notice.json"),
+                ),
+                cwd=self.repo_root,
+                stdout=log,
+                stderr=log,
+                env=self._environment(),
+                start_new_session=True,
+            )
+        (self.exo_root / "exo-adapters.pid").write_text(
+            f"{process.pid}\n", encoding="utf-8"
+        )
+        threading.Thread(target=process.wait, daemon=True).start()
+
+    async def _run(self, *args: str) -> str:
+        process = await asyncio.create_subprocess_exec(
+            *self._argv(*args),
+            cwd=self.repo_root,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=self._environment(),
+        )
+        stdout, stderr = await process.communicate()
+        if process.returncode != 0:
+            raise ExoCommandError(
+                f"exo {' '.join(args)} failed ({process.returncode}): "
+                f"{stderr.decode().strip()}"
+            )
+        return stdout.decode().strip()
+
+    def _environment(self) -> dict[str, str]:
+        return {
+            **os.environ,
+            "EXO_PROFILE": os.environ.get("EXO_PROFILE", "practical"),
+            "EXO_ROOT": str(self.exo_root),
+        }
+
+    async def _exists(self, *args: str) -> bool:
+        process = await asyncio.create_subprocess_exec(
+            *self._argv(*args),
+            cwd=self.repo_root,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await process.communicate()
+        if process.returncode == 0:
+            return True
+        if "not found" in stderr.decode().lower():
+            return False
+        raise ExoCommandError(
+            f"exo {' '.join(args)} failed ({process.returncode}): "
+            f"{stderr.decode().strip()}"
+        )
+
+    def _argv(self, *args: str) -> list[str]:
+        return [
+            str(self.exo_bin),
+            "--root",
+            str(self.exo_root),
+            "--harness",
+            "exo",
+            *args,
+        ]
+
+
+_ADAPTER_SETUP_PROMPT = (
+    "Configure the trial adapter for this conversation. Call list_adapters "
+    "with includeDisabled=true. If there is no enabled adapter named `trial` "
+    "with type `trial` and socketPath exactly `{socket_path}`, call "
+    "create_adapter with name `trial`, source `library`, and config "
+    '{{"type":"trial","socketPath":"{socket_path}"}}. Do not create a '
+    "duplicate. If an adapter named `trial` exists but is disabled or has "
+    "different configuration, report that clearly instead of changing or "
+    "deleting it."
+)

--- a/eval/harbor/src/exo_harbor/feedback.py
+++ b/eval/harbor/src/exo_harbor/feedback.py
@@ -1,0 +1,45 @@
+"""Build the feedback given to Exo after Harbor verifies a trial."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from harbor.models.trial.result import TrialResult
+
+
+REFLECTION_INSTRUCTIONS = """Review your work on this completed trial and the grader feedback. Inspect the restored submitted environment when useful. Determine what went well or wrong and extract general lessons that will help you solve similar tasks in the future. Before completing this reflection, persist every useful generalizable lesson in durable memory so later trial conversations can use it. When warranted, also create or improve reusable tools or change your own policy or implementation. The feedback_complete summary is only a report to the evaluator; it does not persist learning. If there is genuinely nothing worth retaining, say so explicitly in that summary. Focus on improving future behavior; this submission has already been graded."""
+
+MAX_FEEDBACK_BYTES = 250_000
+
+
+def build_feedback(result: TrialResult, verifier_dir: Path) -> str:
+    """Return structured rewards, failures, and available verifier logs."""
+    remaining = MAX_FEEDBACK_BYTES
+    logs: dict[str, str] = {}
+    if verifier_dir.is_dir():
+        for path in sorted(item for item in verifier_dir.rglob("*") if item.is_file()):
+            if remaining <= 0:
+                break
+            data = path.read_bytes()
+            kept = data[:remaining]
+            text = kept.decode("utf-8", errors="replace")
+            remaining -= len(kept)
+            if len(kept) < len(data):
+                text += f"\n[truncated {len(data) - len(kept)} bytes]"
+            logs[str(path.relative_to(verifier_dir))] = text
+
+    payload = {
+        "rewards": (
+            result.verifier_result.rewards
+            if result.verifier_result is not None
+            else None
+        ),
+        "exception": (
+            result.exception_info.model_dump(mode="json")
+            if result.exception_info is not None
+            else None
+        ),
+        "verifier_logs": logs,
+    }
+    return json.dumps(payload, indent=2, sort_keys=True)

--- a/eval/harbor/src/exo_harbor/plugin.py
+++ b/eval/harbor/src/exo_harbor/plugin.py
@@ -1,0 +1,87 @@
+"""ExoSessionPlugin — owner of the Exo process for the whole job.
+
+This plugin owns Exo's job-scoped lifetime, whereas ExoAgent is a
+per-trial stub.
+
+The lifecycle:
+
+    attach_job_plugins(job)
+      on_job_start(job)         start Exo and create the adapter
+      job.run()                 run trials through that persistent Exo agent
+
+Requires --n-concurrent 1. Trials share one Exo, so serial execution gives
+each trial a deterministic view of changes made by earlier trials.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from harbor.job import Job
+from harbor.models.environment_type import EnvironmentType
+from harbor.models.job.plugin import BaseJobPlugin
+from harbor.models.job.result import JobResult
+
+from exo_harbor import conventions
+from exo_harbor.exo import ExoClient
+
+logger = logging.getLogger(__name__)
+
+
+class ExoSessionPlugin(BaseJobPlugin):
+    """Runs one persistent Exo agent across every trial in the job."""
+
+    def __init__(
+        self,
+        *,
+        # Set by --pk. Note exo_root is absent: it is read off the agent's own
+        # kwargs in on_job_start so it stays a single source of truth.
+        adapter_start_timeout_sec: float | str = 90,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._adapter_start_timeout_sec = float(adapter_start_timeout_sec)
+
+    async def on_job_start(self, job: Job) -> None:
+        """Bring Exo up before the first container is built."""
+        if job.config.environment.type != EnvironmentType.DOCKER:
+            raise ValueError(
+                "ExoSessionPlugin resolves task containers by Compose label on "
+                "the host, so it requires --env docker"
+            )
+        if job.config.n_concurrent_trials != 1:
+            # To properly learn, Exo can only handle one task at a time.
+            raise ValueError("ExoSessionPlugin requires --n-concurrent 1")
+        if len(job.config.agents) != 1:
+            raise ValueError("ExoSessionPlugin requires exactly one --agent")
+
+        # Read the agent's --ak values rather than taking --pk copies, so
+        # exo_root and friends are written down once.
+        kwargs = job.config.agents[0].kwargs
+        try:
+            model = kwargs["exo_model"]
+            client = ExoClient(
+                exo_bin=Path(kwargs["exo_bin"]),
+                exo_root=Path(kwargs["exo_root"]),
+                repo_root=Path(kwargs["exo_repo_root"]),
+            )
+        except KeyError as error:
+            raise ValueError(
+                f"ExoAgent is missing required --ak {error.args[0]}"
+            ) from error
+
+        socket_path = conventions.socket_path(client.exo_root)
+        await client.ensure_agent(model)
+        await client.ensure_trial_adapter(socket_path)
+        await client.ensure_adapter_runner(
+            socket_path, timeout_sec=self._adapter_start_timeout_sec
+        )
+        logger.info("Exo ready for job %s on %s", job.id, socket_path)
+
+    async def on_job_end(self, _job_result: JobResult) -> None:
+        """Satisfy Harbor's plugin lifecycle; Exo state remains on disk."""
+
+# TODO: add on_job_end to produce a report on the learnings obtained during
+# the trial.

--- a/eval/harbor/src/exo_harbor/plugin.py
+++ b/eval/harbor/src/exo_harbor/plugin.py
@@ -18,14 +18,19 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 from harbor.job import Job
 from harbor.models.environment_type import EnvironmentType
 from harbor.models.job.plugin import BaseJobPlugin
 from harbor.models.job.result import JobResult
+from harbor.trial.hooks import TrialHookEvent
 
 from exo_harbor import conventions
 from exo_harbor.exo import ExoClient
+from exo_harbor.feedback import REFLECTION_INSTRUCTIONS, build_feedback
+from exo_harbor.protocol import TrialFeedback, send_trial_feedback
+from exo_harbor.trajectory import export_trial_trajectory
 
 logger = logging.getLogger(__name__)
 
@@ -39,10 +44,14 @@ class ExoSessionPlugin(BaseJobPlugin):
         # Set by --pk. Note exo_root is absent: it is read off the agent's own
         # kwargs in on_job_start so it stays a single source of truth.
         adapter_start_timeout_sec: float | str = 90,
+        feedback_timeout_sec: float | str = 600,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self._adapter_start_timeout_sec = float(adapter_start_timeout_sec)
+        self._feedback_timeout_sec = float(feedback_timeout_sec)
+        self._client: ExoClient | None = None
+        self._model: str | None = None
 
     async def on_job_start(self, job: Job) -> None:
         """Bring Exo up before the first container is built."""
@@ -78,10 +87,75 @@ class ExoSessionPlugin(BaseJobPlugin):
         await client.ensure_adapter_runner(
             socket_path, timeout_sec=self._adapter_start_timeout_sec
         )
+        self._client = client
+        self._model = model
+        job.on_trial_ended(self._reflect_on_trial)
         logger.info("Exo ready for job %s on %s", job.id, socket_path)
 
+    async def _reflect_on_trial(self, event: TrialHookEvent) -> None:
+        result = event.result
+        context = result.agent_result
+        metadata = context.metadata if context is not None else None
+        if not metadata or not metadata.get("exo_snapshot_id"):
+            logger.info("trial %s has no Exo snapshot; skipping feedback", result.id)
+            return
+        conversation_id = metadata.get("exo_conversation_id")
+        instruction = metadata.get("exo_instruction")
+        if not isinstance(conversation_id, str) or not isinstance(instruction, str):
+            raise ValueError(f"trial {result.id} has incomplete Exo metadata")
+        if self._client is None or self._model is None:
+            raise RuntimeError("Exo feedback hook ran before job setup")
+
+        trial_dir = event.config.trials_dir / event.trial_name
+        response = await send_trial_feedback(
+            conventions.socket_path(self._client.exo_root),
+            TrialFeedback(
+                request_id=str(uuid4()),
+                target=str(result.id),
+                instructions=REFLECTION_INSTRUCTIONS,
+                feedback=build_feedback(result, trial_dir / "verifier"),
+            ),
+            timeout_sec=self._feedback_timeout_sec,
+        )
+        if response.conversation_id != conversation_id:
+            raise ValueError(f"trial {result.id} feedback changed Exo conversations")
+        await _export_trajectory(
+            self._client,
+            conversation_id,
+            str(result.id),
+            instruction,
+            self._model,
+            trial_dir / "agent" / "trajectory.json",
+        )
+        logger.info("trial %s feedback complete", result.id)
+
     async def on_job_end(self, _job_result: JobResult) -> None:
-        """Satisfy Harbor's plugin lifecycle; Exo state remains on disk."""
+        """Discard temporary snapshots while retaining the run's other artifacts."""
+        if self._client is None:
+            return
+        count = await self._client.delete_snapshots()
+        logger.info("deleted %d Exo snapshot directories", count)
 
 # TODO: add on_job_end to produce a report on the learnings obtained during
 # the trial.
+
+
+async def _export_trajectory(
+    client: ExoClient,
+    conversation_id: str,
+    trial_id: str,
+    instruction: str,
+    model: str,
+    destination: Path,
+) -> None:
+    try:
+        await export_trial_trajectory(
+            client,
+            conversation_id,
+            trial_id,
+            instruction,
+            model,
+            destination,
+        )
+    except Exception:
+        logger.exception("failed to export Harbor trajectory for %s", trial_id)

--- a/eval/harbor/src/exo_harbor/protocol.py
+++ b/eval/harbor/src/exo_harbor/protocol.py
@@ -1,0 +1,124 @@
+"""Typed protocol for submitting a containerized trial to Exo."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+
+@dataclass(frozen=True)
+class TrialRun:
+    request_id: str
+    target: str
+    container_id: str
+    instructions: str
+    deadline_at: str | None = None
+    type: Literal["trial_run"] = "trial_run"
+
+    def payload(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class TrialComplete:
+    request_id: str
+    target: str
+    conversation_id: str
+    summary: str | None = None
+
+
+class TrialAdapterError(RuntimeError):
+    """The trial adapter rejected a request or returned an invalid response."""
+
+
+class _Disconnected(RuntimeError):
+    """The adapter socket disappeared while a trial was running."""
+
+
+async def send_trial_run(
+    socket_path: Path,
+    request: TrialRun,
+    *,
+    timeout_sec: float | None,
+) -> TrialComplete:
+    """Wait for explicit completion, reconnecting across Exo restarts."""
+
+    async def wait_for_completion() -> TrialComplete:
+        while True:
+            try:
+                event = await _exchange(socket_path, request.payload())
+                return _parse_completion(event, request)
+            except (OSError, _Disconnected):
+                await asyncio.sleep(0.5)
+
+    return await asyncio.wait_for(wait_for_completion(), timeout=timeout_sec)
+
+
+async def probe(socket_path: Path, *, timeout_sec: float) -> bool:
+    """Return True once the adapter socket accepts a connection."""
+    deadline = asyncio.get_running_loop().time() + timeout_sec
+    while True:
+        try:
+            _, writer = await asyncio.open_unix_connection(str(socket_path))
+            writer.close()
+            await writer.wait_closed()
+            return True
+        except (OSError, asyncio.TimeoutError):
+            if asyncio.get_running_loop().time() >= deadline:
+                return False
+            await asyncio.sleep(0.5)
+
+
+async def _exchange(socket_path: Path, payload: dict[str, Any]) -> dict[str, Any]:
+    reader, writer = await asyncio.open_unix_connection(str(socket_path))
+    try:
+        writer.write(f"{json.dumps(payload)}\n".encode())
+        await writer.drain()
+        line = await reader.readline()
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+    if not line:
+        raise _Disconnected("trial adapter closed without replying")
+    try:
+        message = json.loads(line)
+    except json.JSONDecodeError as error:
+        raise TrialAdapterError("trial adapter returned invalid JSON") from error
+    if not isinstance(message, dict):
+        raise TrialAdapterError("trial adapter reply must be a JSON object")
+    if message.get("type") == "error":
+        raise TrialAdapterError(str(message.get("message")))
+    if message.get("type") != "response" or not isinstance(message.get("event"), dict):
+        raise TrialAdapterError(f"unexpected trial adapter reply: {message!r}")
+    return message["event"]
+
+
+def _parse_completion(
+    event: dict[str, Any], request: TrialRun
+) -> TrialComplete:
+    expected = {
+        "type": "trial_complete",
+        "request_id": request.request_id,
+        "target": request.target,
+    }
+    for field, value in expected.items():
+        if event.get(field) != value:
+            raise TrialAdapterError(
+                f"trial completion {field} is {event.get(field)!r}, expected {value!r}"
+            )
+    conversation_id = event.get("conversation_id")
+    if not isinstance(conversation_id, str) or not conversation_id:
+        raise TrialAdapterError("trial completion has no conversation_id")
+    summary = event.get("summary")
+    if summary is not None and not isinstance(summary, str):
+        raise TrialAdapterError("trial completion summary must be a string or null")
+    return TrialComplete(
+        request_id=request.request_id,
+        target=request.target,
+        conversation_id=conversation_id,
+        summary=summary,
+    )

--- a/eval/harbor/src/exo_harbor/protocol.py
+++ b/eval/harbor/src/exo_harbor/protocol.py
@@ -1,4 +1,4 @@
-"""Typed protocol for submitting a containerized trial to Exo.
+"""Typed protocol for submitting and reflecting on a containerized trial.
 
 Harbor opens a Unix socket and sends one newline-delimited ``trial_run``
 request containing the task container, instructions, request id, and stable
@@ -10,18 +10,27 @@ trial target. The adapter keeps that connection open and sends two messages:
 2. A final ``trial_complete`` response after Exo explicitly declares the work
    finished with ``send_adapter_message``.
 
-If Exo restarts or the socket disconnects, Harbor reconnects and resends the
-same request. The request id makes that retry idempotent, and the adapter
-replays any durable ``trial_started`` or ``trial_complete`` message.
+After verification, Harbor may send ``trial_feedback`` on the same target. Exo
+restores the submitted snapshot, resumes the same conversation, and replies
+with ``feedback_started`` followed by an explicit ``feedback_complete``.
+
+If Exo restarts or the socket disconnects during either phase, Harbor
+reconnects and resends the same request. The request id makes that retry
+idempotent, and the adapter replays its durable started or completed response.
+If Harbor cancels the wait, it sends ``trial_cancel`` before returning so the
+worker durably removes the request instead of replaying it later.
 """
 
 from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Callable, Literal
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -42,6 +51,7 @@ class TrialComplete:
     request_id: str
     target: str
     conversation_id: str
+    snapshot_id: str
     summary: str | None = None
 
 
@@ -50,6 +60,53 @@ class TrialStarted:
     request_id: str
     target: str
     conversation_id: str
+
+
+@dataclass(frozen=True)
+class TrialFeedback:
+    request_id: str
+    target: str
+    instructions: str
+    feedback: str
+    deadline_at: str | None = None
+    type: Literal["trial_feedback"] = "trial_feedback"
+
+    def payload(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class TrialCancel:
+    request_id: str
+    target: str
+    type: Literal["trial_cancel"] = "trial_cancel"
+
+    def payload(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class TrialCancelled:
+    request_id: str
+    target: str
+    conversation_id: str
+    snapshot_id: str
+
+
+@dataclass(frozen=True)
+class FeedbackStarted:
+    request_id: str
+    target: str
+    conversation_id: str
+    sandbox_id: str
+
+
+@dataclass(frozen=True)
+class FeedbackComplete:
+    request_id: str
+    target: str
+    conversation_id: str
+    summary: str | None = None
 
 
 class TrialAdapterError(RuntimeError):
@@ -66,6 +123,7 @@ async def send_trial_run(
     *,
     timeout_sec: float | None,
     on_started: Callable[[TrialStarted], None] | None = None,
+    on_cancelled: Callable[[TrialCancelled], None] | None = None,
 ) -> TrialComplete:
     """Wait for explicit completion, reconnecting across Exo restarts."""
 
@@ -102,7 +160,79 @@ async def send_trial_run(
             except (OSError, _Disconnected):
                 await asyncio.sleep(0.5)
 
-    return await asyncio.wait_for(wait_for_completion(), timeout=timeout_sec)
+    try:
+        return await asyncio.wait_for(wait_for_completion(), timeout=timeout_sec)
+    except (asyncio.CancelledError, asyncio.TimeoutError):
+        cancelled = await _cancel_trial(socket_path, request)
+        if cancelled is not None and on_cancelled is not None:
+            on_cancelled(cancelled)
+        raise
+
+
+async def send_trial_feedback(
+    socket_path: Path,
+    request: TrialFeedback,
+    *,
+    timeout_sec: float | None,
+    on_started: Callable[[FeedbackStarted], None] | None = None,
+) -> FeedbackComplete:
+    """Restore the submitted environment and wait for explicit reflection completion."""
+
+    started: FeedbackStarted | None = None
+
+    def receive_started(event: dict[str, Any]) -> None:
+        nonlocal started
+        received = _parse_feedback_started(event, request)
+        if started is not None and started != received:
+            raise TrialAdapterError(
+                "feedback_started changed while reconnecting: "
+                f"{started.sandbox_id!r} became {received.sandbox_id!r}"
+            )
+        if started is None:
+            started = received
+            if on_started is not None:
+                on_started(received)
+
+    async def wait_for_completion() -> FeedbackComplete:
+        while True:
+            try:
+                event = await _exchange(
+                    socket_path, request.payload(), receive_started
+                )
+                completion = _parse_feedback_completion(event, request)
+                if (
+                    started is not None
+                    and completion.conversation_id != started.conversation_id
+                ):
+                    raise TrialAdapterError(
+                        "feedback_complete conversation_id does not match feedback_started"
+                    )
+                return completion
+            except (OSError, _Disconnected):
+                await asyncio.sleep(0.5)
+
+    try:
+        return await asyncio.wait_for(wait_for_completion(), timeout=timeout_sec)
+    except (asyncio.CancelledError, asyncio.TimeoutError):
+        await _cancel_trial(socket_path, request)
+        raise
+
+
+async def _cancel_trial(
+    socket_path: Path, request: TrialRun | TrialFeedback
+) -> TrialCancelled | None:
+    cancel = TrialCancel(request_id=request.request_id, target=request.target)
+    try:
+        event = await asyncio.shield(
+            asyncio.wait_for(
+                _exchange(socket_path, cancel.payload(), lambda _event: None),
+                timeout=120,
+            )
+        )
+        return _parse_cancelled(event, cancel)
+    except Exception:
+        logger.exception("failed to cancel trial request %s", request.request_id)
+        return None
 
 
 async def probe(socket_path: Path, *, timeout_sec: float) -> bool:
@@ -176,6 +306,9 @@ def _parse_completion(
 ) -> TrialComplete:
     _validate_routing_fields(event, request, "trial_complete")
     conversation_id = _conversation_id(event, "trial_complete")
+    snapshot_id = event.get("snapshot_id")
+    if not isinstance(snapshot_id, str) or not snapshot_id:
+        raise TrialAdapterError("trial_complete has no snapshot_id")
     summary = event.get("summary")
     if summary is not None and not isinstance(summary, str):
         raise TrialAdapterError("trial completion summary must be a string or null")
@@ -183,12 +316,60 @@ def _parse_completion(
         request_id=request.request_id,
         target=request.target,
         conversation_id=conversation_id,
+        snapshot_id=snapshot_id,
         summary=summary,
     )
 
 
+def _parse_feedback_started(
+    event: dict[str, Any], request: TrialFeedback
+) -> FeedbackStarted:
+    _validate_routing_fields(event, request, "feedback_started")
+    sandbox_id = event.get("sandbox_id")
+    if not isinstance(sandbox_id, str) or not sandbox_id:
+        raise TrialAdapterError("feedback_started has no sandbox_id")
+    return FeedbackStarted(
+        request_id=request.request_id,
+        target=request.target,
+        conversation_id=_conversation_id(event, "feedback_started"),
+        sandbox_id=sandbox_id,
+    )
+
+
+def _parse_feedback_completion(
+    event: dict[str, Any], request: TrialFeedback
+) -> FeedbackComplete:
+    _validate_routing_fields(event, request, "feedback_complete")
+    summary = event.get("summary")
+    if summary is not None and not isinstance(summary, str):
+        raise TrialAdapterError("feedback completion summary must be a string or null")
+    return FeedbackComplete(
+        request_id=request.request_id,
+        target=request.target,
+        conversation_id=_conversation_id(event, "feedback_complete"),
+        summary=summary,
+    )
+
+
+def _parse_cancelled(
+    event: dict[str, Any], request: TrialCancel
+) -> TrialCancelled:
+    _validate_routing_fields(event, request, "trial_cancelled")
+    snapshot_id = event.get("snapshot_id")
+    if not isinstance(snapshot_id, str) or not snapshot_id:
+        raise TrialAdapterError("trial_cancelled has no snapshot_id")
+    return TrialCancelled(
+        request_id=request.request_id,
+        target=request.target,
+        conversation_id=_conversation_id(event, "trial_cancelled"),
+        snapshot_id=snapshot_id,
+    )
+
+
 def _validate_routing_fields(
-    event: dict[str, Any], request: TrialRun, event_type: str
+    event: dict[str, Any],
+    request: TrialRun | TrialFeedback | TrialCancel,
+    event_type: str,
 ) -> None:
     expected = {
         "type": event_type,

--- a/eval/harbor/src/exo_harbor/protocol.py
+++ b/eval/harbor/src/exo_harbor/protocol.py
@@ -1,4 +1,19 @@
-"""Typed protocol for submitting a containerized trial to Exo."""
+"""Typed protocol for submitting a containerized trial to Exo.
+
+Harbor opens a Unix socket and sends one newline-delimited ``trial_run``
+request containing the task container, instructions, request id, and stable
+trial target. The adapter keeps that connection open and sends two messages:
+
+1. A ``trial_started`` event after Exo creates the conversation and attaches
+   the container. Its conversation id lets Harbor export a partial trajectory
+   even if the trial later times out.
+2. A final ``trial_complete`` response after Exo explicitly declares the work
+   finished with ``send_adapter_message``.
+
+If Exo restarts or the socket disconnects, Harbor reconnects and resends the
+same request. The request id makes that retry idempotent, and the adapter
+replays any durable ``trial_started`` or ``trial_complete`` message.
+"""
 
 from __future__ import annotations
 
@@ -6,7 +21,7 @@ import asyncio
 import json
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Callable, Literal
 
 
 @dataclass(frozen=True)
@@ -30,6 +45,13 @@ class TrialComplete:
     summary: str | None = None
 
 
+@dataclass(frozen=True)
+class TrialStarted:
+    request_id: str
+    target: str
+    conversation_id: str
+
+
 class TrialAdapterError(RuntimeError):
     """The trial adapter rejected a request or returned an invalid response."""
 
@@ -43,14 +65,40 @@ async def send_trial_run(
     request: TrialRun,
     *,
     timeout_sec: float | None,
+    on_started: Callable[[TrialStarted], None] | None = None,
 ) -> TrialComplete:
     """Wait for explicit completion, reconnecting across Exo restarts."""
+
+    started: TrialStarted | None = None
+
+    def receive_started(event: dict[str, Any]) -> None:
+        nonlocal started
+        received = _parse_started(event, request)
+        if started is not None and started != received:
+            raise TrialAdapterError(
+                "trial_started changed while reconnecting: "
+                f"{started.conversation_id!r} became {received.conversation_id!r}"
+            )
+        if started is None:
+            started = received
+            if on_started is not None:
+                on_started(received)
 
     async def wait_for_completion() -> TrialComplete:
         while True:
             try:
-                event = await _exchange(socket_path, request.payload())
-                return _parse_completion(event, request)
+                event = await _exchange(
+                    socket_path, request.payload(), receive_started
+                )
+                completion = _parse_completion(event, request)
+                if (
+                    started is not None
+                    and completion.conversation_id != started.conversation_id
+                ):
+                    raise TrialAdapterError(
+                        "trial_complete conversation_id does not match trial_started"
+                    )
+                return completion
             except (OSError, _Disconnected):
                 await asyncio.sleep(0.5)
 
@@ -72,16 +120,30 @@ async def probe(socket_path: Path, *, timeout_sec: float) -> bool:
             await asyncio.sleep(0.5)
 
 
-async def _exchange(socket_path: Path, payload: dict[str, Any]) -> dict[str, Any]:
+async def _exchange(
+    socket_path: Path,
+    payload: dict[str, Any],
+    on_started: Callable[[dict[str, Any]], None],
+) -> dict[str, Any]:
     reader, writer = await asyncio.open_unix_connection(str(socket_path))
     try:
         writer.write(f"{json.dumps(payload)}\n".encode())
         await writer.drain()
-        line = await reader.readline()
+        while True:
+            envelope, event = await _read_event(reader)
+            if envelope == "event":
+                on_started(event)
+                continue
+            return event
     finally:
         writer.close()
         await writer.wait_closed()
 
+
+async def _read_event(
+    reader: asyncio.StreamReader,
+) -> tuple[Literal["event", "response"], dict[str, Any]]:
+    line = await reader.readline()
     if not line:
         raise _Disconnected("trial adapter closed without replying")
     try:
@@ -92,27 +154,28 @@ async def _exchange(socket_path: Path, payload: dict[str, Any]) -> dict[str, Any
         raise TrialAdapterError("trial adapter reply must be a JSON object")
     if message.get("type") == "error":
         raise TrialAdapterError(str(message.get("message")))
-    if message.get("type") != "response" or not isinstance(message.get("event"), dict):
+    envelope = message.get("type")
+    if envelope not in {"event", "response"} or not isinstance(
+        message.get("event"), dict
+    ):
         raise TrialAdapterError(f"unexpected trial adapter reply: {message!r}")
-    return message["event"]
+    return envelope, message["event"]
+
+
+def _parse_started(event: dict[str, Any], request: TrialRun) -> TrialStarted:
+    _validate_routing_fields(event, request, "trial_started")
+    return TrialStarted(
+        request_id=request.request_id,
+        target=request.target,
+        conversation_id=_conversation_id(event, "trial_started"),
+    )
 
 
 def _parse_completion(
     event: dict[str, Any], request: TrialRun
 ) -> TrialComplete:
-    expected = {
-        "type": "trial_complete",
-        "request_id": request.request_id,
-        "target": request.target,
-    }
-    for field, value in expected.items():
-        if event.get(field) != value:
-            raise TrialAdapterError(
-                f"trial completion {field} is {event.get(field)!r}, expected {value!r}"
-            )
-    conversation_id = event.get("conversation_id")
-    if not isinstance(conversation_id, str) or not conversation_id:
-        raise TrialAdapterError("trial completion has no conversation_id")
+    _validate_routing_fields(event, request, "trial_complete")
+    conversation_id = _conversation_id(event, "trial_complete")
     summary = event.get("summary")
     if summary is not None and not isinstance(summary, str):
         raise TrialAdapterError("trial completion summary must be a string or null")
@@ -122,3 +185,25 @@ def _parse_completion(
         conversation_id=conversation_id,
         summary=summary,
     )
+
+
+def _validate_routing_fields(
+    event: dict[str, Any], request: TrialRun, event_type: str
+) -> None:
+    expected = {
+        "type": event_type,
+        "request_id": request.request_id,
+        "target": request.target,
+    }
+    for field, value in expected.items():
+        if event.get(field) != value:
+            raise TrialAdapterError(
+                f"{event_type} {field} is {event.get(field)!r}, expected {value!r}"
+            )
+
+
+def _conversation_id(event: dict[str, Any], event_type: str) -> str:
+    conversation_id = event.get("conversation_id")
+    if not isinstance(conversation_id, str) or not conversation_id:
+        raise TrialAdapterError(f"{event_type} has no conversation_id")
+    return conversation_id

--- a/eval/harbor/src/exo_harbor/trajectory.py
+++ b/eval/harbor/src/exo_harbor/trajectory.py
@@ -1,0 +1,284 @@
+"""Convert an Exo trial conversation into Harbor's native ATIF trajectory."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Annotated, Literal
+
+from harbor.models.trajectories.agent import Agent
+from harbor.models.trajectories.final_metrics import FinalMetrics
+from harbor.models.trajectories.metrics import Metrics
+from harbor.models.trajectories.observation import Observation
+from harbor.models.trajectories.observation_result import ObservationResult
+from harbor.models.trajectories.step import Step
+from harbor.models.trajectories.tool_call import ToolCall
+from harbor.models.trajectories.trajectory import Trajectory
+from pydantic import BaseModel, Field, JsonValue
+
+from exo_harbor import conventions
+from exo_harbor.exo import ExoClient
+
+
+class Usage(BaseModel):
+    model: str
+    prompt_tokens: int
+    completion_tokens: int
+    prompt_cached_tokens: int = 0
+    completion_reasoning_tokens: int = 0
+    cost_usd: float
+
+
+class TextContent(BaseModel):
+    type: Literal["text"]
+    text: str
+
+
+class ReasoningContent(BaseModel):
+    type: Literal["reasoning"]
+    text: str
+    encrypted_content: str | None = None
+
+
+class ValidToolArguments(BaseModel):
+    type: Literal["valid"]
+    value: dict[str, JsonValue]
+
+
+class ToolCallContent(BaseModel):
+    type: Literal["tool_call"]
+    tool_call_id: str
+    tool_name: str
+    arguments: ValidToolArguments
+
+
+AssistantContent = Annotated[
+    TextContent | ReasoningContent | ToolCallContent,
+    Field(discriminator="type"),
+]
+
+
+class UserMessage(BaseModel):
+    role: Literal["user"]
+    content: str
+
+
+class AssistantMessage(BaseModel):
+    role: Literal["assistant"]
+    content: list[AssistantContent]
+
+
+Message = Annotated[UserMessage | AssistantMessage, Field(discriminator="role")]
+
+
+class MessagesData(BaseModel):
+    type: Literal["messages"]
+    messages: list[Message]
+    usage: Usage | None = None
+
+
+class ToolResultValue(BaseModel):
+    ok: bool
+    preview: str
+    source: str
+    tool_name: str = Field(alias="toolName")
+    truncated: bool
+    value: JsonValue = None
+
+
+class ToolResultData(BaseModel):
+    type: Literal["tool_result"]
+    tool_call_id: str
+    result: ToolResultValue
+
+
+EventData = Annotated[MessagesData | ToolResultData, Field(discriminator="type")]
+
+
+class ConversationEvent(BaseModel):
+    id: str
+    session_id: str
+    turn_id: str
+    created_at: str
+    data: EventData
+
+
+class ConversationEvents(BaseModel):
+    events: list[ConversationEvent]
+    cursor: str | None = None
+
+
+async def export_trial_trajectory(
+    client: ExoClient,
+    conversation: str,
+    trial_id: str,
+    instruction: str,
+    model_name: str,
+    destination: Path,
+) -> None:
+    """Fetch and export every Exo turn that handled ``trial_id``."""
+    page = ConversationEvents.model_validate_json(
+        await client.read_conversation_events(
+            conversation,
+            types=["messages", "tool_result"],
+            limit=10_000,
+        )
+    )
+    marker = f"Trial `{trial_id}` has started"
+    start_index = next(
+        (
+            index
+            for index, event in enumerate(page.events)
+            if isinstance(event.data, MessagesData)
+            and any(
+                isinstance(message, UserMessage) and marker in message.content
+                for message in event.data.messages
+            )
+        ),
+        None,
+    )
+    if start_index is None:
+        raise ValueError(f"Exo turn for trial {trial_id} was not found")
+
+    events = page.events[start_index:]
+    turn_ids = list(dict.fromkeys(event.turn_id for event in events))
+    trajectory = build_trajectory(
+        events=events,
+        trial_id=trial_id,
+        turn_ids=turn_ids,
+        instruction=instruction,
+        model_name=model_name,
+        conversation=conversation,
+        started_at=events[0].created_at,
+    )
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_suffix(destination.suffix + ".tmp")
+    temporary.write_text(json.dumps(trajectory.to_json_dict(), indent=2) + "\n")
+    temporary.replace(destination)
+
+
+def build_trajectory(
+    *,
+    events: list[ConversationEvent],
+    trial_id: str,
+    turn_ids: list[str],
+    instruction: str,
+    model_name: str,
+    conversation: str,
+    started_at: str,
+) -> Trajectory:
+    """Map Exo's canonical events to one validated ATIF trajectory."""
+    steps = [
+        Step(
+            step_id=1,
+            timestamp=started_at,
+            source="user",
+            message=instruction,
+        )
+    ]
+    calls: dict[str, Step] = {}
+    usages: list[Usage] = []
+
+    for event in events:
+        if isinstance(event.data, MessagesData):
+            assistant_messages = [
+                message
+                for message in event.data.messages
+                if isinstance(message, AssistantMessage)
+            ]
+            if not assistant_messages:
+                continue
+
+            text: list[str] = []
+            reasoning: list[str] = []
+            tool_calls: list[ToolCall] = []
+            for message in assistant_messages:
+                for content in message.content:
+                    if isinstance(content, TextContent):
+                        if content.text:
+                            text.append(content.text)
+                    elif isinstance(content, ReasoningContent):
+                        if content.text:
+                            reasoning.append(content.text)
+                    else:
+                        tool_calls.append(
+                            ToolCall(
+                                tool_call_id=content.tool_call_id,
+                                function_name=content.tool_name,
+                                arguments=content.arguments.value,
+                            )
+                        )
+
+            metrics = _metrics(event.data.usage)
+            step = Step(
+                step_id=len(steps) + 1,
+                timestamp=event.created_at,
+                source="agent",
+                model_name=event.data.usage.model if event.data.usage else None,
+                message="\n".join(text),
+                reasoning_content="\n".join(reasoning) or None,
+                tool_calls=tool_calls or None,
+                metrics=metrics,
+                llm_call_count=1,
+            )
+            steps.append(step)
+            for call in tool_calls:
+                calls[call.tool_call_id] = step
+            if event.data.usage is not None:
+                usages.append(event.data.usage)
+            continue
+
+        result = event.data.result
+        step = calls.get(event.data.tool_call_id)
+        if step is None:
+            continue
+        observation = ObservationResult(
+            source_call_id=event.data.tool_call_id,
+            content=(
+                json.dumps(result.value, indent=2)
+                if result.value is not None
+                else result.preview
+            ),
+            extra={
+                "ok": result.ok,
+                "source": result.source,
+                "tool_name": result.tool_name,
+                "truncated": result.truncated,
+            },
+        )
+        if step.observation is None:
+            step.observation = Observation(results=[observation])
+        else:
+            step.observation.results.append(observation)
+
+    return Trajectory(
+        session_id=conversation,
+        trajectory_id=trial_id,
+        agent=Agent(name="exo", version="unknown", model_name=model_name),
+        steps=steps,
+        final_metrics=FinalMetrics(
+            total_prompt_tokens=sum(usage.prompt_tokens for usage in usages),
+            total_completion_tokens=sum(usage.completion_tokens for usage in usages),
+            total_cached_tokens=sum(usage.prompt_cached_tokens for usage in usages),
+            total_cost_usd=sum(usage.cost_usd for usage in usages),
+            total_steps=len(steps),
+        ),
+        extra={
+            "harbor_trial_id": trial_id,
+            "exo_agent": conventions.AGENT_SLUG,
+            "exo_conversation": conversation,
+            "exo_turn_ids": turn_ids,
+        },
+    )
+
+
+def _metrics(usage: Usage | None) -> Metrics | None:
+    if usage is None:
+        return None
+    return Metrics(
+        prompt_tokens=usage.prompt_tokens,
+        completion_tokens=usage.completion_tokens,
+        cached_tokens=usage.prompt_cached_tokens,
+        cost_usd=usage.cost_usd,
+        extra={"reasoning_tokens": usage.completion_reasoning_tokens},
+    )

--- a/eval/harbor/tests/test_agent.py
+++ b/eval/harbor/tests/test_agent.py
@@ -1,0 +1,54 @@
+import asyncio
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+from exo_harbor.agent import ExoAgent
+from exo_harbor.protocol import TrialStarted
+
+
+class ExoAgentTest(unittest.IsolatedAsyncioTestCase):
+    async def test_timeout_exports_partial_trajectory_after_trial_started(self) -> None:
+        with TemporaryDirectory() as directory:
+            agent = ExoAgent(
+                logs_dir=Path(directory),
+                exo_root=Path(directory) / "exo-root",
+                exo_bin=Path("/opt/exo/bin/exo"),
+                exo_repo_root=Path("/src/exo"),
+                exo_model="gpt-5.6-sol",
+            )
+            agent.context_id = uuid4()
+            agent._container_id = "container-1"
+
+            async def time_out(*args, on_started, **kwargs):
+                on_started(
+                    TrialStarted(
+                        request_id="request-1",
+                        target=str(agent.context_id),
+                        conversation_id="conversation-1",
+                    )
+                )
+                raise asyncio.TimeoutError
+
+            export = AsyncMock()
+            with (
+                patch("exo_harbor.agent.send_trial_run", side_effect=time_out),
+                patch("exo_harbor.agent.export_trial_trajectory", export),
+                self.assertRaises(asyncio.TimeoutError),
+            ):
+                await agent.run("Fix it", AsyncMock(), AsyncMock())
+
+            export.assert_awaited_once_with(
+                agent._client,
+                "conversation-1",
+                str(agent.context_id),
+                "Fix it",
+                "gpt-5.6-sol",
+                Path(directory) / "trajectory.json",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/eval/harbor/tests/test_agent.py
+++ b/eval/harbor/tests/test_agent.py
@@ -2,11 +2,11 @@ import asyncio
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 from exo_harbor.agent import ExoAgent
-from exo_harbor.protocol import TrialStarted
+from exo_harbor.protocol import TrialCancelled, TrialStarted
 
 
 class ExoAgentTest(unittest.IsolatedAsyncioTestCase):
@@ -22,12 +22,20 @@ class ExoAgentTest(unittest.IsolatedAsyncioTestCase):
             agent.context_id = uuid4()
             agent._container_id = "container-1"
 
-            async def time_out(*args, on_started, **kwargs):
+            async def time_out(*args, on_started, on_cancelled, **kwargs):
                 on_started(
                     TrialStarted(
                         request_id="request-1",
                         target=str(agent.context_id),
                         conversation_id="conversation-1",
+                    )
+                )
+                on_cancelled(
+                    TrialCancelled(
+                        request_id="request-1",
+                        target=str(agent.context_id),
+                        conversation_id="conversation-1",
+                        snapshot_id="snapshot-1",
                     )
                 )
                 raise asyncio.TimeoutError
@@ -38,7 +46,9 @@ class ExoAgentTest(unittest.IsolatedAsyncioTestCase):
                 patch("exo_harbor.agent.export_trial_trajectory", export),
                 self.assertRaises(asyncio.TimeoutError),
             ):
-                await agent.run("Fix it", AsyncMock(), AsyncMock())
+                context = MagicMock()
+                context.metadata = {}
+                await agent.run("Fix it", AsyncMock(), context)
 
             export.assert_awaited_once_with(
                 agent._client,
@@ -48,6 +58,8 @@ class ExoAgentTest(unittest.IsolatedAsyncioTestCase):
                 "gpt-5.6-sol",
                 Path(directory) / "trajectory.json",
             )
+            self.assertEqual(context.metadata["exo_snapshot_id"], "snapshot-1")
+            self.assertEqual(context.metadata["exo_instruction"], "Fix it")
 
 
 if __name__ == "__main__":

--- a/eval/harbor/tests/test_eval.py
+++ b/eval/harbor/tests/test_eval.py
@@ -29,6 +29,7 @@ class EvalScriptTest(unittest.TestCase):
         self.assertEqual(args.model, "gpt-5.5")
         self.assertIsNone(args.n_tasks)
         self.assertEqual(args.n_attempts, 1)
+        self.assertEqual(args.include_task_names, [])
 
     def test_all_tasks_omits_harbor_limit(self) -> None:
         args = self.parse()
@@ -121,6 +122,40 @@ class EvalScriptTest(unittest.TestCase):
                 "--include-task-name",
                 "cobol-modernization",
             ],
+        )
+
+    def test_include_task_names_can_be_repeated(self) -> None:
+        args = self.parse(
+            "--dataset=terminal-bench",
+            "--include-task-name=path-tracing",
+            "--include-task-name=gpt2-codegolf",
+        )
+
+        self.assertEqual(
+            eval_script.dataset_arguments(args),
+            [
+                "--dataset",
+                "terminal-bench@2.0",
+                "--include-task-name",
+                "path-tracing",
+                "--include-task-name",
+                "gpt2-codegolf",
+            ],
+        )
+
+    def test_include_task_names_can_come_from_config(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            config = Path(directory) / "eval.toml"
+            config.write_text(
+                'dataset = "terminal-bench"\n'
+                'include_task_names = ["path-tracing", "gpt2-codegolf"]\n'
+            )
+
+            args = self.parse(f"--config={config}")
+
+        self.assertEqual(
+            args.include_task_names,
+            ["path-tracing", "gpt2-codegolf"],
         )
 
     def test_result_paths_include_harbor_result_and_viewer(self) -> None:

--- a/eval/harbor/tests/test_eval.py
+++ b/eval/harbor/tests/test_eval.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT = Path(__file__).parents[1] / "eval.py"
+SPEC = importlib.util.spec_from_file_location("eval_script", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+eval_script = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(eval_script)
+
+
+class EvalScriptTest(unittest.TestCase):
+    def parse(self, *arguments: str):
+        with patch.object(sys, "argv", [str(SCRIPT), *arguments]):
+            return eval_script.parse_args()
+
+    def test_defaults_run_all_terminal_bench_tasks(self) -> None:
+        args = self.parse()
+
+        self.assertEqual(args.dataset, "terminal-bench")
+        self.assertEqual(args.model, "gpt-5.5")
+        self.assertIsNone(args.n_tasks)
+        self.assertEqual(args.n_attempts, 1)
+
+    def test_all_tasks_omits_harbor_limit(self) -> None:
+        args = self.parse()
+
+        command = eval_script.harbor_command(
+            args,
+            harbor="harbor",
+            repo=Path("/repo"),
+            exo=Path("/repo/exo"),
+            run_dir=Path("/runs/one"),
+            job_name="terminal-bench-all",
+        )
+
+        self.assertNotIn("--n-tasks", command)
+
+    def test_flags_override_config_file(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            config = Path(directory) / "eval.toml"
+            config.write_text(
+                'dataset = "terminal-bench-sample"\n'
+                'model = "configured-model"\n'
+                "n_tasks = 4\n"
+            )
+
+            args = self.parse(
+                f"--config={config}", "--model=flag-model", "--n-tasks=2"
+            )
+
+        self.assertEqual(args.dataset, "terminal-bench-sample")
+        self.assertEqual(args.model, "flag-model")
+        self.assertEqual(args.n_tasks, 2)
+
+    def test_local_dataset_path_can_come_from_config(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            dataset = Path(directory) / "dataset"
+            dataset.mkdir()
+            config = Path(directory) / "eval.toml"
+            config.write_text(
+                'dataset = "endless-terminals"\n'
+                f'dataset_path = "{dataset}"\n'
+            )
+
+            args = self.parse(f"--config={config}")
+
+            self.assertEqual(
+                eval_script.dataset_arguments(args), ["--path", str(dataset)]
+            )
+
+    def test_smoke_test_uses_the_bundled_task(self) -> None:
+        args = self.parse("--dataset=smoke-test")
+
+        self.assertEqual(
+            eval_script.dataset_arguments(args),
+            ["--path", str(SCRIPT.parent / "datasets/smoke-test")],
+        )
+
+    def test_self_evolution_smoke_test_uses_bundled_dataset(self) -> None:
+        args = self.parse("--dataset=self-evolution-smoke-test")
+        dataset = SCRIPT.parent / "datasets/self-evolution-smoke-test"
+
+        self.assertEqual(
+            eval_script.dataset_arguments(args),
+            [
+                "--path",
+                str(dataset),
+            ],
+        )
+        self.assertEqual(
+            sorted(path.name for path in dataset.iterdir()),
+            ["01-install-tool", "02-reuse-tool", "03-restart-policy"],
+        )
+
+    def test_terminal_bench_easy_selects_three_tasks(self) -> None:
+        args = self.parse("--dataset=terminal-bench-easy")
+
+        self.assertEqual(
+            eval_script.dataset_arguments(args),
+            [
+                "--dataset",
+                "terminal-bench@2.0",
+                "--include-task-name",
+                "fix-git",
+                "--include-task-name",
+                "prove-plus-comm",
+                "--include-task-name",
+                "cobol-modernization",
+            ],
+        )
+
+    def test_result_paths_include_harbor_result_and_viewer(self) -> None:
+        output = io.StringIO()
+
+        with redirect_stdout(output):
+            eval_script.print_result_paths(Path("/runs/one"), "terminal-bench-3")
+
+        self.assertIn(
+            "Harbor results: /runs/one/jobs/terminal-bench-3/result.json",
+            output.getvalue(),
+        )
+        self.assertIn(
+            "View: harbor view /runs/one/jobs",
+            output.getvalue(),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/eval/harbor/tests/test_eval.py
+++ b/eval/harbor/tests/test_eval.py
@@ -98,7 +98,12 @@ class EvalScriptTest(unittest.TestCase):
         )
         self.assertEqual(
             sorted(path.name for path in dataset.iterdir()),
-            ["01-install-tool", "02-reuse-tool", "03-restart-policy"],
+            [
+                "01-install-tool",
+                "02-reuse-tool",
+                "03-restart-policy",
+                "04-timeout-trajectory",
+            ],
         )
 
     def test_terminal_bench_easy_selects_three_tasks(self) -> None:

--- a/eval/harbor/tests/test_exo.py
+++ b/eval/harbor/tests/test_exo.py
@@ -7,6 +7,33 @@ from exo_harbor.exo import ExoClient
 
 
 class ExoClientTest(unittest.IsolatedAsyncioTestCase):
+    async def test_delete_snapshots_preserves_other_exo_state(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            exo_root = Path(temporary_directory) / "exo"
+            conversation = (
+                exo_root
+                / "exoharness"
+                / "agents"
+                / "agent-1"
+                / "conversations"
+                / "conversation-1"
+            )
+            snapshot = conversation / "snapshots" / "snapshot-1"
+            snapshot.mkdir(parents=True)
+            (snapshot / "payload.bin").write_bytes(b"snapshot")
+            (conversation / "record.json").write_text("{}", encoding="utf-8")
+            client = ExoClient(
+                exo_bin=Path("/opt/exo/bin/exo"),
+                exo_root=exo_root,
+                repo_root=Path("/src/exo"),
+            )
+
+            count = await client.delete_snapshots()
+
+            self.assertEqual(count, 1)
+            self.assertFalse((conversation / "snapshots").exists())
+            self.assertTrue((conversation / "record.json").exists())
+
     async def test_adapter_runner_uses_eval_root_and_records_pid(self) -> None:
         with TemporaryDirectory() as temporary_directory:
             exo_root = Path(temporary_directory) / "exo"

--- a/eval/harbor/tests/test_exo.py
+++ b/eval/harbor/tests/test_exo.py
@@ -1,0 +1,78 @@
+import unittest
+from tempfile import TemporaryDirectory
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from exo_harbor.exo import ExoClient
+
+
+class ExoClientTest(unittest.IsolatedAsyncioTestCase):
+    async def test_adapter_runner_uses_eval_root_and_records_pid(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            exo_root = Path(temporary_directory) / "exo"
+            client = ExoClient(
+                exo_bin=Path("/opt/exo/bin/exo"),
+                exo_root=exo_root,
+                repo_root=Path("/src/exo"),
+            )
+            process = MagicMock(pid=1234)
+            with patch("exo_harbor.exo.subprocess.Popen", return_value=process) as popen:
+                client._spawn_adapter_runner()
+
+            self.assertEqual(
+                (exo_root / "exo-adapters.pid").read_text(encoding="utf-8"),
+                "1234\n",
+            )
+            self.assertEqual(popen.call_args.kwargs["env"]["EXO_ROOT"], str(exo_root))
+
+    async def test_evaluation_agent_can_create_tools(self) -> None:
+        client = ExoClient(
+            exo_bin=Path("/opt/exo/bin/exo"),
+            exo_root=Path("/tmp/exo-root"),
+            repo_root=Path("/src/exo"),
+        )
+        exists = AsyncMock(return_value=False)
+        run = AsyncMock()
+        with (
+            patch.object(ExoClient, "_exists", exists),
+            patch.object(ExoClient, "_run", run),
+        ):
+            await client.ensure_agent("gpt-5.5")
+
+        self.assertIn("--tool-creation", run.await_args.args)
+        self.assertIn("enabled", run.await_args.args)
+
+    async def test_read_conversation_events_filters_one_turn(self) -> None:
+        client = ExoClient(
+            exo_bin=Path("/opt/exo/bin/exo"),
+            exo_root=Path("/tmp/exo-root"),
+            repo_root=Path("/src/exo"),
+        )
+        run = AsyncMock(return_value='{"events":[],"cursor":null}')
+        with patch.object(ExoClient, "_run", run):
+            result = await client.read_conversation_events(
+                "conversation",
+                types=["messages", "tool_result"],
+                turn_id="turn-1",
+                limit=10_000,
+            )
+
+        self.assertEqual(result, '{"events":[],"cursor":null}')
+        run.assert_awaited_once_with(
+            "conversation",
+            "events",
+            "harbor-eval",
+            "conversation",
+            "--type",
+            "messages",
+            "--type",
+            "tool_result",
+            "--turn-id",
+            "turn-1",
+            "--limit",
+            "10000",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/eval/harbor/tests/test_feedback.py
+++ b/eval/harbor/tests/test_feedback.py
@@ -1,0 +1,36 @@
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import SimpleNamespace
+
+from exo_harbor.feedback import REFLECTION_INSTRUCTIONS, build_feedback
+
+
+class FeedbackTest(unittest.TestCase):
+    def test_reflection_requires_durable_learning_before_completion(self) -> None:
+        self.assertIn("persist every useful generalizable lesson", REFLECTION_INSTRUCTIONS)
+        self.assertIn("does not persist learning", REFLECTION_INSTRUCTIONS)
+
+    def test_includes_rewards_exception_and_verifier_output(self) -> None:
+        with TemporaryDirectory() as directory:
+            verifier_dir = Path(directory)
+            (verifier_dir / "test-stdout.txt").write_text("one test failed")
+            result = SimpleNamespace(
+                verifier_result=SimpleNamespace(rewards={"reward": 0.5}),
+                exception_info=SimpleNamespace(
+                    model_dump=lambda **_kwargs: {"message": "verification failed"}
+                ),
+            )
+
+            feedback = json.loads(build_feedback(result, verifier_dir))
+
+        self.assertEqual(feedback["rewards"], {"reward": 0.5})
+        self.assertEqual(feedback["exception"]["message"], "verification failed")
+        self.assertEqual(
+            feedback["verifier_logs"]["test-stdout.txt"], "one test failed"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/eval/harbor/tests/test_plugin.py
+++ b/eval/harbor/tests/test_plugin.py
@@ -1,14 +1,44 @@
 import unittest
-from unittest.mock import AsyncMock
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
-from exo_harbor.plugin import ExoSessionPlugin
+from exo_harbor.plugin import ExoSessionPlugin, _export_trajectory
 
 
 class ExoSessionPluginTest(unittest.IsolatedAsyncioTestCase):
-    async def test_job_end_has_no_side_effects(self) -> None:
+    async def test_trajectory_export_failure_does_not_fail_trial(self) -> None:
+        with (
+            patch(
+                "exo_harbor.plugin.export_trial_trajectory",
+                AsyncMock(side_effect=ValueError("missing turn")),
+            ),
+            patch("exo_harbor.plugin.logger.exception") as log_exception,
+        ):
+            await _export_trajectory(
+                AsyncMock(),
+                "conversation-1",
+                "trial-1",
+                "instruction",
+                "model",
+                Path("trajectory.json"),
+            )
+
+        log_exception.assert_called_once()
+
+    async def test_job_end_without_started_client_has_no_side_effects(self) -> None:
         plugin = ExoSessionPlugin()
 
         await plugin.on_job_end(AsyncMock())
+
+    async def test_job_end_deletes_snapshots(self) -> None:
+        plugin = ExoSessionPlugin()
+        client = AsyncMock()
+        client.delete_snapshots.return_value = 3
+        plugin._client = client
+
+        await plugin.on_job_end(AsyncMock())
+
+        client.delete_snapshots.assert_awaited_once_with()
 
 
 if __name__ == "__main__":

--- a/eval/harbor/tests/test_plugin.py
+++ b/eval/harbor/tests/test_plugin.py
@@ -1,0 +1,15 @@
+import unittest
+from unittest.mock import AsyncMock
+
+from exo_harbor.plugin import ExoSessionPlugin
+
+
+class ExoSessionPluginTest(unittest.IsolatedAsyncioTestCase):
+    async def test_job_end_has_no_side_effects(self) -> None:
+        plugin = ExoSessionPlugin()
+
+        await plugin.on_job_end(AsyncMock())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/eval/harbor/tests/test_protocol.py
+++ b/eval/harbor/tests/test_protocol.py
@@ -6,13 +6,78 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from exo_harbor.protocol import TrialRun, TrialStarted, send_trial_run
+from exo_harbor.protocol import (
+    FeedbackStarted,
+    TrialCancelled,
+    TrialFeedback,
+    TrialRun,
+    TrialStarted,
+    send_trial_feedback,
+    send_trial_run,
+)
 
 
 class TrialProtocolTest(unittest.IsolatedAsyncioTestCase):
+    async def test_sends_feedback_and_waits_for_explicit_completion(self) -> None:
+        request = TrialFeedback(
+            request_id="feedback-1",
+            target="trial-1",
+            instructions="Extract reusable lessons.",
+            feedback="The edge case failed.",
+        )
+        started: list[FeedbackStarted] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            socket_path = Path(directory) / "trial.sock"
+
+            async def respond(
+                reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+            ) -> None:
+                self.assertEqual(json.loads(await reader.readline()), request.payload())
+                for envelope, event in (
+                    (
+                        "event",
+                        {
+                            "type": "feedback_started",
+                            "request_id": "feedback-1",
+                            "target": "trial-1",
+                            "conversation_id": "conversation-1",
+                            "sandbox_id": "sandbox-2",
+                        },
+                    ),
+                    (
+                        "response",
+                        {
+                            "type": "feedback_complete",
+                            "request_id": "feedback-1",
+                            "target": "trial-1",
+                            "conversation_id": "conversation-1",
+                            "summary": "learned",
+                        },
+                    ),
+                ):
+                    writer.write(
+                        f"{json.dumps({'type': envelope, 'event': event})}\n".encode()
+                    )
+                await writer.drain()
+                writer.close()
+                await writer.wait_closed()
+
+            server = await asyncio.start_unix_server(respond, path=socket_path)
+            response = await send_trial_feedback(
+                socket_path, request, timeout_sec=1, on_started=started.append
+            )
+            server.close()
+            await server.wait_closed()
+
+        self.assertEqual(response.conversation_id, "conversation-1")
+        self.assertEqual(response.summary, "learned")
+        self.assertEqual(started[0].sandbox_id, "sandbox-2")
+
     async def test_cancellation_propagates_and_closes_socket(self) -> None:
         request_received = asyncio.Event()
         client_disconnected = asyncio.Event()
+        cancelled: list[dict] = []
 
         with tempfile.TemporaryDirectory() as directory:
             socket_path = Path(directory) / "trial.sock"
@@ -20,14 +85,36 @@ class TrialProtocolTest(unittest.IsolatedAsyncioTestCase):
             async def wait_forever(
                 reader: asyncio.StreamReader, writer: asyncio.StreamWriter
             ) -> None:
-                await reader.readline()
-                request_received.set()
-                await reader.read()
-                client_disconnected.set()
+                request = json.loads(await reader.readline())
+                if request["type"] == "trial_cancel":
+                    cancelled.append(request)
+                    writer.write(
+                        (
+                            json.dumps(
+                                {
+                                    "type": "response",
+                                    "event": {
+                                        "type": "trial_cancelled",
+                                        "request_id": "request-1",
+                                        "target": "trial-1",
+                                        "conversation_id": "conversation-1",
+                                        "snapshot_id": "snapshot-1",
+                                    },
+                                }
+                            )
+                            + "\n"
+                        ).encode()
+                    )
+                    await writer.drain()
+                else:
+                    request_received.set()
+                    await reader.read()
+                    client_disconnected.set()
                 writer.close()
                 await writer.wait_closed()
 
             server = await asyncio.start_unix_server(wait_forever, path=socket_path)
+            cancellation: list[TrialCancelled] = []
             task = asyncio.create_task(
                 send_trial_run(
                     socket_path,
@@ -38,6 +125,7 @@ class TrialProtocolTest(unittest.IsolatedAsyncioTestCase):
                         instructions="Fix it",
                     ),
                     timeout_sec=None,
+                    on_cancelled=cancellation.append,
                 )
             )
             await asyncio.wait_for(request_received.wait(), timeout=1)
@@ -45,6 +133,17 @@ class TrialProtocolTest(unittest.IsolatedAsyncioTestCase):
             with self.assertRaises(asyncio.CancelledError):
                 await task
             await asyncio.wait_for(client_disconnected.wait(), timeout=1)
+            self.assertEqual(
+                cancelled,
+                [
+                    {
+                        "type": "trial_cancel",
+                        "request_id": "request-1",
+                        "target": "trial-1",
+                    }
+                ],
+            )
+            self.assertEqual(cancellation[0].snapshot_id, "snapshot-1")
             server.close()
             await server.wait_closed()
 
@@ -121,6 +220,7 @@ class TrialProtocolTest(unittest.IsolatedAsyncioTestCase):
                             "request_id": "request-1",
                             "target": "trial-1",
                             "conversation_id": "conversation-1",
+                            "snapshot_id": "snapshot-1",
                             "summary": "done",
                         },
                     },
@@ -138,6 +238,7 @@ class TrialProtocolTest(unittest.IsolatedAsyncioTestCase):
             await second.wait_closed()
 
         self.assertEqual(received, [request.payload(), request.payload()])
+        self.assertEqual(response.snapshot_id, "snapshot-1")
         self.assertEqual(
             started,
             [
@@ -160,7 +261,29 @@ class TrialProtocolTest(unittest.IsolatedAsyncioTestCase):
             async def start_only(
                 reader: asyncio.StreamReader, writer: asyncio.StreamWriter
             ) -> None:
-                await reader.readline()
+                request = json.loads(await reader.readline())
+                if request["type"] == "trial_cancel":
+                    writer.write(
+                        (
+                            json.dumps(
+                                {
+                                    "type": "response",
+                                    "event": {
+                                        "type": "trial_cancelled",
+                                        "request_id": "request-1",
+                                        "target": "trial-1",
+                                        "conversation_id": "conversation-1",
+                                        "snapshot_id": "snapshot-1",
+                                    },
+                                }
+                            )
+                            + "\n"
+                        ).encode()
+                    )
+                    await writer.drain()
+                    writer.close()
+                    await writer.wait_closed()
+                    return
                 writer.write(
                     (
                         json.dumps(

--- a/eval/harbor/tests/test_protocol.py
+++ b/eval/harbor/tests/test_protocol.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from exo_harbor.protocol import TrialRun, send_trial_run
+
+
+class TrialProtocolTest(unittest.IsolatedAsyncioTestCase):
+    async def test_cancellation_propagates_and_closes_socket(self) -> None:
+        request_received = asyncio.Event()
+        client_disconnected = asyncio.Event()
+
+        with tempfile.TemporaryDirectory() as directory:
+            socket_path = Path(directory) / "trial.sock"
+
+            async def wait_forever(
+                reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+            ) -> None:
+                await reader.readline()
+                request_received.set()
+                await reader.read()
+                client_disconnected.set()
+                writer.close()
+                await writer.wait_closed()
+
+            server = await asyncio.start_unix_server(wait_forever, path=socket_path)
+            task = asyncio.create_task(
+                send_trial_run(
+                    socket_path,
+                    TrialRun(
+                        request_id="request-1",
+                        target="trial-1",
+                        container_id="container-1",
+                        instructions="Fix it",
+                    ),
+                    timeout_sec=None,
+                )
+            )
+            await asyncio.wait_for(request_received.wait(), timeout=1)
+            task.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await task
+            await asyncio.wait_for(client_disconnected.wait(), timeout=1)
+            server.close()
+            await server.wait_closed()
+
+    async def test_reconnects_with_same_request_after_worker_restart(self) -> None:
+        request = TrialRun(
+            request_id="request-1",
+            target="trial-1",
+            container_id="container-1",
+            instructions="Fix it",
+        )
+        received: list[dict] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            socket_path = Path(directory) / "trial.sock"
+
+            async def disconnect(
+                reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+            ) -> None:
+                received.append(json.loads(await reader.readline()))
+                writer.close()
+                await writer.wait_closed()
+
+            first = await asyncio.start_unix_server(disconnect, path=socket_path)
+            task = asyncio.create_task(
+                send_trial_run(socket_path, request, timeout_sec=5)
+            )
+            while not received:
+                await asyncio.sleep(0.01)
+            first.close()
+            await first.wait_closed()
+            socket_path.unlink(missing_ok=True)
+
+            async def complete(
+                reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+            ) -> None:
+                received.append(json.loads(await reader.readline()))
+                writer.write(
+                    (
+                        json.dumps(
+                            {
+                                "type": "response",
+                                "event": {
+                                    "type": "trial_complete",
+                                    "request_id": "request-1",
+                                    "target": "trial-1",
+                                    "conversation_id": "conversation-1",
+                                    "summary": "done",
+                                },
+                            }
+                        )
+                        + "\n"
+                    ).encode()
+                )
+                await writer.drain()
+                writer.close()
+                await writer.wait_closed()
+
+            second = await asyncio.start_unix_server(complete, path=socket_path)
+            response = await task
+            second.close()
+            await second.wait_closed()
+
+        self.assertEqual(received, [request.payload(), request.payload()])
+        self.assertEqual(response.conversation_id, "conversation-1")
+        self.assertEqual(response.summary, "done")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/eval/harbor/tests/test_protocol.py
+++ b/eval/harbor/tests/test_protocol.py
@@ -6,7 +6,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from exo_harbor.protocol import TrialRun, send_trial_run
+from exo_harbor.protocol import TrialRun, TrialStarted, send_trial_run
 
 
 class TrialProtocolTest(unittest.IsolatedAsyncioTestCase):
@@ -56,6 +56,7 @@ class TrialProtocolTest(unittest.IsolatedAsyncioTestCase):
             instructions="Fix it",
         )
         received: list[dict] = []
+        started: list[TrialStarted] = []
 
         with tempfile.TemporaryDirectory() as directory:
             socket_path = Path(directory) / "trial.sock"
@@ -64,12 +65,34 @@ class TrialProtocolTest(unittest.IsolatedAsyncioTestCase):
                 reader: asyncio.StreamReader, writer: asyncio.StreamWriter
             ) -> None:
                 received.append(json.loads(await reader.readline()))
+                writer.write(
+                    (
+                        json.dumps(
+                            {
+                                "type": "event",
+                                "event": {
+                                    "type": "trial_started",
+                                    "request_id": "request-1",
+                                    "target": "trial-1",
+                                    "conversation_id": "conversation-1",
+                                },
+                            }
+                        )
+                        + "\n"
+                    ).encode()
+                )
+                await writer.drain()
                 writer.close()
                 await writer.wait_closed()
 
             first = await asyncio.start_unix_server(disconnect, path=socket_path)
             task = asyncio.create_task(
-                send_trial_run(socket_path, request, timeout_sec=5)
+                send_trial_run(
+                    socket_path,
+                    request,
+                    timeout_sec=5,
+                    on_started=started.append,
+                )
             )
             while not received:
                 await asyncio.sleep(0.01)
@@ -81,22 +104,29 @@ class TrialProtocolTest(unittest.IsolatedAsyncioTestCase):
                 reader: asyncio.StreamReader, writer: asyncio.StreamWriter
             ) -> None:
                 received.append(json.loads(await reader.readline()))
+                messages = [
+                    {
+                        "type": "event",
+                        "event": {
+                            "type": "trial_started",
+                            "request_id": "request-1",
+                            "target": "trial-1",
+                            "conversation_id": "conversation-1",
+                        },
+                    },
+                    {
+                        "type": "response",
+                        "event": {
+                            "type": "trial_complete",
+                            "request_id": "request-1",
+                            "target": "trial-1",
+                            "conversation_id": "conversation-1",
+                            "summary": "done",
+                        },
+                    },
+                ]
                 writer.write(
-                    (
-                        json.dumps(
-                            {
-                                "type": "response",
-                                "event": {
-                                    "type": "trial_complete",
-                                    "request_id": "request-1",
-                                    "target": "trial-1",
-                                    "conversation_id": "conversation-1",
-                                    "summary": "done",
-                                },
-                            }
-                        )
-                        + "\n"
-                    ).encode()
+                    "".join(f"{json.dumps(message)}\n" for message in messages).encode()
                 )
                 await writer.drain()
                 writer.close()
@@ -108,8 +138,67 @@ class TrialProtocolTest(unittest.IsolatedAsyncioTestCase):
             await second.wait_closed()
 
         self.assertEqual(received, [request.payload(), request.payload()])
+        self.assertEqual(
+            started,
+            [
+                TrialStarted(
+                    request_id="request-1",
+                    target="trial-1",
+                    conversation_id="conversation-1",
+                )
+            ],
+        )
         self.assertEqual(response.conversation_id, "conversation-1")
         self.assertEqual(response.summary, "done")
+
+    async def test_timeout_retains_started_conversation(self) -> None:
+        started: list[TrialStarted] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            socket_path = Path(directory) / "trial.sock"
+
+            async def start_only(
+                reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+            ) -> None:
+                await reader.readline()
+                writer.write(
+                    (
+                        json.dumps(
+                            {
+                                "type": "event",
+                                "event": {
+                                    "type": "trial_started",
+                                    "request_id": "request-1",
+                                    "target": "trial-1",
+                                    "conversation_id": "conversation-1",
+                                },
+                            }
+                        )
+                        + "\n"
+                    ).encode()
+                )
+                await writer.drain()
+                await reader.read()
+                writer.close()
+                await writer.wait_closed()
+
+            server = await asyncio.start_unix_server(start_only, path=socket_path)
+            with self.assertRaises(asyncio.TimeoutError):
+                await send_trial_run(
+                    socket_path,
+                    TrialRun(
+                        request_id="request-1",
+                        target="trial-1",
+                        container_id="container-1",
+                        instructions="Fix it",
+                    ),
+                    timeout_sec=0.05,
+                    on_started=started.append,
+                )
+            server.close()
+            await server.wait_closed()
+
+        self.assertEqual(started[0].conversation_id, "conversation-1")
 
 
 if __name__ == "__main__":

--- a/eval/harbor/tests/test_trajectory.py
+++ b/eval/harbor/tests/test_trajectory.py
@@ -1,0 +1,193 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+from exo_harbor.trajectory import (
+    ConversationEvents,
+    build_trajectory,
+    export_trial_trajectory,
+)
+
+
+TRIAL_ID = "514afdba-87e0-43cc-a3ac-86422ade3cf8"
+TURN_ID = "019fde0e-d687-7be3-8771-d9f5a4309e0d"
+CONTINUATION_TURN_ID = "019fde0e-e000-7000-8000-000000000001"
+
+
+def event_page(events: list[dict]) -> str:
+    return json.dumps({"events": events, "cursor": events[-1]["id"] if events else None})
+
+
+def messages_event(
+    event_id: str,
+    messages: list[dict],
+    *,
+    turn_id: str = TURN_ID,
+    usage: dict | None = None,
+) -> dict:
+    data = {"type": "messages", "messages": messages, "response_id": None}
+    if usage is not None:
+        data["usage"] = usage
+    return {
+        "id": event_id,
+        "thread_id": "conversation-id",
+        "session_id": "session-id",
+        "turn_id": turn_id,
+        "created_at": "2026-08-07T21:09:02.215Z",
+        "data": data,
+    }
+
+
+class TrajectoryTest(unittest.IsolatedAsyncioTestCase):
+    async def test_export_includes_trial_continuation_turns_and_writes_atif(self) -> None:
+        other = messages_event(
+            "event-1",
+            [{"role": "user", "content": "Trial `other-trial` has started"}],
+            turn_id="other-turn",
+        )
+        start = messages_event(
+            "event-2",
+            [
+                {
+                    "role": "user",
+                    "content": f"Trial `{TRIAL_ID}` has started.",
+                }
+            ],
+        )
+        assistant = messages_event(
+            "event-3",
+            [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "reasoning",
+                            "text": "Inspect the output.",
+                            "encrypted_content": "ciphertext",
+                        },
+                        {
+                            "type": "tool_call",
+                            "tool_call_id": "call-1",
+                            "tool_name": "shell",
+                            "arguments": {
+                                "type": "valid",
+                                "value": {"command": "run tests"},
+                            },
+                        },
+                    ],
+                    "id": "response-item",
+                }
+            ],
+            usage={
+                "model": "gpt-5.5-2026-04-23",
+                "prompt_tokens": 100,
+                "completion_tokens": 20,
+                "prompt_cached_tokens": 80,
+                "completion_reasoning_tokens": 10,
+                "cost_usd": 0.02,
+            },
+        )
+        tool_result = {
+            "id": "event-4",
+            "thread_id": "conversation-id",
+            "session_id": "session-id",
+            "turn_id": TURN_ID,
+            "created_at": "2026-08-07T21:09:03.215Z",
+            "data": {
+                "type": "tool_result",
+                "tool_call_id": "call-1",
+                "result": {
+                    "ok": True,
+                    "preview": '{"stdout":"Smy Smy"}',
+                    "source": "built_in",
+                    "toolName": "shell",
+                    "truncated": False,
+                    "value": {"exit_code": 0, "stdout": "Smy Smy", "stderr": ""},
+                },
+            },
+        }
+        continuation = messages_event(
+            "event-5",
+            [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Continued after restart.",
+                        }
+                    ],
+                    "id": "continuation-response",
+                }
+            ],
+            turn_id=CONTINUATION_TURN_ID,
+        )
+        client = AsyncMock()
+        client.read_conversation_events.return_value = event_page(
+            [other, start, assistant, tool_result, continuation]
+        )
+
+        with tempfile.TemporaryDirectory() as directory:
+            destination = Path(directory) / "agent" / "trajectory.json"
+            await export_trial_trajectory(
+                client,
+                "harbor-shared",
+                TRIAL_ID,
+                "Do the task",
+                "gpt-5.5",
+                destination,
+            )
+            output = json.loads(destination.read_text())
+
+        self.assertEqual(output["schema_version"], "ATIF-v1.7")
+        self.assertEqual(output["trajectory_id"], TRIAL_ID)
+        self.assertEqual(output["session_id"], "harbor-shared")
+        self.assertEqual(output["steps"][0]["message"], "Do the task")
+        self.assertEqual(len(output["steps"]), 3)
+        agent_step = output["steps"][1]
+        self.assertEqual(agent_step["reasoning_content"], "Inspect the output.")
+        self.assertEqual(agent_step["tool_calls"][0]["function_name"], "shell")
+        self.assertIn("Smy Smy", agent_step["observation"]["results"][0]["content"])
+        self.assertEqual(output["final_metrics"]["total_prompt_tokens"], 100)
+        self.assertEqual(output["steps"][2]["message"], "Continued after restart.")
+        self.assertEqual(
+            output["extra"]["exo_turn_ids"],
+            [TURN_ID, CONTINUATION_TURN_ID],
+        )
+        self.assertNotIn("ciphertext", json.dumps(output))
+        client.read_conversation_events.assert_awaited_once_with(
+            "harbor-shared",
+            types=["messages", "tool_result"],
+            limit=10_000,
+        )
+
+    def test_build_trajectory_replaces_adapter_envelope_with_instruction(self) -> None:
+        events = ConversationEvents.model_validate_json(
+            event_page(
+                [
+                    messages_event(
+                        "event-1",
+                        [{"role": "user", "content": "adapter protocol envelope"}],
+                    )
+                ]
+            )
+        ).events
+
+        trajectory = build_trajectory(
+            events=events,
+            trial_id=TRIAL_ID,
+            turn_ids=[TURN_ID],
+            instruction="Do the task",
+            model_name="gpt-5.5",
+            conversation="harbor-shared",
+            started_at="2026-08-07T21:09:02.215Z",
+        )
+
+        self.assertEqual(len(trajectory.steps), 1)
+        self.assertEqual(trajectory.steps[0].message, "Do the task")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/exo/adapters/protocol.ts
+++ b/exo/adapters/protocol.ts
@@ -31,6 +31,11 @@ export type WorkerInboundEvent =
       attachments?: AdapterAttachment[];
     }
   | {
+      type: "control";
+      target: string;
+      metadata: JsonObject;
+    }
+  | {
       type: "lifecycle";
       name: string;
       metadata?: JsonObject;

--- a/exo/adapters/trial/README.md
+++ b/exo/adapters/trial/README.md
@@ -1,0 +1,32 @@
+# Trial Adapter
+
+This adapter provides an interface to hand off containerized work to Exo over a local Unix socket. It manages the end-to-end complexities of running a task such as handling rebuild/restart continuations. Eventually it will also enable cancelling a running trial.
+
+Each `target` recieves a dedicated convo, while all trials share the same persistent Exo agent so retain memories, tools, harness edits, etc.
+
+The given container is assumed to be owned by the caller, i.e. the responsibolity to manage its lifecycle is on the caller.
+
+There are two classes of events: _trial_run_ and _feedback_.
+
+## Trial Run
+
+The trial run event schema is as follows:
+
+```json
+{
+  "type": "trial_run",
+  "request_id": "unique request id",
+  "target": "stable trial id",
+  "container_id": "running Docker container id",
+  "instructions": "work to perform"
+}
+```
+
+The caller waits for `trial_complete`. The response includes the Exo
+conversation id for trajectory export. Pending requests are persisted and
+replayed after an Exo restart; completion requires an explicit
+`send_adapter_message` call from the trial conversation.
+
+## Feedback
+
+Feedback is not implemented yet. When implented, it will provide a way for evaluation feedback to be handed off to Exo for reflection and self-improvement. This will use the same conversation, and a container containing the state at submission time.

--- a/exo/adapters/trial/README.md
+++ b/exo/adapters/trial/README.md
@@ -2,9 +2,11 @@
 
 This adapter provides an interface to hand off containerized work to Exo over a local Unix socket. It manages the end-to-end complexities of running a task such as handling rebuild/restart continuations. Eventually it will also enable cancelling a running trial.
 
-Each `target` recieves a dedicated convo, while all trials share the same persistent Exo agent so retain memories, tools, harness edits, etc.
+Each `target` receives a dedicated conversation, while all trials share the
+same persistent Exo agent and therefore retain memories, tools, harness edits,
+and other durable learning.
 
-The given container is assumed to be owned by the caller, i.e. the responsibolity to manage its lifecycle is on the caller.
+The given container remains owned by the caller, which manages its lifecycle.
 
 There are two classes of events: _trial_run_ and _feedback_.
 
@@ -22,11 +24,36 @@ The trial run event schema is as follows:
 }
 ```
 
-The caller waits for `trial_complete`. The response includes the Exo
-conversation id for trajectory export. Pending requests are persisted and
-replayed after an Exo restart; completion requires an explicit
-`send_adapter_message` call from the trial conversation.
+The caller first receives `trial_started`, then waits for `trial_complete`.
+Completion snapshots the submitted container and returns both the Exo
+conversation id and snapshot id. Pending requests are persisted and replayed
+after an Exo restart; completion requires an explicit `send_adapter_message`
+call from the trial conversation.
 
 ## Feedback
 
-Feedback is not implemented yet. When implented, it will provide a way for evaluation feedback to be handed off to Exo for reflection and self-improvement. This will use the same conversation, and a container containing the state at submission time.
+After grading, the caller may send one feedback request on the same target:
+
+```json
+{
+  "type": "trial_feedback",
+  "request_id": "new unique request id",
+  "target": "the same stable trial id",
+  "instructions": "how to reflect and retain useful learning",
+  "feedback": "rewards, verifier output, and failure details"
+}
+```
+
+The adapter creates an Exo-owned sandbox from the submission snapshot and
+wakes the original conversation. It emits `feedback_started`, then waits for
+Exo to explicitly send `feedback_complete`. Feedback does not create another
+snapshot.
+
+## Cancellation
+
+When the evaluator times out or otherwise cancels its wait, it sends a
+`trial_cancel` control request containing the active `request_id` and `target`.
+The worker removes that request from durable pending state and acknowledges
+`trial_cancelled`, preventing a deleted task container from being replayed
+after later adapter restarts. Cancellation does not yet interrupt an active
+Exo turn.

--- a/exo/adapters/trial/trial.test.ts
+++ b/exo/adapters/trial/trial.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { composeTrialPrompt, parseTrialComplete, parseTrialRun } from "./trial";
+import { composeTrialPrompt, parseTrialResponse, parseTrialRun } from "./trial";
 
 const request = parseTrialRun({
   type: "trial_run",
@@ -21,7 +21,7 @@ describe("trial adapter protocol", () => {
 
   it("validates the runtime-completed response", () => {
     expect(
-      parseTrialComplete(
+      parseTrialResponse(
         JSON.stringify({
           type: "trial_complete",
           request_id: "request-1",
@@ -37,6 +37,25 @@ describe("trial adapter protocol", () => {
       target: "trial-1",
       conversation_id: "conversation-1",
       summary: "done",
+    });
+  });
+
+  it("validates the runtime-started response", () => {
+    expect(
+      parseTrialResponse(
+        JSON.stringify({
+          type: "trial_started",
+          request_id: "request-1",
+          target: "trial-1",
+          conversation_id: "conversation-1",
+        }),
+        request,
+      ),
+    ).toEqual({
+      type: "trial_started",
+      request_id: "request-1",
+      target: "trial-1",
+      conversation_id: "conversation-1",
     });
   });
 });

--- a/exo/adapters/trial/trial.test.ts
+++ b/exo/adapters/trial/trial.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from "vitest";
 
-import { composeTrialPrompt, parseTrialResponse, parseTrialRun } from "./trial";
+import {
+  composeTrialPrompt,
+  parseTrialRequest,
+  parseTrialResponse,
+  parseTrialSocketRequest,
+} from "./trial";
 
-const request = parseTrialRun({
+const request = parseTrialRequest({
   type: "trial_run",
   request_id: "request-1",
   target: "trial-1",
@@ -11,6 +16,20 @@ const request = parseTrialRun({
 });
 
 describe("trial adapter protocol", () => {
+  it("parses cancellation as a socket control request", () => {
+    expect(
+      parseTrialSocketRequest({
+        type: "trial_cancel",
+        request_id: "request-1",
+        target: "trial-1",
+      }),
+    ).toEqual({
+      type: "trial_cancel",
+      request_id: "request-1",
+      target: "trial-1",
+    });
+  });
+
   it("parses a trial and composes the explicit completion protocol", () => {
     const prompt = composeTrialPrompt(request, "adapter-1", false);
     expect(prompt).toContain("Fix the service");
@@ -27,6 +46,7 @@ describe("trial adapter protocol", () => {
           request_id: "request-1",
           target: "trial-1",
           conversation_id: "conversation-1",
+          snapshot_id: "snapshot-1",
           summary: "done",
         }),
         request,
@@ -36,7 +56,29 @@ describe("trial adapter protocol", () => {
       request_id: "request-1",
       target: "trial-1",
       conversation_id: "conversation-1",
+      snapshot_id: "snapshot-1",
       summary: "done",
+    });
+  });
+
+  it("validates a cancellation snapshot response", () => {
+    expect(
+      parseTrialResponse(
+        JSON.stringify({
+          type: "trial_cancelled",
+          request_id: "request-1",
+          target: "trial-1",
+          conversation_id: "conversation-1",
+          snapshot_id: "snapshot-1",
+        }),
+        request,
+      ),
+    ).toEqual({
+      type: "trial_cancelled",
+      request_id: "request-1",
+      target: "trial-1",
+      conversation_id: "conversation-1",
+      snapshot_id: "snapshot-1",
     });
   });
 
@@ -56,6 +98,40 @@ describe("trial adapter protocol", () => {
       request_id: "request-1",
       target: "trial-1",
       conversation_id: "conversation-1",
+    });
+  });
+
+  it("composes and validates feedback in the restored trial", () => {
+    const feedback = parseTrialRequest({
+      type: "trial_feedback",
+      request_id: "feedback-1",
+      target: "trial-1",
+      instructions: "Extract reusable lessons and improve your tools.",
+      feedback: "The verifier found an edge case.",
+    });
+    const prompt = composeTrialPrompt(feedback, "adapter-1", false);
+    expect(prompt).toContain("restored snapshot");
+    expect(prompt).toContain("The verifier found an edge case.");
+    expect(prompt).toContain("Extract reusable lessons");
+    expect(prompt).toContain('"type":"feedback_complete"');
+
+    expect(
+      parseTrialResponse(
+        JSON.stringify({
+          type: "feedback_complete",
+          request_id: "feedback-1",
+          target: "trial-1",
+          conversation_id: "conversation-1",
+          summary: "learned",
+        }),
+        feedback,
+      ),
+    ).toEqual({
+      type: "feedback_complete",
+      request_id: "feedback-1",
+      target: "trial-1",
+      conversation_id: "conversation-1",
+      summary: "learned",
     });
   });
 });

--- a/exo/adapters/trial/trial.test.ts
+++ b/exo/adapters/trial/trial.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { composeTrialPrompt, parseTrialComplete, parseTrialRun } from "./trial";
+
+const request = parseTrialRun({
+  type: "trial_run",
+  request_id: "request-1",
+  target: "trial-1",
+  container_id: "container-1",
+  instructions: "Fix the service",
+});
+
+describe("trial adapter protocol", () => {
+  it("parses a trial and composes the explicit completion protocol", () => {
+    const prompt = composeTrialPrompt(request, "adapter-1", false);
+    expect(prompt).toContain("Fix the service");
+    expect(prompt).toContain("send_adapter_message");
+    expect(prompt).toContain("target `trial-1`");
+    expect(prompt).toContain('"request_id":"request-1"');
+  });
+
+  it("validates the runtime-completed response", () => {
+    expect(
+      parseTrialComplete(
+        JSON.stringify({
+          type: "trial_complete",
+          request_id: "request-1",
+          target: "trial-1",
+          conversation_id: "conversation-1",
+          summary: "done",
+        }),
+        request,
+      ),
+    ).toEqual({
+      type: "trial_complete",
+      request_id: "request-1",
+      target: "trial-1",
+      conversation_id: "conversation-1",
+      summary: "done",
+    });
+  });
+});

--- a/exo/adapters/trial/trial.ts
+++ b/exo/adapters/trial/trial.ts
@@ -10,12 +10,48 @@ export type TrialRun = {
   deadline_at?: string | null;
 };
 
+export type TrialFeedback = {
+  type: "trial_feedback";
+  request_id: string;
+  target: string;
+  instructions: string;
+  feedback: string;
+  deadline_at?: string | null;
+};
+
+export type TrialRequest = TrialRun | TrialFeedback;
+
+export type TrialCancel = {
+  type: "trial_cancel";
+  request_id: string;
+  target: string;
+};
+
+export type TrialSocketRequest = TrialRequest | TrialCancel;
+
 export type TrialComplete = {
   type: "trial_complete";
   request_id: string;
   target: string;
   conversation_id: string;
+  snapshot_id: string;
   summary?: string | null;
+};
+
+export type FeedbackComplete = {
+  type: "feedback_complete";
+  request_id: string;
+  target: string;
+  conversation_id: string;
+  summary?: string | null;
+};
+
+export type TrialCancelled = {
+  type: "trial_cancelled";
+  request_id: string;
+  target: string;
+  conversation_id: string;
+  snapshot_id: string;
 };
 
 export type TrialStarted = {
@@ -25,30 +61,65 @@ export type TrialStarted = {
   conversation_id: string;
 };
 
-export type TrialResponse = TrialStarted | TrialComplete;
+export type FeedbackStarted = {
+  type: "feedback_started";
+  request_id: string;
+  target: string;
+  conversation_id: string;
+  sandbox_id: string;
+};
+
+export type TrialResponse =
+  | TrialStarted
+  | FeedbackStarted
+  | TrialComplete
+  | FeedbackComplete
+  | TrialCancelled;
 
 export function defaultSocketPath(homedir: string = os.homedir()): string {
   return path.join(homedir, ".exo", "trial.sock");
 }
 
-export function parseTrialRun(value: unknown): TrialRun {
-  const record = objectValue(value, "trial_run");
-  if (record.type !== "trial_run") {
-    throw new Error("request type must be trial_run");
-  }
-  return {
-    type: "trial_run",
+export function parseTrialRequest(value: unknown): TrialRequest {
+  const record = objectValue(value, "trial request");
+  const common = {
     request_id: stringValue(record.request_id, "request_id"),
     target: stringValue(record.target, "target"),
-    container_id: stringValue(record.container_id, "container_id"),
     instructions: stringValue(record.instructions, "instructions"),
     deadline_at: nullableString(record.deadline_at, "deadline_at"),
   };
+  if (record.type === "trial_run") {
+    return {
+      type: "trial_run",
+      ...common,
+      container_id: stringValue(record.container_id, "container_id"),
+    };
+  }
+  if (record.type === "trial_feedback") {
+    return {
+      type: "trial_feedback",
+      ...common,
+      feedback: stringValue(record.feedback, "feedback"),
+    };
+  }
+  throw new Error("request type must be trial_run or trial_feedback");
+}
+
+export function parseTrialSocketRequest(value: unknown): TrialSocketRequest {
+  const record = objectValue(value, "trial socket request");
+  if (record.type === "trial_cancel") {
+    return {
+      type: "trial_cancel",
+      request_id: stringValue(record.request_id, "request_id"),
+      target: stringValue(record.target, "target"),
+    };
+  }
+  return parseTrialRequest(record);
 }
 
 export function parseTrialResponse(
   text: string,
-  request: TrialRun,
+  request: TrialRequest,
 ): TrialResponse {
   let value: unknown;
   try {
@@ -57,8 +128,18 @@ export function parseTrialResponse(
     throw new Error("trial response must be a JSON object");
   }
   const record = objectValue(value, "trial response");
-  if (record.type !== "trial_started" && record.type !== "trial_complete") {
-    throw new Error("response type must be trial_started or trial_complete");
+  const expectedStarted =
+    request.type === "trial_run" ? "trial_started" : "feedback_started";
+  const expectedComplete =
+    request.type === "trial_run" ? "trial_complete" : "feedback_complete";
+  if (
+    record.type !== expectedStarted &&
+    record.type !== expectedComplete &&
+    record.type !== "trial_cancelled"
+  ) {
+    throw new Error(
+      `response type must be ${expectedStarted} or ${expectedComplete}`,
+    );
   }
   const requestId = stringValue(record.request_id, "request_id");
   if (requestId !== request.request_id) {
@@ -81,35 +162,78 @@ export function parseTrialResponse(
       conversation_id: conversationId,
     };
   }
+  if (record.type === "feedback_started") {
+    return {
+      type: "feedback_started",
+      request_id: requestId,
+      target,
+      conversation_id: conversationId,
+      sandbox_id: stringValue(record.sandbox_id, "sandbox_id"),
+    };
+  }
+  if (record.type === "trial_cancelled") {
+    return {
+      type: "trial_cancelled",
+      request_id: requestId,
+      target,
+      conversation_id: conversationId,
+      snapshot_id: stringValue(record.snapshot_id, "snapshot_id"),
+    };
+  }
+  const summary = nullableString(record.summary, "summary");
+  if (record.type === "trial_complete") {
+    return {
+      type: "trial_complete",
+      request_id: requestId,
+      target,
+      conversation_id: conversationId,
+      snapshot_id: stringValue(record.snapshot_id, "snapshot_id"),
+      summary,
+    };
+  }
   return {
-    type: "trial_complete",
+    type: "feedback_complete",
     request_id: requestId,
     target,
     conversation_id: conversationId,
-    summary: nullableString(record.summary, "summary"),
+    summary,
   };
 }
 
 export function composeTrialPrompt(
-  request: TrialRun,
+  request: TrialRequest,
   adapterId: string,
   resuming: boolean,
 ): string {
+  const feedback = request.type === "trial_feedback";
   const completion = JSON.stringify({
-    type: "trial_complete",
+    type: feedback ? "feedback_complete" : "trial_complete",
     request_id: request.request_id,
     summary: "optional short summary",
   });
-  return [
-    resuming
+  const opening = feedback
+    ? resuming
+      ? `Feedback for trial \`${request.target}\` is still active after Exo restarted. Continue reflecting in the restored submitted environment.`
+      : `Feedback for trial \`${request.target}\` is ready. Your shell is attached to a restored snapshot of the submitted task environment.`
+    : resuming
       ? `Trial \`${request.target}\` is still active after Exo restarted. Continue the work in its attached container.`
-      : `Trial \`${request.target}\` has started. Your shell is attached to its task container.`,
+      : `Trial \`${request.target}\` has started. Your shell is attached to its task container.`;
+  const body = feedback
+    ? [
+        "Feedback:",
+        request.feedback,
+        "",
+        "Reflection instructions:",
+        request.instructions,
+      ]
+    : ["Instructions:", request.instructions];
+  return [
+    opening,
     request.deadline_at ? `Deadline: ${request.deadline_at}` : "",
     "",
-    "Instructions:",
-    request.instructions,
+    ...body,
     "",
-    `When the trial is finished, call send_adapter_message exactly once with adapterId \`${adapterId}\`, target \`${request.target}\`, and text containing ${completion}. Ending a model turn does not complete the trial.`,
+    `When this ${feedback ? "reflection" : "trial"} is finished, call send_adapter_message exactly once with adapterId \`${adapterId}\`, target \`${request.target}\`, and text containing ${completion}. Ending a model turn does not complete the phase.`,
   ]
     .filter((line) => line !== "")
     .join("\n");

--- a/exo/adapters/trial/trial.ts
+++ b/exo/adapters/trial/trial.ts
@@ -1,0 +1,124 @@
+import os from "node:os";
+import path from "node:path";
+
+export type TrialRun = {
+  type: "trial_run";
+  request_id: string;
+  target: string;
+  container_id: string;
+  instructions: string;
+  deadline_at?: string | null;
+};
+
+export type TrialComplete = {
+  type: "trial_complete";
+  request_id: string;
+  target: string;
+  conversation_id: string;
+  summary?: string | null;
+};
+
+export function defaultSocketPath(homedir: string = os.homedir()): string {
+  return path.join(homedir, ".exo", "trial.sock");
+}
+
+export function parseTrialRun(value: unknown): TrialRun {
+  const record = objectValue(value, "trial_run");
+  if (record.type !== "trial_run") {
+    throw new Error("request type must be trial_run");
+  }
+  return {
+    type: "trial_run",
+    request_id: stringValue(record.request_id, "request_id"),
+    target: stringValue(record.target, "target"),
+    container_id: stringValue(record.container_id, "container_id"),
+    instructions: stringValue(record.instructions, "instructions"),
+    deadline_at: nullableString(record.deadline_at, "deadline_at"),
+  };
+}
+
+export function parseTrialComplete(
+  text: string,
+  request: TrialRun,
+): TrialComplete {
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    throw new Error("trial response must be a JSON object");
+  }
+  const record = objectValue(value, "trial response");
+  if (record.type !== "trial_complete") {
+    throw new Error("response type must be trial_complete");
+  }
+  const requestId = stringValue(record.request_id, "request_id");
+  if (requestId !== request.request_id) {
+    throw new Error(
+      `response request_id ${requestId} does not match ${request.request_id}`,
+    );
+  }
+  const target = stringValue(record.target, "target");
+  if (target !== request.target) {
+    throw new Error(
+      `response target ${target} does not match ${request.target}`,
+    );
+  }
+  return {
+    type: "trial_complete",
+    request_id: requestId,
+    target,
+    conversation_id: stringValue(record.conversation_id, "conversation_id"),
+    summary: nullableString(record.summary, "summary"),
+  };
+}
+
+export function composeTrialPrompt(
+  request: TrialRun,
+  adapterId: string,
+  resuming: boolean,
+): string {
+  const completion = JSON.stringify({
+    type: "trial_complete",
+    request_id: request.request_id,
+    summary: "optional short summary",
+  });
+  return [
+    resuming
+      ? `Trial \`${request.target}\` is still active after Exo restarted. Continue the work in its attached container.`
+      : `Trial \`${request.target}\` has started. Your shell is attached to its task container.`,
+    request.deadline_at ? `Deadline: ${request.deadline_at}` : "",
+    "",
+    "Instructions:",
+    request.instructions,
+    "",
+    `When the trial is finished, call send_adapter_message exactly once with adapterId \`${adapterId}\`, target \`${request.target}\`, and text containing ${completion}. Ending a model turn does not complete the trial.`,
+  ]
+    .filter((line) => line !== "")
+    .join("\n");
+}
+
+type JsonObject = Record<string, unknown>;
+
+function objectValue(value: unknown, name: string): JsonObject {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${name} must be a JSON object`);
+  }
+  return value as JsonObject;
+}
+
+function stringValue(value: unknown, name: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${name} must be a non-empty string`);
+  }
+  return value;
+}
+
+function nullableString(value: unknown, name: string): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (typeof value !== "string") {
+    throw new Error(`${name} must be null or a string`);
+  }
+  return value;
+}

--- a/exo/adapters/trial/trial.ts
+++ b/exo/adapters/trial/trial.ts
@@ -18,6 +18,15 @@ export type TrialComplete = {
   summary?: string | null;
 };
 
+export type TrialStarted = {
+  type: "trial_started";
+  request_id: string;
+  target: string;
+  conversation_id: string;
+};
+
+export type TrialResponse = TrialStarted | TrialComplete;
+
 export function defaultSocketPath(homedir: string = os.homedir()): string {
   return path.join(homedir, ".exo", "trial.sock");
 }
@@ -37,10 +46,10 @@ export function parseTrialRun(value: unknown): TrialRun {
   };
 }
 
-export function parseTrialComplete(
+export function parseTrialResponse(
   text: string,
   request: TrialRun,
-): TrialComplete {
+): TrialResponse {
   let value: unknown;
   try {
     value = JSON.parse(text);
@@ -48,8 +57,8 @@ export function parseTrialComplete(
     throw new Error("trial response must be a JSON object");
   }
   const record = objectValue(value, "trial response");
-  if (record.type !== "trial_complete") {
-    throw new Error("response type must be trial_complete");
+  if (record.type !== "trial_started" && record.type !== "trial_complete") {
+    throw new Error("response type must be trial_started or trial_complete");
   }
   const requestId = stringValue(record.request_id, "request_id");
   if (requestId !== request.request_id) {
@@ -63,11 +72,20 @@ export function parseTrialComplete(
       `response target ${target} does not match ${request.target}`,
     );
   }
+  const conversationId = stringValue(record.conversation_id, "conversation_id");
+  if (record.type === "trial_started") {
+    return {
+      type: "trial_started",
+      request_id: requestId,
+      target,
+      conversation_id: conversationId,
+    };
+  }
   return {
     type: "trial_complete",
     request_id: requestId,
     target,
-    conversation_id: stringValue(record.conversation_id, "conversation_id"),
+    conversation_id: conversationId,
     summary: nullableString(record.summary, "summary"),
   };
 }

--- a/exo/adapters/trial/worker.test.ts
+++ b/exo/adapters/trial/worker.test.ts
@@ -45,6 +45,74 @@ afterEach(() => {
 });
 
 describe("trial adapter worker", () => {
+  it("forwards cancellation and returns the snapshot response", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "exo-trial-worker-"));
+    tempDirs.push(tempDir);
+    const socketPath = path.join(tempDir, "trial.sock");
+    const stateDir = path.join(tempDir, "state");
+    const worker = startWorker(socketPath, stateDir);
+    await worker.events.next();
+
+    const waiting = await connect(socketPath);
+    waiting.write(
+      `${JSON.stringify({
+        type: "trial_run",
+        request_id: "request-1",
+        target: "trial-1",
+        container_id: "container-1",
+        instructions: "Solve it",
+      })}\n`,
+    );
+    await worker.events.next();
+
+    const cancelling = await connect(socketPath);
+    const responses = new LineQueue(cancelling);
+    cancelling.write(
+      `${JSON.stringify({
+        type: "trial_cancel",
+        request_id: "request-1",
+        target: "trial-1",
+      })}\n`,
+    );
+    expect(JSON.parse(await worker.events.next())).toMatchObject({
+      type: "control",
+      target: "trial-1",
+      metadata: { type: "trial_cancel", request_id: "request-1" },
+    });
+    const workerInput = worker.child.stdin;
+    if (workerInput === null) {
+      throw new Error("trial worker stdin is not piped");
+    }
+    workerInput.write(
+      `${JSON.stringify({
+        type: "send_message",
+        id: "cancel-command-1",
+        target: "trial-1",
+        text: JSON.stringify({
+          type: "trial_cancelled",
+          request_id: "request-1",
+          target: "trial-1",
+          conversation_id: "conversation-1",
+          snapshot_id: "snapshot-1",
+        }),
+      })}\n`,
+    );
+    expect(JSON.parse(await responses.next())).toEqual({
+      type: "response",
+      event: {
+        type: "trial_cancelled",
+        request_id: "request-1",
+        target: "trial-1",
+        conversation_id: "conversation-1",
+        snapshot_id: "snapshot-1",
+      },
+    });
+    expect(fs.readdirSync(stateDir)).toHaveLength(1);
+    expect(fs.readdirSync(stateDir)[0]).toMatch(/^response-/);
+    waiting.destroy();
+    cancelling.end();
+  });
+
   it("recovers a pending trial after restart and replays its response", async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "exo-trial-worker-"));
     tempDirs.push(tempDir);
@@ -148,6 +216,7 @@ describe("trial adapter worker", () => {
           request_id: "request-1",
           target: "trial-1",
           conversation_id: "conversation-1",
+          snapshot_id: "snapshot-1",
           summary: "done",
         }),
         attachments: [],
@@ -160,6 +229,7 @@ describe("trial adapter worker", () => {
         request_id: "request-1",
         target: "trial-1",
         conversation_id: "conversation-1",
+        snapshot_id: "snapshot-1",
         summary: "done",
       },
     });
@@ -179,10 +249,76 @@ describe("trial adapter worker", () => {
         request_id: "request-1",
         target: "trial-1",
         conversation_id: "conversation-1",
+        snapshot_id: "snapshot-1",
         summary: "done",
       },
     });
     retry.end();
+
+    const feedback = {
+      type: "trial_feedback",
+      request_id: "feedback-1",
+      target: "trial-1",
+      instructions: "Extract reusable lessons.",
+      feedback: "The verifier found an edge case.",
+    };
+    const feedbackClient = await connect(socketPath);
+    const feedbackResponses = new LineQueue(feedbackClient);
+    feedbackClient.write(`${JSON.stringify(feedback)}\n`);
+    expect(JSON.parse(await second.events.next())).toMatchObject({
+      type: "message",
+      target: "trial-1",
+      message_id: "feedback-1",
+      metadata: { type: "trial_feedback", request_id: "feedback-1" },
+      text: expect.stringContaining("The verifier found an edge case."),
+    });
+    workerInput.write(
+      `${JSON.stringify({
+        type: "send_message",
+        id: "feedback-started-command",
+        target: "trial-1",
+        text: JSON.stringify({
+          type: "feedback_started",
+          request_id: "feedback-1",
+          target: "trial-1",
+          conversation_id: "conversation-1",
+          sandbox_id: "sandbox-2",
+        }),
+        attachments: [],
+      })}\n`,
+    );
+    expect(JSON.parse(await feedbackResponses.next())).toMatchObject({
+      type: "event",
+      event: { type: "feedback_started", sandbox_id: "sandbox-2" },
+    });
+    expect(JSON.parse(await second.events.next())).toEqual({
+      type: "command_ack",
+      command_id: "feedback-started-command",
+    });
+    workerInput.write(
+      `${JSON.stringify({
+        type: "send_message",
+        id: "feedback-complete-command",
+        target: "trial-1",
+        text: JSON.stringify({
+          type: "feedback_complete",
+          request_id: "feedback-1",
+          target: "trial-1",
+          conversation_id: "conversation-1",
+          summary: "learned",
+        }),
+        attachments: [],
+      })}\n`,
+    );
+    expect(JSON.parse(await feedbackResponses.next())).toMatchObject({
+      type: "response",
+      event: { type: "feedback_complete", summary: "learned" },
+    });
+    expect(JSON.parse(await second.events.next())).toEqual({
+      type: "command_ack",
+      command_id: "feedback-complete-command",
+    });
+    feedbackClient.end();
   }, 10_000);
 });
 

--- a/exo/adapters/trial/worker.test.ts
+++ b/exo/adapters/trial/worker.test.ts
@@ -64,6 +64,7 @@ describe("trial adapter worker", () => {
       subject: socketPath,
     });
     const firstClient = await connect(socketPath);
+    const firstResponses = new LineQueue(firstClient);
     firstClient.write(`${JSON.stringify(request)}\n`);
     expect(JSON.parse(await first.events.next())).toMatchObject({
       type: "message",
@@ -73,6 +74,37 @@ describe("trial adapter worker", () => {
         request_id: "request-1",
         container_id: "container-1",
       },
+    });
+    const firstInput = first.child.stdin;
+    if (firstInput === null) {
+      throw new Error("trial worker stdin is not piped");
+    }
+    firstInput.write(
+      `${JSON.stringify({
+        type: "send_message",
+        id: "started-command-1",
+        target: "trial-1",
+        text: JSON.stringify({
+          type: "trial_started",
+          request_id: "request-1",
+          target: "trial-1",
+          conversation_id: "conversation-1",
+        }),
+        attachments: [],
+      })}\n`,
+    );
+    expect(JSON.parse(await firstResponses.next())).toEqual({
+      type: "event",
+      event: {
+        type: "trial_started",
+        request_id: "request-1",
+        target: "trial-1",
+        conversation_id: "conversation-1",
+      },
+    });
+    expect(JSON.parse(await first.events.next())).toEqual({
+      type: "command_ack",
+      command_id: "started-command-1",
     });
 
     first.child.kill("SIGKILL");
@@ -93,6 +125,15 @@ describe("trial adapter worker", () => {
     const secondClient = await connect(socketPath);
     const responses = new LineQueue(secondClient);
     secondClient.write(`${JSON.stringify(request)}\n`);
+    expect(JSON.parse(await responses.next())).toEqual({
+      type: "event",
+      event: {
+        type: "trial_started",
+        request_id: "request-1",
+        target: "trial-1",
+        conversation_id: "conversation-1",
+      },
+    });
     const workerInput = second.child.stdin;
     if (workerInput === null) {
       throw new Error("trial worker stdin is not piped");

--- a/exo/adapters/trial/worker.test.ts
+++ b/exo/adapters/trial/worker.test.ts
@@ -1,0 +1,184 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import readline from "node:readline";
+import { afterEach, describe, expect, it } from "vitest";
+
+class LineQueue {
+  private readonly lines: string[] = [];
+  private readonly waiters: Array<(line: string) => void> = [];
+
+  constructor(stream: NodeJS.ReadableStream) {
+    readline
+      .createInterface({ input: stream, crlfDelay: Number.POSITIVE_INFINITY })
+      .on("line", (line) => {
+        const waiter = this.waiters.shift();
+        if (waiter) {
+          waiter(line);
+        } else {
+          this.lines.push(line);
+        }
+      });
+  }
+
+  async next(): Promise<string> {
+    const line = this.lines.shift();
+    if (line !== undefined) {
+      return line;
+    }
+    return new Promise((resolve) => this.waiters.push(resolve));
+  }
+}
+
+const children: ReturnType<typeof spawn>[] = [];
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const child of children.splice(0)) {
+    child.kill("SIGKILL");
+  }
+  for (const tempDir of tempDirs.splice(0)) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+describe("trial adapter worker", () => {
+  it("recovers a pending trial after restart and replays its response", async () => {
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "exo-trial-worker-"));
+    tempDirs.push(tempDir);
+    const socketPath = path.join(tempDir, "trial.sock");
+    const stateDir = path.join(tempDir, "state");
+    const request = {
+      type: "trial_run",
+      request_id: "request-1",
+      target: "trial-1",
+      container_id: "container-1",
+      instructions: "Solve it",
+    };
+
+    const first = startWorker(socketPath, stateDir);
+    expect(JSON.parse(await first.events.next())).toMatchObject({
+      type: "connected",
+      subject: socketPath,
+    });
+    const firstClient = await connect(socketPath);
+    firstClient.write(`${JSON.stringify(request)}\n`);
+    expect(JSON.parse(await first.events.next())).toMatchObject({
+      type: "message",
+      target: "trial-1",
+      message_id: "request-1",
+      metadata: {
+        request_id: "request-1",
+        container_id: "container-1",
+      },
+    });
+
+    first.child.kill("SIGKILL");
+    await new Promise((resolve) => first.child.once("exit", resolve));
+    firstClient.destroy();
+
+    const second = startWorker(socketPath, stateDir);
+    expect(JSON.parse(await second.events.next())).toMatchObject({
+      type: "connected",
+      subject: socketPath,
+    });
+    expect(JSON.parse(await second.events.next())).toMatchObject({
+      type: "message",
+      target: "trial-1",
+      message_id: expect.stringMatching(/^request-1:resume:/),
+    });
+
+    const secondClient = await connect(socketPath);
+    const responses = new LineQueue(secondClient);
+    secondClient.write(`${JSON.stringify(request)}\n`);
+    const workerInput = second.child.stdin;
+    if (workerInput === null) {
+      throw new Error("trial worker stdin is not piped");
+    }
+    workerInput.write(
+      `${JSON.stringify({
+        type: "send_message",
+        id: "command-1",
+        target: "trial-1",
+        text: JSON.stringify({
+          type: "trial_complete",
+          request_id: "request-1",
+          target: "trial-1",
+          conversation_id: "conversation-1",
+          summary: "done",
+        }),
+        attachments: [],
+      })}\n`,
+    );
+    expect(JSON.parse(await responses.next())).toEqual({
+      type: "response",
+      event: {
+        type: "trial_complete",
+        request_id: "request-1",
+        target: "trial-1",
+        conversation_id: "conversation-1",
+        summary: "done",
+      },
+    });
+    expect(JSON.parse(await second.events.next())).toEqual({
+      type: "command_ack",
+      command_id: "command-1",
+    });
+    secondClient.end();
+
+    const retry = await connect(socketPath);
+    const retryResponses = new LineQueue(retry);
+    retry.write(`${JSON.stringify(request)}\n`);
+    expect(JSON.parse(await retryResponses.next())).toEqual({
+      type: "response",
+      event: {
+        type: "trial_complete",
+        request_id: "request-1",
+        target: "trial-1",
+        conversation_id: "conversation-1",
+        summary: "done",
+      },
+    });
+    retry.end();
+  }, 10_000);
+});
+
+function startWorker(
+  socketPath: string,
+  stateDir: string,
+): {
+  child: ReturnType<typeof spawn>;
+  events: LineQueue;
+} {
+  const child = spawn(
+    process.execPath,
+    [
+      path.resolve("node_modules/tsx/dist/cli.mjs"),
+      path.resolve("exo/adapters/trial/worker.ts"),
+    ],
+    {
+      cwd: path.resolve("."),
+      env: {
+        ...process.env,
+        EXO_ADAPTER_ID: "adapter-1",
+        EXO_ADAPTER_TYPE: "trial",
+        EXO_ADAPTER_STATE_DIR: stateDir,
+        EXO_ADAPTER_CONFIG: JSON.stringify({ socketPath }),
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    },
+  );
+  children.push(child);
+  return { child, events: new LineQueue(child.stdout) };
+}
+
+function connect(socketPath: string): Promise<net.Socket> {
+  return new Promise((resolve, reject) => {
+    const socket = net.createConnection(socketPath);
+    socket.setEncoding("utf8");
+    socket.once("connect", () => resolve(socket));
+    socket.once("error", reject);
+  });
+}

--- a/exo/adapters/trial/worker.ts
+++ b/exo/adapters/trial/worker.ts
@@ -15,10 +15,11 @@ import {
 import {
   composeTrialPrompt,
   defaultSocketPath,
-  parseTrialComplete,
+  parseTrialResponse,
   parseTrialRun,
   type TrialComplete,
   type TrialRun,
+  type TrialStarted,
 } from "./trial";
 
 type PendingTrial = {
@@ -27,8 +28,13 @@ type PendingTrial = {
 };
 
 type CompletedTrial = {
-  commandId: string;
+  commandIds: string[];
   response: TrialComplete;
+};
+
+type StartedTrial = {
+  commandIds: string[];
+  response: TrialStarted;
 };
 
 const config = adapterConfig();
@@ -79,6 +85,10 @@ const server = net.createServer((socket) => {
         return;
       }
       pending.sockets.add(socket);
+      const started = readStartedTrial(request.request_id);
+      if (started) {
+        sendToClient(socket, { type: "event", event: started.response });
+      }
       return;
     }
     if (findPendingRequest(request.request_id)) {
@@ -158,9 +168,37 @@ for await (const line of input) {
       throw new Error(`trial target ${target} is not awaiting completion`);
     }
 
-    const response = parseTrialComplete(command.text, pending.request);
-    writeCompletedTrial(pending.request.request_id, command.id, response);
+    const response = parseTrialResponse(command.text, pending.request);
+    if (response.type === "trial_started") {
+      const started = readStartedTrial(pending.request.request_id);
+      if (
+        started &&
+        started.response.conversation_id !== response.conversation_id
+      ) {
+        throw new Error(
+          `trial target ${target} changed conversations while active`,
+        );
+      }
+      writeStartedTrial(pending.request.request_id, {
+        commandIds: [...(started?.commandIds ?? []), command.id],
+        response,
+      });
+      if (!started) {
+        for (const socket of pending.sockets) {
+          sendToClient(socket, { type: "event", event: response });
+        }
+      }
+      writeWorkerEvent({ type: "command_ack", command_id: command.id });
+      continue;
+    }
+
+    const started = readStartedTrial(pending.request.request_id);
+    writeCompletedTrial(pending.request.request_id, {
+      commandIds: [...(started?.commandIds ?? []), command.id],
+      response,
+    });
     removePendingTrial(pending.request.request_id);
+    removeStartedTrial(pending.request.request_id);
     pendingByTarget.delete(target);
     for (const socket of pending.sockets) {
       sendToClient(socket, { type: "response", event: response });
@@ -205,6 +243,7 @@ function loadPendingTrials(): void {
     const request = parseTrialRun(JSON.parse(fs.readFileSync(file, "utf8")));
     if (readCompletedTrial(request.request_id)) {
       fs.rmSync(file, { force: true });
+      removeStartedTrial(request.request_id);
       continue;
     }
     if (pendingByTarget.has(request.target)) {
@@ -231,6 +270,10 @@ function completedPath(requestId: string): string {
   return statePath("response", requestId);
 }
 
+function startedPath(requestId: string): string {
+  return statePath("started", requestId);
+}
+
 function statePath(kind: string, requestId: string): string {
   const digest = crypto.createHash("sha256").update(requestId).digest("hex");
   return path.join(stateDir, `${kind}-${digest}.json`);
@@ -242,6 +285,24 @@ function writePendingTrial(request: TrialRun): void {
 
 function removePendingTrial(requestId: string): void {
   fs.rmSync(pendingPath(requestId), { force: true });
+}
+
+function readStartedTrial(requestId: string): StartedTrial | null {
+  try {
+    return JSON.parse(
+      fs.readFileSync(startedPath(requestId), "utf8"),
+    ) as StartedTrial;
+  } catch {
+    return null;
+  }
+}
+
+function writeStartedTrial(requestId: string, started: StartedTrial): void {
+  writeJsonAtomically(startedPath(requestId), started);
+}
+
+function removeStartedTrial(requestId: string): void {
+  fs.rmSync(startedPath(requestId), { force: true });
 }
 
 function readCompletedTrial(requestId: string): CompletedTrial | null {
@@ -256,10 +317,9 @@ function readCompletedTrial(requestId: string): CompletedTrial | null {
 
 function writeCompletedTrial(
   requestId: string,
-  commandId: string,
-  response: TrialComplete,
+  completed: CompletedTrial,
 ): void {
-  writeJsonAtomically(completedPath(requestId), { commandId, response });
+  writeJsonAtomically(completedPath(requestId), completed);
 }
 
 function writeJsonAtomically(destination: string, value: object): void {
@@ -277,7 +337,7 @@ function hasCompletedCommand(commandId: string): boolean {
       const completed = JSON.parse(
         fs.readFileSync(path.join(stateDir, name), "utf8"),
       ) as CompletedTrial;
-      return completed.commandId === commandId;
+      return completed.commandIds.includes(commandId);
     } catch {
       return false;
     }

--- a/exo/adapters/trial/worker.ts
+++ b/exo/adapters/trial/worker.ts
@@ -1,0 +1,293 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import net from "node:net";
+import path from "node:path";
+import process from "node:process";
+import readline from "node:readline";
+import inputReadline from "node:readline/promises";
+
+import {
+  adapterConfig,
+  optionalStringField,
+  parseWorkerCommand,
+  writeWorkerEvent,
+} from "../protocol";
+import {
+  composeTrialPrompt,
+  defaultSocketPath,
+  parseTrialComplete,
+  parseTrialRun,
+  type TrialComplete,
+  type TrialRun,
+} from "./trial";
+
+type PendingTrial = {
+  request: TrialRun;
+  sockets: Set<net.Socket>;
+};
+
+type CompletedTrial = {
+  commandId: string;
+  response: TrialComplete;
+};
+
+const config = adapterConfig();
+const socketPath =
+  optionalStringField(config, "socketPath") ?? defaultSocketPath();
+const stateDir = process.env.EXO_ADAPTER_STATE_DIR ?? ".";
+const adapterId = process.env.EXO_ADAPTER_ID ?? "";
+const startupId = crypto.randomUUID();
+const pendingByTarget = new Map<string, PendingTrial>();
+
+fs.mkdirSync(path.dirname(socketPath), { recursive: true });
+fs.mkdirSync(stateDir, { recursive: true });
+fs.rmSync(socketPath, { force: true });
+loadPendingTrials();
+
+const server = net.createServer((socket) => {
+  socket.setEncoding("utf8");
+  const lines = readline.createInterface({
+    input: socket,
+    crlfDelay: Number.POSITIVE_INFINITY,
+  });
+
+  lines.on("line", (line) => {
+    if (line.trim().length === 0) {
+      return;
+    }
+    let request: TrialRun;
+    try {
+      request = parseTrialRun(JSON.parse(line));
+    } catch (error) {
+      sendToClient(socket, { type: "error", message: errorText(error) });
+      return;
+    }
+
+    const completed = readCompletedTrial(request.request_id);
+    if (completed) {
+      sendToClient(socket, { type: "response", event: completed.response });
+      return;
+    }
+
+    const pending = pendingByTarget.get(request.target);
+    if (pending) {
+      if (pending.request.request_id !== request.request_id) {
+        sendToClient(socket, {
+          type: "error",
+          message: `trial target ${request.target} already has an active request`,
+        });
+        return;
+      }
+      pending.sockets.add(socket);
+      return;
+    }
+    if (findPendingRequest(request.request_id)) {
+      sendToClient(socket, {
+        type: "error",
+        message: `request_id ${request.request_id} is already active for another target`,
+      });
+      return;
+    }
+
+    writePendingTrial(request);
+    pendingByTarget.set(request.target, {
+      request,
+      sockets: new Set([socket]),
+    });
+    emitTrialRun(request, false);
+  });
+
+  socket.on("error", () => {
+    // A waiting evaluator may disconnect during an Exo restart or timeout.
+  });
+  socket.on("close", () => {
+    for (const pending of pendingByTarget.values()) {
+      pending.sockets.delete(socket);
+    }
+  });
+});
+
+server.on("error", (error) => {
+  writeWorkerEvent({
+    type: "error",
+    message: `trial listener error: ${error.message}`,
+  });
+  process.exit(1);
+});
+
+server.listen(socketPath, () => {
+  fs.chmodSync(socketPath, 0o600);
+  process.stderr.write(`[trial-adapter] listening on ${socketPath}\n`);
+  writeWorkerEvent({
+    type: "connected",
+    subject: socketPath,
+    metadata: { socketPath },
+  });
+  for (const pending of pendingByTarget.values()) {
+    emitTrialRun(pending.request, true);
+  }
+});
+
+process.on("exit", () => {
+  fs.rmSync(socketPath, { force: true });
+});
+
+const input = inputReadline.createInterface({
+  input: process.stdin,
+  crlfDelay: Number.POSITIVE_INFINITY,
+});
+
+for await (const line of input) {
+  if (line.trim().length === 0) {
+    continue;
+  }
+  let commandId: string | null = null;
+  try {
+    const command = parseWorkerCommand(JSON.parse(line));
+    commandId = command.id;
+    const target = command.target;
+    if (!target) {
+      throw new Error("trial completion requires its inbound target");
+    }
+    const pending = pendingByTarget.get(target);
+    if (!pending) {
+      if (hasCompletedCommand(command.id)) {
+        writeWorkerEvent({ type: "command_ack", command_id: command.id });
+        continue;
+      }
+      throw new Error(`trial target ${target} is not awaiting completion`);
+    }
+
+    const response = parseTrialComplete(command.text, pending.request);
+    writeCompletedTrial(pending.request.request_id, command.id, response);
+    removePendingTrial(pending.request.request_id);
+    pendingByTarget.delete(target);
+    for (const socket of pending.sockets) {
+      sendToClient(socket, { type: "response", event: response });
+    }
+    writeWorkerEvent({ type: "command_ack", command_id: command.id });
+  } catch (error) {
+    const message = errorText(error);
+    if (commandId === null) {
+      writeWorkerEvent({ type: "error", message });
+    } else {
+      writeWorkerEvent({
+        type: "command_nack",
+        command_id: commandId,
+        message,
+      });
+    }
+  }
+}
+
+function emitTrialRun(request: TrialRun, resuming: boolean): void {
+  writeWorkerEvent({
+    type: "message",
+    target: request.target,
+    sender: "trial_runner",
+    text: composeTrialPrompt(request, adapterId, resuming),
+    message_id: resuming
+      ? `${request.request_id}:resume:${startupId}`
+      : request.request_id,
+    metadata: {
+      request_id: request.request_id,
+      container_id: request.container_id,
+    },
+  });
+}
+
+function loadPendingTrials(): void {
+  for (const name of fs.readdirSync(stateDir)) {
+    if (!name.startsWith("pending-") || !name.endsWith(".json")) {
+      continue;
+    }
+    const file = path.join(stateDir, name);
+    const request = parseTrialRun(JSON.parse(fs.readFileSync(file, "utf8")));
+    if (readCompletedTrial(request.request_id)) {
+      fs.rmSync(file, { force: true });
+      continue;
+    }
+    if (pendingByTarget.has(request.target)) {
+      throw new Error(`multiple pending requests for target ${request.target}`);
+    }
+    pendingByTarget.set(request.target, { request, sockets: new Set() });
+  }
+}
+
+function findPendingRequest(requestId: string): PendingTrial | null {
+  for (const pending of pendingByTarget.values()) {
+    if (pending.request.request_id === requestId) {
+      return pending;
+    }
+  }
+  return null;
+}
+
+function pendingPath(requestId: string): string {
+  return statePath("pending", requestId);
+}
+
+function completedPath(requestId: string): string {
+  return statePath("response", requestId);
+}
+
+function statePath(kind: string, requestId: string): string {
+  const digest = crypto.createHash("sha256").update(requestId).digest("hex");
+  return path.join(stateDir, `${kind}-${digest}.json`);
+}
+
+function writePendingTrial(request: TrialRun): void {
+  writeJsonAtomically(pendingPath(request.request_id), request);
+}
+
+function removePendingTrial(requestId: string): void {
+  fs.rmSync(pendingPath(requestId), { force: true });
+}
+
+function readCompletedTrial(requestId: string): CompletedTrial | null {
+  try {
+    return JSON.parse(
+      fs.readFileSync(completedPath(requestId), "utf8"),
+    ) as CompletedTrial;
+  } catch {
+    return null;
+  }
+}
+
+function writeCompletedTrial(
+  requestId: string,
+  commandId: string,
+  response: TrialComplete,
+): void {
+  writeJsonAtomically(completedPath(requestId), { commandId, response });
+}
+
+function writeJsonAtomically(destination: string, value: object): void {
+  const temporary = `${destination}.${crypto.randomUUID()}.tmp`;
+  fs.writeFileSync(temporary, JSON.stringify(value));
+  fs.renameSync(temporary, destination);
+}
+
+function hasCompletedCommand(commandId: string): boolean {
+  return fs.readdirSync(stateDir).some((name) => {
+    if (!name.startsWith("response-") || !name.endsWith(".json")) {
+      return false;
+    }
+    try {
+      const completed = JSON.parse(
+        fs.readFileSync(path.join(stateDir, name), "utf8"),
+      ) as CompletedTrial;
+      return completed.commandId === commandId;
+    } catch {
+      return false;
+    }
+  });
+}
+
+function sendToClient(socket: net.Socket, payload: object): void {
+  socket.write(`${JSON.stringify(payload)}\n`);
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/exo/adapters/trial/worker.ts
+++ b/exo/adapters/trial/worker.ts
@@ -16,25 +16,25 @@ import {
   composeTrialPrompt,
   defaultSocketPath,
   parseTrialResponse,
-  parseTrialRun,
-  type TrialComplete,
-  type TrialRun,
-  type TrialStarted,
+  parseTrialSocketRequest,
+  type TrialRequest,
+  type TrialResponse,
+  type TrialSocketRequest,
 } from "./trial";
 
 type PendingTrial = {
-  request: TrialRun;
+  request: TrialRequest;
   sockets: Set<net.Socket>;
 };
 
 type CompletedTrial = {
   commandIds: string[];
-  response: TrialComplete;
+  response: TrialResponse;
 };
 
 type StartedTrial = {
   commandIds: string[];
-  response: TrialStarted;
+  response: TrialResponse;
 };
 
 const config = adapterConfig();
@@ -61,17 +61,53 @@ const server = net.createServer((socket) => {
     if (line.trim().length === 0) {
       return;
     }
-    let request: TrialRun;
+    let request: TrialSocketRequest;
     try {
-      request = parseTrialRun(JSON.parse(line));
+      request = parseTrialSocketRequest(JSON.parse(line));
     } catch (error) {
       sendToClient(socket, { type: "error", message: errorText(error) });
+      return;
+    }
+
+    if (request.type === "trial_cancel") {
+      cancelTrial(request.request_id, request.target, socket);
       return;
     }
 
     const completed = readCompletedTrial(request.request_id);
     if (completed) {
       sendToClient(socket, { type: "response", event: completed.response });
+      return;
+    }
+
+    const targetResponses = completedResponsesForTarget(request.target);
+    const completedTrial = targetResponses.some(
+      ({ response }) =>
+        response.type === "trial_complete" ||
+        response.type === "trial_cancelled",
+    );
+    const completedFeedback = targetResponses.some(
+      ({ response }) => response.type === "feedback_complete",
+    );
+    if (request.type === "trial_run" && completedTrial) {
+      sendToClient(socket, {
+        type: "error",
+        message: `trial target ${request.target} was already used`,
+      });
+      return;
+    }
+    if (request.type === "trial_feedback" && !completedTrial) {
+      sendToClient(socket, {
+        type: "error",
+        message: `trial target ${request.target} has no completed trial`,
+      });
+      return;
+    }
+    if (request.type === "trial_feedback" && completedFeedback) {
+      sendToClient(socket, {
+        type: "error",
+        message: `trial target ${request.target} already completed feedback`,
+      });
       return;
     }
 
@@ -169,7 +205,10 @@ for await (const line of input) {
     }
 
     const response = parseTrialResponse(command.text, pending.request);
-    if (response.type === "trial_started") {
+    if (
+      response.type === "trial_started" ||
+      response.type === "feedback_started"
+    ) {
       const started = readStartedTrial(pending.request.request_id);
       if (
         started &&
@@ -218,7 +257,7 @@ for await (const line of input) {
   }
 }
 
-function emitTrialRun(request: TrialRun, resuming: boolean): void {
+function emitTrialRun(request: TrialRequest, resuming: boolean): void {
   writeWorkerEvent({
     type: "message",
     target: request.target,
@@ -228,8 +267,11 @@ function emitTrialRun(request: TrialRun, resuming: boolean): void {
       ? `${request.request_id}:resume:${startupId}`
       : request.request_id,
     metadata: {
+      type: request.type,
       request_id: request.request_id,
-      container_id: request.container_id,
+      ...(request.type === "trial_run"
+        ? { container_id: request.container_id }
+        : {}),
     },
   });
 }
@@ -240,7 +282,12 @@ function loadPendingTrials(): void {
       continue;
     }
     const file = path.join(stateDir, name);
-    const request = parseTrialRun(JSON.parse(fs.readFileSync(file, "utf8")));
+    const request = parseTrialSocketRequest(
+      JSON.parse(fs.readFileSync(file, "utf8")),
+    );
+    if (request.type === "trial_cancel") {
+      throw new Error("trial cancellation cannot be pending");
+    }
     if (readCompletedTrial(request.request_id)) {
       fs.rmSync(file, { force: true });
       removeStartedTrial(request.request_id);
@@ -251,6 +298,34 @@ function loadPendingTrials(): void {
     }
     pendingByTarget.set(request.target, { request, sockets: new Set() });
   }
+}
+
+function cancelTrial(
+  requestId: string,
+  target: string,
+  socket: net.Socket,
+): void {
+  const pending = pendingByTarget.get(target);
+  if (pending && pending.request.request_id !== requestId) {
+    sendToClient(socket, {
+      type: "error",
+      message: `trial target ${target} is active under another request`,
+    });
+    return;
+  }
+  if (pending) {
+    pending.sockets.add(socket);
+    writeWorkerEvent({
+      type: "control",
+      target,
+      metadata: { type: "trial_cancel", request_id: requestId },
+    });
+    return;
+  }
+  sendToClient(socket, {
+    type: "error",
+    message: `trial target ${target} is not active`,
+  });
 }
 
 function findPendingRequest(requestId: string): PendingTrial | null {
@@ -279,7 +354,7 @@ function statePath(kind: string, requestId: string): string {
   return path.join(stateDir, `${kind}-${digest}.json`);
 }
 
-function writePendingTrial(request: TrialRun): void {
+function writePendingTrial(request: TrialRequest): void {
   writeJsonAtomically(pendingPath(request.request_id), request);
 }
 
@@ -313,6 +388,22 @@ function readCompletedTrial(requestId: string): CompletedTrial | null {
   } catch {
     return null;
   }
+}
+
+function completedResponsesForTarget(target: string): CompletedTrial[] {
+  const completed: CompletedTrial[] = [];
+  for (const name of fs.readdirSync(stateDir)) {
+    if (!name.startsWith("response-") || !name.endsWith(".json")) {
+      continue;
+    }
+    const response = JSON.parse(
+      fs.readFileSync(path.join(stateDir, name), "utf8"),
+    ) as CompletedTrial;
+    if (response.response.target === target) {
+      completed.push(response);
+    }
+  }
+  return completed;
 }
 
 function writeCompletedTrial(

--- a/exo/docs/design/trial-adapter.md
+++ b/exo/docs/design/trial-adapter.md
@@ -38,7 +38,18 @@ The initial protocol has one request.
 one delivery and makes retrying a request idempotent. A target may have only one
 active phase at a time.
 
-The successful response is:
+Once the conversation exists and the container is attached, the adapter emits:
+
+```json
+{
+  "type": "trial_started",
+  "request_id": "unique delivery id",
+  "target": "stable trial id",
+  "conversation_id": "Exo conversation id"
+}
+```
+
+The final successful response is:
 
 ```json
 {
@@ -77,11 +88,12 @@ For `trial_run`, the adapter:
 
 1. Creates a new conversation for the trial.
 2. Attaches the supplied container as that conversation's sandbox.
-3. Wakes the conversation with the supplied instructions and the explicit
+3. Returns `trial_started` so the evaluator can retain the conversation id.
+4. Wakes the conversation with the supplied instructions and the explicit
    completion protocol.
-4. Continues waking the same conversation after an Exo rebuild until the agent
+5. Continues waking the same conversation after an Exo rebuild until the agent
    calls `send_adapter_message` to declare completion.
-5. Returns `trial_complete` to the waiting evaluator.
+6. Returns `trial_complete` to the waiting evaluator.
 
 In a later version, `trial_feedback` would:
 
@@ -109,10 +121,11 @@ active request id and deadline (when active)
 completed request ids and responses
 ```
 
-The current worker persists active requests and completed responses in its
-adapter state directory. The runtime durably maps each target to its trial
-conversation. A restarted worker can therefore replay a pending wake or return
-an already-completed response after Exo rebuilds.
+The current worker persists active requests, started responses, and completed
+responses in its adapter state directory. The runtime durably maps each target
+to its trial conversation. A restarted worker can therefore replay
+`trial_started`, replay a pending wake, or return an already-completed response
+after Exo rebuilds.
 
 ## Learning across trials
 
@@ -151,9 +164,10 @@ the existing conversation.
 
 ## Trajectory export
 
-Every completion response includes `conversation_id`. That is the stable source
-for exporting the trial's model messages, tool calls, results, and rebuild
-continuations.
+Both responses include `conversation_id`. The evaluator retains it from
+`trial_started`, making it possible to export model messages, tool calls,
+results, and rebuild continuations even when the trial times out before
+`trial_complete`.
 
 ATIF conversion should be a separate exporter over the canonical conversation
 log rather than part of the adapter protocol. A benchmark bridge can export the

--- a/exo/docs/design/trial-adapter.md
+++ b/exo/docs/design/trial-adapter.md
@@ -1,0 +1,195 @@
+# Trial Adapter
+
+## Goal
+
+The trial adapter provides one Exo integration for containerized evaluations
+such as Harbor, SRE Gym, and future task runners. An evaluator supplies a
+running container and instructions; Exo works until it explicitly declares the
+phase complete.
+
+The central purpose is to measure and enable learning across trials. Each trial
+gets a fresh conversation and task environment, but all trials run under the
+same persistent Exo agent. Agent-level changes therefore carry forward,
+including memories, installed or modified tools, prompt and harness changes,
+source edits, and any other rewiring Exo performs while working or processing
+feedback.
+
+The adapter owns the Exo-side lifecycle. Evaluator-specific code should only
+start and grade environments, submit messages, and wait for responses.
+
+## Protocol
+
+The initial protocol has one request.
+
+### `trial_run`
+
+```json
+{
+  "type": "trial_run",
+  "request_id": "unique delivery id",
+  "target": "stable trial id",
+  "container_id": "running container id",
+  "instructions": "work to perform",
+  "deadline_at": "optional ISO-8601 timestamp"
+}
+```
+
+`target` identifies the trial across all of its phases. `request_id` identifies
+one delivery and makes retrying a request idempotent. A target may have only one
+active phase at a time.
+
+The successful response is:
+
+```json
+{
+  "type": "trial_complete",
+  "request_id": "unique delivery id",
+  "target": "stable trial id",
+  "conversation_id": "Exo conversation id",
+  "summary": "optional short summary"
+}
+```
+
+### Future: `trial_feedback`
+
+```json
+{
+  "type": "trial_feedback",
+  "request_id": "new unique delivery id",
+  "target": "the same stable trial id",
+  "instructions": "what Exo should do with the result",
+  "feedback": "grader result and other feedback"
+}
+```
+
+The successful response has the same fields as `trial_complete`, with type
+`feedback_complete`, plus the new final `snapshot_id`, allowing more than one
+feedback phase if needed.
+
+Feedback and snapshotting are deliberately outside the first implementation.
+Cancellation should also be a later request, keyed by `target` and the active
+`request_id`. It cancels only that phase; a late completion must not satisfy a
+later request.
+
+## Trial lifecycle
+
+For `trial_run`, the adapter:
+
+1. Creates a new conversation for the trial.
+2. Attaches the supplied container as that conversation's sandbox.
+3. Wakes the conversation with the supplied instructions and the explicit
+   completion protocol.
+4. Continues waking the same conversation after an Exo rebuild until the agent
+   calls `send_adapter_message` to declare completion.
+5. Returns `trial_complete` to the waiting evaluator.
+
+In a later version, `trial_feedback` would:
+
+1. Resolve the durable trial record by `target`.
+2. Create a sandbox from its latest snapshot and make it active for the existing
+   conversation.
+3. Wake that conversation with the feedback and new instructions.
+4. Handle rebuild continuations until explicit completion.
+5. Snapshot the resulting sandbox, update the trial record, and return
+   `feedback_complete`.
+
+Ending a model turn is not completion. Only a valid `send_adapter_message` for
+the active request completes a phase. In version one, the adapter then responds
+immediately. A future feedback implementation will snapshot at this boundary
+before responding.
+
+## Durable state
+
+The adapter stores one record per target:
+
+```text
+target
+conversation_id
+active request id and deadline (when active)
+completed request ids and responses
+```
+
+The current worker persists active requests and completed responses in its
+adapter state directory. The runtime durably maps each target to its trial
+conversation. A restarted worker can therefore replay a pending wake or return
+an already-completed response after Exo rebuilds.
+
+## Learning across trials
+
+Conversation and agent lifetimes are intentionally different:
+
+- A new conversation isolates each trial's immediate context and trajectory.
+- The persistent agent retains every durable change made during earlier trials
+  and feedback phases.
+- The environment snapshot preserves one trial's filesystem for its feedback
+  phase; it is not the mechanism that carries learning into unrelated trials.
+
+This separation lets later trials benefit from Exo's accumulated memories,
+tools, harness changes, and self-modifications without inheriting another
+trial's raw conversation or task container. Feedback processing uses the same
+trial conversation and restored snapshot so Exo can inspect its original work,
+then materialize useful conclusions into persistent agent state for future
+trials.
+
+## Container ownership
+
+The evaluator owns the original running container until it submits the trial.
+The ownership boundary must be explicit even though Exo can snapshot an
+attached container.
+
+The proposed contract is:
+
+- Exo may execute in and snapshot the supplied container, but does not stop or
+  delete it.
+- The evaluator remains responsible for cleaning up the original container.
+- Sandboxes created from Exo snapshots are Exo-owned.
+
+The core `create_sandbox_from_snapshot` operation creates a new Exo-owned
+sandbox without rewinding or reusing the original handle. A feedback design
+still needs an explicit, unsurprising way to make that new sandbox active for
+the existing conversation.
+
+## Trajectory export
+
+Every completion response includes `conversation_id`. That is the stable source
+for exporting the trial's model messages, tool calls, results, and rebuild
+continuations.
+
+ATIF conversion should be a separate exporter over the canonical conversation
+log rather than part of the adapter protocol. A benchmark bridge can export the
+conversation after either completion response and place the result in its own
+trial output directory.
+
+## Benchmark bridges
+
+- Harbor resolves its task container, sends `trial_run`, waits, and grades the
+  original environment state.
+- SRE Gym launches its isolated agent container, sends the same request, and
+  retains its native diagnosis, mitigation, and grading mechanisms inside the
+  instructions and feedback.
+
+Benchmark-specific fields can be carried as typed optional metadata only when a
+shared need emerges. The core protocol should not contain Harbor or SRE Gym
+concepts.
+
+## Tradeoffs and open questions
+
+- **Explicit completion is reliable but model-driven.** The evaluator knows
+  exactly when Exo is done, but prompts and validation must ensure the tool call
+  is made once with the active request id.
+- **Snapshots preserve the working context but add lifecycle complexity.** We
+  need snapshot support for supplied containers and creation of a new sandbox
+  from a snapshot before feedback can use the same filesystem state safely.
+- **`container_id` keeps version one simple but assumes local Docker.** If a
+  benchmark supplies another environment provider, this field should become a
+  typed environment descriptor rather than accumulating provider-specific
+  optional fields.
+- **Adapter-owned conversation creation is convenient but expands the runtime's
+  responsibility.** It needs durable target-to-conversation routing rather than
+  the usual fixed adapter conversation.
+- **Parallel trials are structurally possible.** Records are keyed by target,
+  but concurrent trials that modify shared agent state may make a learning
+  evaluation nondeterministic. Evaluators should choose their concurrency.
+- **Timeout behavior needs an ownership rule.** The evaluator should send
+  cancellation when its deadline expires; the adapter then stops waking that
+  phase and rejects late completion without deleting the durable trial record.

--- a/exo/docs/design/trial-feedback.md
+++ b/exo/docs/design/trial-feedback.md
@@ -1,0 +1,210 @@
+# Trial Feedback
+
+## Goal
+
+Add a feedback phase to the trial adapter without changing the initial task
+environment or mixing one trial's context into another. Exo should reflect on
+grader feedback in the filesystem state it submitted, then retain useful
+memories, tools, policy changes, and other agent-level learning for later
+trials.
+
+This work builds on the trial adapter and Harbor evaluation branches. It should
+remain a separate change so the basic trial path can be reviewed independently.
+
+## Lifecycle
+
+At the end of `trial_run`:
+
+1. Exo explicitly sends `trial_complete` for the active request.
+2. Before acknowledging completion, the adapter snapshots the attached task
+   container.
+3. The adapter durably records the snapshot against the trial target.
+4. Exo detaches from the evaluator-owned container without stopping or deleting
+   it.
+5. The adapter returns `trial_complete`, including the snapshot id.
+
+When feedback arrives:
+
+1. The adapter resolves the existing trial conversation and latest snapshot by
+   target.
+2. Exoharness creates a new Exo-owned sandbox from that snapshot. It does not
+   rewind or take ownership of the original container.
+3. The restored sandbox becomes the conversation's active sandbox.
+4. The adapter wakes the same conversation with the grader feedback and
+   reflection instructions. The evaluator should include all feedback it has,
+   including rewards, verifier output, and failure details.
+5. Rebuild continuations work as they do for the initial trial.
+6. When Exo explicitly finishes, the adapter returns `feedback_complete`.
+
+Using the same conversation preserves the reasoning and trajectory for that
+trial. Using the same filesystem state lets Exo inspect its submitted work.
+Agent-scoped state remains the mechanism by which lessons affect later trials.
+
+## Protocol
+
+The successful `trial_complete` response gains `snapshot_id`:
+
+```json
+{
+  "type": "trial_complete",
+  "request_id": "trial request id",
+  "target": "stable trial id",
+  "conversation_id": "Exo conversation id",
+  "snapshot_id": "snapshot of the submitted task container",
+  "summary": "optional short summary"
+}
+```
+
+Feedback uses a new request id but the same target:
+
+```json
+{
+  "type": "trial_feedback",
+  "request_id": "new unique delivery id",
+  "target": "the same stable trial id",
+  "instructions": "what Exo should do with the result",
+  "feedback": "grader output and other feedback"
+}
+```
+
+Once the restored sandbox is ready, the adapter emits `feedback_started` with
+`request_id`, `target`, `conversation_id`, and the restored `sandbox_id`. This
+lets the evaluator retain the trajectory even if reflection times out.
+
+The final response is:
+
+```json
+{
+  "type": "feedback_complete",
+  "request_id": "feedback request id",
+  "target": "stable trial id",
+  "conversation_id": "the original trial conversation id",
+  "summary": "optional short summary"
+}
+```
+
+Only one phase may be active for a target. Repeating a completed request id
+returns its recorded response. The first implementation supports one feedback
+phase, starting from the snapshot recorded at trial completion.
+
+The reflection prompt should tell Exo to inspect its prior work and the restored
+filesystem, understand what succeeded or failed, and extract general lessons
+that will help on similar future tasks. It should explicitly consider durable
+memories, reusable tools, and changes to its own policy or implementation. The
+goal is learning, not repairing the already-graded submission.
+
+## Exoharness changes
+
+### Snapshot attached sandboxes
+
+`snapshot_sandbox` should support a running attached Docker container. The
+provider captures its state without changing ownership, stopping it, or
+detaching it. The snapshot and `SandboxSnapshotted` event remain owned by the
+conversation.
+
+The existing prohibition on snapshotting attachments is an Exoharness policy
+restriction rather than a limitation of the snapshot abstraction. Initial
+support can be Docker-only and should return a clear unsupported-provider error
+for other attachment types.
+
+### Create a sandbox from a snapshot
+
+Add a scoped operation with the shape:
+
+```text
+create_sandbox_from_snapshot(snapshot_id, optional provider and idle timeout)
+    -> new sandbox_id
+```
+
+It creates a new sandbox record and backend resource from the stored snapshot.
+The new sandbox:
+
+- has a new Exoharness sandbox id and provider resource;
+- is owned by the same agent or conversation as the snapshot;
+- is not an attachment;
+- inherits the source sandbox's restore-relevant configuration;
+- emits `SandboxCreated` followed by `SandboxStarted` with the source snapshot
+  id.
+
+This differs from `start_sandbox`, which restores into an existing sandbox id
+and therefore represents rollback. Creating from a snapshot represents a fork
+of the environment.
+
+Snapshot manifests must retain enough source configuration to create the new
+sandbox even after the evaluator deletes the original attached container.
+
+### Select the restored sandbox
+
+Conversation configuration describes how Exoharness should create a default
+sandbox. It should not prevent an explicitly attached or explicitly started
+sandbox from being used merely because that sandbox came from a different
+image or has different mounts.
+
+Today the executor searches active conversation sandboxes and reuses a created
+sandbox only when its stored configuration matches the current conversation
+configuration. That check is useful for implicit reuse: it prevents a config
+change from silently selecting an incompatible old sandbox. It should remain
+for the implicit "find or create my configured sandbox" path.
+
+Explicit lifecycle operations should take precedence. The proposed selection
+rule is:
+
+1. Use the most recently explicitly attached or started active sandbox.
+2. Otherwise, reuse the newest active created sandbox matching conversation
+   configuration.
+3. Otherwise, create a sandbox from conversation configuration.
+
+`SandboxStarted` is sufficient to express the restored sandbox becoming
+current; a separate trial-specific event or `started_from_snapshot` exception
+is unnecessary. Sandbox event replay should treat a later `SandboxStarted` as
+moving that active sandbox to the front of selection. The shell and general
+conversation-sandbox paths must share this rule rather than implementing
+slightly different matching behavior.
+
+## Adapter state
+
+The durable record for each target gains:
+
+```text
+conversation_id
+latest_snapshot_id
+active phase: trial or feedback
+active request id
+completed request ids and responses
+```
+
+The Rust trial runtime owns conversation and snapshot state. The worker owns
+socket delivery, request retry, and response replay. A completion response must
+not enter the worker outbox until its snapshot id is durably recorded.
+
+If Exo restarts during work or reflection, the worker replays the active phase
+against the same conversation. If it restarts while finalizing completion, it
+must either return the already-recorded response or finish snapshotting before
+returning; it must never acknowledge a response with no recoverable snapshot.
+
+## Ownership and cleanup
+
+- The evaluator owns and cleans up the original task container.
+- Exo may run commands in and snapshot that container while it is attached.
+- Detaching releases Exo's reference but does not stop or delete the original.
+- Exo owns sandboxes created from its snapshots and may stop or delete them.
+- Snapshot retention follows Exo state retention. Removing a trial record may
+  later garbage-collect snapshots that are no longer referenced.
+
+## Implementation split
+
+The change should be reviewable in two commits:
+
+1. **Exoharness lifecycle support:** snapshot attachments, create a new sandbox
+   from a snapshot, and make explicit sandbox starts win selection.
+2. **Trial feedback:** protocol types, durable target state, prompts, completion
+   snapshotting, feedback restore, and Harbor-side feedback submission/export.
+
+Cancellation and the more general executor-independent trial runner are outside
+this change.
+
+## Open questions
+
+- Whether detachment failure after a successful snapshot should fail trial
+  completion or be logged as cleanup failure. Snapshot durability must remain
+  the hard requirement.

--- a/exo/scripts/deferred-rebuild-and-restart
+++ b/exo/scripts/deferred-rebuild-and-restart
@@ -12,6 +12,7 @@
 #   $4 reason_json          JSON-encoded string|null
 #   $5 exo_bin
 #   $6 env_file
+#   $7 exo_root
 #   $@ guardian command...
 set -u
 
@@ -21,7 +22,8 @@ update_id="$3"
 reason_json="$4"
 exo_bin="$5"
 env_file="$6"
-shift 6
+exo_root="$7"
+shift 7
 
 printf '\n[%s] queued rebuild update %s reason=%s:' \
   "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
@@ -59,7 +61,8 @@ fs.writeFileSync(path, `${JSON.stringify(record)}\n`);
 fi
 
 set +e
-"$exo_bin" --env-file-if-exists "$env_file" conversation complete-rebuild-update \
+"$exo_bin" --root "$exo_root" --env-file-if-exists "$env_file" \
+  conversation complete-rebuild-update \
   --outcome "$record" \
   --status "$status" \
   --exit-code "$code" \

--- a/exo/scripts/exo-service-guardian
+++ b/exo/scripts/exo-service-guardian
@@ -2,7 +2,8 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-STATE_DIR="$ROOT_DIR/.exo"
+EXO_ROOT="${EXO_ROOT:-$ROOT_DIR/.exo}"
+STATE_DIR="$EXO_ROOT"
 CONFIG_FILE="${EXO_SERVICE_GUARDIAN_CONFIG:-$STATE_DIR/exo-service-guardian.env}"
 
 # Match exo.sh: services restarted by the guardian spawn node (harness runner,
@@ -208,11 +209,19 @@ pid_running() {
   [[ -f "$pid_file" ]] || return 1
   pid="$(<"$pid_file")"
   [[ "$pid" =~ ^[0-9]+$ ]] || return 1
-  kill -0 "$pid" >/dev/null 2>&1
+  process_running "$pid"
+}
+
+process_running() {
+  local pid="$1"
+  local state
+  kill -0 "$pid" >/dev/null 2>&1 || return 1
+  state="$(ps -o stat= -p "$pid" 2>/dev/null)" || return 1
+  [[ -n "$state" && "$state" != Z* ]]
 }
 
 exo_global_args() {
-  printf '%s\0' --env-file-if-exists "$ENV_FILE"
+  printf '%s\0' --root "$EXO_ROOT" --env-file-if-exists "$ENV_FILE"
   if [[ -n "$SANDBOX_BACKEND" ]]; then
     printf '%s\0' --sandbox-backend "$SANDBOX_BACKEND"
   fi
@@ -249,7 +258,7 @@ start_scheduler() {
   fi
   rm -f "$(scheduler_lock_file)" "$(scheduler_restart_file)"
   echo "Starting scheduler..."
-  local scheduler_args=(--env-file-if-exists "$ENV_FILE")
+  local scheduler_args=(--root "$EXO_ROOT" --env-file-if-exists "$ENV_FILE")
   if [[ -n "$SANDBOX_BACKEND" ]]; then
     scheduler_args+=(--sandbox-backend "$SANDBOX_BACKEND")
   fi
@@ -289,7 +298,7 @@ stop_pid_file() {
   local pid
   if [[ -f "$pid_file" ]]; then
     pid="$(<"$pid_file")"
-    if [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" >/dev/null 2>&1; then
+    if [[ "$pid" =~ ^[0-9]+$ ]] && process_running "$pid"; then
       echo "Stopping $label..."
       terminate_process_tree "$pid"
     fi
@@ -311,7 +320,7 @@ drain_pid_file() {
     return
   fi
   pid="$(<"$pid_file")"
-  if ! [[ "$pid" =~ ^[0-9]+$ ]] || ! kill -0 "$pid" >/dev/null 2>&1; then
+  if ! [[ "$pid" =~ ^[0-9]+$ ]] || ! process_running "$pid"; then
     rm -f "$pid_file"
     return
   fi
@@ -328,11 +337,11 @@ drain_pid_file() {
     terminate_process_tree "$pid"
   else
     waited=0
-    while kill -0 "$pid" >/dev/null 2>&1 && [[ "$waited" -lt "$DRAIN_GRACE_SECONDS" ]]; do
+    while process_running "$pid" && [[ "$waited" -lt "$DRAIN_GRACE_SECONDS" ]]; do
       sleep 1
       waited=$((waited + 1))
     done
-    if kill -0 "$pid" >/dev/null 2>&1; then
+    if process_running "$pid"; then
       echo "$label still running after ${DRAIN_GRACE_SECONDS}s drain grace; stopping process tree..."
       terminate_process_tree "$pid"
     else
@@ -344,14 +353,11 @@ drain_pid_file() {
 
 stop_scheduler() {
   drain_pid_file "Exo scheduler" "$(scheduler_pid_file)" "$(scheduler_restart_file)"
-  pkill -f "exo-scheduler-runner .*run --watch" >/dev/null 2>&1 || true
   rm -f "$(scheduler_lock_file)"
 }
 
 stop_adapters() {
   drain_pid_file "Exo adapter runner" "$(adapters_pid_file)" "$(adapters_restart_file)"
-  pkill -f "exo .*adapters run" >/dev/null 2>&1 || true
-  pkill -f "tsx exo/adapters/.*/worker.ts" >/dev/null 2>&1 || true
 }
 
 start_services() {

--- a/exo/tools/guardian-tools.test.ts
+++ b/exo/tools/guardian-tools.test.ts
@@ -2,12 +2,20 @@ import { HarnessToolRegistry, type TurnContext } from "@exo/harness";
 import { describe, expect, it } from "vitest";
 
 import {
+  guardianStateDir,
   parseRebuildReason,
   rebuildAndRestartExoTool,
   registerGuardianTools,
 } from "./guardian-tools";
 
 describe("guardian tools", () => {
+  it("uses the active Exo root for guardian state", () => {
+    expect(guardianStateDir({ EXO_ROOT: "/tmp/eval-exo" }, "/src/exo")).toBe(
+      "/tmp/eval-exo",
+    );
+    expect(guardianStateDir({}, "/src/exo")).toBe("/src/exo/.exo");
+  });
+
   it("registers only rebuild_and_restart_exo", () => {
     const registry = new HarnessToolRegistry({} as TurnContext);
 

--- a/exo/tools/guardian-tools.ts
+++ b/exo/tools/guardian-tools.ts
@@ -22,16 +22,23 @@ const GUARDIAN_SCRIPT = new URL(
   import.meta.url,
 ).pathname;
 const DEFERRED_SCRIPT = new URL(
-  "./scripts/deferred-rebuild-and-restart",
+  "../scripts/deferred-rebuild-and-restart",
   import.meta.url,
 ).pathname;
 const ROOT_DIR = new URL("../..", import.meta.url).pathname;
-const STATE_DIR = join(ROOT_DIR, ".exo");
+const STATE_DIR = guardianStateDir(process.env, ROOT_DIR);
 const DEFERRED_LOG_PATH = join(STATE_DIR, "exo-service-guardian-actions.log");
 const UPDATE_DIR = join(STATE_DIR, "guardian-updates");
 const EXO_BIN = join(ROOT_DIR, "target/debug/exo");
 const ENV_FILE = join(ROOT_DIR, ".env");
 const DEFERRED_RESTART_DELAY_SECONDS = 2;
+
+export function guardianStateDir(
+  env: NodeJS.ProcessEnv,
+  repoRoot: string,
+): string {
+  return env.EXO_ROOT ?? join(repoRoot, ".exo");
+}
 
 export function registerGuardianTools(registry: HarnessToolRegistry): void {
   registry.register(rebuildAndRestartExoTool());
@@ -141,6 +148,7 @@ function runGuardianDeferredWithOutcome(
       JSON.stringify(reason),
       EXO_BIN,
       ENV_FILE,
+      STATE_DIR,
       ...command,
     ],
     {

--- a/exoharness/docs/sandbox-snapshots.md
+++ b/exoharness/docs/sandbox-snapshots.md
@@ -23,6 +23,13 @@ it, and the restore path that actually consumes it.
 - `ConversationHandle::start_sandbox(StartSandboxRequest { id, snapshot_id, .. })`
   starts a fresh container whose filesystem is sourced from the snapshot,
   preserving the original sandbox's mounts, network policy, and lifecycle.
+- `ConversationHandle::create_sandbox_from_snapshot(...)` starts the snapshot
+  under a new sandbox id. The source sandbox remains unchanged, which makes
+  this the appropriate operation for copying submitted evaluation state into
+  an Exo-owned feedback environment.
+- Attached Docker containers can be snapshotted without transferring lifecycle
+  ownership. Snapshotting pauses the container only for `docker commit`; Exo
+  still cannot stop or delete the attached container.
 - A chat-REPL slash-command surface — `/snapshot`, `/snapshots`, `/rewind <id>`,
   `/teleport <provider>` — that drives the round-trip without leaving the
   conversation.
@@ -58,6 +65,7 @@ ConversationHandle             ManagedSandboxHandle           ManagedSandboxBack
   (manifest.json + payload.bin)                                         │
                                                                         │
   start_sandbox(req) ─── load manifest + payload ──► acquire_from_snapshot(req, payload)
+  create_sandbox_from_snapshot(req) ───────────────► acquire_from_snapshot(new id, payload)
 ```
 
 `ConversationHandle` orchestrates: it locates the live handle, asks for a
@@ -65,6 +73,11 @@ payload, persists the bytes, updates sandbox metadata, and emits the
 `SandboxSnapshotted` event. `ManagedSandboxHandle::snapshot` and
 `ManagedSandboxBackend::acquire_from_snapshot` are the backend-specific
 methods that produce and consume the bytes.
+
+`start_sandbox` restores in place and retains the source sandbox id.
+`create_sandbox_from_snapshot` copies the source sandbox configuration into a
+new owned sandbox record and restores the payload there. The latter never
+changes the source record or provider resource.
 
 ### SnapshotPayload and SnapshotKind
 

--- a/exoharness/typescript/harness/adapter-tools.ts
+++ b/exoharness/typescript/harness/adapter-tools.ts
@@ -551,6 +551,19 @@ function adapterConfigSchema(): ToolDefinition["parameters"] {
         },
         required: ["type", "socketPath", "mountRoot", "mountPath"],
       },
+      {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          type: { type: "string", enum: ["trial"] },
+          socketPath: {
+            type: "string",
+            description:
+              "Absolute host unix socket path on which an evaluation runner submits containerized trials.",
+          },
+        },
+        required: ["type", "socketPath"],
+      },
     ],
   } as ToolDefinition["parameters"];
 }
@@ -572,7 +585,8 @@ function validateAdapterSource(source: string, type: string): void {
       type === "whatsapp" ||
       type === "signal" ||
       type === "discord" ||
-      type === "slack") &&
+      type === "slack" ||
+      type === "trial") &&
     source !== "library"
   ) {
     throw new Error(`${type} adapters must use source 'library'`);


### PR DESCRIPTION
Adds the generic trial adapter and the Harbor evaluation workflow built on it. Includes trial lifecycle acknowledgements, partial-trajectory export, cancellation, snapshots, feedback reflection, task filtering, and smoke datasets.

The commits remain separated by layer for review.