### PR TITLE
exochat: replay-protect sends with a bounded relay cache

### DIFF
--- a/exo/adapters/exochat/exochat.test.ts
+++ b/exo/adapters/exochat/exochat.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { parseSendAck, sendDedupeId } from "./exochat";
+
+describe("sendDedupeId", () => {
+  const commandId = "0198c4f1-7b2a-7c3d-8e4f-5a6b7c8d9e0f";
+
+  it("is deterministic across restarts", () => {
+    // A replayed command must present the same id as the attempt that
+    // crashed, or the relay sees an unrelated send and broadcasts again.
+    expect(sendDedupeId(commandId)).toBe(sendDedupeId(commandId));
+  });
+
+  it("differs per command", () => {
+    expect(sendDedupeId("command-a")).not.toBe(sendDedupeId("command-b"));
+  });
+
+  it("does not leak the command id to the relay", () => {
+    expect(sendDedupeId(commandId)).not.toContain(commandId);
+  });
+
+  it("fits the relay's id bounds", () => {
+    const id = sendDedupeId(commandId);
+    expect(id.length).toBeGreaterThanOrEqual(8);
+    expect(id.length).toBeLessThanOrEqual(128);
+  });
+});
+
+describe("parseSendAck", () => {
+  it("accepts a relay ack", () => {
+    expect(
+      parseSendAck({
+        channel: "exo.chat.ack",
+        id: "dedupe-id-1",
+        duplicate: true,
+        at: 123,
+      }),
+    ).toEqual({ id: "dedupe-id-1", duplicate: true });
+  });
+
+  it("rejects envelopes, presence, and malformed acks", () => {
+    expect(parseSendAck({ channel: "exo.chat", id: "dedupe-id-1" })).toBeNull();
+    expect(
+      parseSendAck({ channel: "rendezvous", type: "presence" }),
+    ).toBeNull();
+    expect(parseSendAck({ channel: "exo.chat.ack", id: 7 })).toBeNull();
+    expect(parseSendAck(null)).toBeNull();
+    expect(parseSendAck("exo.chat.ack")).toBeNull();
+  });
+});

--- a/exo/adapters/exochat/exochat.ts
+++ b/exo/adapters/exochat/exochat.ts
@@ -1,0 +1,33 @@
+import { createHash } from "node:crypto";
+
+// The relay's replay-protection id rides at envelope level, outside the
+// ciphertext, so the relay can see it. Send a hash of the command id rather
+// than the id itself: deterministic across retries (a replayed command
+// presents the same key), meaningless to the relay.
+export function sendDedupeId(commandId: string): string {
+  return createHash("sha256")
+    .update(commandId)
+    .digest("base64url")
+    .slice(0, 22);
+}
+
+export type SendAck = {
+  id: string;
+  duplicate: boolean;
+};
+
+// Acks are relay metadata like presence, not encrypted frames: the relay has
+// no channel key, and the ack carries only the id the sender already exposed.
+export function parseSendAck(value: unknown): SendAck | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  if (record.channel !== "exo.chat.ack") {
+    return null;
+  }
+  if (typeof record.id !== "string" || typeof record.duplicate !== "boolean") {
+    return null;
+  }
+  return { id: record.id, duplicate: record.duplicate };
+}

--- a/exo/adapters/exochat/relay-testkit.ts
+++ b/exo/adapters/exochat/relay-testkit.ts
@@ -1,0 +1,352 @@
+// Test-only host for the real ExoChat relay: RendezvousSession from
+// website/src/worker.js served over a minimal RFC 6455 server, so the real
+// adapter process and a real peer client exercise the deployed relay code
+// end-to-end. The durable-object runtime is shimmed (sockets survive an
+// instance swap, storage is a map), which is exactly the hibernation contract
+// the replay cache is written against.
+import { createHash } from "node:crypto";
+import http from "node:http";
+import type { Duplex } from "node:stream";
+
+import type {
+  RelayContext,
+  RelayEnv,
+  RelaySocket,
+} from "../../../website/src/worker.js";
+import { RendezvousSession } from "../../../website/src/worker.js";
+
+const WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+const WS_PATH_PATTERN = /^\/chat\/ws\/([A-Za-z0-9_-]{8,128})\/?$/;
+
+class MemoryStorage {
+  values = new Map<string, unknown>();
+
+  async get(key: string): Promise<unknown> {
+    return this.values.get(key);
+  }
+
+  async put(key: string, value: unknown): Promise<void> {
+    this.values.set(key, value);
+  }
+
+  async setAlarm(): Promise<void> {}
+
+  async deleteAll(): Promise<void> {
+    this.values.clear();
+  }
+}
+
+type HostedSocket = RelaySocket & {
+  attachment: { role?: string } | undefined;
+};
+
+type Channel = {
+  context: RelayContext;
+  session: RendezvousSession;
+  sockets: Set<HostedSocket>;
+  storage: MemoryStorage;
+  ackDropsLeft: number;
+  droppedAcks: string[];
+  ackDropWaiters: (() => void)[];
+};
+
+export type RelayHarness = {
+  url: string;
+  dropAcks(channelId: string, count: number): void;
+  waitForDroppedAck(channelId: string): Promise<void>;
+  restartChannel(
+    channelId: string,
+    options: { clearStorage: boolean },
+  ): Promise<void>;
+  close(): Promise<void>;
+};
+
+export async function startRelayHarness(env?: RelayEnv): Promise<RelayHarness> {
+  const channels = new Map<string, Channel>();
+
+  function channelFor(channelId: string): Channel {
+    const existing = channels.get(channelId);
+    if (existing) {
+      return existing;
+    }
+    const sockets = new Set<HostedSocket>();
+    const storage = new MemoryStorage();
+    const context: RelayContext = {
+      getWebSockets: () => [...sockets],
+      acceptWebSocket: (socket) => {
+        sockets.add(socket as HostedSocket);
+      },
+      storage,
+    };
+    const channel: Channel = {
+      context,
+      session: new RendezvousSession(context, env),
+      sockets,
+      storage,
+      ackDropsLeft: 0,
+      droppedAcks: [],
+      ackDropWaiters: [],
+    };
+    channels.set(channelId, channel);
+    return channel;
+  }
+
+  const server = http.createServer((_request, response) => {
+    response.writeHead(426).end();
+  });
+  // Upgraded sockets leave the http server's connection tracking, so keep our
+  // own set or close() waits on them forever.
+  const tcpSockets = new Set<Duplex>();
+
+  server.on("upgrade", (request, tcpSocket) => {
+    tcpSockets.add(tcpSocket);
+    tcpSocket.on("close", () => {
+      tcpSockets.delete(tcpSocket);
+    });
+    const url = new URL(request.url ?? "/", "http://localhost");
+    const match = url.pathname.match(WS_PATH_PATTERN);
+    const role = url.searchParams.get("role");
+    const key = request.headers["sec-websocket-key"];
+    const channelId = match?.[1];
+    if (
+      channelId === undefined ||
+      (role !== "agent" && role !== "user") ||
+      typeof key !== "string"
+    ) {
+      tcpSocket.destroy();
+      return;
+    }
+    const accept = createHash("sha1")
+      .update(`${key}${WS_GUID}`)
+      .digest("base64");
+    tcpSocket.write(
+      "HTTP/1.1 101 Switching Protocols\r\n" +
+        "Upgrade: websocket\r\n" +
+        "Connection: Upgrade\r\n" +
+        `Sec-WebSocket-Accept: ${accept}\r\n\r\n`,
+    );
+    attachConnection(channelFor(channelId), role, tcpSocket);
+  });
+
+  function attachConnection(
+    channel: Channel,
+    role: "agent" | "user",
+    tcpSocket: Duplex,
+  ): void {
+    const socket: HostedSocket = {
+      attachment: undefined,
+      readyState: WebSocket.OPEN,
+      send(message: string) {
+        if (
+          channel.ackDropsLeft > 0 &&
+          socket.attachment?.role === "agent" &&
+          isAck(message)
+        ) {
+          channel.ackDropsLeft -= 1;
+          channel.droppedAcks.push(message);
+          for (const wake of channel.ackDropWaiters.splice(0)) {
+            wake();
+          }
+          return;
+        }
+        tcpSocket.write(encodeTextFrame(message));
+      },
+      close(code = 1000, reason = "") {
+        channel.sockets.delete(socket);
+        tcpSocket.write(encodeCloseFrame(code, reason));
+        tcpSocket.end();
+      },
+      serializeAttachment(value: unknown) {
+        socket.attachment = value as { role?: string };
+      },
+      deserializeAttachment() {
+        return socket.attachment;
+      },
+    };
+
+    // The connection ceremony RendezvousSession.fetch performs before the
+    // runtime takes over the socket.
+    for (const existing of channel.context.getWebSockets()) {
+      if (existing.deserializeAttachment()?.role === role) {
+        existing.close(1000, "Replaced by a newer connection");
+      }
+    }
+    channel.context.acceptWebSocket(socket);
+    socket.serializeAttachment({ role, connectedAt: Date.now() });
+    channel.session.broadcastPresence();
+
+    const state = { buffer: Buffer.alloc(0) };
+    let dispatching: Promise<void> = Promise.resolve();
+    tcpSocket.on("data", (chunk: Buffer) => {
+      state.buffer = Buffer.concat([state.buffer, chunk]);
+      for (const frame of parseFrames(state)) {
+        dispatching = dispatching
+          .then(() => dispatchFrame(frame))
+          .catch(() => {
+            tcpSocket.destroy();
+          });
+      }
+    });
+    tcpSocket.on("close", () => {
+      if (channel.sockets.delete(socket)) {
+        channel.session.webSocketClose();
+      }
+    });
+    tcpSocket.on("error", () => {
+      tcpSocket.destroy();
+    });
+
+    async function dispatchFrame(frame: WsFrame): Promise<void> {
+      if (frame.opcode === 0x1) {
+        await channel.session.webSocketMessage(
+          socket,
+          frame.payload.toString("utf8"),
+        );
+        return;
+      }
+      if (frame.opcode === 0x8) {
+        socket.close(1000, "");
+        return;
+      }
+      if (frame.opcode === 0x9) {
+        tcpSocket.write(encodePongFrame(frame.payload));
+      }
+    }
+  }
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("relay harness did not bind a TCP port");
+  }
+
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    dropAcks(channelId, count) {
+      channelFor(channelId).ackDropsLeft = count;
+    },
+    waitForDroppedAck(channelId) {
+      const channel = channelFor(channelId);
+      if (channel.droppedAcks.length > 0) {
+        return Promise.resolve();
+      }
+      return new Promise((resolve) => {
+        channel.ackDropWaiters.push(resolve);
+      });
+    },
+    async restartChannel(channelId, options) {
+      const channel = channelFor(channelId);
+      if (options.clearStorage) {
+        await channel.storage.deleteAll();
+      }
+      channel.session = new RendezvousSession(channel.context, env);
+    },
+    close() {
+      return new Promise((resolve) => {
+        for (const tcpSocket of tcpSockets) {
+          tcpSocket.destroy();
+        }
+        server.close(() => resolve());
+        server.closeAllConnections();
+      });
+    },
+  };
+}
+
+function isAck(message: string): boolean {
+  try {
+    const value = JSON.parse(message) as { channel?: string };
+    return value.channel === "exo.chat.ack";
+  } catch {
+    return false;
+  }
+}
+
+type WsFrame = {
+  opcode: number;
+  payload: Buffer;
+};
+
+function parseFrames(state: { buffer: Buffer }): WsFrame[] {
+  const frames: WsFrame[] = [];
+  for (;;) {
+    const buffer = state.buffer;
+    if (buffer.length < 2) {
+      break;
+    }
+    const fin = (buffer[0] & 0x80) !== 0;
+    const opcode = buffer[0] & 0x0f;
+    const masked = (buffer[1] & 0x80) !== 0;
+    let length = buffer[1] & 0x7f;
+    let offset = 2;
+    if (length === 126) {
+      if (buffer.length < 4) {
+        break;
+      }
+      length = buffer.readUInt16BE(2);
+      offset = 4;
+    } else if (length === 127) {
+      if (buffer.length < 10) {
+        break;
+      }
+      length = Number(buffer.readBigUInt64BE(2));
+      offset = 10;
+    }
+    const maskOffset = offset;
+    if (masked) {
+      offset += 4;
+    }
+    if (buffer.length < offset + length) {
+      break;
+    }
+    if (!fin || opcode === 0x0) {
+      throw new Error("fragmented frames are unsupported by the test relay");
+    }
+    let payload = Buffer.from(buffer.subarray(offset, offset + length));
+    if (masked) {
+      const mask = buffer.subarray(maskOffset, maskOffset + 4);
+      for (let index = 0; index < payload.length; index += 1) {
+        payload[index] ^= mask[index % 4];
+      }
+    }
+    state.buffer = buffer.subarray(offset + length);
+    frames.push({ opcode, payload });
+  }
+  return frames;
+}
+
+function encodeTextFrame(text: string): Buffer {
+  return encodeFrame(0x81, Buffer.from(text, "utf8"));
+}
+
+function encodePongFrame(payload: Buffer): Buffer {
+  return encodeFrame(0x8a, payload);
+}
+
+function encodeCloseFrame(code: number, reason: string): Buffer {
+  const reasonBytes = Buffer.from(reason, "utf8");
+  const payload = Buffer.alloc(2 + reasonBytes.length);
+  payload.writeUInt16BE(code, 0);
+  reasonBytes.copy(payload, 2);
+  return encodeFrame(0x88, payload);
+}
+
+function encodeFrame(firstByte: number, payload: Buffer): Buffer {
+  if (payload.length < 126) {
+    return Buffer.concat([Buffer.from([firstByte, payload.length]), payload]);
+  }
+  if (payload.length < 65_536) {
+    const header = Buffer.alloc(4);
+    header[0] = firstByte;
+    header[1] = 126;
+    header.writeUInt16BE(payload.length, 2);
+    return Buffer.concat([header, payload]);
+  }
+  const header = Buffer.alloc(10);
+  header[0] = firstByte;
+  header[1] = 127;
+  header.writeBigUInt64BE(BigInt(payload.length), 2);
+  return Buffer.concat([header, payload]);
+}

--- a/exo/adapters/exochat/replay.e2e.test.ts
+++ b/exo/adapters/exochat/replay.e2e.test.ts
@@ -1,0 +1,461 @@
+// End-to-end replay-protection tests: the real adapter worker as a child
+// process, the real relay class over real WebSockets, and a peer client that
+// speaks the pre-id wire protocol so every assertion doubles as a
+// compatibility check.
+import { type ChildProcess, spawn } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { startRelayHarness } from "./relay-testkit";
+
+const TEST_TIMEOUT_MS = 30_000;
+const WAIT_TIMEOUT_MS = 15_000;
+
+const require = createRequire(import.meta.url);
+const tsxCli = path.join(
+  path.dirname(require.resolve("tsx/package.json")),
+  "dist/cli.mjs",
+);
+const workerPath = fileURLToPath(new URL("./worker.ts", import.meta.url));
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitUntil<T>(get: () => T | null, what: string): Promise<T> {
+  const deadline = Date.now() + WAIT_TIMEOUT_MS;
+  for (;;) {
+    const value = get();
+    if (value !== null) {
+      return value;
+    }
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${what}`);
+    }
+    await sleep(25);
+  }
+}
+
+class AdapterProcess {
+  readonly events: Record<string, unknown>[] = [];
+  private readonly child: ChildProcess;
+  private stdoutRest = "";
+
+  private constructor(child: ChildProcess) {
+    this.child = child;
+    child.stdout?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk: string) => {
+      this.stdoutRest += chunk;
+      const lines = this.stdoutRest.split("\n");
+      this.stdoutRest = lines.pop() ?? "";
+      for (const line of lines) {
+        if (line.trim().length > 0) {
+          this.events.push(JSON.parse(line) as Record<string, unknown>);
+        }
+      }
+    });
+    child.stderr?.resume();
+  }
+
+  static async start(options: {
+    baseUrl: string;
+    channelId: string;
+    secret: string;
+    stateDir: string;
+  }): Promise<AdapterProcess> {
+    const child = spawn(process.execPath, [tsxCli, workerPath], {
+      env: {
+        ...process.env,
+        EXO_ADAPTER_CONFIG: JSON.stringify({
+          baseUrl: options.baseUrl,
+          channelId: options.channelId,
+          secret: options.secret,
+        }),
+        EXO_ADAPTER_STATE_DIR: options.stateDir,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const adapter = new AdapterProcess(child);
+    await adapter.waitForEvent((event) => event.type === "connected");
+    return adapter;
+  }
+
+  writeCommand(command: Record<string, unknown>): void {
+    this.child.stdin?.write(`${JSON.stringify(command)}\n`);
+  }
+
+  waitForEvent(
+    predicate: (event: Record<string, unknown>) => boolean,
+  ): Promise<Record<string, unknown>> {
+    let cursor = 0;
+    return waitUntil(() => {
+      while (cursor < this.events.length) {
+        const event = this.events[cursor];
+        cursor += 1;
+        if (predicate(event)) {
+          return event;
+        }
+      }
+      return null;
+    }, "adapter event");
+  }
+
+  countEvents(type: string): number {
+    return this.events.filter((event) => event.type === type).length;
+  }
+
+  kill(): void {
+    this.child.kill("SIGKILL");
+  }
+}
+
+// A peer that speaks the wire protocol exactly as it existed before replay
+// protection: fixed-field AAD, no envelope id, no knowledge of acks. If this
+// peer can authenticate and decrypt what the new adapter sends, an undeployed
+// web client can too.
+class UserPeer {
+  readonly chats: { text: string; envelope: Record<string, unknown> }[] = [];
+  readonly acks: Record<string, unknown>[] = [];
+  private readonly ws: WebSocket;
+  private readonly key: Buffer;
+  private readonly channelId: string;
+  private seq = 0;
+
+  private constructor(ws: WebSocket, channelId: string, secret: string) {
+    this.ws = ws;
+    this.channelId = channelId;
+    this.key = Buffer.from(
+      crypto.hkdfSync(
+        "sha256",
+        Buffer.from(secret, "base64url"),
+        Buffer.from(channelId),
+        Buffer.from("exo-chat-relay:aes-gcm:v1"),
+        32,
+      ),
+    );
+    ws.addEventListener("message", (event) => {
+      if (typeof event.data !== "string") {
+        return;
+      }
+      const message = JSON.parse(event.data) as Record<string, unknown>;
+      if (message.channel === "exo.chat.ack") {
+        this.acks.push(message);
+        return;
+      }
+      if (message.channel !== "exo.chat" || message.from !== "agent") {
+        return;
+      }
+      const frame = this.decrypt(message);
+      if (frame !== null && frame.type === "chat") {
+        this.chats.push({ text: String(frame.text), envelope: message });
+      }
+    });
+  }
+
+  static async connect(
+    baseUrl: string,
+    channelId: string,
+    secret: string,
+  ): Promise<UserPeer> {
+    const wsUrl = new URL(`/chat/ws/${channelId}`, baseUrl);
+    wsUrl.protocol = "ws:";
+    wsUrl.searchParams.set("role", "user");
+    const ws = new WebSocket(wsUrl);
+    await new Promise<void>((resolve, reject) => {
+      ws.addEventListener("open", () => resolve(), { once: true });
+      ws.addEventListener(
+        "error",
+        () => reject(new Error("peer failed to connect")),
+        { once: true },
+      );
+    });
+    return new UserPeer(ws, channelId, secret);
+  }
+
+  sendLegacyChat(id: string, text: string): void {
+    const envelope: Record<string, unknown> = {
+      channel: "exo.chat",
+      channelId: this.channelId,
+      ciphertext: "",
+      from: "user",
+      nonce: crypto.randomBytes(12).toString("base64url"),
+      seq: (this.seq += 1),
+      version: 1,
+    };
+    const cipher = crypto.createCipheriv(
+      "aes-256-gcm",
+      this.key,
+      Buffer.from(String(envelope.nonce), "base64url"),
+    );
+    cipher.setAAD(Buffer.from(canonicalEnvelope(envelope)));
+    const ciphertext = Buffer.concat([
+      cipher.update(
+        JSON.stringify({ type: "chat", id, text, createdAt: Date.now() }),
+        "utf8",
+      ),
+      cipher.final(),
+      cipher.getAuthTag(),
+    ]);
+    envelope.ciphertext = ciphertext.toString("base64url");
+    this.ws.send(JSON.stringify(envelope));
+  }
+
+  waitForChats(count: number): Promise<void> {
+    return waitUntil(
+      () => (this.chats.length >= count ? true : null),
+      `${count} chat broadcasts`,
+    ).then(() => {});
+  }
+
+  close(): void {
+    this.ws.close();
+  }
+
+  private decrypt(
+    envelope: Record<string, unknown>,
+  ): Record<string, unknown> | null {
+    try {
+      const bytes = Buffer.from(String(envelope.ciphertext), "base64url");
+      const ciphertext = bytes.subarray(0, bytes.length - 16);
+      const authTag = bytes.subarray(bytes.length - 16);
+      const decipher = crypto.createDecipheriv(
+        "aes-256-gcm",
+        this.key,
+        Buffer.from(String(envelope.nonce), "base64url"),
+      );
+      decipher.setAAD(Buffer.from(canonicalEnvelope(envelope)));
+      decipher.setAuthTag(authTag);
+      const plaintext = Buffer.concat([
+        decipher.update(ciphertext),
+        decipher.final(),
+      ]).toString("utf8");
+      return JSON.parse(plaintext) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+}
+
+// The pre-id canonical form: any envelope field outside this list — the
+// dedupe id included — must stay outside the AAD or existing peers would fail
+// authentication.
+function canonicalEnvelope(envelope: Record<string, unknown>): string {
+  return JSON.stringify({
+    channel: envelope.channel,
+    channelId: envelope.channelId,
+    from: envelope.from,
+    nonce: envelope.nonce,
+    seq: envelope.seq,
+    version: envelope.version,
+  });
+}
+
+async function freshStateDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "exochat-replay-e2e-"));
+}
+
+function testSecret(): string {
+  return crypto.randomBytes(32).toString("base64url");
+}
+
+const sendCommand = {
+  type: "send_message",
+  id: "0198c4f1-7b2a-7c3d-8e4f-5a6b7c8d9e0f",
+  text: "exactly once, please",
+};
+
+describe("exochat replay protection", () => {
+  it(
+    "replays after a crash between send and ack without a second broadcast",
+    { timeout: TEST_TIMEOUT_MS },
+    async () => {
+      const harness = await startRelayHarness();
+      const channelId = "replay-crash-channel";
+      const secret = testSecret();
+      const stateDir = await freshStateDir();
+      let adapter: AdapterProcess | null = null;
+      const peer = await UserPeer.connect(harness.url, channelId, secret);
+      try {
+        adapter = await AdapterProcess.start({
+          baseUrl: harness.url,
+          channelId,
+          secret,
+          stateDir,
+        });
+
+        // First attempt: the relay accepts and broadcasts, but the ack never
+        // reaches the adapter — the crash window this design exists for.
+        harness.dropAcks(channelId, 1);
+        adapter.writeCommand(sendCommand);
+        await harness.waitForDroppedAck(channelId);
+        await peer.waitForChats(1);
+        expect(adapter.countEvents("command_ack")).toBe(0);
+        adapter.kill();
+
+        // The restarted worker replays the same command id. The relay answers
+        // with the original outcome instead of broadcasting again, and the
+        // command still acks.
+        adapter = await AdapterProcess.start({
+          baseUrl: harness.url,
+          channelId,
+          secret,
+          stateDir,
+        });
+        adapter.writeCommand(sendCommand);
+        const ack = await adapter.waitForEvent(
+          (event) => event.type === "command_ack",
+        );
+        expect(ack.command_id).toBe(sendCommand.id);
+
+        await sleep(200);
+        expect(peer.chats.length).toBe(1);
+        expect(peer.chats[0].text).toBe(sendCommand.text);
+        // The broadcast the old-protocol peer authenticated carried the new
+        // envelope-level id.
+        expect(typeof peer.chats[0].envelope.id).toBe("string");
+      } finally {
+        adapter?.kill();
+        peer.close();
+        await harness.close();
+      }
+    },
+  );
+
+  it(
+    "re-broadcasts honestly after the replay window expires",
+    { timeout: TEST_TIMEOUT_MS },
+    async () => {
+      const harness = await startRelayHarness({ EXOCHAT_REPLAY_TTL_MS: "200" });
+      const channelId = "replay-expiry-channel";
+      const secret = testSecret();
+      const stateDir = await freshStateDir();
+      let adapter: AdapterProcess | null = null;
+      const peer = await UserPeer.connect(harness.url, channelId, secret);
+      try {
+        adapter = await AdapterProcess.start({
+          baseUrl: harness.url,
+          channelId,
+          secret,
+          stateDir,
+        });
+
+        adapter.writeCommand(sendCommand);
+        await adapter.waitForEvent((event) => event.type === "command_ack");
+        await sleep(400);
+        adapter.writeCommand(sendCommand);
+        await adapter.waitForEvent(
+          (event) =>
+            event.type === "command_ack" &&
+            adapter !== null &&
+            adapter.countEvents("command_ack") === 2,
+        );
+        await peer.waitForChats(2);
+      } finally {
+        adapter?.kill();
+        peer.close();
+        await harness.close();
+      }
+    },
+  );
+
+  it(
+    "dedupes across a relay wake, and degrades to at-least-once when the cache is lost",
+    { timeout: TEST_TIMEOUT_MS },
+    async () => {
+      const harness = await startRelayHarness();
+      const channelId = "replay-restart-channel";
+      const secret = testSecret();
+      const stateDir = await freshStateDir();
+      let adapter: AdapterProcess | null = null;
+      const peer = await UserPeer.connect(harness.url, channelId, secret);
+      try {
+        adapter = await AdapterProcess.start({
+          baseUrl: harness.url,
+          channelId,
+          secret,
+          stateDir,
+        });
+
+        adapter.writeCommand(sendCommand);
+        await adapter.waitForEvent((event) => event.type === "command_ack");
+        await peer.waitForChats(1);
+
+        // A hibernation wake: new instance, storage intact. The window holds.
+        await harness.restartChannel(channelId, { clearStorage: false });
+        adapter.writeCommand(sendCommand);
+        await adapter.waitForEvent(
+          (event) =>
+            event.type === "command_ack" &&
+            adapter !== null &&
+            adapter.countEvents("command_ack") === 2,
+        );
+        await sleep(200);
+        expect(peer.chats.length).toBe(1);
+
+        // Cache loss: the send is accepted as new. Duplicate delivery, no
+        // corruption — every broadcast still authenticates and decrypts.
+        await harness.restartChannel(channelId, { clearStorage: true });
+        adapter.writeCommand(sendCommand);
+        await adapter.waitForEvent(
+          (event) =>
+            event.type === "command_ack" &&
+            adapter !== null &&
+            adapter.countEvents("command_ack") === 3,
+        );
+        await peer.waitForChats(2);
+        expect(peer.chats[1].text).toBe(sendCommand.text);
+      } finally {
+        adapter?.kill();
+        peer.close();
+        await harness.close();
+      }
+    },
+  );
+
+  it(
+    "relays id-less traffic from an old client untouched and never acks it",
+    { timeout: TEST_TIMEOUT_MS },
+    async () => {
+      const harness = await startRelayHarness();
+      const channelId = "replay-legacy-channel";
+      const secret = testSecret();
+      const stateDir = await freshStateDir();
+      let adapter: AdapterProcess | null = null;
+      const peer = await UserPeer.connect(harness.url, channelId, secret);
+      try {
+        adapter = await AdapterProcess.start({
+          baseUrl: harness.url,
+          channelId,
+          secret,
+          stateDir,
+        });
+
+        peer.sendLegacyChat("legacy-message-1", "hello from before ids");
+        const message = await adapter.waitForEvent(
+          (event) => event.type === "message",
+        );
+        expect(message.text).toBe("hello from before ids");
+        expect(peer.acks.length).toBe(0);
+
+        // Same id-less envelope again: the relay has no opinion, both copies
+        // arrive — old clients keep exactly the semantics they had.
+        peer.sendLegacyChat("legacy-message-1", "hello from before ids");
+        await adapter.waitForEvent(
+          (event) =>
+            event.type === "message" &&
+            adapter !== null &&
+            adapter.countEvents("message") === 2,
+        );
+      } finally {
+        adapter?.kill();
+        peer.close();
+        await harness.close();
+      }
+    },
+  );
+});

--- a/exo/adapters/exochat/worker.ts
+++ b/exo/adapters/exochat/worker.ts
@@ -9,6 +9,7 @@ import {
   parseWorkerCommand,
   writeWorkerEvent,
 } from "../protocol";
+import { parseSendAck, type SendAck, sendDedupeId } from "./exochat";
 
 const config = adapterConfig();
 const baseUrl = normalizeBaseUrl(
@@ -40,6 +41,10 @@ const userUrl = sessionUrl("user", session.channelId, session.secret);
 const agentUrl = sessionUrl("agent", session.channelId, session.secret);
 let seq = 0;
 let socket: WebSocket | null = null;
+const pendingAcks = new Map<
+  string,
+  { resolve: (ack: SendAck) => void; reject: (error: Error) => void }
+>();
 // Declared before the top-level connect() call below runs.
 let reconnectDelayMs = 1000;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -86,12 +91,15 @@ for await (const line of input) {
         "ExoChat is text-only right now; use another adapter for attachments",
       );
     }
-    await sendFrame({
-      type: "chat",
-      id: command.id,
-      text: command.text,
-      createdAt: Date.now(),
-    });
+    await sendFrame(
+      {
+        type: "chat",
+        id: command.id,
+        text: command.text,
+        createdAt: Date.now(),
+      },
+      sendDedupeId(command.id),
+    );
     writeWorkerEvent({
       type: "lifecycle",
       name: "send_result",
@@ -140,6 +148,7 @@ async function connect(): Promise<void> {
       type: "disconnected",
       reason: event.reason || String(event.code),
     });
+    failPendingAcks("ExoChat WebSocket closed before the send was acked");
     // The relay drops idle connections; reconnect in-process instead of
     // exiting so the runner does not restart us (and reprint the chat URL).
     scheduleReconnect();
@@ -196,6 +205,11 @@ async function handleSocketMessage(data: unknown): Promise<void> {
     return;
   }
   const message = JSON.parse(data) as unknown;
+  const ack = parseSendAck(message);
+  if (ack) {
+    pendingAcks.get(ack.id)?.resolve(ack);
+    return;
+  }
   if (isPresenceMessage(message)) {
     writeWorkerEvent({
       type: "lifecycle",
@@ -241,12 +255,56 @@ async function handleSocketMessage(data: unknown): Promise<void> {
   });
 }
 
-async function sendFrame(frame: Record<string, unknown>): Promise<void> {
+// A dedupe id opts the frame into the relay's replay protection: the id rides
+// at envelope level (outside the ciphertext and outside the AAD, so pre-id
+// peers still authenticate the envelope), and the send only settles once the
+// relay acks the id. A duplicate ack is still success — the original broadcast
+// already happened.
+async function sendFrame(
+  frame: Record<string, unknown>,
+  dedupeId?: string,
+): Promise<void> {
   if (!socket || socket.readyState !== WebSocket.OPEN) {
     throw new Error("ExoChat WebSocket is not open");
   }
   const envelope = encryptRelayFrame(frame, ++seq);
+  if (dedupeId !== undefined) {
+    envelope.id = dedupeId;
+  }
+  const acked = dedupeId !== undefined ? waitForSendAck(dedupeId) : null;
   socket.send(JSON.stringify(envelope));
+  if (acked) {
+    await acked;
+  }
+}
+
+function waitForSendAck(dedupeId: string): Promise<SendAck> {
+  return new Promise<SendAck>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      pendingAcks.delete(dedupeId);
+      reject(
+        new Error(`ExoChat send was not acked within ${SEND_TIMEOUT_MS}ms`),
+      );
+    }, SEND_TIMEOUT_MS);
+    pendingAcks.set(dedupeId, {
+      resolve: (ack) => {
+        clearTimeout(timeout);
+        pendingAcks.delete(dedupeId);
+        resolve(ack);
+      },
+      reject: (error) => {
+        clearTimeout(timeout);
+        pendingAcks.delete(dedupeId);
+        reject(error);
+      },
+    });
+  });
+}
+
+function failPendingAcks(message: string): void {
+  for (const pending of pendingAcks.values()) {
+    pending.reject(new Error(message));
+  }
 }
 
 function encryptRelayFrame(
@@ -448,6 +506,7 @@ type RelayEnvelope = {
   channelId: string;
   ciphertext: string;
   from: "agent" | "user";
+  id?: string;
   nonce: string;
   seq: number;
   version: 1;

--- a/website/src/worker.d.ts
+++ b/website/src/worker.d.ts
@@ -1,0 +1,35 @@
+// Hand-written surface for worker.js (the repo compiles with allowJs off) so
+// the relay class can be exercised from TypeScript tests.
+export type RelaySocket = {
+  readyState: number;
+  send(message: string): void;
+  close(code?: number, reason?: string): void;
+  serializeAttachment(value: unknown): void;
+  deserializeAttachment(): { role?: string } | undefined;
+};
+
+export type RelayContext = {
+  getWebSockets(): RelaySocket[];
+  acceptWebSocket(socket: RelaySocket): void;
+  storage: {
+    get(key: string): Promise<unknown>;
+    put(key: string, value: unknown): Promise<void>;
+    setAlarm(at: number): Promise<void>;
+    deleteAll(): Promise<void>;
+  };
+};
+
+export type RelayEnv = {
+  EXOCHAT_REPLAY_LIMIT?: string;
+  EXOCHAT_REPLAY_TTL_MS?: string;
+};
+
+export class RendezvousSession {
+  constructor(ctx: RelayContext, env?: RelayEnv);
+  fetch(request: Request): Promise<Response>;
+  webSocketMessage(socket: RelaySocket, message: unknown): Promise<void>;
+  webSocketClose(): void;
+  webSocketError(): void;
+  alarm(): Promise<void>;
+  broadcastPresence(): void;
+}

--- a/website/src/worker.js
+++ b/website/src/worker.js
@@ -11,9 +11,20 @@ const SECURITY_HEADERS = {
 const SESSION_TTL_MS = 30 * 60 * 1000;
 const MAX_RELAY_MESSAGE_BYTES = 10 * 1024 * 1024;
 
+// A sender that includes an envelope-level `id` gets replay protection: the
+// relay remembers recently accepted ids and answers a repeat with an ack
+// instead of a second broadcast. The window is a bounded cache, not a ledger —
+// losing it (expiry, session teardown) degrades to at-least-once delivery.
+const REPLAY_CACHE_KEY = "replay-cache";
+const REPLAY_CACHE_LIMIT = 64;
+const REPLAY_CACHE_TTL_MS = 10 * 60 * 1000;
+
 export class RendezvousSession {
-  constructor(ctx) {
+  constructor(ctx, env) {
     this.ctx = ctx;
+    this.replayLimit = Number(env?.EXOCHAT_REPLAY_LIMIT) || REPLAY_CACHE_LIMIT;
+    this.replayTtlMs =
+      Number(env?.EXOCHAT_REPLAY_TTL_MS) || REPLAY_CACHE_TTL_MS;
   }
 
   async fetch(request) {
@@ -59,7 +70,7 @@ export class RendezvousSession {
     });
   }
 
-  webSocketMessage(socket, message) {
+  async webSocketMessage(socket, message) {
     if (typeof message !== "string") {
       socket.close(1003, "Only text relay messages are supported");
       return;
@@ -76,6 +87,15 @@ export class RendezvousSession {
       return;
     }
 
+    const sendId = relaySendId(message);
+    if (sendId !== null) {
+      const cache = await this.replayCache();
+      if (cache.has(sendId)) {
+        socket.send(sendAck(sendId, true));
+        return;
+      }
+    }
+
     for (const peer of this.ctx.getWebSockets()) {
       if (peer === socket) {
         continue;
@@ -89,6 +109,13 @@ export class RendezvousSession {
       ) {
         peer.send(message);
       }
+    }
+
+    // Record after the broadcast and ack after the record, so a crash anywhere
+    // in between resolves as a retry-and-duplicate, never a silent loss.
+    if (sendId !== null) {
+      await this.recordSend(sendId);
+      socket.send(sendAck(sendId, false));
     }
   }
 
@@ -105,6 +132,33 @@ export class RendezvousSession {
       socket.close(1000, "Session expired");
     }
     await this.ctx.storage.deleteAll();
+    this.replaySends = undefined;
+  }
+
+  // The in-memory map dies with every hibernation, so accepted ids are written
+  // through to durable object storage and rehydrated on the next wake. Expired
+  // entries are pruned on read; the storage row dies with the session alarm.
+  async replayCache() {
+    if (!this.replaySends) {
+      const stored = await this.ctx.storage.get(REPLAY_CACHE_KEY);
+      this.replaySends = new Map(stored ?? []);
+    }
+    const cutoff = Date.now() - this.replayTtlMs;
+    for (const [id, at] of this.replaySends) {
+      if (at < cutoff) {
+        this.replaySends.delete(id);
+      }
+    }
+    return this.replaySends;
+  }
+
+  async recordSend(id) {
+    const cache = await this.replayCache();
+    cache.set(id, Date.now());
+    while (cache.size > this.replayLimit) {
+      cache.delete(cache.keys().next().value);
+    }
+    await this.ctx.storage.put(REPLAY_CACHE_KEY, [...cache]);
   }
 
   broadcastPresence() {
@@ -188,6 +242,37 @@ function isSessionPage(url) {
   return Boolean(
     url.searchParams.get("c") && parseRole(url.searchParams.get("role")),
   );
+}
+
+// Only an `exo.chat` envelope that opted in with a string `id` is inspected;
+// everything else stays an opaque string and follows the legacy path
+// byte-for-byte. The ciphertext is never touched.
+function relaySendId(message) {
+  let value;
+  try {
+    value = JSON.parse(message);
+  } catch {
+    return null;
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  if (value.channel !== "exo.chat" || typeof value.id !== "string") {
+    return null;
+  }
+  if (value.id.length < 8 || value.id.length > 128) {
+    return null;
+  }
+  return value.id;
+}
+
+function sendAck(id, duplicate) {
+  return JSON.stringify({
+    channel: "exo.chat.ack",
+    id,
+    duplicate,
+    at: Date.now(),
+  });
 }
 
 function parseRole(role) {

--- a/website/src/worker.test.ts
+++ b/website/src/worker.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "vitest";
+
+import type { RelayContext, RelayEnv, RelaySocket } from "./worker.js";
+import { RendezvousSession } from "./worker.js";
+
+type FakeSocket = RelaySocket & {
+  attachment: { role?: string } | undefined;
+  sent: string[];
+};
+
+function fakeSocket(role: "agent" | "user"): FakeSocket {
+  const socket: FakeSocket = {
+    attachment: undefined,
+    sent: [],
+    readyState: WebSocket.OPEN,
+    send(message: string) {
+      socket.sent.push(message);
+    },
+    close() {},
+    serializeAttachment(value: unknown) {
+      socket.attachment = value as { role?: string };
+    },
+    deserializeAttachment() {
+      return socket.attachment;
+    },
+  };
+  socket.serializeAttachment({ role, connectedAt: 0 });
+  return socket;
+}
+
+function fakeContext(sockets: FakeSocket[]) {
+  const values = new Map<string, unknown>();
+  const context: RelayContext = {
+    getWebSockets: () => [...sockets],
+    acceptWebSocket: () => {},
+    storage: {
+      get: async (key) => values.get(key),
+      put: async (key, value) => {
+        values.set(key, value);
+      },
+      setAlarm: async () => {},
+      deleteAll: async () => {
+        values.clear();
+      },
+    },
+  };
+  return { context, values };
+}
+
+function channel(env?: RelayEnv) {
+  const agent = fakeSocket("agent");
+  const user = fakeSocket("user");
+  const { context, values } = fakeContext([agent, user]);
+  const session = new RendezvousSession(context, env);
+  return { agent, user, context, values, session };
+}
+
+function envelope(id?: string): string {
+  const frame: Record<string, unknown> = {
+    channel: "exo.chat",
+    channelId: "chan-0123456789",
+    ciphertext: "b3BhcXVl",
+    from: "agent",
+    nonce: "bm9uY2U0NTY3ODkwMTI",
+    seq: 1,
+    version: 1,
+  };
+  if (id !== undefined) {
+    frame.id = id;
+  }
+  return JSON.stringify(frame);
+}
+
+function acks(socket: FakeSocket): { id: string; duplicate: boolean }[] {
+  return socket.sent
+    .map((message) => JSON.parse(message) as Record<string, unknown>)
+    .filter((message) => message.channel === "exo.chat.ack")
+    .map((message) => ({
+      id: message.id as string,
+      duplicate: message.duplicate as boolean,
+    }));
+}
+
+describe("RendezvousSession replay cache", () => {
+  it("forwards id-less messages untouched and never acks them", async () => {
+    const { agent, user, session } = channel();
+    await session.webSocketMessage(agent, "not even json");
+    await session.webSocketMessage(agent, envelope());
+    expect(user.sent).toEqual(["not even json", envelope()]);
+    expect(agent.sent).toEqual([]);
+  });
+
+  it("broadcasts a fresh id once and answers the repeat with a duplicate ack", async () => {
+    const { agent, user, session } = channel();
+    await session.webSocketMessage(agent, envelope("dedupe-id-1"));
+    await session.webSocketMessage(agent, envelope("dedupe-id-1"));
+    expect(user.sent).toEqual([envelope("dedupe-id-1")]);
+    expect(acks(agent)).toEqual([
+      { id: "dedupe-id-1", duplicate: false },
+      { id: "dedupe-id-1", duplicate: true },
+    ]);
+  });
+
+  it("treats ids outside the length bounds as legacy traffic", async () => {
+    const { agent, user, session } = channel();
+    await session.webSocketMessage(agent, envelope("short"));
+    await session.webSocketMessage(agent, envelope("short"));
+    expect(user.sent.length).toBe(2);
+    expect(acks(agent)).toEqual([]);
+  });
+
+  it("evicts the oldest id once the ring is full", async () => {
+    const { agent, user, session } = channel({ EXOCHAT_REPLAY_LIMIT: "2" });
+    await session.webSocketMessage(agent, envelope("dedupe-id-1"));
+    await session.webSocketMessage(agent, envelope("dedupe-id-2"));
+    await session.webSocketMessage(agent, envelope("dedupe-id-3"));
+    await session.webSocketMessage(agent, envelope("dedupe-id-1"));
+    expect(user.sent.length).toBe(4);
+    expect(acks(agent).map((ack) => ack.duplicate)).toEqual([
+      false,
+      false,
+      false,
+      false,
+    ]);
+  });
+
+  it("forgets an id after the ttl and honestly re-broadcasts", async () => {
+    const { agent, user, session } = channel({ EXOCHAT_REPLAY_TTL_MS: "40" });
+    await session.webSocketMessage(agent, envelope("dedupe-id-1"));
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    await session.webSocketMessage(agent, envelope("dedupe-id-1"));
+    expect(user.sent.length).toBe(2);
+    expect(acks(agent).map((ack) => ack.duplicate)).toEqual([false, false]);
+  });
+
+  it("still dedupes after an instance restart when storage survives", async () => {
+    const { agent, user, context, session } = channel();
+    await session.webSocketMessage(agent, envelope("dedupe-id-1"));
+    const woken = new RendezvousSession(context);
+    await woken.webSocketMessage(agent, envelope("dedupe-id-1"));
+    expect(user.sent).toEqual([envelope("dedupe-id-1")]);
+    expect(acks(agent).map((ack) => ack.duplicate)).toEqual([false, true]);
+  });
+
+  it("degrades to at-least-once when storage is lost", async () => {
+    const { agent, user, context, values, session } = channel();
+    await session.webSocketMessage(agent, envelope("dedupe-id-1"));
+    values.clear();
+    const woken = new RendezvousSession(context);
+    await woken.webSocketMessage(agent, envelope("dedupe-id-1"));
+    expect(user.sent.length).toBe(2);
+    expect(acks(agent).map((ack) => ack.duplicate)).toEqual([false, false]);
+  });
+});


### PR DESCRIPTION
This gives exochat what #196 gave Discord: a platform-checked idempotency key. Discord already had one (`enforceNonce`) and we just started sending it; exochat is our own platform, so this adds the key on the relay side and uses it from the adapter.

**What it does.** The adapter stamps each outgoing envelope with an opt-in `id` (sha256 of the command id — the relay never sees raw command ids). The relay broadcasts once, records the id, acks. A replayed id — worker crashed between send and ack, restarted, retried — gets a duplicate ack and no second broadcast. And `command_ack` now waits for the relay ack, so an unacked send fails and retries instead of being assumed delivered.

**State and cost.** Per channel: at most 64 ids for at most 10 minutes, written through to durable-object storage (the WS hibernation API drops in-memory state between messages, so a plain ring buffer forgets). Typical size ~2–4 KB; adversarial hard cap ~10 KB if a client sends max-length ids. Cleanup is the existing 30-minute session alarm — no new lifecycle, no new cleanup path.

**Wire.** The protocol had no ack of any kind; the new `exo.chat.ack` frame is plaintext relay metadata, like presence. The `id` rides outside the AAD, which is what keeps old peers wire-compatible — but it also means the id is unauthenticated until an envelope version bump (a forged or stripped id can cause a dropped or duplicate delivery, nothing worse; the ciphertext path is untouched). Deploy relay before clients. Old clients are unaffected: id-less traffic takes the legacy path byte-for-byte and is never acked.

**What it is not.** Not exactly-once. If the window is gone — TTL expired, session torn down, storage lost — a replay is delivered again as an honest duplicate. At-least-once holds in every failure I could construct; the cache narrows the duplicate window, it can't close it.

**Tests.** 17 new — crash-between-send-and-ack replay, TTL expiry, cache loss, pre-id peer compatibility — with the real adapter worker as a subprocess against the real relay class. Core diff is ~186 lines; the rest is testkit and tests. End-to-end evidence, including a run on real workerd via `wrangler dev`, is in the PR thread.
