### PR TITLE
Add Harbor trial evaluation integration

### DIFF
--- a/crates/executor/src/adapter/runtime.rs
+++ b/crates/executor/src/adapter/runtime.rs
@@ -15,7 +15,7 @@ use lingua::universal::{TextContentPart, UserContent, UserContentPart};
 
 use super::store::{AdapterStore, stable_target_key};
 use super::tools::download_attachment;
-use super::trial::prepare_trial_run;
+use super::trial::{prepare_trial_run, trial_started};
 use super::types::{
     AdapterAttachment, AdapterAttachmentKind, AdapterConfig, AdapterDeliveryStatus,
     AdapterEventType, AdapterRecord, AdapterTargetConversationRecord, now_ms,
@@ -381,6 +381,16 @@ pub async fn send_adapter_message_with_handles(
     target: Option<&str>,
     attachments: Vec<AdapterAttachment>,
 ) -> Result<String> {
+    queue_adapter_message(store, adapter, text, target, attachments).await
+}
+
+async fn queue_adapter_message(
+    store: &AdapterStore,
+    adapter: &AdapterRecord,
+    text: &str,
+    target: Option<&str>,
+    attachments: Vec<AdapterAttachment>,
+) -> Result<String> {
     if !adapter.enabled {
         bail!("adapter is disabled: {}", adapter.id);
     }
@@ -587,7 +597,12 @@ async fn handle_worker_event(
             )
             .await?;
             if config.adapter_type == "trial" {
-                prepare_trial_run(conversation.as_ref(), metadata.clone()).await?;
+                let prepared = prepare_trial_run(conversation.as_ref(), metadata.clone()).await?;
+                let conversation_id = conversation.record().id.to_string();
+                let started = trial_started(&prepared, &target, &conversation_id)?;
+                // Publish the conversation id before entering the potentially
+                // long-running wakeup turn so evaluators can retain it on timeout.
+                queue_adapter_message(store, adapter, &started, Some(&target), Vec::new()).await?;
             }
             handle_worker_message(
                 store,

--- a/crates/executor/src/adapter/trial.rs
+++ b/crates/executor/src/adapter/trial.rs
@@ -12,6 +12,10 @@ struct TrialRunMetadata {
     container_id: String,
 }
 
+pub(super) struct PreparedTrialRun {
+    request_id: String,
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
 enum TrialCompletionSignal {
@@ -32,10 +36,19 @@ struct TrialComplete<'a> {
     summary: Option<&'a str>,
 }
 
+#[derive(Debug, Serialize)]
+struct TrialStarted<'a> {
+    #[serde(rename = "type")]
+    message_type: &'static str,
+    request_id: &'a str,
+    target: &'a str,
+    conversation_id: &'a str,
+}
+
 pub(super) async fn prepare_trial_run(
     conversation: &dyn HarnessConversation,
     metadata: serde_json::Value,
-) -> Result<()> {
+) -> Result<PreparedTrialRun> {
     let metadata = serde_json::from_value::<TrialRunMetadata>(metadata)
         .context("trial_run metadata is invalid")?;
     if metadata.request_id.trim().is_empty() {
@@ -52,7 +65,9 @@ pub(super) async fn prepare_trial_run(
         .await?
         .is_some()
     {
-        return Ok(());
+        return Ok(PreparedTrialRun {
+            request_id: metadata.request_id,
+        });
     }
 
     conversation
@@ -64,7 +79,22 @@ pub(super) async fn prepare_trial_run(
             default_workdir: None,
         })
         .await?;
-    Ok(())
+    Ok(PreparedTrialRun {
+        request_id: metadata.request_id,
+    })
+}
+
+pub(super) fn trial_started(
+    prepared: &PreparedTrialRun,
+    target: &str,
+    conversation_id: &str,
+) -> Result<String> {
+    Ok(serde_json::to_string(&TrialStarted {
+        message_type: "trial_started",
+        request_id: &prepared.request_id,
+        target,
+        conversation_id,
+    })?)
 }
 
 pub(super) fn finalize_trial_completion(
@@ -112,6 +142,27 @@ mod tests {
                 "target": "trial-1",
                 "conversation_id": "conversation-1",
                 "summary": "done",
+            })
+        );
+    }
+
+    #[test]
+    fn started_adds_runtime_owned_conversation_id() {
+        let response = trial_started(
+            &PreparedTrialRun {
+                request_id: "request-1".to_string(),
+            },
+            "trial-1",
+            "conversation-1",
+        )
+        .expect("started response");
+        assert_eq!(
+            serde_json::from_str::<serde_json::Value>(&response).expect("response JSON"),
+            serde_json::json!({
+                "type": "trial_started",
+                "request_id": "request-1",
+                "target": "trial-1",
+                "conversation_id": "conversation-1",
             })
         );
     }

--- a/eval/harbor/.gitignore
+++ b/eval/harbor/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+*.egg-info/
+.venv/

--- a/eval/harbor/README.md
+++ b/eval/harbor/README.md
@@ -1,0 +1,126 @@
+# Exo agent for Harbor
+
+Runs Exo as a Harbor external agent so it can be evaluated over Harbor's
+benchmark catalog. The Exo-side adapter that handles waking Exo's
+conversation and waiting on a response lives in the generic
+[`exo/adapters/trial`](../../exo/adapters/trial) adapter.
+
+## The split
+
+Harbor has two lifecycle planes relevant to Exo:
+
+1. `BaseAgent`, which is constructed fresh for each trial and controls what
+   happens during the trail.
+2. `Plugin`, which lives for the duration of a full job and exposes hooks for
+   initial agent setup, per-trial completions, and final Exo tear-down.
+
+|                                                            | Owns                                                                |
+| ---------------------------------------------------------- | ------------------------------------------------------------------- |
+| [`plugin.py`](src/exo_harbor/plugin.py) `ExoSessionPlugin` | Exo's lifetime and the adapter runner. Job-scoped.                  |
+| [`agent.py`](src/exo_harbor/agent.py) `ExoAgent`           | One task: resolve the container, submit it, and wait. Trial-scoped. |
+
+Thus the end-to-end lifecycle looks like this:
+
+```
+attach_job_plugins(job)
+  on_job_start(job)          start Exo, create adapter (fixed slug + socket)
+  job.run()
+    Trial.create()           new ExoAgent
+      setup(env)             resolve Harbor's container     [once per trial]
+      run(instruction)       trial_run -> trial_complete    [once per step]
+      <verifier runs>
+      TrialEvent.END         record accumulated agent state
+    ... next trial ...
+```
+
+Nit: run() is called per-_step_, which is a construct that exists for some
+types of tasks where there are intermediate checkpoints to specify. For most
+common task-sets, such as terminal-bench, there is only one default step.
+
+## Responsibilities
+
+Harbor constructs the agent and plugin independently:
+
+- The plugin creates the persistent Exo agent and trial adapter, then starts
+  the adapter runner.
+- Each Harbor agent resolves its task container, submits it through the shared
+  socket, and uses the returned conversation id to export its trajectory.
+
+The plugin recovers `exo_root` from `job.config.agents[0].kwargs` rather than
+taking its own `--pk` copy, so the path is written down once.
+
+Because nothing is handed over, `setup()` instead probes the adapter socket as
+a preflight. That is what catches a run launched with `--agent` but no
+`--plugin`: every convention would still resolve to something plausible, but
+there would be no worker to accept the trial. A live probe is a stronger check
+than a marker file, which can be stale from an earlier run.
+
+## Running
+
+The usual entry point is deliberately small:
+
+```bash
+cd eval/harbor
+./eval.sh --dataset=terminal-bench
+```
+
+It defaults to GPT-5.5, all tasks in the dataset, and one attempt. Flags can
+limit or override those defaults:
+
+```bash
+./eval.sh --dataset=terminal-bench --model=gpt-5.5 --n-tasks=10 --n-attempts=2
+```
+
+For a quick end-to-end check using the bundled tiny task:
+
+```bash
+./eval.sh --dataset=smoke-test --n-tasks=1
+```
+
+To test self-evolution across trials, run the bundled three-task dataset. Its
+first trial asks Exo to install and use a custom tool; its second trial uses
+the installed tool again from a fresh conversation and container; its third
+trial changes durable agent policy state, rebuilds and restarts Exo, then
+finishes the trial after the adapter reconnects.
+
+```bash
+./eval.sh --dataset=self-evolution-smoke-test
+```
+
+For a short real benchmark run, `terminal-bench-easy` selects three Terminal
+Bench 2 tasks marked easy: `fix-git`, `prove-plus-comm`, and
+`cobol-modernization`.
+
+```bash
+./eval.sh --dataset=terminal-bench-easy
+```
+
+For repeatable runs, copy [`eval.example.toml`](eval.example.toml), edit it,
+and run:
+
+```bash
+./eval.sh --config=my-eval.toml
+```
+
+Command-line flags take precedence over the config file. Harbor datasets can
+also be given as `name@version`. Endless Terminals is not currently in the
+Harbor registry, so pass a local checkout with
+`--dataset=endless-terminals --dataset-path=/path/to/dataset`.
+
+The wrapper creates `.venv` on its first run. The runner builds Exo, starts the
+evaluation, shows Harbor's live task progress, and prints the score and result
+paths when it finishes. Runs are saved under `.local/harbor-evals` at the
+repository root. Harbor also prints a `harbor view ...` command for opening its
+full results UI. Each trial's Trajectory tab shows the Exo rollout, including
+model messages, tool calls and results, token usage, and cost. Each trial gets
+its own target-scoped Exo conversation.
+
+`--n-concurrent 1` is intentionally fixed so each trial deterministically sees
+the persistent agent changes made by all earlier trials.
+
+Feedback and container snapshotting are intentionally deferred. Version one
+ends at `trial_complete`; Harbor then grades and cleans up its original
+container normally.
+
+The package is pinned to `harbor>=0.20,<0.21` because the `JobPlugin` protocol
+and the `TrialEvent.END` payload may move between Harbor minor releases.

--- a/eval/harbor/README.md
+++ b/eval/harbor/README.md
@@ -27,7 +27,8 @@ attach_job_plugins(job)
   job.run()
     Trial.create()           new ExoAgent
       setup(env)             resolve Harbor's container     [once per trial]
-      run(instruction)       trial_run -> trial_complete    [once per step]
+      run(instruction)       trial_run -> trial_started -> trial_complete
+                                                             [once per step]
       <verifier runs>
       TrialEvent.END         record accumulated agent state
     ... next trial ...
@@ -44,7 +45,8 @@ Harbor constructs the agent and plugin independently:
 - The plugin creates the persistent Exo agent and trial adapter, then starts
   the adapter runner.
 - Each Harbor agent resolves its task container, submits it through the shared
-  socket, and uses the returned conversation id to export its trajectory.
+  socket, and retains the conversation id from `trial_started`. It exports the
+  trajectory after completion or timeout.
 
 The plugin recovers `exo_root` from `job.config.agents[0].kwargs` rather than
 taking its own `--pk` copy, so the path is written down once.

--- a/eval/harbor/README.md
+++ b/eval/harbor/README.md
@@ -73,6 +73,17 @@ limit or override those defaults:
 ./eval.sh --dataset=terminal-bench --model=gpt-5.5 --n-tasks=10 --n-attempts=2
 ```
 
+Select particular tasks by repeating `--include-task-name`:
+
+```bash
+./eval.sh --dataset=terminal-bench \
+  --include-task-name=path-tracing \
+  --include-task-name=gpt2-codegolf
+```
+
+The equivalent TOML field is `include_task_names = ["path-tracing",
+"gpt2-codegolf"]`.
+
 For a quick end-to-end check using the bundled tiny task:
 
 ```bash

--- a/eval/harbor/datasets/self-evolution-smoke-test/01-install-tool/environment/Dockerfile
+++ b/eval/harbor/datasets/self-evolution-smoke-test/01-install-tool/environment/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:24.04
+
+WORKDIR /app

--- a/eval/harbor/datasets/self-evolution-smoke-test/01-install-tool/instruction.md
+++ b/eval/harbor/datasets/self-evolution-smoke-test/01-install-tool/instruction.md
@@ -1,0 +1,16 @@
+Create and install an agent tool with module name `evolution-stamp` and tool
+name `evolution_stamp`.
+
+The tool must take one required string parameter named `text` and return an
+object with one string field named `stamped`. Its result must be `EVOLVED:`
+followed by `text` converted to uppercase.
+
+Install it with `install_agent_tool`, then call the newly installed
+`evolution_stamp` tool with `text` set to `first trial`. Use the tool's returned
+value to create `/app/evolution.txt`, containing exactly:
+
+```text
+EVOLVED:FIRST TRIAL
+```
+
+Do not implement the transformation with shell or another existing tool.

--- a/eval/harbor/datasets/self-evolution-smoke-test/01-install-tool/task.toml
+++ b/eval/harbor/datasets/self-evolution-smoke-test/01-install-tool/task.toml
@@ -1,0 +1,30 @@
+schema_version = "1.4"
+
+[task]
+name = "exo/self-evolution-install-tool"
+version = "1.0.0"
+authors = []
+keywords = ["smoke", "self-evolution", "tools"]
+
+[metadata]
+difficulty = "easy"
+category = "testing"
+tags = ["smoke", "self-evolution"]
+
+[verifier]
+timeout_sec = 30.0
+
+[agent]
+timeout_sec = 180.0
+
+[environment]
+build_timeout_sec = 120.0
+cpus = 1
+memory_mb = 512
+storage_mb = 1024
+gpus = 0
+mcp_servers = []
+
+[verifier.env]
+
+[solution.env]

--- a/eval/harbor/datasets/self-evolution-smoke-test/01-install-tool/tests/test.sh
+++ b/eval/harbor/datasets/self-evolution-smoke-test/01-install-tool/tests/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+if [[ -f /app/evolution.txt ]] &&
+  [[ $(cat /app/evolution.txt) == "EVOLVED:FIRST TRIAL" ]]; then
+  echo 1 > /logs/verifier/reward.txt
+else
+  echo 0 > /logs/verifier/reward.txt
+fi

--- a/eval/harbor/datasets/self-evolution-smoke-test/02-reuse-tool/environment/Dockerfile
+++ b/eval/harbor/datasets/self-evolution-smoke-test/02-reuse-tool/environment/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:24.04
+
+WORKDIR /app

--- a/eval/harbor/datasets/self-evolution-smoke-test/02-reuse-tool/instruction.md
+++ b/eval/harbor/datasets/self-evolution-smoke-test/02-reuse-tool/instruction.md
@@ -1,0 +1,12 @@
+The previous trial installed an agent tool named `evolution_stamp`. Do not
+reinstall, replace, or recreate it. Call that existing tool with `text` set to
+`second trial`, then use its returned value to create `/app/evolution.txt`,
+containing exactly:
+
+```text
+EVOLVED:SECOND TRIAL
+```
+
+Do not implement the transformation with shell or another tool. The point of
+this trial is to demonstrate that the tool installed by the earlier trial is
+available in this fresh conversation and container.

--- a/eval/harbor/datasets/self-evolution-smoke-test/02-reuse-tool/task.toml
+++ b/eval/harbor/datasets/self-evolution-smoke-test/02-reuse-tool/task.toml
@@ -1,0 +1,30 @@
+schema_version = "1.4"
+
+[task]
+name = "exo/self-evolution-reuse-tool"
+version = "1.0.0"
+authors = []
+keywords = ["smoke", "self-evolution", "tools"]
+
+[metadata]
+difficulty = "easy"
+category = "testing"
+tags = ["smoke", "self-evolution"]
+
+[verifier]
+timeout_sec = 30.0
+
+[agent]
+timeout_sec = 120.0
+
+[environment]
+build_timeout_sec = 120.0
+cpus = 1
+memory_mb = 512
+storage_mb = 1024
+gpus = 0
+mcp_servers = []
+
+[verifier.env]
+
+[solution.env]

--- a/eval/harbor/datasets/self-evolution-smoke-test/02-reuse-tool/tests/test.sh
+++ b/eval/harbor/datasets/self-evolution-smoke-test/02-reuse-tool/tests/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+if [[ -f /app/evolution.txt ]] &&
+  [[ $(cat /app/evolution.txt) == "EVOLVED:SECOND TRIAL" ]]; then
+  echo 1 > /logs/verifier/reward.txt
+else
+  echo 0 > /logs/verifier/reward.txt
+fi

--- a/eval/harbor/datasets/self-evolution-smoke-test/03-restart-policy/environment/Dockerfile
+++ b/eval/harbor/datasets/self-evolution-smoke-test/03-restart-policy/environment/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:24.04
+
+WORKDIR /app

--- a/eval/harbor/datasets/self-evolution-smoke-test/03-restart-policy/instruction.md
+++ b/eval/harbor/datasets/self-evolution-smoke-test/03-restart-policy/instruction.md
@@ -1,0 +1,23 @@
+This trial tests durable policy state and continuation across an Exo restart.
+Complete it in two distinct phases.
+
+Before the restart:
+
+1. Call `remember` with exactly this standalone policy statement:
+   `Restart smoke policy: after Exo restarts, write RESTARTED:POLICY ACTIVE to /app/restarted.txt.`
+2. Call `rebuild_and_restart_exo` with reason
+   `activate restart smoke policy`.
+3. Once the restart has been queued, end the current model turn immediately.
+   Do not create `/app/restarted.txt` and do not send the trial completion
+   message before the restart.
+
+After the adapter reconnects and wakes this conversation following the host
+restart, follow the durable policy you saved: create `/app/restarted.txt`
+containing exactly:
+
+```text
+RESTARTED:POLICY ACTIVE
+```
+
+Only then complete the trial. Do not call `rebuild_and_restart_exo` a second
+time.

--- a/eval/harbor/datasets/self-evolution-smoke-test/03-restart-policy/task.toml
+++ b/eval/harbor/datasets/self-evolution-smoke-test/03-restart-policy/task.toml
@@ -1,0 +1,30 @@
+schema_version = "1.4"
+
+[task]
+name = "exo/self-evolution-restart-policy"
+version = "1.0.0"
+authors = []
+keywords = ["smoke", "self-evolution", "restart"]
+
+[metadata]
+difficulty = "easy"
+category = "testing"
+tags = ["smoke", "self-evolution", "restart"]
+
+[verifier]
+timeout_sec = 30.0
+
+[agent]
+timeout_sec = 300.0
+
+[environment]
+build_timeout_sec = 120.0
+cpus = 1
+memory_mb = 512
+storage_mb = 1024
+gpus = 0
+mcp_servers = []
+
+[verifier.env]
+
+[solution.env]

--- a/eval/harbor/datasets/self-evolution-smoke-test/03-restart-policy/tests/test.sh
+++ b/eval/harbor/datasets/self-evolution-smoke-test/03-restart-policy/tests/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+if [[ -f /app/restarted.txt ]] &&
+  [[ $(cat /app/restarted.txt) == "RESTARTED:POLICY ACTIVE" ]]; then
+  echo 1 > /logs/verifier/reward.txt
+else
+  echo 0 > /logs/verifier/reward.txt
+fi

--- a/eval/harbor/datasets/self-evolution-smoke-test/04-timeout-trajectory/environment/Dockerfile
+++ b/eval/harbor/datasets/self-evolution-smoke-test/04-timeout-trajectory/environment/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:24.04
+
+WORKDIR /app

--- a/eval/harbor/datasets/self-evolution-smoke-test/04-timeout-trajectory/instruction.md
+++ b/eval/harbor/datasets/self-evolution-smoke-test/04-timeout-trajectory/instruction.md
@@ -1,0 +1,12 @@
+This trial intentionally tests trajectory export when Harbor times out.
+
+Use the shell once to run exactly this foreground command, and wait for it to
+finish:
+
+```bash
+printf 'STARTED\n' > /app/timeout-started.txt && sleep 120 && printf 'FINISHED\n' > /app/timeout-finished.txt
+```
+
+Only after that command finishes, complete the trial normally. Do not shorten,
+background, interrupt, or otherwise avoid the sleep. Harbor will stop waiting
+after 30 seconds, so the trial is not expected to reach completion.

--- a/eval/harbor/datasets/self-evolution-smoke-test/04-timeout-trajectory/task.toml
+++ b/eval/harbor/datasets/self-evolution-smoke-test/04-timeout-trajectory/task.toml
@@ -1,0 +1,30 @@
+schema_version = "1.4"
+
+[task]
+name = "exo/self-evolution-timeout-trajectory"
+version = "1.0.0"
+authors = []
+keywords = ["smoke", "self-evolution", "timeout", "trajectory"]
+
+[metadata]
+difficulty = "easy"
+category = "testing"
+tags = ["smoke", "self-evolution", "timeout", "trajectory"]
+
+[verifier]
+timeout_sec = 30.0
+
+[agent]
+timeout_sec = 30.0
+
+[environment]
+build_timeout_sec = 120.0
+cpus = 1
+memory_mb = 512
+storage_mb = 1024
+gpus = 0
+mcp_servers = []
+
+[verifier.env]
+
+[solution.env]

--- a/eval/harbor/datasets/self-evolution-smoke-test/04-timeout-trajectory/tests/test.sh
+++ b/eval/harbor/datasets/self-evolution-smoke-test/04-timeout-trajectory/tests/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+if [[ $(cat /app/timeout-started.txt 2>/dev/null) == "STARTED" ]] &&
+  [[ ! -e /app/timeout-finished.txt ]]; then
+  echo 1 > /logs/verifier/reward.txt
+else
+  echo 0 > /logs/verifier/reward.txt
+fi

--- a/eval/harbor/datasets/smoke-test/environment/Dockerfile
+++ b/eval/harbor/datasets/smoke-test/environment/Dockerfile
@@ -1,0 +1,3 @@
+FROM ubuntu:24.04
+
+WORKDIR /app

--- a/eval/harbor/datasets/smoke-test/instruction.md
+++ b/eval/harbor/datasets/smoke-test/instruction.md
@@ -1,0 +1,1 @@
+Create `/app/done.txt` containing exactly `ready` followed by a newline.

--- a/eval/harbor/datasets/smoke-test/task.toml
+++ b/eval/harbor/datasets/smoke-test/task.toml
@@ -1,0 +1,30 @@
+schema_version = "1.4"
+
+[task]
+name = "exo/harbor-lifecycle-smoke"
+version = "1.0.0"
+authors = []
+keywords = ["smoke"]
+
+[metadata]
+difficulty = "easy"
+category = "testing"
+tags = ["smoke"]
+
+[verifier]
+timeout_sec = 30.0
+
+[agent]
+timeout_sec = 120.0
+
+[environment]
+build_timeout_sec = 120.0
+cpus = 1
+memory_mb = 512
+storage_mb = 1024
+gpus = 0
+mcp_servers = []
+
+[verifier.env]
+
+[solution.env]

--- a/eval/harbor/datasets/smoke-test/tests/test.sh
+++ b/eval/harbor/datasets/smoke-test/tests/test.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [[ -f /app/done.txt ]] && [[ $(cat /app/done.txt) == ready ]]; then
+  echo 1 > /logs/verifier/reward.txt
+else
+  echo 0 > /logs/verifier/reward.txt
+fi

--- a/eval/harbor/eval.example.toml
+++ b/eval/harbor/eval.example.toml
@@ -1,0 +1,14 @@
+# Flags passed to eval.sh override this file.
+dataset = "terminal-bench"
+# For a shorter run of three easy tasks, use "terminal-bench-easy".
+model = "gpt-5.5"
+n_tasks = 10
+n_attempts = 1
+
+# "shared" measures learning across tasks. "per_task" isolates task context
+# while retaining agent-level state such as tools, memory, and source changes.
+
+# Endless Terminals is currently a local dataset rather than a Harbor registry
+# entry. To run it, replace dataset above and set its local path.
+# dataset = "endless-terminals"
+# dataset_path = ".local/datasets/endless-terminals"

--- a/eval/harbor/eval.py
+++ b/eval/harbor/eval.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Run Exo on a Harbor dataset and print the result."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import os
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+
+DATASETS = {
+    "terminal-bench": "terminal-bench@2.0",
+    "terminal-bench-easy": "terminal-bench@2.0",
+    "terminal-bench-sample": "terminal-bench-sample@2.0",
+    "terminal-bench-pro": "terminal-bench-pro@1.0",
+}
+LOCAL_DATASETS = {
+    "smoke-test": "datasets/smoke-test",
+    "self-evolution-smoke-test": "datasets/self-evolution-smoke-test",
+}
+DATASET_TASKS = {
+    "terminal-bench-easy": (
+        "fix-git",
+        "prove-plus-comm",
+        "cobol-modernization",
+    ),
+}
+CONFIG_FIELDS = {
+    "dataset",
+    "dataset_path",
+    "model",
+    "n_tasks",
+    "n_attempts",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    config_parser = argparse.ArgumentParser(add_help=False)
+    config_parser.add_argument("--config", type=Path)
+    known, _ = config_parser.parse_known_args()
+
+    defaults = {
+        "dataset": "terminal-bench",
+        "dataset_path": None,
+        "model": "gpt-5.5",
+        "n_tasks": None,
+        "n_attempts": 1,
+    }
+    if known.config is not None:
+        with known.config.open("rb") as file:
+            configured = tomllib.load(file)
+        unknown = sorted(set(configured) - CONFIG_FIELDS)
+        if unknown:
+            raise ValueError(f"unknown config fields: {', '.join(unknown)}")
+        defaults.update(configured)
+
+    parser = argparse.ArgumentParser(
+        parents=[config_parser],
+        description="Run Exo on a Harbor dataset.",
+    )
+    parser.set_defaults(**defaults)
+    parser.add_argument(
+        "--dataset",
+        help=(
+            "smoke-test, self-evolution-smoke-test, terminal-bench, "
+            "terminal-bench-easy, terminal-bench-sample, terminal-bench-pro, "
+            "or name@version"
+        ),
+    )
+    parser.add_argument(
+        "--dataset-path",
+        type=Path,
+        help="local dataset directory, for example an Endless Terminals checkout",
+    )
+    parser.add_argument("--model")
+    parser.add_argument("--n-tasks", type=int)
+    parser.add_argument(
+        "--n-attempts", "--number-tries", dest="n_attempts", type=int
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the resolved command without running it",
+    )
+    return parser.parse_args()
+
+
+def dataset_arguments(args: argparse.Namespace) -> list[str]:
+    if args.dataset_path is not None:
+        dataset_path = Path(args.dataset_path).expanduser().resolve()
+        if not dataset_path.is_dir():
+            raise ValueError(f"dataset path is not a directory: {dataset_path}")
+        return ["--path", str(dataset_path)]
+    if local_dataset := LOCAL_DATASETS.get(args.dataset):
+        return ["--path", str(Path(__file__).resolve().parent / local_dataset)]
+    if args.dataset == "endless-terminals":
+        raise ValueError(
+            "Endless Terminals is not in Harbor's registry; pass --dataset-path"
+        )
+    dataset = DATASETS.get(args.dataset, args.dataset)
+    if not re.fullmatch(r"[^@\s]+@[^@\s]+", dataset):
+        raise ValueError(
+            f"unknown dataset {args.dataset!r}; use a built-in name or name@version"
+        )
+    arguments = ["--dataset", dataset]
+    for task in DATASET_TASKS.get(args.dataset, ()):
+        arguments.extend(["--include-task-name", task])
+    return arguments
+
+
+def slug(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-") or "eval"
+
+
+def harbor_command(
+    args: argparse.Namespace,
+    *,
+    harbor: Path | str,
+    repo: Path,
+    exo: Path,
+    run_dir: Path,
+    job_name: str,
+) -> list[str]:
+    task_limit = [] if args.n_tasks is None else ["--n-tasks", str(args.n_tasks)]
+    command = [
+        str(harbor),
+        "run",
+        "--env",
+        "docker",
+        "--n-concurrent",
+        "1",
+        "--n-attempts",
+        str(args.n_attempts),
+        "--agent",
+        "exo_harbor.agent:ExoAgent",
+        "--plugin",
+        "exo_harbor.plugin:ExoSessionPlugin",
+        "--model",
+        args.model,
+        "--ak",
+        f"exo_repo_root={repo}",
+        "--ak",
+        f"exo_root={run_dir / 'exo'}",
+        "--ak",
+        f"exo_bin={exo}",
+        "--ak",
+        f"exo_model={args.model}",
+        "--pk",
+        "adapter_start_timeout_sec=90",
+        "--jobs-dir",
+        str(run_dir / "jobs"),
+        *task_limit,
+        "--job-name",
+        job_name,
+        "--yes",
+        "--debug",
+        *dataset_arguments(args),
+    ]
+    return command
+
+
+def require_command(name: str) -> str:
+    command = shutil.which(name)
+    if command is None:
+        raise ValueError(f"required command is not on PATH: {name}")
+    return command
+
+
+def print_result_paths(run_dir: Path, job_name: str) -> None:
+    job_dir = run_dir / "jobs" / job_name
+    print("\n===Results===")
+    print(f"Harbor results: {job_dir / 'result.json'}")
+    print(f"View: harbor view {run_dir / 'jobs'}")
+
+
+def main() -> int:
+    try:
+        args = parse_args()
+        if (args.n_tasks is not None and args.n_tasks <= 0) or args.n_attempts <= 0:
+            raise ValueError("n_tasks and n_attempts must be positive")
+
+        repo = Path(__file__).resolve().parents[2]
+        exo = repo / "target/debug/exo"
+        timestamp = dt.datetime.now(dt.UTC).strftime("%Y%m%dT%H%M%SZ")
+        # Keep the Unix socket below Linux's 108-byte path limit. Harbor's job
+        # metadata already records the dataset and model.
+        run_dir = repo / ".local/harbor-evals" / timestamp
+        task_count = args.n_tasks if args.n_tasks is not None else "all"
+        job_name = f"{slug(args.dataset)}-{task_count}"
+        harbor = Path(sys.executable).with_name("harbor")
+        if not harbor.is_file():
+            harbor = Path(require_command("harbor"))
+        command = harbor_command(
+            args,
+            harbor=harbor,
+            repo=repo,
+            exo=exo,
+            run_dir=run_dir,
+            job_name=job_name,
+        )
+
+        if args.dry_run:
+            print(shlex.join(command))
+            return 0
+
+        print("\n===Setup===", flush=True)
+        if not os.environ.get("OPENAI_API_KEY"):
+            raise ValueError("OPENAI_API_KEY is not set")
+        for required in ("cargo", "docker", "node", "pnpm"):
+            require_command(required)
+        if subprocess.run(
+            ["docker", "info"],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        ).returncode:
+            raise ValueError("Docker is unavailable; run this through ./eval.sh")
+
+        run_dir.mkdir(parents=True)
+        subprocess.run(["cargo", "build", "-p", "exo"], cwd=repo, check=True)
+        subprocess.run(
+            [
+                str(exo),
+                "--root",
+                str(run_dir / "exo"),
+                "secret",
+                "set",
+                "openai",
+                "--env",
+                "OPENAI_API_KEY",
+            ],
+            cwd=repo,
+            check=True,
+        )
+        subprocess.run(
+            [
+                str(exo),
+                "--root",
+                str(run_dir / "exo"),
+                "model",
+                "register",
+                args.model,
+                "--secret",
+                "openai",
+                "--model",
+                args.model,
+            ],
+            cwd=repo,
+            check=True,
+        )
+        print(f"Run directory: {run_dir}")
+        print("\n===Trials===", flush=True)
+        # Let Harbor own the terminal so its built-in live progress UI works.
+        subprocess.run(command, cwd=repo, check=True)
+        print_result_paths(run_dir, job_name)
+        return 0
+    except (OSError, ValueError, subprocess.CalledProcessError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+    except KeyboardInterrupt:
+        print("\nEvaluation stopped.", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/eval/harbor/eval.py
+++ b/eval/harbor/eval.py
@@ -38,6 +38,7 @@ CONFIG_FIELDS = {
     "model",
     "n_tasks",
     "n_attempts",
+    "include_task_names",
 }
 
 
@@ -52,6 +53,7 @@ def parse_args() -> argparse.Namespace:
         "model": "gpt-5.5",
         "n_tasks": None,
         "n_attempts": 1,
+        "include_task_names": [],
     }
     if known.config is not None:
         with known.config.open("rb") as file:
@@ -82,6 +84,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--model")
     parser.add_argument("--n-tasks", type=int)
     parser.add_argument(
+        "--include-task-name",
+        dest="include_task_names",
+        action="append",
+        help="task name to include; may be passed more than once",
+    )
+    parser.add_argument(
         "--n-attempts", "--number-tries", dest="n_attempts", type=int
     )
     parser.add_argument(
@@ -110,7 +118,7 @@ def dataset_arguments(args: argparse.Namespace) -> list[str]:
             f"unknown dataset {args.dataset!r}; use a built-in name or name@version"
         )
     arguments = ["--dataset", dataset]
-    for task in DATASET_TASKS.get(args.dataset, ()):
+    for task in (*DATASET_TASKS.get(args.dataset, ()), *args.include_task_names):
         arguments.extend(["--include-task-name", task])
     return arguments
 

--- a/eval/harbor/eval.sh
+++ b/eval/harbor/eval.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+eval_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "$eval_dir/../.." && pwd)
+venv="$eval_dir/.venv"
+
+if [[ ! -x "$venv/bin/python" ]]; then
+  python3.12 -m venv "$venv"
+fi
+
+if ! "$venv/bin/python" -c 'import harbor, exo_harbor' 2>/dev/null; then
+  "$venv/bin/pip" install -e "$eval_dir"
+fi
+
+command=("$venv/bin/python" "$eval_dir/eval.py" "$@")
+
+# Harbor runs each benchmark task in a Docker container. Most shells can use
+# Docker directly; this workspace needs its configured docker group activated.
+if docker info >/dev/null 2>&1; then
+  cd "$repo_root"
+  exec "${command[@]}"
+fi
+
+if command -v sg >/dev/null 2>&1 && getent group docker >/dev/null 2>&1; then
+  printf -v quoted_command '%q ' "${command[@]}"
+  cd "$repo_root"
+  exec sg docker -c "$quoted_command"
+fi
+
+echo "Docker is unavailable. Start Docker or grant this user Docker access." >&2
+exit 1

--- a/eval/harbor/pyproject.toml
+++ b/eval/harbor/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "exo-harbor"
+version = "0.1.0"
+description = "Run Exo as a Harbor external agent"
+requires-python = ">=3.12"
+dependencies = [
+  # Pinned to the minor. The integration depends on the JobPlugin protocol
+  # and the TrialEvent.END hook payload, both of which are young enough to
+  # move between minors.
+  "harbor>=0.20,<0.21",
+]
+
+[project.entry-points."harbor.plugins"]
+# Lets runs say `--plugin exo-session` instead of the full import path.
+exo-session = "exo_harbor.plugin:ExoSessionPlugin"
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/eval/harbor/src/exo_harbor/__init__.py
+++ b/eval/harbor/src/exo_harbor/__init__.py
@@ -1,0 +1,18 @@
+"""Run Exo as a Harbor external agent.
+
+    harbor run \\
+      --env docker \\
+      --n-concurrent 1 \\
+      --agent exo_harbor.agent:ExoAgent \\
+      --plugin exo_harbor.plugin:ExoSessionPlugin \\
+      --ak exo_root=/path/to/run/exo \\
+      --ak exo_bin=/path/to/target/debug/exo
+
+Both flags are required. The agent alone would run tasks but never receive a
+grade, producing a job that looks scored but measures nothing.
+"""
+
+from exo_harbor.agent import ExoAgent
+from exo_harbor.plugin import ExoSessionPlugin
+
+__all__ = ["ExoAgent", "ExoSessionPlugin"]

--- a/eval/harbor/src/exo_harbor/agent.py
+++ b/eval/harbor/src/exo_harbor/agent.py
@@ -1,0 +1,155 @@
+"""ExoAgent — Harbor's per-trial bridge to the generic Exo trial adapter.
+
+Where this sits in Harbor's trial lifecycle:
+
+    Trial.create()                    <- new ExoAgent instance
+    trial.run()
+      _prepare()
+        _setup_agent_environment()    <- docker compose up --wait
+        run_healthcheck()
+        setup(environment)            <- HERE: resolve the container  [1/trial]
+      _run()
+        run(instruction, ...)         <- HERE: work the task      [1/step]
+        _run_verifier()               <- the grade appears here
+        _stop_agent_environment()
+      _finalize() -> TrialEvent.END   <- plugin records the inventory
+
+Notes:
+ * a fresh instance is constructed for each trial then thrown away, so holds
+no cross-task state. The actual Exo process is managed by ExoSessionPlugin.
+ * setup() is called for each trial, and run()/resume() for each step.
+ * run() returns before the verifier executes. Feedback is intentionally not
+   part of the first version of the trial protocol.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, override
+from uuid import uuid4
+
+from harbor.agents.base import BaseAgent
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+
+from exo_harbor import conventions
+from exo_harbor.docker import resolve_main_container
+from exo_harbor.exo import ExoClient
+from exo_harbor.protocol import TrialRun, send_trial_run
+from exo_harbor.trajectory import export_trial_trajectory
+
+logger = logging.getLogger(__name__)
+
+
+class ExoAgent(BaseAgent):
+    """Submits Harbor's task container to Exo and waits for completion."""
+
+    # Can be enabled for multi-step tasks after resume() support is added.
+    SUPPORTS_RESUME = False
+    SUPPORTS_ATIF = True
+    SUPPORTS_WINDOWS = False
+
+    def __init__(
+        self,
+        *args: Any,
+        # Set by --ak. The plugin reads these same values back off job.config.agents[0].kwargs.
+        exo_root: str | Path,
+        exo_bin: str | Path,
+        exo_repo_root: str | Path,
+        exo_model: str,
+        task_timeout_sec: float | str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._exo_root = Path(exo_root)
+        self._model = exo_model
+        self._task_timeout_sec = (
+            float(task_timeout_sec) if task_timeout_sec is not None else None
+        )
+        self._client = ExoClient(
+            exo_bin=Path(exo_bin),
+            exo_root=Path(exo_root),
+            repo_root=Path(exo_repo_root),
+        )
+
+        self._container_id: str | None = None
+
+    @staticmethod
+    @override
+    def name() -> str:
+        return "exo"
+
+    @override
+    def version(self) -> str | None:
+        # TODO: report the Exo build under test rather than this package's
+        # version — the eval result needs to identify the agent, and "0.1.0"
+        # identifies the wrapper.
+        return None
+
+    # ----------------------------------------------------------------------
+    # Per-trial setup
+    # ----------------------------------------------------------------------
+    @override
+    async def setup(self, environment: BaseEnvironment) -> None:
+        """Resolve the Docker container supplied by Harbor for this trial.
+
+        Runs once per trial, after Harbor has started and health-checked the
+        environment. Everything expensive happened in on_job_start.
+        """
+        socket_path = conventions.socket_path(self._exo_root)
+        if not socket_path.exists():
+            raise RuntimeError(
+                f"no trial adapter socket at {socket_path}. Pass "
+                "--plugin exo_harbor.plugin:ExoSessionPlugin alongside --agent."
+            )
+
+        container = resolve_main_container(environment.session_id)
+        self._container_id = container.container_id
+        logger.info(
+            "resolved Harbor container %s for trial %s",
+            container.container_id[:12],
+            self.context_id,
+        )
+
+    # ----------------------------------------------------------------------
+    # Per-step execution
+    # ----------------------------------------------------------------------
+
+    @override
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        """Hand Exo the task and block until it says it is done."""
+        if self._container_id is None:
+            raise RuntimeError("ExoAgent.run called before setup")
+
+        response = await send_trial_run(
+            conventions.socket_path(self._exo_root),
+            TrialRun(
+                request_id=str(uuid4()),
+                target=str(self.context_id),
+                container_id=self._container_id,
+                instructions=instruction,
+            ),
+            timeout_sec=self._task_timeout_sec,
+        )
+        try:
+            await export_trial_trajectory(
+                self._client,
+                response.conversation_id,
+                str(self.context_id),
+                instruction,
+                self._model,
+                self.logs_dir / "trajectory.json",
+            )
+        except Exception:
+            logger.exception(
+                "failed to export Harbor trajectory for %s", self.context_id
+            )
+
+        if response.summary:
+            logger.info("trial %s complete: %s", self.context_id, response.summary)

--- a/eval/harbor/src/exo_harbor/agent.py
+++ b/eval/harbor/src/exo_harbor/agent.py
@@ -36,7 +36,7 @@ from harbor.models.agent.context import AgentContext
 from exo_harbor import conventions
 from exo_harbor.docker import resolve_main_container
 from exo_harbor.exo import ExoClient
-from exo_harbor.protocol import TrialRun, send_trial_run
+from exo_harbor.protocol import TrialRun, TrialStarted, send_trial_run
 from exo_harbor.trajectory import export_trial_trajectory
 
 logger = logging.getLogger(__name__)
@@ -127,29 +127,45 @@ class ExoAgent(BaseAgent):
         if self._container_id is None:
             raise RuntimeError("ExoAgent.run called before setup")
 
-        response = await send_trial_run(
-            conventions.socket_path(self._exo_root),
-            TrialRun(
-                request_id=str(uuid4()),
-                target=str(self.context_id),
-                container_id=self._container_id,
-                instructions=instruction,
-            ),
-            timeout_sec=self._task_timeout_sec,
-        )
+        conversation_id: str | None = None
+
+        def trial_started(started: TrialStarted) -> None:
+            nonlocal conversation_id
+            conversation_id = started.conversation_id
+            logger.info(
+                "trial %s started in conversation %s",
+                self.context_id,
+                conversation_id,
+            )
+
         try:
-            await export_trial_trajectory(
-                self._client,
-                response.conversation_id,
-                str(self.context_id),
-                instruction,
-                self._model,
-                self.logs_dir / "trajectory.json",
+            response = await send_trial_run(
+                conventions.socket_path(self._exo_root),
+                TrialRun(
+                    request_id=str(uuid4()),
+                    target=str(self.context_id),
+                    container_id=self._container_id,
+                    instructions=instruction,
+                ),
+                timeout_sec=self._task_timeout_sec,
+                on_started=trial_started,
             )
-        except Exception:
-            logger.exception(
-                "failed to export Harbor trajectory for %s", self.context_id
-            )
+            conversation_id = response.conversation_id
+        finally:
+            if conversation_id is not None:
+                try:
+                    await export_trial_trajectory(
+                        self._client,
+                        conversation_id,
+                        str(self.context_id),
+                        instruction,
+                        self._model,
+                        self.logs_dir / "trajectory.json",
+                    )
+                except Exception:
+                    logger.exception(
+                        "failed to export Harbor trajectory for %s", self.context_id
+                    )
 
         if response.summary:
             logger.info("trial %s complete: %s", self.context_id, response.summary)

--- a/eval/harbor/src/exo_harbor/conventions.py
+++ b/eval/harbor/src/exo_harbor/conventions.py
@@ -1,0 +1,20 @@
+"""Names shared by Harbor's independently constructed plugin and agents."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Fixed slugs are safe because each job has its own exo_root.
+AGENT_SLUG = "harbor-eval"
+
+# Keep adapter setup chatter out of measured trial conversations.
+SETUP_CONVERSATION_SLUG = "harbor-setup"
+
+
+def socket_path(exo_root: Path) -> Path:
+    """Where the trial adapter listens for this job.
+
+    Under exo_root rather than the adapter's ~/.exo/trial.sock default, so
+    concurrent jobs on one host do not fight over one socket.
+    """
+    return exo_root / "trial.sock"

--- a/eval/harbor/src/exo_harbor/docker.py
+++ b/eval/harbor/src/exo_harbor/docker.py
@@ -1,0 +1,103 @@
+"""Host-side resolution of the Docker container Harbor started for a trial.
+
+Harbor's DockerEnvironment brings the task up with Docker Compose under a
+project name derived from the public ``environment.session_id``, with the task
+container as the ``main`` service. We find it by label from the host.
+
+Deliberately not done via ``BaseEnvironment.exec()``: that runs *inside* the
+task container, where recovering the host-side container identity is
+unreliable. This is host work and belongs in the external agent.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+
+MAIN_SERVICE = "main"
+PROJECT_LABEL = "com.docker.compose.project"
+SERVICE_LABEL = "com.docker.compose.service"
+
+
+class DockerResolutionError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class DockerContainer:
+    container_id: str
+    project: str
+
+
+def compose_project_name(session_id: str) -> str:
+    """Reproduce Harbor's Compose project-name normalization.
+
+    1. lowercase
+    2. prefix "0" if the first character is not alphanumeric
+    3. replace anything outside [a-z0-9_-] with "-"
+
+    Mirrors Harbor's own logic, so it must be re-checked on a Harbor bump.
+    """
+    name = session_id.lower()
+    if not name or not name[0].isalnum():
+        name = f"0{name}"
+    return re.sub(r"[^a-z0-9_-]", "-", name)
+
+
+def resolve_main_container(session_id: str) -> DockerContainer:
+    """Find the single running ``main`` container for this trial.
+
+    Zero matches means the environment is gone. More than one is ambiguous.
+    Both raise: submitting an arbitrary container would silently grade the wrong
+    machine, which is worse than failing the trial.
+    """
+    project = compose_project_name(session_id)
+    ids = _docker(
+        "ps",
+        "--filter",
+        f"label={PROJECT_LABEL}={project}",
+        "--filter",
+        f"label={SERVICE_LABEL}={MAIN_SERVICE}",
+        "--format",
+        "{{.ID}}",
+    ).split()
+
+    if not ids:
+        raise DockerResolutionError(
+            f"no running {MAIN_SERVICE} container for Compose project {project!r}"
+        )
+    if len(ids) > 1:
+        raise DockerResolutionError(
+            f"{len(ids)} running {MAIN_SERVICE} containers for Compose project "
+            f"{project!r}; refusing to guess"
+        )
+
+    container_id = ids[0]
+    # Re-read the labels off the chosen container. `docker ps` filtering and
+    # this inspect are separate calls, and the trial is about to be graded on
+    # whatever we submit.
+    labels = _docker(
+        "inspect",
+        "--format",
+        f"{{{{index .Config.Labels \"{PROJECT_LABEL}\"}}}} "
+        f"{{{{index .Config.Labels \"{SERVICE_LABEL}\"}}}}",
+        container_id,
+    ).split()
+    if labels != [project, MAIN_SERVICE]:
+        raise DockerResolutionError(
+            f"container {container_id} no longer matches {project}/{MAIN_SERVICE}"
+        )
+
+    return DockerContainer(container_id=container_id, project=project)
+
+
+def _docker(*args: str) -> str:
+    result = subprocess.run(
+        ["docker", *args], capture_output=True, text=True, check=False
+    )
+    if result.returncode != 0:
+        raise DockerResolutionError(
+            f"docker {' '.join(args)} failed: {result.stderr.strip()}"
+        )
+    return result.stdout.strip()

--- a/eval/harbor/src/exo_harbor/exo.py
+++ b/eval/harbor/src/exo_harbor/exo.py
@@ -1,0 +1,195 @@
+"""Small CLI client for Exo job setup and trajectory export."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+
+from exo_harbor import conventions
+from exo_harbor.protocol import probe
+
+
+class ExoCommandError(RuntimeError):
+    """An Exo CLI command failed."""
+
+
+@dataclass(frozen=True)
+class ExoClient:
+    exo_bin: Path
+    exo_root: Path
+    repo_root: Path
+
+    async def ensure_agent(self, model: str) -> None:
+        """Create the persistent evaluation agent if it does not exist."""
+        if await self._exists("agent", "show", conventions.AGENT_SLUG):
+            return
+        await self._run(
+            "agent",
+            "create",
+            "Harbor eval",
+            "--slug",
+            conventions.AGENT_SLUG,
+            "--model",
+            model,
+            "--module",
+            str(self.repo_root / "exo/harness.ts"),
+            "--sandbox-provider",
+            "docker",
+            "--sandbox-scope",
+            "agent",
+            "--tool-creation",
+            "enabled",
+        )
+
+    async def ensure_trial_adapter(self, socket_path: Path) -> None:
+        """Create the job's trial adapter if it does not exist."""
+        setup = conventions.SETUP_CONVERSATION_SLUG
+        await self._ensure_conversation(setup)
+        await self._run(
+            "conversation",
+            "send",
+            conventions.AGENT_SLUG,
+            setup,
+            _ADAPTER_SETUP_PROMPT.format(socket_path=socket_path),
+        )
+
+    async def ensure_adapter_runner(
+        self, socket_path: Path, *, timeout_sec: float
+    ) -> None:
+        """Start the adapter supervisor and wait for its socket."""
+        if await probe(socket_path, timeout_sec=0.5):
+            return
+        await asyncio.to_thread(self._spawn_adapter_runner)
+        if not await probe(socket_path, timeout_sec=timeout_sec):
+            raise ExoCommandError(
+                f"trial adapter socket never appeared at {socket_path}; "
+                f"check {self.exo_root / 'exo-adapters.log'}"
+            )
+
+    async def read_conversation_events(
+        self,
+        conversation: str,
+        *,
+        types: list[str],
+        turn_id: str | None = None,
+        limit: int,
+    ) -> str:
+        """Return canonical conversation events as JSON."""
+        args = [
+            "conversation",
+            "events",
+            conventions.AGENT_SLUG,
+            conversation,
+        ]
+        for event_type in types:
+            args.extend(("--type", event_type))
+        if turn_id is not None:
+            args.extend(("--turn-id", turn_id))
+        args.extend(("--limit", str(limit)))
+        return await self._run(*args)
+
+    async def _ensure_conversation(self, slug: str) -> None:
+        if await self._exists("conversation", "show", conventions.AGENT_SLUG, slug):
+            return
+        await self._run(
+            "conversation",
+            "create",
+            conventions.AGENT_SLUG,
+            slug,
+            "--slug",
+            slug,
+            "--sandbox-scope",
+            "agent",
+        )
+
+    def _spawn_adapter_runner(self) -> None:
+        log_path = self.exo_root / "exo-adapters.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        with log_path.open("ab") as log:
+            process = subprocess.Popen(  # noqa: S603 - fixed argv, no shell
+                self._argv(
+                    "adapters",
+                    "run",
+                    "--lock-file",
+                    str(self.exo_root / "exo-adapters.lock"),
+                    "--drain-marker",
+                    str(self.exo_root / "exo-adapters.restart"),
+                    "--reboot-notice",
+                    str(self.exo_root / "exo-reboot-notice.json"),
+                ),
+                cwd=self.repo_root,
+                stdout=log,
+                stderr=log,
+                env=self._environment(),
+                start_new_session=True,
+            )
+        (self.exo_root / "exo-adapters.pid").write_text(
+            f"{process.pid}\n", encoding="utf-8"
+        )
+        threading.Thread(target=process.wait, daemon=True).start()
+
+    async def _run(self, *args: str) -> str:
+        process = await asyncio.create_subprocess_exec(
+            *self._argv(*args),
+            cwd=self.repo_root,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=self._environment(),
+        )
+        stdout, stderr = await process.communicate()
+        if process.returncode != 0:
+            raise ExoCommandError(
+                f"exo {' '.join(args)} failed ({process.returncode}): "
+                f"{stderr.decode().strip()}"
+            )
+        return stdout.decode().strip()
+
+    def _environment(self) -> dict[str, str]:
+        return {
+            **os.environ,
+            "EXO_PROFILE": os.environ.get("EXO_PROFILE", "practical"),
+            "EXO_ROOT": str(self.exo_root),
+        }
+
+    async def _exists(self, *args: str) -> bool:
+        process = await asyncio.create_subprocess_exec(
+            *self._argv(*args),
+            cwd=self.repo_root,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await process.communicate()
+        if process.returncode == 0:
+            return True
+        if "not found" in stderr.decode().lower():
+            return False
+        raise ExoCommandError(
+            f"exo {' '.join(args)} failed ({process.returncode}): "
+            f"{stderr.decode().strip()}"
+        )
+
+    def _argv(self, *args: str) -> list[str]:
+        return [
+            str(self.exo_bin),
+            "--root",
+            str(self.exo_root),
+            "--harness",
+            "exo",
+            *args,
+        ]
+
+
+_ADAPTER_SETUP_PROMPT = (
+    "Configure the trial adapter for this conversation. Call list_adapters "
+    "with includeDisabled=true. If there is no enabled adapter named `trial` "
+    "with type `trial` and socketPath exactly `{socket_path}`, call "
+    "create_adapter with name `trial`, source `library`, and config "
+    '{{"type":"trial","socketPath":"{socket_path}"}}. Do not create a '
+    "duplicate. If an adapter named `trial` exists but is disabled or has "
+    "different configuration, report that clearly instead of changing or "
+    "deleting it."
+)

--- a/eval/harbor/src/exo_harbor/plugin.py
+++ b/eval/harbor/src/exo_harbor/plugin.py
@@ -1,0 +1,87 @@
+"""ExoSessionPlugin — owner of the Exo process for the whole job.
+
+This plugin owns Exo's job-scoped lifetime, whereas ExoAgent is a
+per-trial stub.
+
+The lifecycle:
+
+    attach_job_plugins(job)
+      on_job_start(job)         start Exo and create the adapter
+      job.run()                 run trials through that persistent Exo agent
+
+Requires --n-concurrent 1. Trials share one Exo, so serial execution gives
+each trial a deterministic view of changes made by earlier trials.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from harbor.job import Job
+from harbor.models.environment_type import EnvironmentType
+from harbor.models.job.plugin import BaseJobPlugin
+from harbor.models.job.result import JobResult
+
+from exo_harbor import conventions
+from exo_harbor.exo import ExoClient
+
+logger = logging.getLogger(__name__)
+
+
+class ExoSessionPlugin(BaseJobPlugin):
+    """Runs one persistent Exo agent across every trial in the job."""
+
+    def __init__(
+        self,
+        *,
+        # Set by --pk. Note exo_root is absent: it is read off the agent's own
+        # kwargs in on_job_start so it stays a single source of truth.
+        adapter_start_timeout_sec: float | str = 90,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._adapter_start_timeout_sec = float(adapter_start_timeout_sec)
+
+    async def on_job_start(self, job: Job) -> None:
+        """Bring Exo up before the first container is built."""
+        if job.config.environment.type != EnvironmentType.DOCKER:
+            raise ValueError(
+                "ExoSessionPlugin resolves task containers by Compose label on "
+                "the host, so it requires --env docker"
+            )
+        if job.config.n_concurrent_trials != 1:
+            # To properly learn, Exo can only handle one task at a time.
+            raise ValueError("ExoSessionPlugin requires --n-concurrent 1")
+        if len(job.config.agents) != 1:
+            raise ValueError("ExoSessionPlugin requires exactly one --agent")
+
+        # Read the agent's --ak values rather than taking --pk copies, so
+        # exo_root and friends are written down once.
+        kwargs = job.config.agents[0].kwargs
+        try:
+            model = kwargs["exo_model"]
+            client = ExoClient(
+                exo_bin=Path(kwargs["exo_bin"]),
+                exo_root=Path(kwargs["exo_root"]),
+                repo_root=Path(kwargs["exo_repo_root"]),
+            )
+        except KeyError as error:
+            raise ValueError(
+                f"ExoAgent is missing required --ak {error.args[0]}"
+            ) from error
+
+        socket_path = conventions.socket_path(client.exo_root)
+        await client.ensure_agent(model)
+        await client.ensure_trial_adapter(socket_path)
+        await client.ensure_adapter_runner(
+            socket_path, timeout_sec=self._adapter_start_timeout_sec
+        )
+        logger.info("Exo ready for job %s on %s", job.id, socket_path)
+
+    async def on_job_end(self, _job_result: JobResult) -> None:
+        """Satisfy Harbor's plugin lifecycle; Exo state remains on disk."""
+
+# TODO: add on_job_end to produce a report on the learnings obtained during
+# the trial.

--- a/eval/harbor/src/exo_harbor/protocol.py
+++ b/eval/harbor/src/exo_harbor/protocol.py
@@ -1,0 +1,124 @@
+"""Typed protocol for submitting a containerized trial to Exo."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+
+@dataclass(frozen=True)
+class TrialRun:
+    request_id: str
+    target: str
+    container_id: str
+    instructions: str
+    deadline_at: str | None = None
+    type: Literal["trial_run"] = "trial_run"
+
+    def payload(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class TrialComplete:
+    request_id: str
+    target: str
+    conversation_id: str
+    summary: str | None = None
+
+
+class TrialAdapterError(RuntimeError):
+    """The trial adapter rejected a request or returned an invalid response."""
+
+
+class _Disconnected(RuntimeError):
+    """The adapter socket disappeared while a trial was running."""
+
+
+async def send_trial_run(
+    socket_path: Path,
+    request: TrialRun,
+    *,
+    timeout_sec: float | None,
+) -> TrialComplete:
+    """Wait for explicit completion, reconnecting across Exo restarts."""
+
+    async def wait_for_completion() -> TrialComplete:
+        while True:
+            try:
+                event = await _exchange(socket_path, request.payload())
+                return _parse_completion(event, request)
+            except (OSError, _Disconnected):
+                await asyncio.sleep(0.5)
+
+    return await asyncio.wait_for(wait_for_completion(), timeout=timeout_sec)
+
+
+async def probe(socket_path: Path, *, timeout_sec: float) -> bool:
+    """Return True once the adapter socket accepts a connection."""
+    deadline = asyncio.get_running_loop().time() + timeout_sec
+    while True:
+        try:
+            _, writer = await asyncio.open_unix_connection(str(socket_path))
+            writer.close()
+            await writer.wait_closed()
+            return True
+        except (OSError, asyncio.TimeoutError):
+            if asyncio.get_running_loop().time() >= deadline:
+                return False
+            await asyncio.sleep(0.5)
+
+
+async def _exchange(socket_path: Path, payload: dict[str, Any]) -> dict[str, Any]:
+    reader, writer = await asyncio.open_unix_connection(str(socket_path))
+    try:
+        writer.write(f"{json.dumps(payload)}\n".encode())
+        await writer.drain()
+        line = await reader.readline()
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+    if not line:
+        raise _Disconnected("trial adapter closed without replying")
+    try:
+        message = json.loads(line)
+    except json.JSONDecodeError as error:
+        raise TrialAdapterError("trial adapter returned invalid JSON") from error
+    if not isinstance(message, dict):
+        raise TrialAdapterError("trial adapter reply must be a JSON object")
+    if message.get("type") == "error":
+        raise TrialAdapterError(str(message.get("message")))
+    if message.get("type") != "response" or not isinstance(message.get("event"), dict):
+        raise TrialAdapterError(f"unexpected trial adapter reply: {message!r}")
+    return message["event"]
+
+
+def _parse_completion(
+    event: dict[str, Any], request: TrialRun
+) -> TrialComplete:
+    expected = {
+        "type": "trial_complete",
+        "request_id": request.request_id,
+        "target": request.target,
+    }
+    for field, value in expected.items():
+        if event.get(field) != value:
+            raise TrialAdapterError(
+                f"trial completion {field} is {event.get(field)!r}, expected {value!r}"
+            )
+    conversation_id = event.get("conversation_id")
+    if not isinstance(conversation_id, str) or not conversation_id:
+        raise TrialAdapterError("trial completion has no conversation_id")
+    summary = event.get("summary")
+    if summary is not None and not isinstance(summary, str):
+        raise TrialAdapterError("trial completion summary must be a string or null")
+    return TrialComplete(
+        request_id=request.request_id,
+        target=request.target,
+        conversation_id=conversation_id,
+        summary=summary,
+    )

--- a/eval/harbor/src/exo_harbor/protocol.py
+++ b/eval/harbor/src/exo_harbor/protocol.py
@@ -1,4 +1,19 @@
-"""Typed protocol for submitting a containerized trial to Exo."""
+"""Typed protocol for submitting a containerized trial to Exo.
+
+Harbor opens a Unix socket and sends one newline-delimited ``trial_run``
+request containing the task container, instructions, request id, and stable
+trial target. The adapter keeps that connection open and sends two messages:
+
+1. A ``trial_started`` event after Exo creates the conversation and attaches
+   the container. Its conversation id lets Harbor export a partial trajectory
+   even if the trial later times out.
+2. A final ``trial_complete`` response after Exo explicitly declares the work
+   finished with ``send_adapter_message``.
+
+If Exo restarts or the socket disconnects, Harbor reconnects and resends the
+same request. The request id makes that retry idempotent, and the adapter
+replays any durable ``trial_started`` or ``trial_complete`` message.
+"""
 
 from __future__ import annotations
 
@@ -6,7 +21,7 @@ import asyncio
 import json
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Callable, Literal
 
 
 @dataclass(frozen=True)
@@ -30,6 +45,13 @@ class TrialComplete:
     summary: str | None = None
 
 
+@dataclass(frozen=True)
+class TrialStarted:
+    request_id: str
+    target: str
+    conversation_id: str
+
+
 class TrialAdapterError(RuntimeError):
     """The trial adapter rejected a request or returned an invalid response."""
 
@@ -43,14 +65,40 @@ async def send_trial_run(
     request: TrialRun,
     *,
     timeout_sec: float | None,
+    on_started: Callable[[TrialStarted], None] | None = None,
 ) -> TrialComplete:
     """Wait for explicit completion, reconnecting across Exo restarts."""
+
+    started: TrialStarted | None = None
+
+    def receive_started(event: dict[str, Any]) -> None:
+        nonlocal started
+        received = _parse_started(event, request)
+        if started is not None and started != received:
+            raise TrialAdapterError(
+                "trial_started changed while reconnecting: "
+                f"{started.conversation_id!r} became {received.conversation_id!r}"
+            )
+        if started is None:
+            started = received
+            if on_started is not None:
+                on_started(received)
 
     async def wait_for_completion() -> TrialComplete:
         while True:
             try:
-                event = await _exchange(socket_path, request.payload())
-                return _parse_completion(event, request)
+                event = await _exchange(
+                    socket_path, request.payload(), receive_started
+                )
+                completion = _parse_completion(event, request)
+                if (
+                    started is not None
+                    and completion.conversation_id != started.conversation_id
+                ):
+                    raise TrialAdapterError(
+                        "trial_complete conversation_id does not match trial_started"
+                    )
+                return completion
             except (OSError, _Disconnected):
                 await asyncio.sleep(0.5)
 
@@ -72,16 +120,30 @@ async def probe(socket_path: Path, *, timeout_sec: float) -> bool:
             await asyncio.sleep(0.5)
 
 
-async def _exchange(socket_path: Path, payload: dict[str, Any]) -> dict[str, Any]:
+async def _exchange(
+    socket_path: Path,
+    payload: dict[str, Any],
+    on_started: Callable[[dict[str, Any]], None],
+) -> dict[str, Any]:
     reader, writer = await asyncio.open_unix_connection(str(socket_path))
     try:
         writer.write(f"{json.dumps(payload)}\n".encode())
         await writer.drain()
-        line = await reader.readline()
+        while True:
+            envelope, event = await _read_event(reader)
+            if envelope == "event":
+                on_started(event)
+                continue
+            return event
     finally:
         writer.close()
         await writer.wait_closed()
 
+
+async def _read_event(
+    reader: asyncio.StreamReader,
+) -> tuple[Literal["event", "response"], dict[str, Any]]:
+    line = await reader.readline()
     if not line:
         raise _Disconnected("trial adapter closed without replying")
     try:
@@ -92,27 +154,28 @@ async def _exchange(socket_path: Path, payload: dict[str, Any]) -> dict[str, Any
         raise TrialAdapterError("trial adapter reply must be a JSON object")
     if message.get("type") == "error":
         raise TrialAdapterError(str(message.get("message")))
-    if message.get("type") != "response" or not isinstance(message.get("event"), dict):
+    envelope = message.get("type")
+    if envelope not in {"event", "response"} or not isinstance(
+        message.get("event"), dict
+    ):
         raise TrialAdapterError(f"unexpected trial adapter reply: {message!r}")
-    return message["event"]
+    return envelope, message["event"]
+
+
+def _parse_started(event: dict[str, Any], request: TrialRun) -> TrialStarted:
+    _validate_routing_fields(event, request, "trial_started")
+    return TrialStarted(
+        request_id=request.request_id,
+        target=request.target,
+        conversation_id=_conversation_id(event, "trial_started"),
+    )
 
 
 def _parse_completion(
     event: dict[str, Any], request: TrialRun
 ) -> TrialComplete:
-    expected = {
-        "type": "trial_complete",
-        "request_id": request.request_id,
-        "target": request.target,
-    }
-    for field, value in expected.items():
-        if event.get(field) != value:
-            raise TrialAdapterError(
-                f"trial completion {field} is {event.get(field)!r}, expected {value!r}"
-            )
-    conversation_id = event.get("conversation_id")
-    if not isinstance(conversation_id, str) or not conversation_id:
-        raise TrialAdapterError("trial completion has no conversation_id")
+    _validate_routing_fields(event, request, "trial_complete")
+    conversation_id = _conversation_id(event, "trial_complete")
     summary = event.get("summary")
     if summary is not None and not isinstance(summary, str):
         raise TrialAdapterError("trial completion summary must be a string or null")
@@ -122,3 +185,25 @@ def _parse_completion(
         conversation_id=conversation_id,
         summary=summary,
     )
+
+
+def _validate_routing_fields(
+    event: dict[str, Any], request: TrialRun, event_type: str
+) -> None:
+    expected = {
+        "type": event_type,
+        "request_id": request.request_id,
+        "target": request.target,
+    }
+    for field, value in expected.items():
+        if event.get(field) != value:
+            raise TrialAdapterError(
+                f"{event_type} {field} is {event.get(field)!r}, expected {value!r}"
+            )
+
+
+def _conversation_id(event: dict[str, Any], event_type: str) -> str:
+    conversation_id = event.get("conversation_id")
+    if not isinstance(conversation_id, str) or not conversation_id:
+        raise TrialAdapterError(f"{event_type} has no conversation_id")
+    return conversation_id

--- a/eval/harbor/src/exo_harbor/trajectory.py
+++ b/eval/harbor/src/exo_harbor/trajectory.py
@@ -1,0 +1,284 @@
+"""Convert an Exo trial conversation into Harbor's native ATIF trajectory."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Annotated, Literal
+
+from harbor.models.trajectories.agent import Agent
+from harbor.models.trajectories.final_metrics import FinalMetrics
+from harbor.models.trajectories.metrics import Metrics
+from harbor.models.trajectories.observation import Observation
+from harbor.models.trajectories.observation_result import ObservationResult
+from harbor.models.trajectories.step import Step
+from harbor.models.trajectories.tool_call import ToolCall
+from harbor.models.trajectories.trajectory import Trajectory
+from pydantic import BaseModel, Field, JsonValue
+
+from exo_harbor import conventions
+from exo_harbor.exo import ExoClient
+
+
+class Usage(BaseModel):
+    model: str
+    prompt_tokens: int
+    completion_tokens: int
+    prompt_cached_tokens: int = 0
+    completion_reasoning_tokens: int = 0
+    cost_usd: float
+
+
+class TextContent(BaseModel):
+    type: Literal["text"]
+    text: str
+
+
+class ReasoningContent(BaseModel):
+    type: Literal["reasoning"]
+    text: str
+    encrypted_content: str | None = None
+
+
+class ValidToolArguments(BaseModel):
+    type: Literal["valid"]
+    value: dict[str, JsonValue]
+
+
+class ToolCallContent(BaseModel):
+    type: Literal["tool_call"]
+    tool_call_id: str
+    tool_name: str
+    arguments: ValidToolArguments
+
+
+AssistantContent = Annotated[
+    TextContent | ReasoningContent | ToolCallContent,
+    Field(discriminator="type"),
+]
+
+
+class UserMessage(BaseModel):
+    role: Literal["user"]
+    content: str
+
+
+class AssistantMessage(BaseModel):
+    role: Literal["assistant"]
+    content: list[AssistantContent]
+
+
+Message = Annotated[UserMessage | AssistantMessage, Field(discriminator="role")]
+
+
+class MessagesData(BaseModel):
+    type: Literal["messages"]
+    messages: list[Message]
+    usage: Usage | None = None
+
+
+class ToolResultValue(BaseModel):
+    ok: bool
+    preview: str
+    source: str
+    tool_name: str = Field(alias="toolName")
+    truncated: bool
+    value: JsonValue = None
+
+
+class ToolResultData(BaseModel):
+    type: Literal["tool_result"]
+    tool_call_id: str
+    result: ToolResultValue
+
+
+EventData = Annotated[MessagesData | ToolResultData, Field(discriminator="type")]
+
+
+class ConversationEvent(BaseModel):
+    id: str
+    session_id: str
+    turn_id: str
+    created_at: str
+    data: EventData
+
+
+class ConversationEvents(BaseModel):
+    events: list[ConversationEvent]
+    cursor: str | None = None
+
+
+async def export_trial_trajectory(
+    client: ExoClient,
+    conversation: str,
+    trial_id: str,
+    instruction: str,
+    model_name: str,
+    destination: Path,
+) -> None:
+    """Fetch and export every Exo turn that handled ``trial_id``."""
+    page = ConversationEvents.model_validate_json(
+        await client.read_conversation_events(
+            conversation,
+            types=["messages", "tool_result"],
+            limit=10_000,
+        )
+    )
+    marker = f"Trial `{trial_id}` has started"
+    start_index = next(
+        (
+            index
+            for index, event in enumerate(page.events)
+            if isinstance(event.data, MessagesData)
+            and any(
+                isinstance(message, UserMessage) and marker in message.content
+                for message in event.data.messages
+            )
+        ),
+        None,
+    )
+    if start_index is None:
+        raise ValueError(f"Exo turn for trial {trial_id} was not found")
+
+    events = page.events[start_index:]
+    turn_ids = list(dict.fromkeys(event.turn_id for event in events))
+    trajectory = build_trajectory(
+        events=events,
+        trial_id=trial_id,
+        turn_ids=turn_ids,
+        instruction=instruction,
+        model_name=model_name,
+        conversation=conversation,
+        started_at=events[0].created_at,
+    )
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_suffix(destination.suffix + ".tmp")
+    temporary.write_text(json.dumps(trajectory.to_json_dict(), indent=2) + "\n")
+    temporary.replace(destination)
+
+
+def build_trajectory(
+    *,
+    events: list[ConversationEvent],
+    trial_id: str,
+    turn_ids: list[str],
+    instruction: str,
+    model_name: str,
+    conversation: str,
+    started_at: str,
+) -> Trajectory:
+    """Map Exo's canonical events to one validated ATIF trajectory."""
+    steps = [
+        Step(
+            step_id=1,
+            timestamp=started_at,
+            source="user",
+            message=instruction,
+        )
+    ]
+    calls: dict[str, Step] = {}
+    usages: list[Usage] = []
+
+    for event in events:
+        if isinstance(event.data, MessagesData):
+            assistant_messages = [
+                message
+                for message in event.data.messages
+                if isinstance(message, AssistantMessage)
+            ]
+            if not assistant_messages:
+                continue
+
+            text: list[str] = []
+            reasoning: list[str] = []
+            tool_calls: list[ToolCall] = []
+            for message in assistant_messages:
+                for content in message.content:
+                    if isinstance(content, TextContent):
+                        if content.text:
+                            text.append(content.text)
+                    elif isinstance(content, ReasoningContent):
+                        if content.text:
+                            reasoning.append(content.text)
+                    else:
+                        tool_calls.append(
+                            ToolCall(
+                                tool_call_id=content.tool_call_id,
+                                function_name=content.tool_name,
+                                arguments=content.arguments.value,
+                            )
+                        )
+
+            metrics = _metrics(event.data.usage)
+            step = Step(
+                step_id=len(steps) + 1,
+                timestamp=event.created_at,
+                source="agent",
+                model_name=event.data.usage.model if event.data.usage else None,
+                message="\n".join(text),
+                reasoning_content="\n".join(reasoning) or None,
+                tool_calls=tool_calls or None,
+                metrics=metrics,
+                llm_call_count=1,
+            )
+            steps.append(step)
+            for call in tool_calls:
+                calls[call.tool_call_id] = step
+            if event.data.usage is not None:
+                usages.append(event.data.usage)
+            continue
+
+        result = event.data.result
+        step = calls.get(event.data.tool_call_id)
+        if step is None:
+            continue
+        observation = ObservationResult(
+            source_call_id=event.data.tool_call_id,
+            content=(
+                json.dumps(result.value, indent=2)
+                if result.value is not None
+                else result.preview
+            ),
+            extra={
+                "ok": result.ok,
+                "source": result.source,
+                "tool_name": result.tool_name,
+                "truncated": result.truncated,
+            },
+        )
+        if step.observation is None:
+            step.observation = Observation(results=[observation])
+        else:
+            step.observation.results.append(observation)
+
+    return Trajectory(
+        session_id=conversation,
+        trajectory_id=trial_id,
+        agent=Agent(name="exo", version="unknown", model_name=model_name),
+        steps=steps,
+        final_metrics=FinalMetrics(
+            total_prompt_tokens=sum(usage.prompt_tokens for usage in usages),
+            total_completion_tokens=sum(usage.completion_tokens for usage in usages),
+            total_cached_tokens=sum(usage.prompt_cached_tokens for usage in usages),
+            total_cost_usd=sum(usage.cost_usd for usage in usages),
+            total_steps=len(steps),
+        ),
+        extra={
+            "harbor_trial_id": trial_id,
+            "exo_agent": conventions.AGENT_SLUG,
+            "exo_conversation": conversation,
+            "exo_turn_ids": turn_ids,
+        },
+    )
+
+
+def _metrics(usage: Usage | None) -> Metrics | None:
+    if usage is None:
+        return None
+    return Metrics(
+        prompt_tokens=usage.prompt_tokens,
+        completion_tokens=usage.completion_tokens,
+        cached_tokens=usage.prompt_cached_tokens,
+        cost_usd=usage.cost_usd,
+        extra={"reasoning_tokens": usage.completion_reasoning_tokens},
+    )

--- a/eval/harbor/tests/test_agent.py
+++ b/eval/harbor/tests/test_agent.py
@@ -1,0 +1,54 @@
+import asyncio
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+from exo_harbor.agent import ExoAgent
+from exo_harbor.protocol import TrialStarted
+
+
+class ExoAgentTest(unittest.IsolatedAsyncioTestCase):
+    async def test_timeout_exports_partial_trajectory_after_trial_started(self) -> None:
+        with TemporaryDirectory() as directory:
+            agent = ExoAgent(
+                logs_dir=Path(directory),
+                exo_root=Path(directory) / "exo-root",
+                exo_bin=Path("/opt/exo/bin/exo"),
+                exo_repo_root=Path("/src/exo"),
+                exo_model="gpt-5.6-sol",
+            )
+            agent.context_id = uuid4()
+            agent._container_id = "container-1"
+
+            async def time_out(*args, on_started, **kwargs):
+                on_started(
+                    TrialStarted(
+                        request_id="request-1",
+                        target=str(agent.context_id),
+                        conversation_id="conversation-1",
+                    )
+                )
+                raise asyncio.TimeoutError
+
+            export = AsyncMock()
+            with (
+                patch("exo_harbor.agent.send_trial_run", side_effect=time_out),
+                patch("exo_harbor.agent.export_trial_trajectory", export),
+                self.assertRaises(asyncio.TimeoutError),
+            ):
+                await agent.run("Fix it", AsyncMock(), AsyncMock())
+
+            export.assert_awaited_once_with(
+                agent._client,
+                "conversation-1",
+                str(agent.context_id),
+                "Fix it",
+                "gpt-5.6-sol",
+                Path(directory) / "trajectory.json",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/eval/harbor/tests/test_eval.py
+++ b/eval/harbor/tests/test_eval.py
@@ -29,6 +29,7 @@ class EvalScriptTest(unittest.TestCase):
         self.assertEqual(args.model, "gpt-5.5")
         self.assertIsNone(args.n_tasks)
         self.assertEqual(args.n_attempts, 1)
+        self.assertEqual(args.include_task_names, [])
 
     def test_all_tasks_omits_harbor_limit(self) -> None:
         args = self.parse()
@@ -121,6 +122,40 @@ class EvalScriptTest(unittest.TestCase):
                 "--include-task-name",
                 "cobol-modernization",
             ],
+        )
+
+    def test_include_task_names_can_be_repeated(self) -> None:
+        args = self.parse(
+            "--dataset=terminal-bench",
+            "--include-task-name=path-tracing",
+            "--include-task-name=gpt2-codegolf",
+        )
+
+        self.assertEqual(
+            eval_script.dataset_arguments(args),
+            [
+                "--dataset",
+                "terminal-bench@2.0",
+                "--include-task-name",
+                "path-tracing",
+                "--include-task-name",
+                "gpt2-codegolf",
+            ],
+        )
+
+    def test_include_task_names_can_come_from_config(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            config = Path(directory) / "eval.toml"
+            config.write_text(
+                'dataset = "terminal-bench"\n'
+                'include_task_names = ["path-tracing", "gpt2-codegolf"]\n'
+            )
+
+            args = self.parse(f"--config={config}")
+
+        self.assertEqual(
+            args.include_task_names,
+            ["path-tracing", "gpt2-codegolf"],
         )
 
     def test_result_paths_include_harbor_result_and_viewer(self) -> None:

--- a/eval/harbor/tests/test_eval.py
+++ b/eval/harbor/tests/test_eval.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import patch
+
+
+SCRIPT = Path(__file__).parents[1] / "eval.py"
+SPEC = importlib.util.spec_from_file_location("eval_script", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+eval_script = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(eval_script)
+
+
+class EvalScriptTest(unittest.TestCase):
+    def parse(self, *arguments: str):
+        with patch.object(sys, "argv", [str(SCRIPT), *arguments]):
+            return eval_script.parse_args()
+
+    def test_defaults_run_all_terminal_bench_tasks(self) -> None:
+        args = self.parse()
+
+        self.assertEqual(args.dataset, "terminal-bench")
+        self.assertEqual(args.model, "gpt-5.5")
+        self.assertIsNone(args.n_tasks)
+        self.assertEqual(args.n_attempts, 1)
+
+    def test_all_tasks_omits_harbor_limit(self) -> None:
+        args = self.parse()
+
+        command = eval_script.harbor_command(
+            args,
+            harbor="harbor",
+            repo=Path("/repo"),
+            exo=Path("/repo/exo"),
+            run_dir=Path("/runs/one"),
+            job_name="terminal-bench-all",
+        )
+
+        self.assertNotIn("--n-tasks", command)
+
+    def test_flags_override_config_file(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            config = Path(directory) / "eval.toml"
+            config.write_text(
+                'dataset = "terminal-bench-sample"\n'
+                'model = "configured-model"\n'
+                "n_tasks = 4\n"
+            )
+
+            args = self.parse(
+                f"--config={config}", "--model=flag-model", "--n-tasks=2"
+            )
+
+        self.assertEqual(args.dataset, "terminal-bench-sample")
+        self.assertEqual(args.model, "flag-model")
+        self.assertEqual(args.n_tasks, 2)
+
+    def test_local_dataset_path_can_come_from_config(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            dataset = Path(directory) / "dataset"
+            dataset.mkdir()
+            config = Path(directory) / "eval.toml"
+            config.write_text(
+                'dataset = "endless-terminals"\n'
+                f'dataset_path = "{dataset}"\n'
+            )
+
+            args = self.parse(f"--config={config}")
+
+            self.assertEqual(
+                eval_script.dataset_arguments(args), ["--path", str(dataset)]
+            )
+
+    def test_smoke_test_uses_the_bundled_task(self) -> None:
+        args = self.parse("--dataset=smoke-test")
+
+        self.assertEqual(
+            eval_script.dataset_arguments(args),
+            ["--path", str(SCRIPT.parent / "datasets/smoke-test")],
+        )
+
+    def test_self_evolution_smoke_test_uses_bundled_dataset(self) -> None:
+        args = self.parse("--dataset=self-evolution-smoke-test")
+        dataset = SCRIPT.parent / "datasets/self-evolution-smoke-test"
+
+        self.assertEqual(
+            eval_script.dataset_arguments(args),
+            [
+                "--path",
+                str(dataset),
+            ],
+        )
+        self.assertEqual(
+            sorted(path.name for path in dataset.iterdir()),
+            ["01-install-tool", "02-reuse-tool", "03-restart-policy"],
+        )
+
+    def test_terminal_bench_easy_selects_three_tasks(self) -> None:
+        args = self.parse("--dataset=terminal-bench-easy")
+
+        self.assertEqual(
+            eval_script.dataset_arguments(args),
+            [
+                "--dataset",
+                "terminal-bench@2.0",
+                "--include-task-name",
+                "fix-git",
+                "--include-task-name",
+                "prove-plus-comm",
+                "--include-task-name",
+                "cobol-modernization",
+            ],
+        )
+
+    def test_result_paths_include_harbor_result_and_viewer(self) -> None:
+        output = io.StringIO()
+
+        with redirect_stdout(output):
+            eval_script.print_result_paths(Path("/runs/one"), "terminal-bench-3")
+
+        self.assertIn(
+            "Harbor results: /runs/one/jobs/terminal-bench-3/result.json",
+            output.getvalue(),
+        )
+        self.assertIn(
+            "View: harbor view /runs/one/jobs",
+            output.getvalue(),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/eval/harbor/tests/test_eval.py
+++ b/eval/harbor/tests/test_eval.py
@@ -98,7 +98,12 @@ class EvalScriptTest(unittest.TestCase):
         )
         self.assertEqual(
             sorted(path.name for path in dataset.iterdir()),
-            ["01-install-tool", "02-reuse-tool", "03-restart-policy"],
+            [
+                "01-install-tool",
+                "02-reuse-tool",
+                "03-restart-policy",
+                "04-timeout-trajectory",
+            ],
         )
 
     def test_terminal_bench_easy_selects_three_tasks(self) -> None:

--- a/eval/harbor/tests/test_exo.py
+++ b/eval/harbor/tests/test_exo.py
@@ -1,0 +1,78 @@
+import unittest
+from tempfile import TemporaryDirectory
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from exo_harbor.exo import ExoClient
+
+
+class ExoClientTest(unittest.IsolatedAsyncioTestCase):
+    async def test_adapter_runner_uses_eval_root_and_records_pid(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            exo_root = Path(temporary_directory) / "exo"
+            client = ExoClient(
+                exo_bin=Path("/opt/exo/bin/exo"),
+                exo_root=exo_root,
+                repo_root=Path("/src/exo"),
+            )
+            process = MagicMock(pid=1234)
+            with patch("exo_harbor.exo.subprocess.Popen", return_value=process) as popen:
+                client._spawn_adapter_runner()
+
+            self.assertEqual(
+                (exo_root / "exo-adapters.pid").read_text(encoding="utf-8"),
+                "1234\n",
+            )
+            self.assertEqual(popen.call_args.kwargs["env"]["EXO_ROOT"], str(exo_root))
+
+    async def test_evaluation_agent_can_create_tools(self) -> None:
+        client = ExoClient(
+            exo_bin=Path("/opt/exo/bin/exo"),
+            exo_root=Path("/tmp/exo-root"),
+            repo_root=Path("/src/exo"),
+        )
+        exists = AsyncMock(return_value=False)
+        run = AsyncMock()
+        with (
+            patch.object(ExoClient, "_exists", exists),
+            patch.object(ExoClient, "_run", run),
+        ):
+            await client.ensure_agent("gpt-5.5")
+
+        self.assertIn("--tool-creation", run.await_args.args)
+        self.assertIn("enabled", run.await_args.args)
+
+    async def test_read_conversation_events_filters_one_turn(self) -> None:
+        client = ExoClient(
+            exo_bin=Path("/opt/exo/bin/exo"),
+            exo_root=Path("/tmp/exo-root"),
+            repo_root=Path("/src/exo"),
+        )
+        run = AsyncMock(return_value='{"events":[],"cursor":null}')
+        with patch.object(ExoClient, "_run", run):
+            result = await client.read_conversation_events(
+                "conversation",
+                types=["messages", "tool_result"],
+                turn_id="turn-1",
+                limit=10_000,
+            )
+
+        self.assertEqual(result, '{"events":[],"cursor":null}')
+        run.assert_awaited_once_with(
+            "conversation",
+            "events",
+            "harbor-eval",
+            "conversation",
+            "--type",
+            "messages",
+            "--type",
+            "tool_result",
+            "--turn-id",
+            "turn-1",
+            "--limit",
+            "10000",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/eval/harbor/tests/test_plugin.py
+++ b/eval/harbor/tests/test_plugin.py
@@ -1,0 +1,15 @@
+import unittest
+from unittest.mock import AsyncMock
+
+from exo_harbor.plugin import ExoSessionPlugin
+
+
+class ExoSessionPluginTest(unittest.IsolatedAsyncioTestCase):
+    async def test_job_end_has_no_side_effects(self) -> None:
+        plugin = ExoSessionPlugin()
+
+        await plugin.on_job_end(AsyncMock())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/eval/harbor/tests/test_protocol.py
+++ b/eval/harbor/tests/test_protocol.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from exo_harbor.protocol import TrialRun, send_trial_run
+
+
+class TrialProtocolTest(unittest.IsolatedAsyncioTestCase):
+    async def test_cancellation_propagates_and_closes_socket(self) -> None:
+        request_received = asyncio.Event()
+        client_disconnected = asyncio.Event()
+
+        with tempfile.TemporaryDirectory() as directory:
+            socket_path = Path(directory) / "trial.sock"
+
+            async def wait_forever(
+                reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+            ) -> None:
+                await reader.readline()
+                request_received.set()
+                await reader.read()
+                client_disconnected.set()
+                writer.close()
+                await writer.wait_closed()
+
+            server = await asyncio.start_unix_server(wait_forever, path=socket_path)
+            task = asyncio.create_task(
+                send_trial_run(
+                    socket_path,
+                    TrialRun(
+                        request_id="request-1",
+                        target="trial-1",
+                        container_id="container-1",
+                        instructions="Fix it",
+                    ),
+                    timeout_sec=None,
+                )
+            )
+            await asyncio.wait_for(request_received.wait(), timeout=1)
+            task.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await task
+            await asyncio.wait_for(client_disconnected.wait(), timeout=1)
+            server.close()
+            await server.wait_closed()
+
+    async def test_reconnects_with_same_request_after_worker_restart(self) -> None:
+        request = TrialRun(
+            request_id="request-1",
+            target="trial-1",
+            container_id="container-1",
+            instructions="Fix it",
+        )
+        received: list[dict] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            socket_path = Path(directory) / "trial.sock"
+
+            async def disconnect(
+                reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+            ) -> None:
+                received.append(json.loads(await reader.readline()))
+                writer.close()
+                await writer.wait_closed()
+
+            first = await asyncio.start_unix_server(disconnect, path=socket_path)
+            task = asyncio.create_task(
+                send_trial_run(socket_path, request, timeout_sec=5)
+            )
+            while not received:
+                await asyncio.sleep(0.01)
+            first.close()
+            await first.wait_closed()
+            socket_path.unlink(missing_ok=True)
+
+            async def complete(
+                reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+            ) -> None:
+                received.append(json.loads(await reader.readline()))
+                writer.write(
+                    (
+                        json.dumps(
+                            {
+                                "type": "response",
+                                "event": {
+                                    "type": "trial_complete",
+                                    "request_id": "request-1",
+                                    "target": "trial-1",
+                                    "conversation_id": "conversation-1",
+                                    "summary": "done",
+                                },
+                            }
+                        )
+                        + "\n"
+                    ).encode()
+                )
+                await writer.drain()
+                writer.close()
+                await writer.wait_closed()
+
+            second = await asyncio.start_unix_server(complete, path=socket_path)
+            response = await task
+            second.close()
+            await second.wait_closed()
+
+        self.assertEqual(received, [request.payload(), request.payload()])
+        self.assertEqual(response.conversation_id, "conversation-1")
+        self.assertEqual(response.summary, "done")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/eval/harbor/tests/test_protocol.py
+++ b/eval/harbor/tests/test_protocol.py
@@ -6,7 +6,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from exo_harbor.protocol import TrialRun, send_trial_run
+from exo_harbor.protocol import TrialRun, TrialStarted, send_trial_run
 
 
 class TrialProtocolTest(unittest.IsolatedAsyncioTestCase):
@@ -56,6 +56,7 @@ class TrialProtocolTest(unittest.IsolatedAsyncioTestCase):
             instructions="Fix it",
         )
         received: list[dict] = []
+        started: list[TrialStarted] = []
 
         with tempfile.TemporaryDirectory() as directory:
             socket_path = Path(directory) / "trial.sock"
@@ -64,12 +65,34 @@ class TrialProtocolTest(unittest.IsolatedAsyncioTestCase):
                 reader: asyncio.StreamReader, writer: asyncio.StreamWriter
             ) -> None:
                 received.append(json.loads(await reader.readline()))
+                writer.write(
+                    (
+                        json.dumps(
+                            {
+                                "type": "event",
+                                "event": {
+                                    "type": "trial_started",
+                                    "request_id": "request-1",
+                                    "target": "trial-1",
+                                    "conversation_id": "conversation-1",
+                                },
+                            }
+                        )
+                        + "\n"
+                    ).encode()
+                )
+                await writer.drain()
                 writer.close()
                 await writer.wait_closed()
 
             first = await asyncio.start_unix_server(disconnect, path=socket_path)
             task = asyncio.create_task(
-                send_trial_run(socket_path, request, timeout_sec=5)
+                send_trial_run(
+                    socket_path,
+                    request,
+                    timeout_sec=5,
+                    on_started=started.append,
+                )
             )
             while not received:
                 await asyncio.sleep(0.01)
@@ -81,22 +104,29 @@ class TrialProtocolTest(unittest.IsolatedAsyncioTestCase):
                 reader: asyncio.StreamReader, writer: asyncio.StreamWriter
             ) -> None:
                 received.append(json.loads(await reader.readline()))
+                messages = [
+                    {
+                        "type": "event",
+                        "event": {
+                            "type": "trial_started",
+                            "request_id": "request-1",
+                            "target": "trial-1",
+                            "conversation_id": "conversation-1",
+                        },
+                    },
+                    {
+                        "type": "response",
+                        "event": {
+                            "type": "trial_complete",
+                            "request_id": "request-1",
+                            "target": "trial-1",
+                            "conversation_id": "conversation-1",
+                            "summary": "done",
+                        },
+                    },
+                ]
                 writer.write(
-                    (
-                        json.dumps(
-                            {
-                                "type": "response",
-                                "event": {
-                                    "type": "trial_complete",
-                                    "request_id": "request-1",
-                                    "target": "trial-1",
-                                    "conversation_id": "conversation-1",
-                                    "summary": "done",
-                                },
-                            }
-                        )
-                        + "\n"
-                    ).encode()
+                    "".join(f"{json.dumps(message)}\n" for message in messages).encode()
                 )
                 await writer.drain()
                 writer.close()
@@ -108,8 +138,67 @@ class TrialProtocolTest(unittest.IsolatedAsyncioTestCase):
             await second.wait_closed()
 
         self.assertEqual(received, [request.payload(), request.payload()])
+        self.assertEqual(
+            started,
+            [
+                TrialStarted(
+                    request_id="request-1",
+                    target="trial-1",
+                    conversation_id="conversation-1",
+                )
+            ],
+        )
         self.assertEqual(response.conversation_id, "conversation-1")
         self.assertEqual(response.summary, "done")
+
+    async def test_timeout_retains_started_conversation(self) -> None:
+        started: list[TrialStarted] = []
+
+        with tempfile.TemporaryDirectory() as directory:
+            socket_path = Path(directory) / "trial.sock"
+
+            async def start_only(
+                reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+            ) -> None:
+                await reader.readline()
+                writer.write(
+                    (
+                        json.dumps(
+                            {
+                                "type": "event",
+                                "event": {
+                                    "type": "trial_started",
+                                    "request_id": "request-1",
+                                    "target": "trial-1",
+                                    "conversation_id": "conversation-1",
+                                },
+                            }
+                        )
+                        + "\n"
+                    ).encode()
+                )
+                await writer.drain()
+                await reader.read()
+                writer.close()
+                await writer.wait_closed()
+
+            server = await asyncio.start_unix_server(start_only, path=socket_path)
+            with self.assertRaises(asyncio.TimeoutError):
+                await send_trial_run(
+                    socket_path,
+                    TrialRun(
+                        request_id="request-1",
+                        target="trial-1",
+                        container_id="container-1",
+                        instructions="Fix it",
+                    ),
+                    timeout_sec=0.05,
+                    on_started=started.append,
+                )
+            server.close()
+            await server.wait_closed()
+
+        self.assertEqual(started[0].conversation_id, "conversation-1")
 
 
 if __name__ == "__main__":

--- a/eval/harbor/tests/test_trajectory.py
+++ b/eval/harbor/tests/test_trajectory.py
@@ -1,0 +1,193 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+from exo_harbor.trajectory import (
+    ConversationEvents,
+    build_trajectory,
+    export_trial_trajectory,
+)
+
+
+TRIAL_ID = "514afdba-87e0-43cc-a3ac-86422ade3cf8"
+TURN_ID = "019fde0e-d687-7be3-8771-d9f5a4309e0d"
+CONTINUATION_TURN_ID = "019fde0e-e000-7000-8000-000000000001"
+
+
+def event_page(events: list[dict]) -> str:
+    return json.dumps({"events": events, "cursor": events[-1]["id"] if events else None})
+
+
+def messages_event(
+    event_id: str,
+    messages: list[dict],
+    *,
+    turn_id: str = TURN_ID,
+    usage: dict | None = None,
+) -> dict:
+    data = {"type": "messages", "messages": messages, "response_id": None}
+    if usage is not None:
+        data["usage"] = usage
+    return {
+        "id": event_id,
+        "thread_id": "conversation-id",
+        "session_id": "session-id",
+        "turn_id": turn_id,
+        "created_at": "2026-08-07T21:09:02.215Z",
+        "data": data,
+    }
+
+
+class TrajectoryTest(unittest.IsolatedAsyncioTestCase):
+    async def test_export_includes_trial_continuation_turns_and_writes_atif(self) -> None:
+        other = messages_event(
+            "event-1",
+            [{"role": "user", "content": "Trial `other-trial` has started"}],
+            turn_id="other-turn",
+        )
+        start = messages_event(
+            "event-2",
+            [
+                {
+                    "role": "user",
+                    "content": f"Trial `{TRIAL_ID}` has started.",
+                }
+            ],
+        )
+        assistant = messages_event(
+            "event-3",
+            [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "reasoning",
+                            "text": "Inspect the output.",
+                            "encrypted_content": "ciphertext",
+                        },
+                        {
+                            "type": "tool_call",
+                            "tool_call_id": "call-1",
+                            "tool_name": "shell",
+                            "arguments": {
+                                "type": "valid",
+                                "value": {"command": "run tests"},
+                            },
+                        },
+                    ],
+                    "id": "response-item",
+                }
+            ],
+            usage={
+                "model": "gpt-5.5-2026-04-23",
+                "prompt_tokens": 100,
+                "completion_tokens": 20,
+                "prompt_cached_tokens": 80,
+                "completion_reasoning_tokens": 10,
+                "cost_usd": 0.02,
+            },
+        )
+        tool_result = {
+            "id": "event-4",
+            "thread_id": "conversation-id",
+            "session_id": "session-id",
+            "turn_id": TURN_ID,
+            "created_at": "2026-08-07T21:09:03.215Z",
+            "data": {
+                "type": "tool_result",
+                "tool_call_id": "call-1",
+                "result": {
+                    "ok": True,
+                    "preview": '{"stdout":"Smy Smy"}',
+                    "source": "built_in",
+                    "toolName": "shell",
+                    "truncated": False,
+                    "value": {"exit_code": 0, "stdout": "Smy Smy", "stderr": ""},
+                },
+            },
+        }
+        continuation = messages_event(
+            "event-5",
+            [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": "Continued after restart.",
+                        }
+                    ],
+                    "id": "continuation-response",
+                }
+            ],
+            turn_id=CONTINUATION_TURN_ID,
+        )
+        client = AsyncMock()
+        client.read_conversation_events.return_value = event_page(
+            [other, start, assistant, tool_result, continuation]
+        )
+
+        with tempfile.TemporaryDirectory() as directory:
+            destination = Path(directory) / "agent" / "trajectory.json"
+            await export_trial_trajectory(
+                client,
+                "harbor-shared",
+                TRIAL_ID,
+                "Do the task",
+                "gpt-5.5",
+                destination,
+            )
+            output = json.loads(destination.read_text())
+
+        self.assertEqual(output["schema_version"], "ATIF-v1.7")
+        self.assertEqual(output["trajectory_id"], TRIAL_ID)
+        self.assertEqual(output["session_id"], "harbor-shared")
+        self.assertEqual(output["steps"][0]["message"], "Do the task")
+        self.assertEqual(len(output["steps"]), 3)
+        agent_step = output["steps"][1]
+        self.assertEqual(agent_step["reasoning_content"], "Inspect the output.")
+        self.assertEqual(agent_step["tool_calls"][0]["function_name"], "shell")
+        self.assertIn("Smy Smy", agent_step["observation"]["results"][0]["content"])
+        self.assertEqual(output["final_metrics"]["total_prompt_tokens"], 100)
+        self.assertEqual(output["steps"][2]["message"], "Continued after restart.")
+        self.assertEqual(
+            output["extra"]["exo_turn_ids"],
+            [TURN_ID, CONTINUATION_TURN_ID],
+        )
+        self.assertNotIn("ciphertext", json.dumps(output))
+        client.read_conversation_events.assert_awaited_once_with(
+            "harbor-shared",
+            types=["messages", "tool_result"],
+            limit=10_000,
+        )
+
+    def test_build_trajectory_replaces_adapter_envelope_with_instruction(self) -> None:
+        events = ConversationEvents.model_validate_json(
+            event_page(
+                [
+                    messages_event(
+                        "event-1",
+                        [{"role": "user", "content": "adapter protocol envelope"}],
+                    )
+                ]
+            )
+        ).events
+
+        trajectory = build_trajectory(
+            events=events,
+            trial_id=TRIAL_ID,
+            turn_ids=[TURN_ID],
+            instruction="Do the task",
+            model_name="gpt-5.5",
+            conversation="harbor-shared",
+            started_at="2026-08-07T21:09:02.215Z",
+        )
+
+        self.assertEqual(len(trajectory.steps), 1)
+        self.assertEqual(trajectory.steps[0].message, "Do the task")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/exo/adapters/trial/trial.test.ts
+++ b/exo/adapters/trial/trial.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { composeTrialPrompt, parseTrialComplete, parseTrialRun } from "./trial";
+import { composeTrialPrompt, parseTrialResponse, parseTrialRun } from "./trial";
 
 const request = parseTrialRun({
   type: "trial_run",
@@ -21,7 +21,7 @@ describe("trial adapter protocol", () => {
 
   it("validates the runtime-completed response", () => {
     expect(
-      parseTrialComplete(
+      parseTrialResponse(
         JSON.stringify({
           type: "trial_complete",
           request_id: "request-1",
@@ -37,6 +37,25 @@ describe("trial adapter protocol", () => {
       target: "trial-1",
       conversation_id: "conversation-1",
       summary: "done",
+    });
+  });
+
+  it("validates the runtime-started response", () => {
+    expect(
+      parseTrialResponse(
+        JSON.stringify({
+          type: "trial_started",
+          request_id: "request-1",
+          target: "trial-1",
+          conversation_id: "conversation-1",
+        }),
+        request,
+      ),
+    ).toEqual({
+      type: "trial_started",
+      request_id: "request-1",
+      target: "trial-1",
+      conversation_id: "conversation-1",
     });
   });
 });

--- a/exo/adapters/trial/trial.ts
+++ b/exo/adapters/trial/trial.ts
@@ -18,6 +18,15 @@ export type TrialComplete = {
   summary?: string | null;
 };
 
+export type TrialStarted = {
+  type: "trial_started";
+  request_id: string;
+  target: string;
+  conversation_id: string;
+};
+
+export type TrialResponse = TrialStarted | TrialComplete;
+
 export function defaultSocketPath(homedir: string = os.homedir()): string {
   return path.join(homedir, ".exo", "trial.sock");
 }
@@ -37,10 +46,10 @@ export function parseTrialRun(value: unknown): TrialRun {
   };
 }
 
-export function parseTrialComplete(
+export function parseTrialResponse(
   text: string,
   request: TrialRun,
-): TrialComplete {
+): TrialResponse {
   let value: unknown;
   try {
     value = JSON.parse(text);
@@ -48,8 +57,8 @@ export function parseTrialComplete(
     throw new Error("trial response must be a JSON object");
   }
   const record = objectValue(value, "trial response");
-  if (record.type !== "trial_complete") {
-    throw new Error("response type must be trial_complete");
+  if (record.type !== "trial_started" && record.type !== "trial_complete") {
+    throw new Error("response type must be trial_started or trial_complete");
   }
   const requestId = stringValue(record.request_id, "request_id");
   if (requestId !== request.request_id) {
@@ -63,11 +72,20 @@ export function parseTrialComplete(
       `response target ${target} does not match ${request.target}`,
     );
   }
+  const conversationId = stringValue(record.conversation_id, "conversation_id");
+  if (record.type === "trial_started") {
+    return {
+      type: "trial_started",
+      request_id: requestId,
+      target,
+      conversation_id: conversationId,
+    };
+  }
   return {
     type: "trial_complete",
     request_id: requestId,
     target,
-    conversation_id: stringValue(record.conversation_id, "conversation_id"),
+    conversation_id: conversationId,
     summary: nullableString(record.summary, "summary"),
   };
 }

--- a/exo/adapters/trial/worker.test.ts
+++ b/exo/adapters/trial/worker.test.ts
@@ -64,6 +64,7 @@ describe("trial adapter worker", () => {
       subject: socketPath,
     });
     const firstClient = await connect(socketPath);
+    const firstResponses = new LineQueue(firstClient);
     firstClient.write(`${JSON.stringify(request)}\n`);
     expect(JSON.parse(await first.events.next())).toMatchObject({
       type: "message",
@@ -73,6 +74,37 @@ describe("trial adapter worker", () => {
         request_id: "request-1",
         container_id: "container-1",
       },
+    });
+    const firstInput = first.child.stdin;
+    if (firstInput === null) {
+      throw new Error("trial worker stdin is not piped");
+    }
+    firstInput.write(
+      `${JSON.stringify({
+        type: "send_message",
+        id: "started-command-1",
+        target: "trial-1",
+        text: JSON.stringify({
+          type: "trial_started",
+          request_id: "request-1",
+          target: "trial-1",
+          conversation_id: "conversation-1",
+        }),
+        attachments: [],
+      })}\n`,
+    );
+    expect(JSON.parse(await firstResponses.next())).toEqual({
+      type: "event",
+      event: {
+        type: "trial_started",
+        request_id: "request-1",
+        target: "trial-1",
+        conversation_id: "conversation-1",
+      },
+    });
+    expect(JSON.parse(await first.events.next())).toEqual({
+      type: "command_ack",
+      command_id: "started-command-1",
     });
 
     first.child.kill("SIGKILL");
@@ -93,6 +125,15 @@ describe("trial adapter worker", () => {
     const secondClient = await connect(socketPath);
     const responses = new LineQueue(secondClient);
     secondClient.write(`${JSON.stringify(request)}\n`);
+    expect(JSON.parse(await responses.next())).toEqual({
+      type: "event",
+      event: {
+        type: "trial_started",
+        request_id: "request-1",
+        target: "trial-1",
+        conversation_id: "conversation-1",
+      },
+    });
     const workerInput = second.child.stdin;
     if (workerInput === null) {
       throw new Error("trial worker stdin is not piped");

--- a/exo/adapters/trial/worker.ts
+++ b/exo/adapters/trial/worker.ts
@@ -15,10 +15,11 @@ import {
 import {
   composeTrialPrompt,
   defaultSocketPath,
-  parseTrialComplete,
+  parseTrialResponse,
   parseTrialRun,
   type TrialComplete,
   type TrialRun,
+  type TrialStarted,
 } from "./trial";
 
 type PendingTrial = {
@@ -27,8 +28,13 @@ type PendingTrial = {
 };
 
 type CompletedTrial = {
-  commandId: string;
+  commandIds: string[];
   response: TrialComplete;
+};
+
+type StartedTrial = {
+  commandIds: string[];
+  response: TrialStarted;
 };
 
 const config = adapterConfig();
@@ -79,6 +85,10 @@ const server = net.createServer((socket) => {
         return;
       }
       pending.sockets.add(socket);
+      const started = readStartedTrial(request.request_id);
+      if (started) {
+        sendToClient(socket, { type: "event", event: started.response });
+      }
       return;
     }
     if (findPendingRequest(request.request_id)) {
@@ -158,9 +168,37 @@ for await (const line of input) {
       throw new Error(`trial target ${target} is not awaiting completion`);
     }
 
-    const response = parseTrialComplete(command.text, pending.request);
-    writeCompletedTrial(pending.request.request_id, command.id, response);
+    const response = parseTrialResponse(command.text, pending.request);
+    if (response.type === "trial_started") {
+      const started = readStartedTrial(pending.request.request_id);
+      if (
+        started &&
+        started.response.conversation_id !== response.conversation_id
+      ) {
+        throw new Error(
+          `trial target ${target} changed conversations while active`,
+        );
+      }
+      writeStartedTrial(pending.request.request_id, {
+        commandIds: [...(started?.commandIds ?? []), command.id],
+        response,
+      });
+      if (!started) {
+        for (const socket of pending.sockets) {
+          sendToClient(socket, { type: "event", event: response });
+        }
+      }
+      writeWorkerEvent({ type: "command_ack", command_id: command.id });
+      continue;
+    }
+
+    const started = readStartedTrial(pending.request.request_id);
+    writeCompletedTrial(pending.request.request_id, {
+      commandIds: [...(started?.commandIds ?? []), command.id],
+      response,
+    });
     removePendingTrial(pending.request.request_id);
+    removeStartedTrial(pending.request.request_id);
     pendingByTarget.delete(target);
     for (const socket of pending.sockets) {
       sendToClient(socket, { type: "response", event: response });
@@ -205,6 +243,7 @@ function loadPendingTrials(): void {
     const request = parseTrialRun(JSON.parse(fs.readFileSync(file, "utf8")));
     if (readCompletedTrial(request.request_id)) {
       fs.rmSync(file, { force: true });
+      removeStartedTrial(request.request_id);
       continue;
     }
     if (pendingByTarget.has(request.target)) {
@@ -231,6 +270,10 @@ function completedPath(requestId: string): string {
   return statePath("response", requestId);
 }
 
+function startedPath(requestId: string): string {
+  return statePath("started", requestId);
+}
+
 function statePath(kind: string, requestId: string): string {
   const digest = crypto.createHash("sha256").update(requestId).digest("hex");
   return path.join(stateDir, `${kind}-${digest}.json`);
@@ -242,6 +285,24 @@ function writePendingTrial(request: TrialRun): void {
 
 function removePendingTrial(requestId: string): void {
   fs.rmSync(pendingPath(requestId), { force: true });
+}
+
+function readStartedTrial(requestId: string): StartedTrial | null {
+  try {
+    return JSON.parse(
+      fs.readFileSync(startedPath(requestId), "utf8"),
+    ) as StartedTrial;
+  } catch {
+    return null;
+  }
+}
+
+function writeStartedTrial(requestId: string, started: StartedTrial): void {
+  writeJsonAtomically(startedPath(requestId), started);
+}
+
+function removeStartedTrial(requestId: string): void {
+  fs.rmSync(startedPath(requestId), { force: true });
 }
 
 function readCompletedTrial(requestId: string): CompletedTrial | null {
@@ -256,10 +317,9 @@ function readCompletedTrial(requestId: string): CompletedTrial | null {
 
 function writeCompletedTrial(
   requestId: string,
-  commandId: string,
-  response: TrialComplete,
+  completed: CompletedTrial,
 ): void {
-  writeJsonAtomically(completedPath(requestId), { commandId, response });
+  writeJsonAtomically(completedPath(requestId), completed);
 }
 
 function writeJsonAtomically(destination: string, value: object): void {
@@ -277,7 +337,7 @@ function hasCompletedCommand(commandId: string): boolean {
       const completed = JSON.parse(
         fs.readFileSync(path.join(stateDir, name), "utf8"),
       ) as CompletedTrial;
-      return completed.commandId === commandId;
+      return completed.commandIds.includes(commandId);
     } catch {
       return false;
     }

--- a/exo/docs/design/trial-adapter.md
+++ b/exo/docs/design/trial-adapter.md
@@ -38,7 +38,18 @@ The initial protocol has one request.
 one delivery and makes retrying a request idempotent. A target may have only one
 active phase at a time.
 
-The successful response is:
+Once the conversation exists and the container is attached, the adapter emits:
+
+```json
+{
+  "type": "trial_started",
+  "request_id": "unique delivery id",
+  "target": "stable trial id",
+  "conversation_id": "Exo conversation id"
+}
+```
+
+The final successful response is:
 
 ```json
 {
@@ -77,11 +88,12 @@ For `trial_run`, the adapter:
 
 1. Creates a new conversation for the trial.
 2. Attaches the supplied container as that conversation's sandbox.
-3. Wakes the conversation with the supplied instructions and the explicit
+3. Returns `trial_started` so the evaluator can retain the conversation id.
+4. Wakes the conversation with the supplied instructions and the explicit
    completion protocol.
-4. Continues waking the same conversation after an Exo rebuild until the agent
+5. Continues waking the same conversation after an Exo rebuild until the agent
    calls `send_adapter_message` to declare completion.
-5. Returns `trial_complete` to the waiting evaluator.
+6. Returns `trial_complete` to the waiting evaluator.
 
 In a later version, `trial_feedback` would:
 
@@ -109,10 +121,11 @@ active request id and deadline (when active)
 completed request ids and responses
 ```
 
-The current worker persists active requests and completed responses in its
-adapter state directory. The runtime durably maps each target to its trial
-conversation. A restarted worker can therefore replay a pending wake or return
-an already-completed response after Exo rebuilds.
+The current worker persists active requests, started responses, and completed
+responses in its adapter state directory. The runtime durably maps each target
+to its trial conversation. A restarted worker can therefore replay
+`trial_started`, replay a pending wake, or return an already-completed response
+after Exo rebuilds.
 
 ## Learning across trials
 
@@ -151,9 +164,10 @@ the existing conversation.
 
 ## Trajectory export
 
-Every completion response includes `conversation_id`. That is the stable source
-for exporting the trial's model messages, tool calls, results, and rebuild
-continuations.
+Both responses include `conversation_id`. The evaluator retains it from
+`trial_started`, making it possible to export model messages, tool calls,
+results, and rebuild continuations even when the trial times out before
+`trial_complete`.
 
 ATIF conversion should be a separate exporter over the canonical conversation
 log rather than part of the adapter protocol. A benchmark bridge can export the


### PR DESCRIPTION
Adds the Harbor bridge and evaluation runner over the generic trial adapter, including ATIF trajectory export and local smoke datasets.

Stacked on #202.