### PR TITLE
Add Pi coding-agent harness preset

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -57,7 +57,7 @@ use tui::run_chat_repl;
 struct Cli {
     #[arg(long, global = true, default_value = ".exo")]
     root: PathBuf,
-    /// Executor runtime: basic, rlm, typescript, codex, claude-code, cursor, or a TypeScript module path.
+    /// Executor runtime: basic, rlm, typescript, codex, claude-code, cursor, pi, or a TypeScript module path.
     #[arg(long, global = true, value_name = "HARNESS")]
     harness: Option<HarnessSelection>,
     #[arg(long, global = true, value_enum, env = "EXO_SECRET_BACKEND")]
@@ -124,6 +124,7 @@ enum TypeScriptHarnessPreset {
     Codex,
     ClaudeCode,
     Cursor,
+    Pi,
 }
 
 impl HarnessSelection {
@@ -170,11 +171,12 @@ impl FromStr for HarnessSelection {
             "codex" => Ok(Self::TypeScriptPreset(TypeScriptHarnessPreset::Codex)),
             "claude-code" => Ok(Self::TypeScriptPreset(TypeScriptHarnessPreset::ClaudeCode)),
             "cursor" | "cursor-sdk" => Ok(Self::TypeScriptPreset(TypeScriptHarnessPreset::Cursor)),
+            "pi" => Ok(Self::TypeScriptPreset(TypeScriptHarnessPreset::Pi)),
             value if looks_like_typescript_module_path(value) => {
                 Ok(Self::TypeScriptModule(PathBuf::from(value)))
             }
             _ => Err(format!(
-                "unknown harness `{raw}`; expected basic, rlm, typescript, exo, codex, claude-code, cursor, or a TypeScript module path"
+                "unknown harness `{raw}`; expected basic, rlm, typescript, exo, codex, claude-code, cursor, pi, or a TypeScript module path"
             )),
         }
     }
@@ -186,6 +188,7 @@ impl TypeScriptHarnessPreset {
             Self::Codex => "codex",
             Self::ClaudeCode => "claude-code",
             Self::Cursor => "cursor",
+            Self::Pi => "pi",
         }
     }
 
@@ -194,6 +197,7 @@ impl TypeScriptHarnessPreset {
             Self::Codex => Path::new("exoharness/examples/typescript/codex-harness.ts"),
             Self::ClaudeCode => Path::new("exoharness/examples/typescript/claude-code-harness.ts"),
             Self::Cursor => Path::new("exoharness/examples/typescript/cursor-sdk-harness.ts"),
+            Self::Pi => Path::new("exoharness/examples/typescript/pi-harness.ts"),
         }
     }
 
@@ -202,6 +206,7 @@ impl TypeScriptHarnessPreset {
             Self::Codex => Some("exo-codex-sandbox:latest"),
             Self::ClaudeCode => Some("exo-claude-code-sandbox:latest"),
             Self::Cursor => Some("exo-cursor-sdk-sandbox:latest"),
+            Self::Pi => Some("exo-pi-sandbox:latest"),
         }
     }
 }
@@ -937,7 +942,7 @@ async fn main() -> Result<()> {
                     };
                     if matches!(harness_kind, HarnessKind::TypeScript) && typescript.is_none() {
                         bail!(
-                            "repl --harness typescript needs an existing TypeScript agent; use --harness codex, --harness claude-code, --harness cursor, or --harness <module.ts> to create one"
+                            "repl --harness typescript needs an existing TypeScript agent; use --harness codex, --harness claude-code, --harness cursor, --harness pi, or --harness <module.ts> to create one"
                         );
                     }
                     harness
@@ -2495,7 +2500,7 @@ fn build_typescript_harness_config(
             )?))
         }
         (_, HarnessKind::TypeScript, None) => Err(anyhow!(
-            "typescript agents require --module <path>, or use --harness codex, --harness claude-code, --harness cursor, or --harness <module.ts>"
+            "typescript agents require --module <path>, or use --harness codex, --harness claude-code, --harness cursor, --harness pi, or --harness <module.ts>"
         )),
         (_, HarnessKind::Exo, None) => Err(anyhow!("exo agents require --module <path>")),
         (_, _, Some(_)) => Err(anyhow!(
@@ -2599,6 +2604,7 @@ fn format_harness_selection(selection: &HarnessSelection) -> String {
             TypeScriptHarnessPreset::Codex => "codex".to_string(),
             TypeScriptHarnessPreset::ClaudeCode => "claude-code".to_string(),
             TypeScriptHarnessPreset::Cursor => "cursor".to_string(),
+            TypeScriptHarnessPreset::Pi => "pi".to_string(),
         },
         HarnessSelection::TypeScriptModule(path) => path.display().to_string(),
     }
@@ -3074,6 +3080,31 @@ mod create_tests {
                 super::TypeScriptHarnessPreset::Codex
             ))
         ));
+    }
+
+    #[test]
+    fn repl_command_accepts_pi_preset_harness() {
+        use clap::Parser;
+        let cli = super::Cli::try_parse_from(["exo", "repl", "--harness", "pi"])
+            .expect("repl parses with the Pi preset");
+        assert!(matches!(
+            cli.harness,
+            Some(super::HarnessSelection::TypeScriptPreset(
+                super::TypeScriptHarnessPreset::Pi
+            ))
+        ));
+    }
+
+    #[test]
+    fn pi_preset_selects_module_image_and_networking() {
+        let selection =
+            super::HarnessSelection::TypeScriptPreset(super::TypeScriptHarnessPreset::Pi);
+        assert_eq!(super::default_repl_agent_slug(Some(&selection)), "pi");
+        assert_eq!(
+            selection.default_sandbox_image(),
+            Some("exo-pi-sandbox:latest")
+        );
+        assert!(selection.default_enable_networking());
     }
 
     #[test]

--- a/docs/EXOREADME.md
+++ b/docs/EXOREADME.md
@@ -25,8 +25,8 @@ agents can fork, rewind, or return to known-good states without losing critical
 state such as secrets, config, or history.
 
 This directory contains the exoharness. And everything you need to build your
-own agent from scratch, or to back Codex, Claude Code, or the Cursor SDK with
-durable sessions you can stop, resume, and rewind across runs.
+own agent from scratch, or to back Codex, Claude Code, the Cursor SDK, or Pi
+with durable sessions you can stop, resume, and rewind across runs.
 
 ## The Why and What of Exo
 
@@ -46,7 +46,7 @@ decisions run on: history, state, secrets, and sandboxing.
 Because the exoharness substrate doesn't depend on the executor, an agent built on exo can:
 
 - **Fork or rewind** at any past event, without losing secrets, sandboxes, or history.
-- **Swap executors**, running the same agent via Codex, Claude Code, the Cursor SDK, or your own executor, without rebuilding state.
+- **Swap executors**, running the same agent via Codex, Claude Code, the Cursor SDK, Pi, or your own executor, without rebuilding state.
 - **Evolve safely** to change its own policy processes, with access to inspect its own history and artifacts while the exoharness isolates secrets and compute resources to maintain safety.
 
 For the architectural model and terminology, see
@@ -110,8 +110,8 @@ Then create an agent backed by a TypeScript harness module:
   --model gpt-5.5
 ```
 
-The `exoharness/examples/typescript` directory also contains Codex, Claude Code, Cursor,
-and recursive-language-model harness experiments.
+The `exoharness/examples/typescript` directory also contains Codex, Claude Code,
+Cursor, Pi, and recursive-language-model harness experiments.
 
 For the coding-agent setup commands, see
 [exoharness/docs/coding-agent-harnesses.md](../exoharness/docs/coding-agent-harnesses.md).

--- a/exoharness/containers/pi-sandbox/Containerfile
+++ b/exoharness/containers/pi-sandbox/Containerfile
@@ -14,10 +14,11 @@ RUN apt-get update \
 RUN corepack enable && corepack prepare pnpm@10.26.2 --activate
 
 COPY package.json pnpm-lock.yaml tsconfig.json ./
-COPY exoharness/typescript ./exoharness/typescript
 COPY scripts ./scripts
 
 RUN pnpm install --frozen-lockfile --config.dangerously-allow-all-builds=true
+
+COPY exoharness/typescript ./exoharness/typescript
 
 ENV HOME=/home/exo
 WORKDIR /home/exo/workspace

--- a/exoharness/containers/pi-sandbox/Containerfile
+++ b/exoharness/containers/pi-sandbox/Containerfile
@@ -1,0 +1,25 @@
+FROM docker.io/library/node:22-bookworm
+
+WORKDIR /opt/exo
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    bash \
+    ca-certificates \
+    git \
+    ripgrep \
+  && rm -rf /var/lib/apt/lists/* \
+  && mkdir -p /home/exo/workspace
+
+RUN corepack enable && corepack prepare pnpm@10.26.2 --activate
+
+COPY package.json pnpm-lock.yaml tsconfig.json ./
+COPY exoharness/typescript ./exoharness/typescript
+COPY scripts ./scripts
+
+RUN pnpm install --frozen-lockfile --config.dangerously-allow-all-builds=true
+
+ENV HOME=/home/exo
+WORKDIR /home/exo/workspace
+
+CMD ["bash"]

--- a/exoharness/docs/coding-agent-harnesses.md
+++ b/exoharness/docs/coding-agent-harnesses.md
@@ -1,8 +1,8 @@
 # Coding Agent Harnesses
 
-The Codex, Claude Code, and Cursor examples treat exoharness events as canonical
-conversation state and run their native agent runtimes inside configured
-exoharness sandboxes.
+The Codex, Claude Code, Cursor, and Pi examples treat exoharness events as
+canonical conversation state and run their native agent runtimes inside
+configured exoharness sandboxes.
 
 Install dependencies and build the CLI first:
 
@@ -14,8 +14,8 @@ cargo build -p exo
 The examples below use `./target/debug/exo`. If you have the binary on your
 `PATH`, you can use `exo` instead.
 
-The `codex`, `claude-code`, and `cursor` harness presets select the matching
-TypeScript module, sandbox image, and networking defaults.
+The `codex`, `claude-code`, `cursor`, and `pi` harness presets select the
+matching TypeScript module, sandbox image, and networking defaults.
 
 For `secret set`, `--env` takes the variable name literally. For example, use
 `--env OPENAI_API_KEY`, not `--env $OPENAI_API_KEY`.
@@ -126,6 +126,47 @@ Create the agent and start a conversation:
 ./target/debug/exo repl --agent ts-cursor --conversation <conversation>
 ```
 
+## Pi
+
+Register a Pi model using its `provider/model` form:
+
+```bash
+./target/debug/exo secret set pi-anthropic --env ANTHROPIC_API_KEY
+./target/debug/exo model register pi-claude \
+  --model anthropic/claude-sonnet-4-6 \
+  --secret pi-anthropic
+```
+
+Build the sandbox image from the repository root:
+
+```bash
+container build \
+  --platform linux/arm64 \
+  -f exoharness/containers/pi-sandbox/Containerfile \
+  -t exo-pi-sandbox:latest \
+  .
+```
+
+Create the agent and start a conversation:
+
+```bash
+./target/debug/exo --harness pi agent create "TS Pi" \
+  --model pi-claude
+
+./target/debug/exo conversation create pi
+./target/debug/exo conversation mount add pi <conversation> "$PWD" /workspace --rw
+./target/debug/exo repl --agent pi --conversation <conversation>
+```
+
+Like the other coding-agent harnesses, Pi runs inside the configured sandbox
+and treats exoharness events as canonical history. Each turn uses an in-memory
+Pi session, so no separate Pi session is persisted. The worker does not load
+ambient `~/.pi` or project extensions, skills, prompts, or context files.
+
+The preset enables networking because Pi makes model requests in the sandbox.
+It currently supports Pi's built-in model catalog; an Exo `--base-url` overrides
+the selected model's endpoint.
+
 ## Live E2E
 
 The live e2e script runs replay checks against the coding-agent harnesses:
@@ -134,6 +175,7 @@ The live e2e script runs replay checks against the coding-agent harnesses:
 pnpm e2e:agent-harnesses --only codex
 pnpm e2e:agent-harnesses --only claude
 pnpm e2e:agent-harnesses --only cursor
+pnpm e2e:agent-harnesses --only pi
 ```
 
 Use `--build-images` to build the required sandbox images before running.

--- a/exoharness/docs/coding-agent-harnesses.md
+++ b/exoharness/docs/coding-agent-harnesses.md
@@ -162,10 +162,23 @@ Like the other coding-agent harnesses, Pi runs inside the configured sandbox
 and treats exoharness events as canonical history. Each turn uses an in-memory
 Pi session, so no separate Pi session is persisted. The worker does not load
 ambient `~/.pi` or project extensions, skills, prompts, or context files.
+Prior history and tool results use the same bounded replay approach as the Codex
+harness, with truncation metadata recorded on `pi_turn_started` events.
+
+Pi text, tools, raw SDK messages, retries, compaction, and standard usage/cost
+records are projected into exoharness events. The worker removes the provider
+credential from its environment before starting Pi, so tool subprocesses do not
+inherit it. Worker messages are scoped to the current turn ID, and turns time
+out after ten minutes by default; set
+`EXO_PI_TURN_TIMEOUT_MS` to a positive number of milliseconds to override it.
+Agent `max_output_tokens` and `max_tool_round_trips` limits are forwarded to the
+Pi runtime.
 
 The preset enables networking because Pi makes model requests in the sandbox.
-It currently supports Pi's built-in model catalog; an Exo `--base-url` overrides
-the selected model's endpoint.
+Remote endpoints fail early with an actionable networking error when it is
+disabled; loopback endpoints remain available for sandbox-local inference. The
+harness currently supports Pi's built-in model catalog; an Exo `--base-url`
+overrides the selected model's endpoint.
 
 ## Live E2E
 

--- a/exoharness/examples/typescript/pi-harness.ts
+++ b/exoharness/examples/typescript/pi-harness.ts
@@ -1,0 +1,502 @@
+import {
+  appendCustomEvent,
+  assistantTextMessage,
+  defineHarness,
+  messageText,
+  messagesEvent,
+  messagesToTranscript,
+  toolRequestedEvent,
+  toolResultEvent,
+  turnMetadata,
+  type EventData,
+  type JsonObject,
+  type JsonValue,
+  type Message,
+  type PendingToolCall,
+  type TurnContext,
+} from "@exo/harness";
+import {
+  traceExecutorTurn,
+  tracedUnderParent,
+  type TraceParent,
+} from "@exo/model-runtime/responses";
+import {
+  appendAndTraceObservedToolEvents,
+  materializePriorConversationMessages,
+  resolveLlmBinding,
+  sandboxCwd,
+  WarmJsonlSandboxWorker,
+  WarmResourceCache,
+  type ResolvedLlmBinding,
+} from "@exo/model-runtime/shared";
+import {
+  type PiWorkerEvent,
+  type PiWorkerRequest,
+  type PiWorkerRunResult,
+} from "@exo/pi/protocol";
+
+interface PiTraceState {
+  finalText: string;
+  promptMessages: Message[];
+  rawMessages: JsonValue[];
+  runResult: PiWorkerRunResult | null;
+  sawTextDelta: boolean;
+  startedAt: number;
+  streamedText: string;
+  ttftMs: number | null;
+  observedToolCalls: Map<string, PendingToolCall>;
+}
+
+type PiSandboxWorker = WarmJsonlSandboxWorker<PiWorkerRequest, PiWorkerEvent>;
+
+const piWorkers = new WarmResourceCache<PiSandboxWorker>();
+
+export default defineHarness({
+  async runTurn(context) {
+    const modelBinding = await resolveLlmBinding(context);
+    await traceExecutorTurn(context, (turnParent) =>
+      runPiHarnessTurn(context, turnParent, modelBinding),
+    );
+  },
+});
+
+async function runPiHarnessTurn(
+  context: TurnContext,
+  turnParent: TraceParent,
+  modelBinding: ResolvedLlmBinding,
+): Promise<string | null> {
+  const state: PiTraceState = {
+    finalText: "",
+    promptMessages: await materializePriorConversationMessages(context),
+    rawMessages: [],
+    runResult: null,
+    sawTextDelta: false,
+    startedAt: Date.now(),
+    streamedText: "",
+    ttftMs: null,
+    observedToolCalls: new Map(),
+  };
+  const prompt = piPrompt(context, state.promptMessages);
+
+  await appendCustomEvent(context.exoharness.current.turn, "pi_turn_started", {
+    metadata: turnMetadata(context),
+    model: modelBinding.model,
+    cwd: sandboxCwd(context),
+    hydrated_from: "exoharness_events",
+    sandbox_command: piSandboxCommand(context).join(" "),
+  });
+
+  try {
+    const result = await tracePiRun(
+      turnParent,
+      context,
+      state,
+      prompt,
+      modelBinding,
+    );
+    state.runResult = result;
+    state.finalText = result.finalText || state.finalText;
+    await streamFinalTextSuffix(context, state);
+    await appendPiFinalEvents(context, state, result);
+    if (result.status === "error") {
+      throw new Error(result.error || "Pi run failed");
+    }
+  } finally {
+    await flushPiRawMessages(context, state);
+  }
+  return null;
+}
+
+async function tracePiRun(
+  turnParent: TraceParent,
+  context: TurnContext,
+  state: PiTraceState,
+  prompt: string,
+  modelBinding: ResolvedLlmBinding,
+): Promise<PiWorkerRunResult> {
+  return tracedUnderParent(
+    turnParent,
+    async (span) => {
+      try {
+        const result = await runPiSandboxWorker(
+          context,
+          turnParent,
+          state,
+          prompt,
+          modelBinding,
+        );
+        span.log({
+          input: [piPromptMessage(prompt)],
+          output: piTraceOutput(state, result),
+          metrics: piTraceMetrics(state, result),
+        });
+        return result;
+      } catch (error) {
+        const message = errorMessage(error);
+        span.log({
+          input: [piPromptMessage(prompt)],
+          output: piTraceOutput(state, state.runResult),
+          metrics: piTraceMetrics(state, state.runResult),
+          error: message,
+        });
+        await appendCustomEvent(
+          context.exoharness.current.turn,
+          "pi_run_failed",
+          { metadata: turnMetadata(context), error: message },
+        );
+        throw error;
+      }
+    },
+    {
+      name: `pi:${modelBinding.model}`,
+      type: "llm",
+      spanAttributes: { purpose: "pi_turn" },
+      event: {
+        input: [piPromptMessage(prompt)],
+        metadata: {
+          ...turnMetadata(context),
+          runtime: "pi_sdk",
+          model: modelBinding.model,
+          streamed: context.streaming,
+        },
+      },
+    },
+  );
+}
+
+async function runPiSandboxWorker(
+  context: TurnContext,
+  turnParent: TraceParent,
+  state: PiTraceState,
+  prompt: string,
+  modelBinding: ResolvedLlmBinding,
+): Promise<PiWorkerRunResult> {
+  const workerKey = piWarmWorkerKey(context, modelBinding);
+  const { resource: worker, reused } = await piWorkers.get(workerKey, () =>
+    startPiSandboxWorker(context, modelBinding),
+  );
+  await appendCustomEvent(context.exoharness.current.turn, "pi_worker_ready", {
+    metadata: turnMetadata(context),
+    warm_worker_reused: reused,
+  });
+  const request: PiWorkerRequest = {
+    prompt,
+    systemPrompt: piSystemPrompt(context),
+    model: modelBinding.model,
+    baseUrl: modelBinding.baseUrl ?? undefined,
+    cwd: sandboxCwd(context),
+  };
+  try {
+    return await worker.request(request, async (event) => {
+      await handlePiWorkerEvent(context, turnParent, state, event);
+      return event.type === "completed" ? event.result : undefined;
+    });
+  } catch (error) {
+    await piWorkers.delete(workerKey, (cachedWorker) => cachedWorker.close());
+    throw error;
+  }
+}
+
+async function startPiSandboxWorker(
+  context: TurnContext,
+  modelBinding: ResolvedLlmBinding,
+): Promise<PiSandboxWorker> {
+  return new WarmJsonlSandboxWorker({
+    name: "Pi sandbox worker",
+    parseEvent: parseWorkerEvent,
+    process: await context.startSandboxProcess({
+      command: piSandboxCommand(context),
+      env: piSandboxEnv(modelBinding),
+    }),
+  });
+}
+
+async function handlePiWorkerEvent(
+  context: TurnContext,
+  turnParent: TraceParent,
+  state: PiTraceState,
+  event: PiWorkerEvent,
+): Promise<void> {
+  switch (event.type) {
+    case "delta":
+      await streamTextDelta(context, state, event.text);
+      return;
+    case "message":
+      state.rawMessages.push(event.message);
+      state.finalText =
+        assistantTextFromRawMessage(event.message) || state.finalText;
+      return;
+    case "tool_start":
+    case "tool_end":
+      await handlePiToolEvent(context, turnParent, state, event);
+      return;
+    case "retry":
+      await appendCustomEvent(
+        context.exoharness.current.turn,
+        event.phase === "start" ? "pi_retry_started" : "pi_retry_finished",
+        { metadata: turnMetadata(context), details: event.details },
+      );
+      return;
+    case "compaction":
+      await appendCustomEvent(
+        context.exoharness.current.turn,
+        event.phase === "start"
+          ? "pi_compaction_started"
+          : "pi_compaction_finished",
+        { metadata: turnMetadata(context), details: event.details },
+      );
+      return;
+    case "completed":
+      state.runResult = event.result;
+      return;
+    case "error":
+      await appendCustomEvent(
+        context.exoharness.current.turn,
+        "pi_worker_error",
+        {
+          metadata: turnMetadata(context),
+          error: event.message,
+          details: event.error,
+        },
+      );
+      throw new Error(event.message);
+  }
+}
+
+async function handlePiToolEvent(
+  context: TurnContext,
+  turnParent: TraceParent,
+  state: PiTraceState,
+  event: Extract<PiWorkerEvent, { type: "tool_start" | "tool_end" }>,
+): Promise<void> {
+  const events: EventData[] =
+    event.type === "tool_start"
+      ? [
+          toolRequestedEvent({
+            toolCallId: event.callId,
+            request: {
+              functionName: `pi.${event.name}`,
+              arguments: jsonObjectOrEmpty(event.args),
+            },
+          }),
+        ]
+      : [
+          toolResultEvent(event.callId, {
+            result: event.result,
+            is_error: event.isError,
+          }),
+        ];
+  await appendAndTraceObservedToolEvents(
+    context,
+    turnParent,
+    events,
+    state.observedToolCalls,
+    "pi_observed_tool",
+  );
+}
+
+async function streamTextDelta(
+  context: TurnContext,
+  state: PiTraceState,
+  text: string,
+): Promise<void> {
+  if (!text) {
+    return;
+  }
+  if (!state.sawTextDelta) {
+    state.sawTextDelta = true;
+    state.ttftMs = Date.now() - state.startedAt;
+    if (context.streaming) {
+      await context.stream.firstChunk(state.ttftMs);
+    }
+  }
+  state.streamedText += text;
+  if (context.streaming) {
+    await context.stream.text(text);
+  }
+}
+
+async function streamFinalTextSuffix(
+  context: TurnContext,
+  state: PiTraceState,
+): Promise<void> {
+  if (!state.finalText || !context.streaming) {
+    return;
+  }
+  if (!state.sawTextDelta) {
+    await streamTextDelta(context, state, state.finalText);
+    return;
+  }
+  if (state.finalText.startsWith(state.streamedText)) {
+    const suffix = state.finalText.slice(state.streamedText.length);
+    if (suffix) {
+      await streamTextDelta(context, state, suffix);
+    }
+  }
+}
+
+async function appendPiFinalEvents(
+  context: TurnContext,
+  state: PiTraceState,
+  result: PiWorkerRunResult,
+): Promise<void> {
+  if (state.finalText) {
+    await context.exoharness.current.turn.addEvents([
+      messagesEvent([assistantTextMessage(state.finalText)]),
+    ]);
+  }
+  await appendCustomEvent(context.exoharness.current.turn, "pi_run_completed", {
+    metadata: turnMetadata(context),
+    status: result.status,
+    model: result.model,
+    provider: result.provider,
+    usage: result.usage,
+  });
+}
+
+async function flushPiRawMessages(
+  context: TurnContext,
+  state: PiTraceState,
+): Promise<void> {
+  if (state.rawMessages.length === 0) {
+    return;
+  }
+  await appendCustomEvent(context.exoharness.current.turn, "pi_messages", {
+    metadata: turnMetadata(context),
+    messages: state.rawMessages,
+  });
+  state.rawMessages = [];
+}
+
+function piPrompt(context: TurnContext, priorMessages: Message[]): string {
+  const transcript = messagesToTranscript(priorMessages);
+  const currentInput = context.request.input.map(messageText).join("\n\n");
+  return [
+    transcript ? `Conversation so far:\n\n${transcript}` : null,
+    `Current user input:\n\n${currentInput}`,
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function piSystemPrompt(context: TurnContext): string {
+  const instructions = context.agentConfig.instructions
+    .map(messageText)
+    .filter(Boolean)
+    .join("\n\n");
+  return [
+    "You are Pi running inside an Exoharness-managed sandbox.",
+    "Exoharness is the source of truth for durable conversation history. Treat the transcript in each prompt as canonical prior state.",
+    "Only files exposed inside the sandbox are available. Do not claim access to host paths that are not mounted.",
+    `Your working directory is ${sandboxCwd(context)}.`,
+    instructions ? `Agent instructions:\n\n${instructions}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+}
+
+function piPromptMessage(prompt: string): Message {
+  return { role: "user", content: prompt };
+}
+
+function assistantTextFromRawMessage(message: JsonValue): string {
+  if (!isRecord(message) || message.role !== "assistant") {
+    return "";
+  }
+  const content = Array.isArray(message.content) ? message.content : [];
+  return content
+    .map((part) => {
+      return isRecord(part) &&
+        part.type === "text" &&
+        typeof part.text === "string"
+        ? part.text
+        : "";
+    })
+    .join("");
+}
+
+function piTraceOutput(
+  state: PiTraceState,
+  result: PiWorkerRunResult | null,
+): Record<string, unknown> {
+  const finalText = result?.finalText || state.finalText;
+  return {
+    messages: finalText ? [assistantTextMessage(finalText)] : [],
+    status: result?.status ?? "unknown",
+  };
+}
+
+function piTraceMetrics(
+  state: PiTraceState,
+  result: PiWorkerRunResult | null,
+): Record<string, number> {
+  const metrics: Record<string, number> = {};
+  if (result) {
+    metrics.prompt_tokens = result.usage.input;
+    metrics.completion_tokens = result.usage.output;
+    metrics.tokens = result.usage.totalTokens;
+    metrics.prompt_cached_tokens = result.usage.cacheRead;
+    metrics.prompt_cache_creation_tokens = result.usage.cacheWrite;
+    metrics.estimated_cost = result.usage.cost;
+  }
+  if (state.ttftMs !== null) {
+    metrics.time_to_first_token = state.ttftMs / 1000;
+  }
+  return metrics;
+}
+
+function piSandboxCommand(context: TurnContext): string[] {
+  const shell = context.conversationConfig.shellProgram ?? "/bin/bash";
+  const command =
+    process.env.EXO_PI_SANDBOX_COMMAND ??
+    "cd /opt/exo && node --import tsx exoharness/typescript/pi/sandbox-worker.ts";
+  return [shell, "-lc", command];
+}
+
+function piSandboxEnv(
+  modelBinding: ResolvedLlmBinding,
+): Record<string, string> {
+  const env: Record<string, string> = {
+    HOME: process.env.EXO_PI_HOME ?? "/home/exo",
+    PI_OFFLINE: "1",
+  };
+  if (modelBinding.apiKey) {
+    env.EXO_PI_API_KEY = modelBinding.apiKey;
+  }
+  return env;
+}
+
+function piWarmWorkerKey(
+  context: TurnContext,
+  modelBinding: ResolvedLlmBinding,
+): string {
+  return JSON.stringify({
+    agent_id: context.exoharness.current.agent.record.id,
+    conversation_id: context.exoharness.current.conversation.record.id,
+    model_binding: modelBinding.name,
+    model: modelBinding.model,
+    base_url: modelBinding.baseUrl ?? null,
+    cwd: sandboxCwd(context),
+    command: piSandboxCommand(context),
+  });
+}
+
+function parseWorkerEvent(line: string): PiWorkerEvent {
+  const parsed = JSON.parse(line) as unknown;
+  if (!isRecord(parsed) || typeof parsed.type !== "string") {
+    throw new Error(`invalid Pi sandbox worker event: ${line}`);
+  }
+  return parsed as PiWorkerEvent;
+}
+
+function jsonObjectOrEmpty(value: JsonValue): JsonObject {
+  return isRecord(value) ? value : {};
+}
+
+function isRecord(value: unknown): value is Record<string, JsonValue> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/exoharness/examples/typescript/pi-harness.ts
+++ b/exoharness/examples/typescript/pi-harness.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 import {
   appendCustomEvent,
   assistantTextMessage,
@@ -26,25 +28,39 @@ import {
   resolveLlmBinding,
   sandboxCwd,
   WarmJsonlSandboxWorker,
+  WarmJsonlSandboxWorkerTimeoutError,
   WarmResourceCache,
   type ResolvedLlmBinding,
 } from "@exo/model-runtime/shared";
+import { capPiHistory } from "@exo/pi/history";
 import {
+  piResultUsageRecord,
+  projectPiAssistantMessage,
+} from "@exo/pi/projection";
+import {
+  parsePiWorkerEvent,
   type PiWorkerEvent,
   type PiWorkerRequest,
   type PiWorkerRunResult,
 } from "@exo/pi/protocol";
 
+const PI_WORKER_STARTUP_TIMEOUT_MS = 20_000;
+const DEFAULT_PI_TURN_TIMEOUT_MS = 10 * 60_000;
+
 interface PiTraceState {
   finalText: string;
+  lastPersistedAssistantText: string | null;
   promptMessages: Message[];
   rawMessages: JsonValue[];
+  requestId: string;
   runResult: PiWorkerRunResult | null;
   sawTextDelta: boolean;
   startedAt: number;
   streamedText: string;
   ttftMs: number | null;
+  usageEventsPersisted: number;
   observedToolCalls: Map<string, PendingToolCall>;
+  upstreamModel: string;
 }
 
 type PiSandboxWorker = WarmJsonlSandboxWorker<PiWorkerRequest, PiWorkerEvent>;
@@ -65,25 +81,38 @@ async function runPiHarnessTurn(
   turnParent: TraceParent,
   modelBinding: ResolvedLlmBinding,
 ): Promise<string | null> {
+  await requirePiSandboxNetworking(context, modelBinding);
+  const priorMessages = await materializePriorConversationMessages(context);
+  const cappedHistory = capPiHistory(priorMessages);
+  const requestId = context.exoharness.current.turn.record.id;
   const state: PiTraceState = {
     finalText: "",
-    promptMessages: await materializePriorConversationMessages(context),
+    lastPersistedAssistantText: null,
+    promptMessages: cappedHistory.messages,
     rawMessages: [],
+    requestId,
     runResult: null,
     sawTextDelta: false,
     startedAt: Date.now(),
     streamedText: "",
     ttftMs: null,
+    usageEventsPersisted: 0,
     observedToolCalls: new Map(),
+    upstreamModel: modelBinding.model,
   };
   const prompt = piPrompt(context, state.promptMessages);
 
   await appendCustomEvent(context.exoharness.current.turn, "pi_turn_started", {
     metadata: turnMetadata(context),
+    request_id: requestId,
     model: modelBinding.model,
     cwd: sandboxCwd(context),
     hydrated_from: "exoharness_events",
     sandbox_command: piSandboxCommand(context).join(" "),
+    prior_source_messages: cappedHistory.sourceMessageCount,
+    prior_dropped_messages: cappedHistory.droppedMessageCount,
+    prior_truncated_messages: cappedHistory.truncatedMessageCount,
+    prior_text_chars: cappedHistory.textChars,
   });
 
   try {
@@ -142,7 +171,11 @@ async function tracePiRun(
         await appendCustomEvent(
           context.exoharness.current.turn,
           "pi_run_failed",
-          { metadata: turnMetadata(context), error: message },
+          {
+            metadata: turnMetadata(context),
+            request_id: state.requestId,
+            error: message,
+          },
         );
         throw error;
       }
@@ -157,6 +190,7 @@ async function tracePiRun(
           ...turnMetadata(context),
           runtime: "pi_sdk",
           model: modelBinding.model,
+          request_id: state.requestId,
           streamed: context.streaming,
         },
       },
@@ -177,21 +211,50 @@ async function runPiSandboxWorker(
   );
   await appendCustomEvent(context.exoharness.current.turn, "pi_worker_ready", {
     metadata: turnMetadata(context),
+    request_id: state.requestId,
     warm_worker_reused: reused,
   });
   const request: PiWorkerRequest = {
+    requestId: state.requestId,
     prompt,
     systemPrompt: piSystemPrompt(context),
     model: modelBinding.model,
     baseUrl: modelBinding.baseUrl ?? undefined,
     cwd: sandboxCwd(context),
+    maxOutputTokens: context.agentConfig.maxOutputTokens ?? undefined,
+    maxToolRoundTrips: context.agentConfig.maxToolRoundTrips ?? undefined,
   };
+  const timeoutMs = piTurnTimeoutMs();
   try {
-    return await worker.request(request, async (event) => {
-      await handlePiWorkerEvent(context, turnParent, state, event);
-      return event.type === "completed" ? event.result : undefined;
-    });
+    return await worker.request(
+      request,
+      async (event) => {
+        if (event.requestId !== request.requestId) {
+          throw new Error(
+            `Pi worker returned request ${event.requestId} while handling ${request.requestId}`,
+          );
+        }
+        await handlePiWorkerEvent(context, turnParent, state, event);
+        return event.type === "completed" ? event.result : undefined;
+      },
+      {
+        startupTimeoutMs: PI_WORKER_STARTUP_TIMEOUT_MS,
+        timeoutMs,
+      },
+    );
   } catch (error) {
+    if (error instanceof WarmJsonlSandboxWorkerTimeoutError) {
+      await appendCustomEvent(
+        context.exoharness.current.turn,
+        "pi_worker_timeout",
+        {
+          metadata: turnMetadata(context),
+          request_id: state.requestId,
+          phase: error.phase === "request" ? "turn" : error.phase,
+          timeout_ms: error.timeoutMs,
+        },
+      );
+    }
     await piWorkers.delete(workerKey, (cachedWorker) => cachedWorker.close());
     throw error;
   }
@@ -203,7 +266,7 @@ async function startPiSandboxWorker(
 ): Promise<PiSandboxWorker> {
   return new WarmJsonlSandboxWorker({
     name: "Pi sandbox worker",
-    parseEvent: parseWorkerEvent,
+    parseEvent: parsePiWorkerEvent,
     process: await context.startSandboxProcess({
       command: piSandboxCommand(context),
       env: piSandboxEnv(modelBinding),
@@ -218,13 +281,22 @@ async function handlePiWorkerEvent(
   event: PiWorkerEvent,
 ): Promise<void> {
   switch (event.type) {
+    case "run_started":
+      await appendCustomEvent(
+        context.exoharness.current.turn,
+        "pi_run_started",
+        {
+          metadata: turnMetadata(context),
+          request_id: event.requestId,
+        },
+      );
+      return;
     case "delta":
       await streamTextDelta(context, state, event.text);
       return;
     case "message":
       state.rawMessages.push(event.message);
-      state.finalText =
-        assistantTextFromRawMessage(event.message) || state.finalText;
+      await projectPiMessage(context, state, event);
       return;
     case "tool_start":
     case "tool_end":
@@ -234,7 +306,11 @@ async function handlePiWorkerEvent(
       await appendCustomEvent(
         context.exoharness.current.turn,
         event.phase === "start" ? "pi_retry_started" : "pi_retry_finished",
-        { metadata: turnMetadata(context), details: event.details },
+        {
+          metadata: turnMetadata(context),
+          request_id: event.requestId,
+          details: event.details,
+        },
       );
       return;
     case "compaction":
@@ -243,7 +319,11 @@ async function handlePiWorkerEvent(
         event.phase === "start"
           ? "pi_compaction_started"
           : "pi_compaction_finished",
-        { metadata: turnMetadata(context), details: event.details },
+        {
+          metadata: turnMetadata(context),
+          request_id: event.requestId,
+          details: event.details,
+        },
       );
       return;
     case "completed":
@@ -255,11 +335,41 @@ async function handlePiWorkerEvent(
         "pi_worker_error",
         {
           metadata: turnMetadata(context),
+          request_id: event.requestId,
           error: event.message,
           details: event.error,
         },
       );
       throw new Error(event.message);
+  }
+}
+
+async function projectPiMessage(
+  context: TurnContext,
+  state: PiTraceState,
+  event: Extract<PiWorkerEvent, { type: "message" }>,
+): Promise<void> {
+  const projection = projectPiAssistantMessage(event.message, {
+    upstreamModel: state.upstreamModel,
+    durationMs: event.durationMs,
+    ttftMs: event.ttftMs,
+  });
+  if (!projection || (!projection.text && !projection.usage)) {
+    return;
+  }
+  if (projection.text) {
+    state.finalText = projection.text;
+    state.lastPersistedAssistantText = projection.text;
+  }
+  await context.exoharness.current.turn.addEvents([
+    messagesEvent(
+      projection.text ? [assistantTextMessage(projection.text)] : [],
+      undefined,
+      projection.usage,
+    ),
+  ]);
+  if (projection.usage) {
+    state.usageEventsPersisted += 1;
   }
 }
 
@@ -340,16 +450,26 @@ async function appendPiFinalEvents(
   state: PiTraceState,
   result: PiWorkerRunResult,
 ): Promise<void> {
-  if (state.finalText) {
+  const textMissing =
+    Boolean(state.finalText) &&
+    state.lastPersistedAssistantText !== state.finalText;
+  const usageMissing = state.usageEventsPersisted === 0;
+  if (textMissing || usageMissing) {
     await context.exoharness.current.turn.addEvents([
-      messagesEvent([assistantTextMessage(state.finalText)]),
+      messagesEvent(
+        textMissing ? [assistantTextMessage(state.finalText)] : [],
+        undefined,
+        usageMissing ? piResultUsageRecord(result, state.ttftMs) : undefined,
+      ),
     ]);
   }
   await appendCustomEvent(context.exoharness.current.turn, "pi_run_completed", {
     metadata: turnMetadata(context),
+    request_id: state.requestId,
     status: result.status,
     model: result.model,
     provider: result.provider,
+    duration_ms: result.durationMs,
     usage: result.usage,
   });
 }
@@ -363,6 +483,7 @@ async function flushPiRawMessages(
   }
   await appendCustomEvent(context.exoharness.current.turn, "pi_messages", {
     metadata: turnMetadata(context),
+    request_id: state.requestId,
     messages: state.rawMessages,
   });
   state.rawMessages = [];
@@ -399,22 +520,6 @@ function piPromptMessage(prompt: string): Message {
   return { role: "user", content: prompt };
 }
 
-function assistantTextFromRawMessage(message: JsonValue): string {
-  if (!isRecord(message) || message.role !== "assistant") {
-    return "";
-  }
-  const content = Array.isArray(message.content) ? message.content : [];
-  return content
-    .map((part) => {
-      return isRecord(part) &&
-        part.type === "text" &&
-        typeof part.text === "string"
-        ? part.text
-        : "";
-    })
-    .join("");
-}
-
 function piTraceOutput(
   state: PiTraceState,
   result: PiWorkerRunResult | null,
@@ -438,11 +543,60 @@ function piTraceMetrics(
     metrics.prompt_cached_tokens = result.usage.cacheRead;
     metrics.prompt_cache_creation_tokens = result.usage.cacheWrite;
     metrics.estimated_cost = result.usage.cost;
+    metrics.duration = result.durationMs / 1000;
+    if (result.usage.reasoning !== undefined) {
+      metrics.completion_reasoning_tokens = result.usage.reasoning;
+    }
   }
   if (state.ttftMs !== null) {
     metrics.time_to_first_token = state.ttftMs / 1000;
   }
   return metrics;
+}
+
+async function requirePiSandboxNetworking(
+  context: TurnContext,
+  modelBinding: ResolvedLlmBinding,
+): Promise<void> {
+  if (
+    context.agentConfig.sandbox.enableNetworking ||
+    isLoopbackUrl(modelBinding.baseUrl)
+  ) {
+    return;
+  }
+  await appendCustomEvent(
+    context.exoharness.current.turn,
+    "pi_networking_required",
+    {
+      metadata: turnMetadata(context),
+      model: modelBinding.model,
+      reason:
+        "Pi makes model requests inside the Exoharness sandbox, so remote providers require sandbox networking.",
+    },
+  );
+  throw new Error(
+    [
+      "Pi requires agent networking for remote model providers.",
+      `Enable it with: exo agent update ${context.exoharness.current.agent.record.slug} --networking enabled`,
+    ].join(" "),
+  );
+}
+
+function isLoopbackUrl(baseUrl: string | null | undefined): boolean {
+  if (!baseUrl) {
+    return false;
+  }
+  try {
+    const hostname = new URL(baseUrl).hostname;
+    return (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "[::1]" ||
+      hostname === "::1"
+    );
+  } catch {
+    return false;
+  }
 }
 
 function piSandboxCommand(context: TurnContext): string[] {
@@ -476,17 +630,24 @@ function piWarmWorkerKey(
     model_binding: modelBinding.name,
     model: modelBinding.model,
     base_url: modelBinding.baseUrl ?? null,
+    credential_fingerprint: credentialFingerprint(modelBinding.apiKey),
     cwd: sandboxCwd(context),
     command: piSandboxCommand(context),
   });
 }
 
-function parseWorkerEvent(line: string): PiWorkerEvent {
-  const parsed = JSON.parse(line) as unknown;
-  if (!isRecord(parsed) || typeof parsed.type !== "string") {
-    throw new Error(`invalid Pi sandbox worker event: ${line}`);
+function credentialFingerprint(apiKey: string | undefined): string | null {
+  if (!apiKey) {
+    return null;
   }
-  return parsed as PiWorkerEvent;
+  return createHash("sha256").update(apiKey).digest("hex").slice(0, 16);
+}
+
+function piTurnTimeoutMs(): number {
+  const configured = Number(process.env.EXO_PI_TURN_TIMEOUT_MS);
+  return Number.isFinite(configured) && configured > 0
+    ? configured
+    : DEFAULT_PI_TURN_TIMEOUT_MS;
 }
 
 function jsonObjectOrEmpty(value: JsonValue): JsonObject {

--- a/exoharness/scripts/agent-harness-e2e.ts
+++ b/exoharness/scripts/agent-harness-e2e.ts
@@ -13,7 +13,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-type HarnessKey = "codex" | "claude" | "cursor";
+type HarnessKey = "codex" | "claude" | "cursor" | "pi";
 
 interface HarnessDefinition {
   key: HarnessKey;
@@ -117,6 +117,19 @@ const harnesses: HarnessDefinition[] = [
     imageBuildArgs: [
       "-f",
       "exoharness/containers/cursor-sdk-sandbox/Containerfile",
+      ".",
+    ],
+  },
+  {
+    key: "pi",
+    envName: "ANTHROPIC_API_KEY",
+    secret: "pi-anthropic",
+    model: "anthropic/claude-sonnet-4-6",
+    module: "exoharness/examples/typescript/pi-harness.ts",
+    image: "exo-pi-sandbox:latest",
+    imageBuildArgs: [
+      "-f",
+      "exoharness/containers/pi-sandbox/Containerfile",
       ".",
     ],
   },
@@ -689,7 +702,12 @@ function parseArgs(rawArgs: string[]): CliArgs {
 }
 
 function isHarnessKey(value: string): value is HarnessKey {
-  return value === "codex" || value === "claude" || value === "cursor";
+  return (
+    value === "codex" ||
+    value === "claude" ||
+    value === "cursor" ||
+    value === "pi"
+  );
 }
 
 function readArgValue(rawArgs: string[], index: number, flag: string): string {
@@ -790,10 +808,10 @@ function fail(message: string): never {
 function printHelpAndExit(): never {
   console.log(`Usage: pnpm e2e:agent-harnesses [options]
 
-Runs live Codex/Claude/Cursor history replay checks against exoharness.
+Runs live Codex/Claude/Cursor/Pi history replay checks against exoharness.
 
 Options:
-  --only <codex|claude|cursor>  Run one harness. Repeatable.
+  --only <codex|claude|cursor|pi>  Run one harness. Repeatable.
   --sandbox                     Also run sandbox escape/network-denial checks.
   --build-images                Build the required Apple container images first.
   --braintrust                  Verify traces using BRAINTRUST_* env vars.

--- a/exoharness/scripts/agent-harness-e2e.ts
+++ b/exoharness/scripts/agent-harness-e2e.ts
@@ -78,6 +78,7 @@ interface ConversationEventsResult {
 
 interface EventRecord {
   id?: string;
+  data?: unknown;
 }
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
@@ -319,6 +320,9 @@ function runHistoryReplayCheck(
     toolMarker,
     `${harness.key} did not read the mounted marker file through a tool call`,
   );
+  if (harness.key === "pi") {
+    assertPiUsageEvents(agent.slug, conversation);
+  }
 
   const firstTurnEndedId = firstTurnEndedEventId(agent.slug, conversation);
   const fork = `fork-${harness.key}-${runId}`;
@@ -344,6 +348,29 @@ function runHistoryReplayCheck(
   );
 
   return { conversation, fork, codeWord };
+}
+
+function assertPiUsageEvents(agent: string, conversation: string): void {
+  const result = conversationEvents(agent, conversation, [
+    "--type",
+    "messages",
+    "--limit",
+    "100",
+  ]);
+  const serialized = JSON.stringify(result.events);
+  if (!serialized.includes('"usage"')) {
+    throw new Error("Pi did not persist usage on canonical message events");
+  }
+  for (const field of [
+    "model",
+    "prompt_tokens",
+    "completion_tokens",
+    "cost_usd",
+  ]) {
+    if (!serialized.includes(`"${field}"`)) {
+      throw new Error(`Pi canonical usage did not include ${field}`);
+    }
+  }
 }
 
 function runSandboxEscapeCheck(

--- a/exoharness/typescript/model-runtime/shared-worker.test.ts
+++ b/exoharness/typescript/model-runtime/shared-worker.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+
+import type { SandboxProcess } from "@exo/harness";
+
+import {
+  WarmJsonlSandboxWorker,
+  WarmJsonlSandboxWorkerTimeoutError,
+} from "./shared";
+
+describe("WarmJsonlSandboxWorker", () => {
+  it("bounds requests with an actionable timeout", async () => {
+    const { process, writes } = idleSandboxProcess();
+    const worker = new WarmJsonlSandboxWorker<{ prompt: string }, unknown>({
+      name: "test worker",
+      parseEvent: JSON.parse,
+      process,
+    });
+
+    const request = worker.request({ prompt: "hello" }, () => undefined, {
+      timeoutMs: 10,
+    });
+    await expect(request).rejects.toMatchObject({
+      name: "WarmJsonlSandboxWorkerTimeoutError",
+      phase: "request",
+      timeoutMs: 10,
+    } satisfies Partial<WarmJsonlSandboxWorkerTimeoutError>);
+    await expect(request).rejects.toThrow("test worker timed out after 10ms");
+    expect(writes).toEqual(['{"prompt":"hello"}\n']);
+  });
+
+  it("uses a separate timeout for the first worker event", async () => {
+    const { process } = idleSandboxProcess();
+    const worker = new WarmJsonlSandboxWorker<{ prompt: string }, unknown>({
+      name: "test worker",
+      parseEvent: JSON.parse,
+      process,
+    });
+
+    const request = worker.request({ prompt: "hello" }, () => undefined, {
+      startupTimeoutMs: 10,
+      timeoutMs: 1_000,
+    });
+    await expect(request).rejects.toMatchObject({
+      name: "WarmJsonlSandboxWorkerTimeoutError",
+      phase: "startup",
+      timeoutMs: 10,
+    } satisfies Partial<WarmJsonlSandboxWorkerTimeoutError>);
+    await expect(request).rejects.toThrow(
+      "test worker produced no events within 10ms",
+    );
+  });
+});
+
+function idleSandboxProcess(): {
+  process: SandboxProcess;
+  writes: string[];
+} {
+  const writes: string[] = [];
+  return {
+    writes,
+    process: {
+      reused: false,
+      stdout: new ReadableStream<string>(),
+      stderr: new ReadableStream<string>(),
+      writeStdin: async (data) => {
+        writes.push(data);
+      },
+      closeStdin: async () => {},
+      close: async () => {},
+      wait: async () => null,
+    },
+  };
+}

--- a/exoharness/typescript/model-runtime/shared.ts
+++ b/exoharness/typescript/model-runtime/shared.ts
@@ -122,9 +122,33 @@ export interface WarmJsonlSandboxWorkerOptions<TEvent> {
   process: SandboxProcess;
 }
 
+export interface WarmJsonlSandboxWorkerRequestOptions {
+  startupTimeoutMs?: number;
+  timeoutMs?: number;
+}
+
+export class WarmJsonlSandboxWorkerTimeoutError extends Error {
+  readonly phase: "startup" | "request";
+  readonly timeoutMs: number;
+
+  constructor(
+    message: string,
+    phase: "startup" | "request",
+    timeoutMs: number,
+  ) {
+    super(message);
+    this.name = "WarmJsonlSandboxWorkerTimeoutError";
+    this.phase = phase;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+const JSONL_WORKER_STDERR_MAX_CHARS = 16_000;
+
 export class WarmJsonlSandboxWorker<TRequest, TEvent> {
   private readonly events = new AsyncQueue<TEvent>();
   private stderr = "";
+  private stderrTruncated = false;
 
   constructor(private readonly options: WarmJsonlSandboxWorkerOptions<TEvent>) {
     void this.readStdout();
@@ -134,24 +158,84 @@ export class WarmJsonlSandboxWorker<TRequest, TEvent> {
   async request<R>(
     request: TRequest,
     onEvent: (event: TEvent) => Promise<R | undefined> | R | undefined,
+    requestOptions: WarmJsonlSandboxWorkerRequestOptions = {},
   ): Promise<R> {
-    await this.options.process.writeStdin(`${JSON.stringify(request)}\n`);
-    while (true) {
-      const next = await this.events.next();
-      if (next.done) {
-        throw new Error(
-          `${this.options.name} exited before completion${this.stderrSuffix()}`,
-        );
+    const run = async (): Promise<R> => {
+      await this.options.process.writeStdin(`${JSON.stringify(request)}\n`);
+      let waitingForFirstEvent = true;
+      while (true) {
+        const next = waitingForFirstEvent
+          ? await this.nextStartupEvent(requestOptions.startupTimeoutMs)
+          : await this.events.next();
+        waitingForFirstEvent = false;
+        if (next.done) {
+          throw new Error(
+            `${this.options.name} exited before completion${this.stderrSuffix()}`,
+          );
+        }
+        const result = await onEvent(next.value);
+        if (result !== undefined) {
+          return result;
+        }
       }
-      const result = await onEvent(next.value);
-      if (result !== undefined) {
-        return result;
+    };
+
+    const timeoutMs = requestOptions.timeoutMs;
+    if (timeoutMs === undefined || timeoutMs <= 0) {
+      return run();
+    }
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const timeoutResult = new Promise<never>((_resolve, reject) => {
+      timeout = setTimeout(() => {
+        reject(
+          new WarmJsonlSandboxWorkerTimeoutError(
+            `${this.options.name} timed out after ${timeoutMs}ms${this.stderrSuffix()}`,
+            "request",
+            timeoutMs,
+          ),
+        );
+      }, timeoutMs);
+      timeout.unref?.();
+    });
+    try {
+      return await Promise.race([run(), timeoutResult]);
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
       }
     }
   }
 
   async close(): Promise<void> {
     await this.options.process.close();
+  }
+
+  private async nextStartupEvent(
+    timeoutMs: number | undefined,
+  ): Promise<IteratorResult<TEvent>> {
+    if (timeoutMs === undefined || timeoutMs <= 0) {
+      return this.events.next();
+    }
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    const timeoutResult = new Promise<never>((_resolve, reject) => {
+      timeout = setTimeout(() => {
+        reject(
+          new WarmJsonlSandboxWorkerTimeoutError(
+            `${this.options.name} produced no events within ${timeoutMs}ms${this.stderrSuffix()}`,
+            "startup",
+            timeoutMs,
+          ),
+        );
+      }, timeoutMs);
+      timeout.unref?.();
+    });
+    try {
+      return await Promise.race([this.events.next(), timeoutResult]);
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout);
+      }
+    }
   }
 
   private async readStdout(): Promise<void> {
@@ -195,12 +279,14 @@ export class WarmJsonlSandboxWorker<TRequest, TEvent> {
         if (result.done) {
           return;
         }
-        this.stderr += result.value;
+        this.appendStderr(result.value);
       }
     } catch (error) {
-      this.stderr += `\nfailed to read stderr: ${
-        error instanceof Error ? error.message : String(error)
-      }`;
+      this.appendStderr(
+        `\nfailed to read stderr: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
     } finally {
       reader.releaseLock();
     }
@@ -212,17 +298,23 @@ export class WarmJsonlSandboxWorker<TRequest, TEvent> {
     }
   }
 
+  private appendStderr(text: string): void {
+    this.stderr += text;
+    if (this.stderr.length > JSONL_WORKER_STDERR_MAX_CHARS) {
+      this.stderr = this.stderr.slice(-JSONL_WORKER_STDERR_MAX_CHARS);
+      this.stderrTruncated = true;
+    }
+  }
+
   private stderrSuffix(): string {
     const stderr = this.stderr.trim();
     if (!stderr) {
       return "";
     }
-    const maxChars = 16_000;
-    const preview =
-      stderr.length > maxChars
-        ? `${stderr.slice(0, maxChars)}\n... stderr truncated ...`
-        : stderr;
-    return `\nstderr:\n${preview}`;
+    const truncation = this.stderrTruncated
+      ? "... earlier stderr truncated ...\n"
+      : "";
+    return `\nstderr:\n${truncation}${stderr}`;
   }
 }
 

--- a/exoharness/typescript/pi/history.test.ts
+++ b/exoharness/typescript/pi/history.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import { messageText, type Message } from "@exo/harness";
+
+import { capPiHistory } from "./history";
+
+describe("capPiHistory", () => {
+  it("keeps recent messages within the total history budget", () => {
+    const messages = ["oldest", "second", "third", "newest"].map(
+      (label): Message => ({
+        role: "user",
+        content: `${label}:${"x".repeat(7_990 - label.length)}`,
+      }),
+    );
+
+    const capped = capPiHistory(messages);
+
+    expect(capped.sourceMessageCount).toBe(4);
+    expect(capped.messages).toHaveLength(3);
+    expect(capped.droppedMessageCount).toBe(1);
+    expect(messageText(capped.messages[0])).toContain("second:");
+    expect(messageText(capped.messages[2])).toContain("newest:");
+    expect(capped.textChars).toBeLessThanOrEqual(24_000);
+  });
+
+  it("keeps a contiguous suffix instead of backfilling older short messages", () => {
+    const capped = capPiHistory([
+      { role: "user", content: "old but short" },
+      { role: "assistant", content: "blocking".repeat(1_000) },
+      { role: "user", content: "a".repeat(7_990) },
+      { role: "assistant", content: "b".repeat(7_990) },
+      { role: "user", content: "c".repeat(7_990) },
+      { role: "assistant", content: "newest" },
+    ]);
+
+    expect(capped.messages).toHaveLength(4);
+    expect(capped.droppedMessageCount).toBe(2);
+    expect(messageText(capped.messages[0])).toBe("a".repeat(7_990));
+    expect(messageText(capped.messages[3])).toBe("newest");
+  });
+
+  it("truncates normal messages and tool results at separate limits", () => {
+    const capped = capPiHistory([
+      { role: "assistant", content: "a".repeat(10_000) },
+      { role: "tool", content: "b".repeat(10_000) },
+    ]);
+
+    expect(capped.truncatedMessageCount).toBe(2);
+    expect(messageText(capped.messages[0])).toHaveLength(8_000);
+    expect(messageText(capped.messages[1])).toHaveLength(4_000);
+    expect(messageText(capped.messages[0])).toContain("[truncated 2000");
+    expect(messageText(capped.messages[1])).toContain("[truncated 6000");
+  });
+
+  it("counts truncation only for retained messages", () => {
+    const capped = capPiHistory([
+      { role: "assistant", content: "old".repeat(10_000) },
+      { role: "user", content: "a".repeat(8_000) },
+      { role: "assistant", content: "b".repeat(8_000) },
+      { role: "user", content: "c".repeat(8_000) },
+    ]);
+
+    expect(capped.droppedMessageCount).toBe(1);
+    expect(capped.truncatedMessageCount).toBe(0);
+  });
+
+  it("always retains at least the newest message", () => {
+    const capped = capPiHistory([
+      { role: "user", content: "x".repeat(50_000) },
+    ]);
+
+    expect(capped.messages).toHaveLength(1);
+    expect(capped.droppedMessageCount).toBe(0);
+    expect(messageText(capped.messages[0])).toHaveLength(8_000);
+  });
+});

--- a/exoharness/typescript/pi/history.ts
+++ b/exoharness/typescript/pi/history.ts
@@ -1,0 +1,83 @@
+import { messageText, type Message } from "@exo/harness";
+
+const PI_PRIOR_MESSAGE_MAX_CHARS = 8_000;
+const PI_PRIOR_TOOL_RESULT_MAX_CHARS = 4_000;
+const PI_PRIOR_HISTORY_MAX_CHARS = 24_000;
+
+export interface CappedPiHistory {
+  messages: Message[];
+  sourceMessageCount: number;
+  droppedMessageCount: number;
+  truncatedMessageCount: number;
+  textChars: number;
+}
+
+interface HistoryCandidate {
+  message: Message;
+  textChars: number;
+  truncated: boolean;
+}
+
+export function capPiHistory(messages: Message[]): CappedPiHistory {
+  const candidates = messages.map(toHistoryCandidate);
+  const selected: HistoryCandidate[] = [];
+  let textChars = 0;
+  let droppedMessageCount = 0;
+
+  for (let index = candidates.length - 1; index >= 0; index -= 1) {
+    const candidate = candidates[index];
+    if (
+      selected.length > 0 &&
+      textChars + candidate.textChars > PI_PRIOR_HISTORY_MAX_CHARS
+    ) {
+      droppedMessageCount = index + 1;
+      break;
+    }
+    selected.push(candidate);
+    textChars += candidate.textChars;
+  }
+  selected.reverse();
+
+  return {
+    messages: selected.map((candidate) => candidate.message),
+    sourceMessageCount: candidates.length,
+    droppedMessageCount,
+    truncatedMessageCount: selected.filter((candidate) => candidate.truncated)
+      .length,
+    textChars,
+  };
+}
+
+function toHistoryCandidate(message: Message): HistoryCandidate {
+  const maxChars =
+    message.role === "tool"
+      ? PI_PRIOR_TOOL_RESULT_MAX_CHARS
+      : PI_PRIOR_MESSAGE_MAX_CHARS;
+  const { text, truncated } = truncateHistoryText(
+    messageText(message),
+    maxChars,
+  );
+  const cappedMessage: Message = truncated
+    ? ({ role: message.role, content: text } as Message)
+    : message;
+  return {
+    message: cappedMessage,
+    textChars: text.length,
+    truncated,
+  };
+}
+
+function truncateHistoryText(
+  text: string,
+  maxChars: number,
+): { text: string; truncated: boolean } {
+  if (text.length <= maxChars) {
+    return { text, truncated: false };
+  }
+  const omittedChars = text.length - maxChars;
+  const suffix = `\n\n[truncated ${omittedChars} characters from prior conversation history]`;
+  return {
+    text: `${text.slice(0, Math.max(0, maxChars - suffix.length))}${suffix}`,
+    truncated: true,
+  };
+}

--- a/exoharness/typescript/pi/projection.test.ts
+++ b/exoharness/typescript/pi/projection.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+
+import { piResultUsageRecord, projectPiAssistantMessage } from "./projection";
+
+describe("projectPiAssistantMessage", () => {
+  it("projects text and standard Exoharness usage", () => {
+    const projection = projectPiAssistantMessage(
+      {
+        role: "assistant",
+        responseId: "response-1",
+        model: "claude-sonnet-4-6",
+        content: [
+          { type: "thinking", thinking: "private" },
+          { type: "text", text: "hello " },
+          { type: "text", text: "world" },
+        ],
+        usage: {
+          input: 12,
+          output: 5,
+          cacheRead: 3,
+          cacheWrite: 2,
+          reasoning: 1,
+          cost: { total: 0.004 },
+        },
+      },
+      {
+        upstreamModel: "anthropic/fallback",
+        durationMs: 125,
+        ttftMs: 42,
+      },
+    );
+
+    expect(projection).toEqual({
+      text: "hello world",
+      usage: {
+        model: "claude-sonnet-4-6",
+        prompt_tokens: 12,
+        completion_tokens: 5,
+        prompt_cached_tokens: 3,
+        prompt_cache_creation_tokens: 2,
+        completion_reasoning_tokens: 1,
+        cost_usd: 0.004,
+        duration_ms: 125,
+        ttft_ms: 42,
+      },
+    });
+  });
+
+  it("ignores non-assistant messages", () => {
+    expect(
+      projectPiAssistantMessage(
+        { role: "toolResult", content: [] },
+        { upstreamModel: "model" },
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("piResultUsageRecord", () => {
+  it("projects aggregate fallback usage and duration", () => {
+    expect(
+      piResultUsageRecord(
+        {
+          status: "finished",
+          finalText: "done",
+          model: "model",
+          provider: "provider",
+          usage: {
+            input: 10,
+            output: 4,
+            cacheRead: 2,
+            cacheWrite: 1,
+            reasoning: 3,
+            totalTokens: 17,
+            cost: 0.02,
+          },
+          durationMs: 1250,
+        },
+        25,
+      ),
+    ).toEqual({
+      model: "model",
+      prompt_tokens: 10,
+      completion_tokens: 4,
+      prompt_cached_tokens: 2,
+      prompt_cache_creation_tokens: 1,
+      completion_reasoning_tokens: 3,
+      cost_usd: 0.02,
+      duration_ms: 1250,
+      ttft_ms: 25,
+    });
+  });
+});

--- a/exoharness/typescript/pi/projection.ts
+++ b/exoharness/typescript/pi/projection.ts
@@ -1,0 +1,99 @@
+import type { JsonObject, JsonValue } from "@exo/harness";
+
+import type { PiWorkerRunResult } from "./protocol";
+
+export interface PiAssistantProjection {
+  text: string;
+  usage?: JsonObject;
+}
+
+export interface PiAssistantProjectionOptions {
+  upstreamModel: string;
+  durationMs?: number;
+  ttftMs?: number | null;
+}
+
+export function projectPiAssistantMessage(
+  message: JsonValue,
+  options: PiAssistantProjectionOptions,
+): PiAssistantProjection | null {
+  if (!isRecord(message) || message.role !== "assistant") {
+    return null;
+  }
+  const content = Array.isArray(message.content) ? message.content : [];
+  const text = content
+    .map((part) => {
+      return isRecord(part) &&
+        part.type === "text" &&
+        typeof part.text === "string"
+        ? part.text
+        : "";
+    })
+    .join("");
+  const usage = usageRecordFromRawMessage(message, options);
+  return { text, usage };
+}
+
+export function piResultUsageRecord(
+  result: PiWorkerRunResult,
+  ttftMs: number | null,
+): JsonObject {
+  const record: JsonObject = {
+    model: result.model,
+    prompt_tokens: result.usage.input,
+    completion_tokens: result.usage.output,
+    prompt_cached_tokens: result.usage.cacheRead,
+    prompt_cache_creation_tokens: result.usage.cacheWrite,
+    cost_usd: result.usage.cost,
+    duration_ms: result.durationMs,
+  };
+  if (result.usage.reasoning !== undefined) {
+    record.completion_reasoning_tokens = result.usage.reasoning;
+  }
+  if (ttftMs !== null) {
+    record.ttft_ms = ttftMs;
+  }
+  return record;
+}
+
+function usageRecordFromRawMessage(
+  message: Record<string, JsonValue>,
+  options: PiAssistantProjectionOptions,
+): JsonObject | undefined {
+  const usage = isRecord(message.usage) ? message.usage : null;
+  if (!usage) {
+    return undefined;
+  }
+  const record: JsonObject = {
+    model:
+      typeof message.model === "string" ? message.model : options.upstreamModel,
+  };
+  copyNumber(record, "prompt_tokens", usage.input);
+  copyNumber(record, "completion_tokens", usage.output);
+  copyNumber(record, "prompt_cached_tokens", usage.cacheRead);
+  copyNumber(record, "prompt_cache_creation_tokens", usage.cacheWrite);
+  copyNumber(record, "completion_reasoning_tokens", usage.reasoning);
+  const cost = isRecord(usage.cost) ? usage.cost.total : undefined;
+  copyNumber(record, "cost_usd", cost);
+  if (options.durationMs !== undefined) {
+    record.duration_ms = options.durationMs;
+  }
+  if (options.ttftMs !== null && options.ttftMs !== undefined) {
+    record.ttft_ms = options.ttftMs;
+  }
+  return record;
+}
+
+function copyNumber(
+  target: JsonObject,
+  key: string,
+  value: JsonValue | undefined,
+): void {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    target[key] = value;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, JsonValue> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/exoharness/typescript/pi/protocol.test.ts
+++ b/exoharness/typescript/pi/protocol.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { parsePiModelReference, toPiJson } from "./protocol";
+import {
+  parsePiModelReference,
+  parsePiWorkerEvent,
+  toPiJson,
+} from "./protocol";
 
 describe("parsePiModelReference", () => {
   it("splits the provider from model ids that contain slashes", () => {
@@ -16,6 +20,48 @@ describe("parsePiModelReference", () => {
     expect(() => parsePiModelReference("claude-sonnet-4-6")).toThrow(
       "provider-qualified",
     );
+  });
+});
+
+describe("parsePiWorkerEvent", () => {
+  it("accepts a request-scoped completed event", () => {
+    const event = {
+      type: "completed",
+      requestId: "request-1",
+      result: {
+        status: "finished",
+        finalText: "done",
+        model: "model",
+        provider: "provider",
+        usage: {
+          input: 1,
+          output: 1,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 2,
+          cost: 0,
+        },
+        durationMs: 10,
+      },
+    };
+    expect(parsePiWorkerEvent(JSON.stringify(event))).toEqual(event);
+  });
+
+  it("rejects unknown and malformed worker events", () => {
+    expect(() => parsePiWorkerEvent("not-json")).toThrow(
+      "invalid Pi sandbox worker event",
+    );
+    expect(() =>
+      parsePiWorkerEvent('{"type":"unknown","requestId":"request-1"}'),
+    ).toThrow("invalid Pi sandbox worker event");
+    expect(() =>
+      parsePiWorkerEvent('{"type":"delta","requestId":"request-1"}'),
+    ).toThrow("invalid Pi sandbox worker event");
+    expect(() =>
+      parsePiWorkerEvent(
+        '{"type":"message","requestId":"request-1","message":{},"durationMs":-1}',
+      ),
+    ).toThrow("invalid Pi sandbox worker event");
   });
 });
 

--- a/exoharness/typescript/pi/protocol.test.ts
+++ b/exoharness/typescript/pi/protocol.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { parsePiModelReference, toPiJson } from "./protocol";
+
+describe("parsePiModelReference", () => {
+  it("splits the provider from model ids that contain slashes", () => {
+    expect(
+      parsePiModelReference("openrouter/anthropic/claude-sonnet-4"),
+    ).toEqual({
+      provider: "openrouter",
+      model: "anthropic/claude-sonnet-4",
+    });
+  });
+
+  it("requires a provider-qualified model", () => {
+    expect(() => parsePiModelReference("claude-sonnet-4-6")).toThrow(
+      "provider-qualified",
+    );
+  });
+});
+
+describe("toPiJson", () => {
+  it("normalizes bigint and circular values", () => {
+    const value: { count: bigint; self?: unknown } = { count: 3n };
+    value.self = value;
+    expect(toPiJson(value)).toEqual({ count: "3", self: "[circular]" });
+  });
+});

--- a/exoharness/typescript/pi/protocol.ts
+++ b/exoharness/typescript/pi/protocol.ts
@@ -1,0 +1,99 @@
+import type { JsonValue } from "@exo/harness";
+
+export interface PiWorkerRequest {
+  prompt: string;
+  systemPrompt: string;
+  model: string;
+  baseUrl?: string;
+  cwd: string;
+}
+
+export interface PiUsage {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  totalTokens: number;
+  cost: number;
+}
+
+export interface PiWorkerRunResult {
+  status: "finished" | "error";
+  finalText: string;
+  model: string;
+  provider: string;
+  usage: PiUsage;
+  error?: string;
+}
+
+export type PiWorkerEvent =
+  | { type: "delta"; text: string }
+  | { type: "message"; message: JsonValue }
+  | {
+      type: "tool_start";
+      callId: string;
+      name: string;
+      args: JsonValue;
+    }
+  | {
+      type: "tool_end";
+      callId: string;
+      name: string;
+      result: JsonValue;
+      isError: boolean;
+    }
+  | { type: "retry"; phase: "start" | "end"; details: JsonValue }
+  | {
+      type: "compaction";
+      phase: "start" | "end";
+      details: JsonValue;
+    }
+  | { type: "completed"; result: PiWorkerRunResult }
+  | { type: "error"; message: string; error: JsonValue };
+
+export interface PiModelReference {
+  provider: string;
+  model: string;
+}
+
+export function parsePiModelReference(value: string): PiModelReference {
+  const separator = value.indexOf("/");
+  if (separator <= 0 || separator === value.length - 1) {
+    throw new Error(
+      `Pi model must be provider-qualified (for example anthropic/claude-sonnet-4-6); received: ${value}`,
+    );
+  }
+  return {
+    provider: value.slice(0, separator),
+    model: value.slice(separator + 1),
+  };
+}
+
+export function toPiJson(value: unknown): JsonValue {
+  if (value === undefined) {
+    return null;
+  }
+  const seen = new WeakSet<object>();
+  const serialized = JSON.stringify(value, (_key, item: unknown) => {
+    if (typeof item === "bigint") {
+      return item.toString();
+    }
+    if (item instanceof Error) {
+      return {
+        name: item.name,
+        message: item.message,
+        stack: item.stack,
+      };
+    }
+    if (item && typeof item === "object") {
+      if (seen.has(item)) {
+        return "[circular]";
+      }
+      seen.add(item);
+    }
+    return item;
+  });
+  return serialized === undefined
+    ? null
+    : (JSON.parse(serialized) as JsonValue);
+}

--- a/exoharness/typescript/pi/protocol.ts
+++ b/exoharness/typescript/pi/protocol.ts
@@ -1,11 +1,14 @@
 import type { JsonValue } from "@exo/harness";
 
 export interface PiWorkerRequest {
+  requestId: string;
   prompt: string;
   systemPrompt: string;
   model: string;
   baseUrl?: string;
   cwd: string;
+  maxOutputTokens?: number;
+  maxToolRoundTrips?: number;
 }
 
 export interface PiUsage {
@@ -13,6 +16,7 @@ export interface PiUsage {
   output: number;
   cacheRead: number;
   cacheWrite: number;
+  reasoning?: number;
   totalTokens: number;
   cost: number;
 }
@@ -23,37 +27,147 @@ export interface PiWorkerRunResult {
   model: string;
   provider: string;
   usage: PiUsage;
+  durationMs: number;
   error?: string;
 }
 
+type RequestEvent<T> = T & { requestId: string };
+
 export type PiWorkerEvent =
-  | { type: "delta"; text: string }
-  | { type: "message"; message: JsonValue }
-  | {
+  | RequestEvent<{ type: "run_started" }>
+  | RequestEvent<{ type: "delta"; text: string }>
+  | RequestEvent<{
+      type: "message";
+      message: JsonValue;
+      durationMs?: number;
+      ttftMs?: number;
+    }>
+  | RequestEvent<{
       type: "tool_start";
       callId: string;
       name: string;
       args: JsonValue;
-    }
-  | {
+    }>
+  | RequestEvent<{
       type: "tool_end";
       callId: string;
       name: string;
       result: JsonValue;
       isError: boolean;
-    }
-  | { type: "retry"; phase: "start" | "end"; details: JsonValue }
-  | {
+    }>
+  | RequestEvent<{
+      type: "retry";
+      phase: "start" | "end";
+      details: JsonValue;
+    }>
+  | RequestEvent<{
       type: "compaction";
       phase: "start" | "end";
       details: JsonValue;
-    }
-  | { type: "completed"; result: PiWorkerRunResult }
-  | { type: "error"; message: string; error: JsonValue };
+    }>
+  | RequestEvent<{ type: "completed"; result: PiWorkerRunResult }>
+  | RequestEvent<{ type: "error"; message: string; error: JsonValue }>;
 
 export interface PiModelReference {
   provider: string;
   model: string;
+}
+
+export function parsePiWorkerEvent(line: string): PiWorkerEvent {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line) as unknown;
+  } catch {
+    throw invalidWorkerEvent(line);
+  }
+  if (
+    !isRecord(parsed) ||
+    typeof parsed.type !== "string" ||
+    typeof parsed.requestId !== "string" ||
+    !parsed.requestId
+  ) {
+    throw new Error(`invalid Pi sandbox worker event: ${line}`);
+  }
+  switch (parsed.type) {
+    case "run_started":
+      break;
+    case "delta":
+      requireString(parsed, "text", line);
+      break;
+    case "message":
+      requireField(parsed, "message", line);
+      requireOptionalNonNegativeNumber(parsed, "durationMs", line);
+      requireOptionalNonNegativeNumber(parsed, "ttftMs", line);
+      break;
+    case "tool_start":
+      requireString(parsed, "callId", line);
+      requireString(parsed, "name", line);
+      requireField(parsed, "args", line);
+      break;
+    case "tool_end":
+      requireString(parsed, "callId", line);
+      requireString(parsed, "name", line);
+      requireField(parsed, "result", line);
+      if (typeof parsed.isError !== "boolean") {
+        throw invalidWorkerEvent(line);
+      }
+      break;
+    case "retry":
+    case "compaction":
+      if (parsed.phase !== "start" && parsed.phase !== "end") {
+        throw invalidWorkerEvent(line);
+      }
+      requireField(parsed, "details", line);
+      break;
+    case "completed":
+      if (!isRecord(parsed.result)) {
+        throw invalidWorkerEvent(line);
+      }
+      if (
+        parsed.result.status !== "finished" &&
+        parsed.result.status !== "error"
+      ) {
+        throw invalidWorkerEvent(line);
+      }
+      requireString(parsed.result, "finalText", line);
+      requireString(parsed.result, "model", line);
+      requireString(parsed.result, "provider", line);
+      if (
+        !isRecord(parsed.result.usage) ||
+        !isFiniteNumber(parsed.result.durationMs) ||
+        parsed.result.durationMs < 0
+      ) {
+        throw invalidWorkerEvent(line);
+      }
+      for (const field of [
+        "input",
+        "output",
+        "cacheRead",
+        "cacheWrite",
+        "totalTokens",
+        "cost",
+      ]) {
+        const value = parsed.result.usage[field];
+        if (!isFiniteNumber(value) || value < 0) {
+          throw invalidWorkerEvent(line);
+        }
+      }
+      if (
+        parsed.result.usage.reasoning !== undefined &&
+        (!isFiniteNumber(parsed.result.usage.reasoning) ||
+          parsed.result.usage.reasoning < 0)
+      ) {
+        throw invalidWorkerEvent(line);
+      }
+      break;
+    case "error":
+      requireString(parsed, "message", line);
+      requireField(parsed, "error", line);
+      break;
+    default:
+      throw invalidWorkerEvent(line);
+  }
+  return parsed as PiWorkerEvent;
 }
 
 export function parsePiModelReference(value: string): PiModelReference {
@@ -67,6 +181,49 @@ export function parsePiModelReference(value: string): PiModelReference {
     provider: value.slice(0, separator),
     model: value.slice(separator + 1),
   };
+}
+
+function requireString(
+  record: Record<string, unknown>,
+  field: string,
+  line: string,
+): void {
+  if (typeof record[field] !== "string") {
+    throw invalidWorkerEvent(line);
+  }
+}
+
+function requireField(
+  record: Record<string, unknown>,
+  field: string,
+  line: string,
+): void {
+  if (!(field in record)) {
+    throw invalidWorkerEvent(line);
+  }
+}
+
+function requireOptionalNonNegativeNumber(
+  record: Record<string, unknown>,
+  field: string,
+  line: string,
+): void {
+  const value = record[field];
+  if (value !== undefined && (!isFiniteNumber(value) || value < 0)) {
+    throw invalidWorkerEvent(line);
+  }
+}
+
+function invalidWorkerEvent(line: string): Error {
+  return new Error(`invalid Pi sandbox worker event: ${line}`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value);
 }
 
 export function toPiJson(value: unknown): JsonValue {

--- a/exoharness/typescript/pi/sandbox-worker.test.ts
+++ b/exoharness/typescript/pi/sandbox-worker.test.ts
@@ -1,0 +1,595 @@
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import http, { type IncomingMessage, type ServerResponse } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  parsePiWorkerEvent,
+  type PiWorkerEvent,
+  type PiWorkerRequest,
+  type PiWorkerRunResult,
+} from "./protocol";
+
+const workerPath = fileURLToPath(
+  new URL("./sandbox-worker.ts", import.meta.url),
+);
+const temporaryDirectories: string[] = [];
+
+interface MockServer {
+  baseUrl: string;
+  requests: unknown[];
+  close(): Promise<void>;
+}
+
+interface WorkerRun {
+  events: PiWorkerEvent[];
+  result: PiWorkerRunResult;
+  stderr: string;
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("Pi sandbox worker", () => {
+  it("streams a model response, reports usage, and ignores ambient Pi resources", async () => {
+    const cwd = temporaryDirectory("exo-pi-worker-");
+    const marker = join(cwd, "ambient-extension-loaded");
+    const agentDir = join(cwd, "pi-agent");
+    await mkdir(join(agentDir, "extensions"), { recursive: true });
+    await mkdir(join(cwd, ".pi"), { recursive: true });
+    writeFileSync(
+      join(agentDir, "extensions", "untrusted.ts"),
+      [
+        'import { writeFileSync } from "node:fs";',
+        `writeFileSync(${JSON.stringify(marker)}, "loaded");`,
+        "export default function () {}",
+      ].join("\n"),
+    );
+    const ambientInstruction = "AMBIENT_PI_INSTRUCTION_MUST_NOT_LOAD";
+    writeFileSync(join(cwd, ".pi", "settings.json"), "{}\n");
+    writeFileSync(join(cwd, "AGENTS.md"), `${ambientInstruction}\n`);
+    writeFileSync(
+      join(cwd, ".pi", "APPEND_SYSTEM.md"),
+      `${ambientInstruction}\n`,
+    );
+
+    const server = await startMockServer((_request, response) => {
+      sendTextResponse(response, "mock ok", { input: 7, output: 2 });
+    });
+    try {
+      const run = await runWorker({
+        requestId: "request-text",
+        prompt: "Say mock ok.",
+        systemPrompt: "isolated Exoharness system prompt",
+        model: "anthropic/claude-sonnet-4-6",
+        baseUrl: server.baseUrl,
+        cwd,
+        maxOutputTokens: 123,
+      });
+
+      expect(run.events.map((event) => event.type)).toEqual([
+        "run_started",
+        "delta",
+        "message",
+        "completed",
+      ]);
+      expect(
+        run.events.every((event) => event.requestId === "request-text"),
+      ).toBe(true);
+      expect(run.result).toMatchObject({
+        status: "finished",
+        finalText: "mock ok",
+        model: "claude-sonnet-4-6",
+        provider: "anthropic",
+        usage: {
+          input: 7,
+          output: 2,
+          totalTokens: 9,
+        },
+      });
+      expect(run.result.durationMs).toBeGreaterThanOrEqual(0);
+      const assistantMessage = run.events.find(
+        (event) => event.type === "message",
+      );
+      expect(assistantMessage).toMatchObject({
+        type: "message",
+        durationMs: expect.any(Number),
+        ttftMs: expect.any(Number),
+      });
+      const requests = JSON.stringify(server.requests);
+      expect(requests).toContain("isolated Exoharness system prompt");
+      expect(requests).toContain('"max_tokens":123');
+      expect(requests).not.toContain(ambientInstruction);
+      expect(existsSync(marker)).toBe(false);
+      expect(run.stderr).toBe("");
+    } finally {
+      await server.close();
+    }
+  }, 30_000);
+
+  it("executes Pi tools and preserves request-scoped tool events", async () => {
+    const cwd = temporaryDirectory("exo-pi-worker-tool-");
+    const file = join(cwd, "tool-marker.txt");
+    writeFileSync(file, "tool-marker-value\n");
+    let requestCount = 0;
+    const server = await startMockServer((request, response) => {
+      requestCount += 1;
+      if (requestCount === 1) {
+        sendToolCallResponse(response, "tool-call-1", "read", { path: file });
+        return;
+      }
+      expect(JSON.stringify(request)).toContain("tool-marker-value");
+      sendTextResponse(response, "read tool-marker-value", {
+        input: 6,
+        output: 3,
+      });
+    });
+
+    try {
+      const run = await runWorker({
+        requestId: "request-tool",
+        prompt: "Read the marker file and report its contents.",
+        systemPrompt: "Use the available tools.",
+        model: "anthropic/claude-sonnet-4-6",
+        baseUrl: server.baseUrl,
+        cwd,
+      });
+
+      expect(requestCount).toBe(2);
+      expect(run.events.map((event) => event.type)).toEqual([
+        "run_started",
+        "message",
+        "tool_start",
+        "tool_end",
+        "message",
+        "delta",
+        "message",
+        "completed",
+      ]);
+      const toolStart = run.events.find((event) => event.type === "tool_start");
+      const toolEnd = run.events.find((event) => event.type === "tool_end");
+      expect(toolStart).toMatchObject({
+        type: "tool_start",
+        requestId: "request-tool",
+        callId: "tool-call-1",
+        name: "read",
+        args: { path: file },
+      });
+      expect(toolEnd).toMatchObject({
+        type: "tool_end",
+        requestId: "request-tool",
+        callId: "tool-call-1",
+        name: "read",
+        isError: false,
+      });
+      expect(JSON.stringify(toolEnd)).toContain("tool-marker-value");
+      expect(run.result).toMatchObject({
+        status: "finished",
+        finalText: "read tool-marker-value",
+        usage: {
+          input: 11,
+          output: 4,
+          totalTokens: 15,
+        },
+      });
+    } finally {
+      await server.close();
+    }
+  }, 30_000);
+
+  it("does not expose the provider credential to Pi's bash tool", async () => {
+    const cwd = temporaryDirectory("exo-pi-worker-credential-");
+    let requestCount = 0;
+    const server = await startMockServer((request, response) => {
+      requestCount += 1;
+      if (requestCount === 1) {
+        sendToolCallResponse(response, "tool-call-env", "bash", {
+          command:
+            'if [ -z "${EXO_PI_API_KEY+x}" ]; then printf credential-hidden; else printf credential-exposed; fi',
+        });
+        return;
+      }
+      sendTextResponse(response, "credential-hidden", { input: 5, output: 2 });
+    });
+
+    try {
+      const run = await runWorker({
+        requestId: "request-credential",
+        prompt: "Check whether the provider credential is in the environment.",
+        systemPrompt: "Use the available tools.",
+        model: "anthropic/claude-sonnet-4-6",
+        baseUrl: server.baseUrl,
+        cwd,
+      });
+
+      expect(requestCount).toBe(2);
+      const followUpRequest = JSON.stringify(server.requests[1]);
+      expect(followUpRequest).toContain(
+        '"content":"credential-hidden","is_error":false',
+      );
+      expect(followUpRequest).not.toContain(
+        '"content":"credential-exposed","is_error":false',
+      );
+      expect(run.result).toMatchObject({
+        status: "finished",
+        finalText: "credential-hidden",
+      });
+    } finally {
+      await server.close();
+    }
+  }, 30_000);
+
+  it("keeps sequential warm-worker events scoped to their requests", async () => {
+    const cwd = temporaryDirectory("exo-pi-worker-sequence-");
+    const server = await startMockServer((request, response) => {
+      const body = JSON.stringify(request);
+      sendTextResponse(
+        response,
+        body.includes("second prompt") ? "second response" : "first response",
+        { input: 4, output: 2 },
+      );
+    });
+
+    try {
+      const common = {
+        systemPrompt: "isolated system prompt",
+        model: "anthropic/claude-sonnet-4-6",
+        baseUrl: server.baseUrl,
+        cwd,
+      };
+      const run = await runWorkerSequence([
+        { ...common, requestId: "sequence-1", prompt: "first prompt" },
+        { ...common, requestId: "sequence-2", prompt: "second prompt" },
+      ]);
+
+      expect(run.results.map((result) => result.finalText)).toEqual([
+        "first response",
+        "second response",
+      ]);
+      expect(
+        run.events
+          .filter((event) => event.type === "completed")
+          .map((event) => event.requestId),
+      ).toEqual(["sequence-1", "sequence-2"]);
+      const firstCompleted = run.events.findIndex(
+        (event) =>
+          event.type === "completed" && event.requestId === "sequence-1",
+      );
+      const secondStarted = run.events.findIndex(
+        (event) =>
+          event.type === "run_started" && event.requestId === "sequence-2",
+      );
+      expect(secondStarted).toBeGreaterThan(firstCompleted);
+    } finally {
+      await server.close();
+    }
+  }, 30_000);
+
+  it("stops gracefully at the configured tool round-trip budget", async () => {
+    const cwd = temporaryDirectory("exo-pi-worker-budget-");
+    const file = join(cwd, "tool-marker.txt");
+    writeFileSync(file, "tool-marker-value\n");
+    let requestCount = 0;
+    const server = await startMockServer((_request, response) => {
+      requestCount += 1;
+      sendToolCallResponse(response, "tool-call-budget", "read", {
+        path: file,
+      });
+    });
+
+    try {
+      const run = await runWorker({
+        requestId: "request-budget",
+        prompt: "Read the marker file.",
+        systemPrompt: "Use the available tools.",
+        model: "anthropic/claude-sonnet-4-6",
+        baseUrl: server.baseUrl,
+        cwd,
+        maxToolRoundTrips: 0,
+      });
+      expect(run.result).toMatchObject({
+        status: "finished",
+        finalText: "",
+      });
+      expect(requestCount).toBe(1);
+    } finally {
+      await server.close();
+    }
+  }, 30_000);
+});
+
+async function runWorker(request: PiWorkerRequest): Promise<WorkerRun> {
+  const run = await runWorkerSequence([request]);
+  const result = run.results[0];
+  if (!result) {
+    throw new Error("Pi worker sequence returned no result");
+  }
+  return { events: run.events, result, stderr: run.stderr };
+}
+
+async function runWorkerSequence(requests: PiWorkerRequest[]): Promise<{
+  events: PiWorkerEvent[];
+  results: PiWorkerRunResult[];
+  stderr: string;
+}> {
+  const firstRequest = requests[0];
+  if (!firstRequest) {
+    throw new Error("Pi worker sequence requires at least one request");
+  }
+  const child = spawn(process.execPath, ["--import", "tsx", workerPath], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      EXO_PI_AGENT_DIR: join(firstRequest.cwd, "pi-agent"),
+      EXO_PI_API_KEY: "test-key",
+      PI_OFFLINE: "1",
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  const events: PiWorkerEvent[] = [];
+  const results: PiWorkerRunResult[] = [];
+  const terminalWaiters = new Map<
+    string,
+    {
+      resolve(event: PiWorkerEvent): void;
+      reject(error: Error): void;
+    }
+  >();
+  let stderr = "";
+  let stdout = "";
+  child.stderr.on("data", (chunk: Buffer) => {
+    stderr += chunk.toString();
+  });
+  child.stdout.on("data", (chunk: Buffer) => {
+    stdout += chunk.toString();
+    while (true) {
+      const newline = stdout.indexOf("\n");
+      if (newline < 0) {
+        return;
+      }
+      const line = stdout.slice(0, newline).trim();
+      stdout = stdout.slice(newline + 1);
+      if (!line) {
+        continue;
+      }
+      try {
+        const event = parsePiWorkerEvent(line);
+        events.push(event);
+        if (event.type === "completed" || event.type === "error") {
+          terminalWaiters.get(event.requestId)?.resolve(event);
+        }
+      } catch (error) {
+        const invalid = new Error(`invalid worker output: ${line}`, {
+          cause: error,
+        });
+        for (const waiter of terminalWaiters.values()) {
+          waiter.reject(invalid);
+        }
+      }
+    }
+  });
+  const rejectAll = (error: Error) => {
+    for (const waiter of terminalWaiters.values()) {
+      waiter.reject(error);
+    }
+  };
+  child.on("error", rejectAll);
+  child.on("exit", (code) => {
+    if (code !== 0) {
+      rejectAll(new Error(`Pi worker exited with ${code}; stderr:\n${stderr}`));
+    }
+  });
+
+  try {
+    for (const request of requests) {
+      const terminal = new Promise<PiWorkerEvent>((resolve, reject) => {
+        terminalWaiters.set(request.requestId, { resolve, reject });
+      });
+      child.stdin.write(`${JSON.stringify(request)}\n`);
+      const terminalEvent = await withWorkerTimeout(terminal, () => stderr);
+      terminalWaiters.delete(request.requestId);
+      if (terminalEvent.type === "error") {
+        throw new Error(terminalEvent.message);
+      }
+      if (terminalEvent.type !== "completed") {
+        throw new Error(`unexpected terminal event: ${terminalEvent.type}`);
+      }
+      results.push(terminalEvent.result);
+    }
+    child.stdin.end();
+    await once(child, "exit");
+    return { events, results, stderr: stderr.trim() };
+  } finally {
+    if (child.exitCode === null) {
+      child.kill("SIGTERM");
+    }
+  }
+}
+
+async function withWorkerTimeout<T>(
+  value: Promise<T>,
+  stderr: () => string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      reject(new Error(`Pi worker timed out; stderr:\n${stderr()}`));
+    }, 25_000);
+    timer.unref?.();
+  });
+  try {
+    return await Promise.race([value, timeout]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+async function startMockServer(
+  handler: (request: unknown, response: ServerResponse) => void,
+): Promise<MockServer> {
+  const requests: unknown[] = [];
+  const server = http.createServer(
+    async (request: IncomingMessage, response: ServerResponse) => {
+      try {
+        let body = "";
+        for await (const chunk of request) {
+          body += chunk.toString();
+        }
+        const parsed = JSON.parse(body) as unknown;
+        requests.push(parsed);
+        handler(parsed, response);
+      } catch (error) {
+        response.writeHead(500, { "content-type": "application/json" });
+        response.end(JSON.stringify({ error: String(error) }));
+      }
+    },
+  );
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("mock server did not expose a TCP port");
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    requests,
+    close: async () => {
+      server.close();
+      await once(server, "close");
+    },
+  };
+}
+
+function sendTextResponse(
+  response: ServerResponse,
+  text: string,
+  usage: { input: number; output: number },
+): void {
+  sendAnthropicEvents(response, [
+    [
+      "message_start",
+      {
+        type: "message_start",
+        message: {
+          id: `message-${Date.now()}`,
+          type: "message",
+          role: "assistant",
+          content: [],
+          model: "claude-sonnet-4-6",
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: usage.input, output_tokens: 0 },
+        },
+      },
+    ],
+    [
+      "content_block_start",
+      {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      },
+    ],
+    [
+      "content_block_delta",
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text },
+      },
+    ],
+    ["content_block_stop", { type: "content_block_stop", index: 0 }],
+    [
+      "message_delta",
+      {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: { output_tokens: usage.output },
+      },
+    ],
+    ["message_stop", { type: "message_stop" }],
+  ]);
+}
+
+function sendToolCallResponse(
+  response: ServerResponse,
+  callId: string,
+  name: string,
+  args: Record<string, unknown>,
+): void {
+  sendAnthropicEvents(response, [
+    [
+      "message_start",
+      {
+        type: "message_start",
+        message: {
+          id: `message-${Date.now()}`,
+          type: "message",
+          role: "assistant",
+          content: [],
+          model: "claude-sonnet-4-6",
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 5, output_tokens: 0 },
+        },
+      },
+    ],
+    [
+      "content_block_start",
+      {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "tool_use", id: callId, name, input: {} },
+      },
+    ],
+    [
+      "content_block_delta",
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: {
+          type: "input_json_delta",
+          partial_json: JSON.stringify(args),
+        },
+      },
+    ],
+    ["content_block_stop", { type: "content_block_stop", index: 0 }],
+    [
+      "message_delta",
+      {
+        type: "message_delta",
+        delta: { stop_reason: "tool_use", stop_sequence: null },
+        usage: { output_tokens: 1 },
+      },
+    ],
+    ["message_stop", { type: "message_stop" }],
+  ]);
+}
+
+function sendAnthropicEvents(
+  response: ServerResponse,
+  events: Array<[string, Record<string, unknown>]>,
+): void {
+  response.writeHead(200, { "content-type": "text/event-stream" });
+  for (const [event, data] of events) {
+    response.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+  }
+  response.end();
+}
+
+function temporaryDirectory(prefix: string): string {
+  const directory = mkdtempSync(join(tmpdir(), prefix));
+  temporaryDirectories.push(directory);
+  return directory;
+}

--- a/exoharness/typescript/pi/sandbox-worker.ts
+++ b/exoharness/typescript/pi/sandbox-worker.ts
@@ -20,8 +20,17 @@ import {
   type PiWorkerRunResult,
 } from "./protocol";
 
-const PI_AGENT_DIR = "/tmp/exo-pi-agent";
+const PI_AGENT_DIR =
+  process.env.EXO_PI_AGENT_DIR ?? `/tmp/exo-pi-agent-${process.pid}`;
+const PI_API_KEY = process.env.EXO_PI_API_KEY;
+delete process.env.EXO_PI_API_KEY;
+
 const PI_TOOLS = ["read", "bash", "edit", "write", "grep", "find", "ls"];
+
+interface PiSessionTiming {
+  assistantStartedAt: number | null;
+  assistantTtftMs: number | null;
+}
 
 async function main(): Promise<void> {
   const rl = readline.createInterface({
@@ -33,11 +42,16 @@ async function main(): Promise<void> {
       if (!line.trim()) {
         continue;
       }
+      let requestId = "unknown";
       try {
-        await handleRequest(parseRequest(line));
+        const request = parseRequest(line);
+        requestId = request.requestId;
+        writeEvent({ type: "run_started", requestId });
+        await handleRequest(request);
       } catch (error) {
         writeEvent({
           type: "error",
+          requestId,
           message: errorMessage(error),
           error: toPiJson(error),
         });
@@ -49,6 +63,7 @@ async function main(): Promise<void> {
 }
 
 async function handleRequest(request: PiWorkerRequest): Promise<void> {
+  const startedAt = Date.now();
   const { provider, model: modelId } = parsePiModelReference(request.model);
   await mkdir(PI_AGENT_DIR, { recursive: true });
   const modelRuntime = await ModelRuntime.create({
@@ -56,9 +71,8 @@ async function handleRequest(request: PiWorkerRequest): Promise<void> {
     modelsPath: null,
     refreshOnCreate: false,
   });
-  const apiKey = process.env.EXO_PI_API_KEY;
-  if (apiKey) {
-    await modelRuntime.setRuntimeApiKey(provider, apiKey);
+  if (PI_API_KEY) {
+    await modelRuntime.setRuntimeApiKey(provider, PI_API_KEY);
   }
 
   const registeredModel = modelRuntime.getModel(provider, modelId);
@@ -67,9 +81,18 @@ async function handleRequest(request: PiWorkerRequest): Promise<void> {
       `Pi does not know model ${request.model}; use a provider/model reference from Pi's built-in model catalog`,
     );
   }
-  const model = request.baseUrl
-    ? { ...registeredModel, baseUrl: request.baseUrl }
-    : registeredModel;
+  const model = {
+    ...registeredModel,
+    ...(request.baseUrl ? { baseUrl: request.baseUrl } : {}),
+    ...(request.maxOutputTokens !== undefined
+      ? {
+          maxTokens: Math.min(
+            registeredModel.maxTokens,
+            request.maxOutputTokens,
+          ),
+        }
+      : {}),
+  };
   const settingsManager = SettingsManager.inMemory({
     compaction: { enabled: true },
     retry: { enabled: true, maxRetries: 2 },
@@ -86,7 +109,14 @@ async function handleRequest(request: PiWorkerRequest): Promise<void> {
     settingsManager,
   });
 
-  const unsubscribe = session.subscribe(handleSessionEvent);
+  installRoundBudget(session.agent, request.maxToolRoundTrips);
+  const timing: PiSessionTiming = {
+    assistantStartedAt: null,
+    assistantTtftMs: null,
+  };
+  const unsubscribe = session.subscribe((event) =>
+    handleSessionEvent(request.requestId, event, timing),
+  );
   try {
     await session.prompt(request.prompt, { expandPromptTemplates: false });
     const finalMessage = [...session.messages]
@@ -109,33 +139,68 @@ async function handleRequest(request: PiWorkerRequest): Promise<void> {
       model: model.id,
       provider: model.provider,
       usage: aggregateUsage(session.messages),
+      durationMs: Date.now() - startedAt,
       error: finalError,
     };
-    writeEvent({ type: "completed", result });
+    writeEvent({ type: "completed", requestId: request.requestId, result });
   } finally {
     unsubscribe();
     session.dispose();
   }
 }
 
-function handleSessionEvent(event: AgentSessionEvent): void {
+function handleSessionEvent(
+  requestId: string,
+  event: AgentSessionEvent,
+  timing: PiSessionTiming,
+): void {
+  if (event.type === "message_start" && event.message.role === "assistant") {
+    timing.assistantStartedAt = Date.now();
+    timing.assistantTtftMs = null;
+    return;
+  }
   if (
     event.type === "message_update" &&
     event.assistantMessageEvent.type === "text_delta"
   ) {
-    writeEvent({ type: "delta", text: event.assistantMessageEvent.delta });
+    if (timing.assistantTtftMs === null && timing.assistantStartedAt !== null) {
+      timing.assistantTtftMs = Date.now() - timing.assistantStartedAt;
+    }
+    writeEvent({
+      type: "delta",
+      requestId,
+      text: event.assistantMessageEvent.delta,
+    });
     return;
   }
-  if (
-    event.type === "message_end" &&
-    (event.message.role === "assistant" || event.message.role === "toolResult")
-  ) {
-    writeEvent({ type: "message", message: toPiJson(event.message) });
+  if (event.type === "message_end" && event.message.role === "assistant") {
+    const durationMs =
+      timing.assistantStartedAt === null
+        ? undefined
+        : Date.now() - timing.assistantStartedAt;
+    writeEvent({
+      type: "message",
+      requestId,
+      message: toPiJson(event.message),
+      durationMs,
+      ttftMs: timing.assistantTtftMs ?? undefined,
+    });
+    timing.assistantStartedAt = null;
+    timing.assistantTtftMs = null;
+    return;
+  }
+  if (event.type === "message_end" && event.message.role === "toolResult") {
+    writeEvent({
+      type: "message",
+      requestId,
+      message: toPiJson(event.message),
+    });
     return;
   }
   if (event.type === "tool_execution_start") {
     writeEvent({
       type: "tool_start",
+      requestId,
       callId: event.toolCallId,
       name: event.toolName,
       args: toPiJson(event.args),
@@ -145,6 +210,7 @@ function handleSessionEvent(event: AgentSessionEvent): void {
   if (event.type === "tool_execution_end") {
     writeEvent({
       type: "tool_end",
+      requestId,
       callId: event.toolCallId,
       name: event.toolName,
       result: toPiJson(event.result),
@@ -155,6 +221,7 @@ function handleSessionEvent(event: AgentSessionEvent): void {
   if (event.type === "auto_retry_start" || event.type === "auto_retry_end") {
     writeEvent({
       type: "retry",
+      requestId,
       phase: event.type === "auto_retry_start" ? "start" : "end",
       details: toPiJson(event),
     });
@@ -163,6 +230,7 @@ function handleSessionEvent(event: AgentSessionEvent): void {
   if (event.type === "compaction_start" || event.type === "compaction_end") {
     writeEvent({
       type: "compaction",
+      requestId,
       phase: event.type === "compaction_start" ? "start" : "end",
       details: toPiJson(event),
     });
@@ -198,6 +266,8 @@ function aggregateUsage(messages: readonly unknown[]): PiUsage {
     totalTokens: 0,
     cost: 0,
   };
+  let reasoning = 0;
+  let hasReasoning = false;
   for (const message of messages) {
     if (!isRecord(message) || message.role !== "assistant") {
       continue;
@@ -208,8 +278,15 @@ function aggregateUsage(messages: readonly unknown[]): PiUsage {
     usage.cacheRead += numberValue(item.cacheRead);
     usage.cacheWrite += numberValue(item.cacheWrite);
     usage.totalTokens += numberValue(item.totalTokens);
+    if (typeof item.reasoning === "number") {
+      reasoning += item.reasoning;
+      hasReasoning = true;
+    }
     const cost = isRecord(item.cost) ? item.cost : {};
     usage.cost += numberValue(cost.total);
+  }
+  if (hasReasoning) {
+    usage.reasoning = reasoning;
   }
   return usage;
 }
@@ -231,18 +308,88 @@ function parseRequest(line: string): PiWorkerRequest {
   if (!isRecord(parsed)) {
     throw new Error("Pi sandbox worker request must be a JSON object");
   }
-  for (const field of ["prompt", "systemPrompt", "model", "cwd"] as const) {
-    if (typeof parsed[field] !== "string") {
+  for (const field of [
+    "requestId",
+    "prompt",
+    "systemPrompt",
+    "model",
+    "cwd",
+  ] as const) {
+    if (typeof parsed[field] !== "string" || !parsed[field]) {
       throw new Error(`Pi sandbox worker request requires ${field}`);
     }
   }
+  const maxOutputTokens = optionalPositiveInteger(
+    parsed.maxOutputTokens,
+    "maxOutputTokens",
+  );
+  const maxToolRoundTrips = optionalNonNegativeInteger(
+    parsed.maxToolRoundTrips,
+    "maxToolRoundTrips",
+  );
   return {
+    requestId: parsed.requestId as string,
     prompt: parsed.prompt as string,
     systemPrompt: parsed.systemPrompt as string,
     model: parsed.model as string,
     cwd: parsed.cwd as string,
     baseUrl: typeof parsed.baseUrl === "string" ? parsed.baseUrl : undefined,
+    maxOutputTokens,
+    maxToolRoundTrips,
   };
+}
+
+function installRoundBudget(
+  agent: Awaited<ReturnType<typeof createAgentSession>>["session"]["agent"],
+  maxToolRoundTrips: number | undefined,
+): void {
+  if (maxToolRoundTrips === undefined) {
+    return;
+  }
+  const previous = agent.shouldStopAfterTurn;
+  let completedToolRoundTrips = 0;
+  agent.shouldStopAfterTurn = async (context, signal) => {
+    if (previous && (await previous(context, signal))) {
+      return true;
+    }
+    const hasToolCalls = context.message.content.some(
+      (part) => part.type === "toolCall",
+    );
+    if (!hasToolCalls) {
+      return false;
+    }
+    const budgetExhausted = completedToolRoundTrips >= maxToolRoundTrips;
+    completedToolRoundTrips += 1;
+    return budgetExhausted;
+  };
+}
+
+function optionalPositiveInteger(
+  value: unknown,
+  field: string,
+): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`Pi sandbox worker ${field} must be a positive integer`);
+  }
+  return value;
+}
+
+function optionalNonNegativeInteger(
+  value: unknown,
+  field: string,
+): number | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error(
+      `Pi sandbox worker ${field} must be a non-negative integer`,
+    );
+  }
+  return value;
 }
 
 function writeEvent(event: PiWorkerEvent): void {
@@ -264,6 +411,7 @@ function errorMessage(error: unknown): string {
 void main().catch((error: unknown) => {
   writeEvent({
     type: "error",
+    requestId: "worker",
     message: errorMessage(error),
     error: toPiJson(error),
   });

--- a/exoharness/typescript/pi/sandbox-worker.ts
+++ b/exoharness/typescript/pi/sandbox-worker.ts
@@ -1,0 +1,271 @@
+import { mkdir } from "node:fs/promises";
+import readline from "node:readline/promises";
+
+import {
+  createAgentSession,
+  createExtensionRuntime,
+  ModelRuntime,
+  SessionManager,
+  SettingsManager,
+  type AgentSessionEvent,
+  type ResourceLoader,
+} from "@earendil-works/pi-coding-agent";
+
+import {
+  parsePiModelReference,
+  toPiJson,
+  type PiUsage,
+  type PiWorkerEvent,
+  type PiWorkerRequest,
+  type PiWorkerRunResult,
+} from "./protocol";
+
+const PI_AGENT_DIR = "/tmp/exo-pi-agent";
+const PI_TOOLS = ["read", "bash", "edit", "write", "grep", "find", "ls"];
+
+async function main(): Promise<void> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    crlfDelay: Infinity,
+  });
+  try {
+    for await (const line of rl) {
+      if (!line.trim()) {
+        continue;
+      }
+      try {
+        await handleRequest(parseRequest(line));
+      } catch (error) {
+        writeEvent({
+          type: "error",
+          message: errorMessage(error),
+          error: toPiJson(error),
+        });
+      }
+    }
+  } finally {
+    rl.close();
+  }
+}
+
+async function handleRequest(request: PiWorkerRequest): Promise<void> {
+  const { provider, model: modelId } = parsePiModelReference(request.model);
+  await mkdir(PI_AGENT_DIR, { recursive: true });
+  const modelRuntime = await ModelRuntime.create({
+    authPath: `${PI_AGENT_DIR}/auth.json`,
+    modelsPath: null,
+    refreshOnCreate: false,
+  });
+  const apiKey = process.env.EXO_PI_API_KEY;
+  if (apiKey) {
+    await modelRuntime.setRuntimeApiKey(provider, apiKey);
+  }
+
+  const registeredModel = modelRuntime.getModel(provider, modelId);
+  if (!registeredModel) {
+    throw new Error(
+      `Pi does not know model ${request.model}; use a provider/model reference from Pi's built-in model catalog`,
+    );
+  }
+  const model = request.baseUrl
+    ? { ...registeredModel, baseUrl: request.baseUrl }
+    : registeredModel;
+  const settingsManager = SettingsManager.inMemory({
+    compaction: { enabled: true },
+    retry: { enabled: true, maxRetries: 2 },
+  });
+  const resourceLoader = isolatedResourceLoader(request.systemPrompt);
+  const { session } = await createAgentSession({
+    cwd: request.cwd,
+    agentDir: PI_AGENT_DIR,
+    model,
+    modelRuntime,
+    tools: PI_TOOLS,
+    resourceLoader,
+    sessionManager: SessionManager.inMemory(request.cwd),
+    settingsManager,
+  });
+
+  const unsubscribe = session.subscribe(handleSessionEvent);
+  try {
+    await session.prompt(request.prompt, { expandPromptTemplates: false });
+    const finalMessage = [...session.messages]
+      .reverse()
+      .find((message) => message.role === "assistant");
+    const finalError =
+      finalMessage?.role !== "assistant"
+        ? "Pi produced no final assistant message"
+        : finalMessage.stopReason === "error" ||
+            finalMessage.stopReason === "aborted"
+          ? (finalMessage.errorMessage ??
+            `Pi stopped: ${finalMessage.stopReason}`)
+          : undefined;
+    const result: PiWorkerRunResult = {
+      status: finalError ? "error" : "finished",
+      finalText:
+        finalMessage?.role === "assistant"
+          ? assistantText(finalMessage.content)
+          : "",
+      model: model.id,
+      provider: model.provider,
+      usage: aggregateUsage(session.messages),
+      error: finalError,
+    };
+    writeEvent({ type: "completed", result });
+  } finally {
+    unsubscribe();
+    session.dispose();
+  }
+}
+
+function handleSessionEvent(event: AgentSessionEvent): void {
+  if (
+    event.type === "message_update" &&
+    event.assistantMessageEvent.type === "text_delta"
+  ) {
+    writeEvent({ type: "delta", text: event.assistantMessageEvent.delta });
+    return;
+  }
+  if (
+    event.type === "message_end" &&
+    (event.message.role === "assistant" || event.message.role === "toolResult")
+  ) {
+    writeEvent({ type: "message", message: toPiJson(event.message) });
+    return;
+  }
+  if (event.type === "tool_execution_start") {
+    writeEvent({
+      type: "tool_start",
+      callId: event.toolCallId,
+      name: event.toolName,
+      args: toPiJson(event.args),
+    });
+    return;
+  }
+  if (event.type === "tool_execution_end") {
+    writeEvent({
+      type: "tool_end",
+      callId: event.toolCallId,
+      name: event.toolName,
+      result: toPiJson(event.result),
+      isError: event.isError,
+    });
+    return;
+  }
+  if (event.type === "auto_retry_start" || event.type === "auto_retry_end") {
+    writeEvent({
+      type: "retry",
+      phase: event.type === "auto_retry_start" ? "start" : "end",
+      details: toPiJson(event),
+    });
+    return;
+  }
+  if (event.type === "compaction_start" || event.type === "compaction_end") {
+    writeEvent({
+      type: "compaction",
+      phase: event.type === "compaction_start" ? "start" : "end",
+      details: toPiJson(event),
+    });
+  }
+}
+
+function isolatedResourceLoader(systemPrompt: string): ResourceLoader {
+  return {
+    getExtensions: () => ({
+      extensions: [],
+      errors: [],
+      runtime: createExtensionRuntime(),
+    }),
+    getSkills: () => ({ skills: [], diagnostics: [] }),
+    getPrompts: () => ({ prompts: [], diagnostics: [] }),
+    getThemes: () => ({ themes: [], diagnostics: [] }),
+    getAgentsFiles: () => ({ agentsFiles: [] }),
+    getSystemPrompt: () => undefined,
+    getSystemPromptSource: () => undefined,
+    getAppendSystemPrompt: () => [systemPrompt],
+    getAppendSystemPromptSources: () => [],
+    extendResources: () => {},
+    reload: async () => {},
+  };
+}
+
+function aggregateUsage(messages: readonly unknown[]): PiUsage {
+  const usage: PiUsage = {
+    input: 0,
+    output: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    totalTokens: 0,
+    cost: 0,
+  };
+  for (const message of messages) {
+    if (!isRecord(message) || message.role !== "assistant") {
+      continue;
+    }
+    const item = isRecord(message.usage) ? message.usage : {};
+    usage.input += numberValue(item.input);
+    usage.output += numberValue(item.output);
+    usage.cacheRead += numberValue(item.cacheRead);
+    usage.cacheWrite += numberValue(item.cacheWrite);
+    usage.totalTokens += numberValue(item.totalTokens);
+    const cost = isRecord(item.cost) ? item.cost : {};
+    usage.cost += numberValue(cost.total);
+  }
+  return usage;
+}
+
+function assistantText(content: readonly unknown[]): string {
+  return content
+    .map((part) => {
+      return isRecord(part) &&
+        part.type === "text" &&
+        typeof part.text === "string"
+        ? part.text
+        : "";
+    })
+    .join("");
+}
+
+function parseRequest(line: string): PiWorkerRequest {
+  const parsed = JSON.parse(line) as unknown;
+  if (!isRecord(parsed)) {
+    throw new Error("Pi sandbox worker request must be a JSON object");
+  }
+  for (const field of ["prompt", "systemPrompt", "model", "cwd"] as const) {
+    if (typeof parsed[field] !== "string") {
+      throw new Error(`Pi sandbox worker request requires ${field}`);
+    }
+  }
+  return {
+    prompt: parsed.prompt as string,
+    systemPrompt: parsed.systemPrompt as string,
+    model: parsed.model as string,
+    cwd: parsed.cwd as string,
+    baseUrl: typeof parsed.baseUrl === "string" ? parsed.baseUrl : undefined,
+  };
+}
+
+function writeEvent(event: PiWorkerEvent): void {
+  process.stdout.write(`${JSON.stringify(event)}\n`);
+}
+
+function numberValue(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+void main().catch((error: unknown) => {
+  writeEvent({
+    type: "error",
+    message: errorMessage(error),
+    error: toPiJson(error),
+  });
+  process.exitCode = 1;
+});

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@braintrust/lingua-wasm": "^0.1.0",
     "@cursor/sdk": "^1.0.12",
     "@discordjs/voice": "^0.19.0",
+    "@earendil-works/pi-coding-agent": "^0.84.2",
     "@mozilla/readability": "^0.6.0",
     "@shadcn/react": "^0.1.0",
     "@whiskeysockets/baileys": "7.0.0-rc13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@discordjs/voice':
         specifier: ^0.19.0
         version: 0.19.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(opusscript@0.1.1)
+      '@earendil-works/pi-coding-agent':
+        specifier: ^0.84.2
+        version: 0.84.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
       '@mozilla/readability':
         specifier: ^0.6.0
         version: 0.6.0
@@ -37,7 +40,7 @@ importers:
         version: 7.0.0-rc13(sharp@0.34.5)
       braintrust:
         specifier: 3.7.0
-        version: 3.7.0(zod@4.3.6)
+        version: 3.7.0(@aws-sdk/credential-provider-web-identity@3.972.75)(zod@4.3.6)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -89,7 +92,7 @@ importers:
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.3.1
-        version: 4.3.1(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0))
+        version: 4.3.1(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@types/node':
         specifier: 25.5.0
         version: 25.5.0
@@ -107,7 +110,7 @@ importers:
         version: 7.0.0-dev.20260328.1
       '@vitejs/plugin-react':
         specifier: ^6.0.3
-        version: 6.0.3(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0))
+        version: 6.0.3(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       oxfmt:
         specifier: ^0.42.0
         version: 0.42.0
@@ -128,13 +131,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: 8.0.3
-        version: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)
+        version: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       vitepress:
         specifier: ^1.6.4
         version: 1.6.4(@algolia/client-search@5.55.1)(@types/node@25.5.0)(@types/react@19.2.17)(lightningcss@1.32.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(search-insights@2.17.3)(typescript@5.9.3)
       vitest:
         specifier: 4.1.2
-        version: 4.1.2(@types/node@25.5.0)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0))
+        version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
 packages:
 
@@ -282,8 +285,114 @@ packages:
       zod:
         optional: true
 
+  '@anthropic-ai/sdk@0.91.1':
+    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   '@apm-js-collab/code-transformer@0.9.0':
     resolution: {integrity: sha512-cfHtufVUBKJz6se/tQBJqizgoot5AOxhVy5B9Cuo493p6b7hXKBEIi6tcZEbr4XwN1VnV9JZOu52MMTCOCSBMw==}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    resolution: {integrity: sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.977.8':
+    resolution: {integrity: sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.69':
+    resolution: {integrity: sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.71':
+    resolution: {integrity: sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.14':
+    resolution: {integrity: sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.76':
+    resolution: {integrity: sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.80':
+    resolution: {integrity: sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.69':
+    resolution: {integrity: sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.13':
+    resolution: {integrity: sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.75':
+    resolution: {integrity: sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/eventstream-handler-node@3.972.33':
+    resolution: {integrity: sha512-1Dd5WyEE2Kb3HvY44u7Ob16ST2W6iutOqsQ8Y2hUmsL2mAH/STlGS1dS9h3IOE6L7Ld3AR2HzKJ6XeCMOw8Peg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-eventstream@3.972.28':
+    resolution: {integrity: sha512-Z1EDXnS01P7H5jVrUx+/dBqV0m7dta7bSxLclkOuDuS93pNNQm0IcT4YLUbuvWKPYNxbI8aTG0p5Br30GSKDgA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-websocket@3.972.51':
+    resolution: {integrity: sha512-jdgP3jR5Q96j1jjZ98GGwpGg1CBNFIO2YE+vXg8cg8PvNY4NvgQNYJsqDaRX2PYv5gSUX/+C0D58Fhspj9ELMQ==}
+    engines: {node: '>= 14.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.43':
+    resolution: {integrity: sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.45':
+    resolution: {integrity: sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1048.0':
+    resolution: {integrity: sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1111.0':
+    resolution: {integrity: sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.4':
+    resolution: {integrity: sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.10':
+    resolution: {integrity: sha512-ycwH6Zd2GhuSqdXX9ihbCjeGTB6xOJs+O3+Jb8/zDG9978XU80qs75dfkPJRMNKe5MvBZPuNeFpd4JZKPoUF4g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.39':
+    resolution: {integrity: sha512-FTti8DS5MMWXNUWiRwXAJeYS+0GHHiMy0+7XOhcwk63ILHmfS2UFy2z/HNpZCSOJJ3P3dnWY6hfYNW3DF0nXUA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -551,6 +660,36 @@ packages:
 
   '@dotenvx/primitives@0.8.0':
     resolution: {integrity: sha512-VYJy0uhFm9zTJ1TxBaW/pA8bjbOM/OttaNMwZ1RHG4JKyRG7DhSdiqD1ipQoAyoD22olUtxbP78W9xY3Wd11bg==}
+
+  '@earendil-works/pi-agent-core@0.84.2':
+    resolution: {integrity: sha512-8Pn3wSCxj0cfo5I6jxQYVB/3uuQRmHhAlEclyjqpOuMEdQMIODHizRogv56FLdbU+dTiGnybeHQ2N+sV1/L2YA==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-ai@0.84.2':
+    resolution: {integrity: sha512-6MzsrYIYNVlE7SfpbL2yYb67Qo58p/7Q+xWG1RZvoX1P80aRCHSod2/13aFpxkow1lPO2LEh3c495J0Gwmyjig==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-client@0.84.2':
+    resolution: {integrity: sha512-/RFSPhD/bZbpOp1oJj+UneSUFSgZhWxzcSENUY+8+8xhoBrWXMYI2t77XNx4Yf+c8YK2qTHquForhNcelYpXvg==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-coding-agent@0.84.2':
+    resolution: {integrity: sha512-l4E+B7hgXKWddRo8bC/eSue2aWZjEgJ9xIpf5p0Og+lq8a2TArCwJ0HCoCPCgaBP/tN4zbYH/wOwvx9pJpeLCA==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-protocol@0.84.2':
+    resolution: {integrity: sha512-jbBh03fkeckWEroHpcZBr4w5/Ibat8WwdXFlXHivYQImrQNFtLpDeL0t1cku4hmK0q3pceIRQHkw4fwbM4YILQ==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-telemetry@0.84.2':
+    resolution: {integrity: sha512-wg5caea7uIv1BHRBm2Y116RvFG4oSAiP5qk9tA2463PDGIr4K8M1Ceyyg5DOpF/shUUl0gk826yQJAeAcHYB9g==}
+    engines: {node: '>=22.19.0'}
+
+  '@earendil-works/pi-tui@0.84.2':
+    resolution: {integrity: sha512-ds2TLihOnM5sLJB3VpXV6y0uR5efVuHf4MN7yDpsty6hA2DUO/EDVzjp/0od0G2JslzVLMjT8T8zavtxVb+qbg==}
+    engines: {node: '>=22.19.0'}
 
   '@emnapi/core@1.9.1':
     resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
@@ -877,6 +1016,15 @@ packages:
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
 
+  '@google/genai@1.52.0':
+    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
   '@hapi/boom@9.1.4':
     resolution: {integrity: sha512-Ls1oH8jaN1vNsqcaHVYJrKmgMcKsC1wcp8bujvXrHaAqD2iDYq3HoOwsxwo09Cuda5R5nC0o0IxlrlTuvPuzSw==}
 
@@ -1063,6 +1211,69 @@ packages:
   '@kwsites/promise-deferred@1.1.1':
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
+  '@mariozechner/clipboard-darwin-arm64@0.3.9':
+    resolution: {integrity: sha512-BfgV7vCEWZwJwZJw03r6bP5+tf0iI/ANuQYCxi9RNn7FrWB3yzGuMKCrNLRl6V761vXRdL8+OqZ0wd4TqlsNOQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@mariozechner/clipboard-darwin-universal@0.3.9':
+    resolution: {integrity: sha512-BGGR4iA9Z2shAjI65eI5xtyb3LYNlDW9X3gxKxDbqtbnREohsrqznov6zpKoIrsRWpzlYVEdKphS7ksJ0/ndSQ==}
+    engines: {node: '>= 10'}
+    os: [darwin]
+
+  '@mariozechner/clipboard-darwin-x64@0.3.9':
+    resolution: {integrity: sha512-4kURmCbS6nt8uYhtmWpUcJWyPHfmAr5dTpXD1nO3pIfa+TSQ9DbrGOYCKH+aEFW47XhQ4Vp8ZTszie+wfFvDKg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
+    resolution: {integrity: sha512-g59OkUGP2DDfCOIKypHeYgv2M55u/cKvXa5dSxFbEJ34XvIQMdcVmpKCkGUro3ZgefXiGVdwguvTMQGpHWzIXw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
+    resolution: {integrity: sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
+    resolution: {integrity: sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
+    resolution: {integrity: sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-x64-musl@0.3.9':
+    resolution: {integrity: sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
+    resolution: {integrity: sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
+    resolution: {integrity: sha512-ihQC3EufqEY81vhXBgVBtK4prL+wc62zJsSvxrgz7K1hsdt6OObz6v9p3Rn1OG3GJksTTKMJF0u/guMISHPhSA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@mariozechner/clipboard@0.3.9':
+    resolution: {integrity: sha512-ABnA53mdfkGZwOFUdZNv2S0CWGO/EIuPj8Vv9xmBFmSYg/qFc7ihO6q5FcQjvoE67kZpWkEc4AhD6B/os04yuA==}
+    engines: {node: '>= 10'}
+
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
 
@@ -1108,6 +1319,10 @@ packages:
     resolution: {integrity: sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==}
     engines: {node: '>=10'}
     deprecated: This functionality has been moved to @npmcli/fs
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
 
   '@oxc-project/types@0.122.0':
     resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
@@ -2337,9 +2552,52 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@silvia-odwyer/photon-node@0.3.4':
+    resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
+
   '@sindresorhus/merge-streams@4.0.0':
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
+
+  '@smithy/core@3.33.2':
+    resolution: {integrity: sha512-CUGXpnPkVdjUCbix+83sWLW9VFgQOm44MDOx/ihITJMAnOZKvL8YYIc7DR9pP/tZ8CIRvMiON/TucvygqbHO3w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.5.2':
+    resolution: {integrity: sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.7.2':
+    resolution: {integrity: sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/node-http-handler@4.11.2':
+    resolution: {integrity: sha512-avwAh9HM3h2lcfjvP3zYIZGf+XVgLQ91wOJ2qoFbNpW1UZeZb33aGlhTZvtkANHfcGhJroRY64525OjfgOg30g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.7.3':
+    resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.7.2':
+    resolution: {integrity: sha512-P7Ki6px6OOrxVtx8K7nLmyx4SlXUW/uTKDdMG44UHefmPGSRMBKe2v+TM59WdLcpUIrBrnuCsIqiM2MbsZjmhw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.17.2':
+    resolution: {integrity: sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
 
   '@snazzah/davey-android-arm-eabi@0.1.11':
     resolution: {integrity: sha512-T1RYbNYKN6tLOcGIDKJd8OI6FBSEemwL7DOYdTMmhqfhhMr3YVN8WOhfoxGg63OcnpTN2e2c5tdY2bAx25RmQQ==}
@@ -2585,6 +2843,9 @@ packages:
   '@types/react@19.2.17':
     resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
   '@types/turndown@5.0.6':
     resolution: {integrity: sha512-ru00MoyeeouE5BX4gRL+6m/BsDfbRayOskWqUvh7CLGW+UXxHQItqALa38kKnOiZPqJrtzJUgAC2+F0rL1S4Pg==}
 
@@ -2828,6 +3089,10 @@ packages:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   agentkeepalive@4.6.0:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
@@ -3002,6 +3267,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
@@ -3021,6 +3289,9 @@ packages:
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   boxen@8.0.1:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
@@ -3050,6 +3321,9 @@ packages:
     resolution: {integrity: sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
@@ -3250,6 +3524,10 @@ packages:
   curve25519-js@0.0.4:
     resolution: {integrity: sha512-axn2UMEnkhyDUPWOwVKBMVIzSQy2ejH2xRGy1wq81dqRwApXfIzfbE3hIX0ZRFBIihf/KDqK158DLwESu4AK1w==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   dc-browser@1.0.4:
     resolution: {integrity: sha512-7oEtnzNlcE+hr4OvO3GR6Gndgw8BhW+wKOEwMqSleyY7N29jbAxzyW5BaJl7qBCw+6OIxfMWtY0T+6dxq8RWLw==}
 
@@ -3374,6 +3652,9 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -3521,6 +3802,9 @@ packages:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -3548,6 +3832,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -3578,6 +3866,10 @@ packages:
 
   focus-trap@7.8.0:
     resolution: {integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -3621,12 +3913,24 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This package is no longer supported.
 
+  gaxios@7.3.1:
+    resolution: {integrity: sha512-kB3rzJV7d9juLZh8/56QTXCwQfxyhdOMdyYk1HdQKFtF8TJTDTZQJtixWIwXdE9Jji91mC41DUNpjleo4L4eAQ==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
   get-east-asian-width@1.5.0:
     resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+    engines: {node: '>=18'}
+
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
 
   get-intrinsic@1.3.0:
@@ -3663,9 +3967,21 @@ packages:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  google-auth-library@10.9.1:
+    resolution: {integrity: sha512-i1ydyHrqcIxXkWh/uBmVkzCvIuq5yiK2ATndIe5XxKholrG/MTYP9xGYka4sQhrbIAgGjL2B6NOE7rFaiF3fXw==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -3673,6 +3989,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  grok-mermaid@0.2.2:
+    resolution: {integrity: sha512-XcJEP5dDC8liHBh52mlLjU18fNvu1ckFsu0QpIG3+APZ270fsj9wxpiA6cOURmbUEuoMVgjbC2+UYgTdCqqgzA==}
+    engines: {node: '>=18'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -3699,6 +4019,9 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
   hono@4.12.16:
     resolution: {integrity: sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==}
     engines: {node: '>=16.9.0'}
@@ -3711,6 +4034,10 @@ packages:
 
   hookified@2.2.0:
     resolution: {integrity: sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==}
+
+  hosted-git-info@9.0.3:
+    resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
@@ -3732,9 +4059,17 @@ packages:
     resolution: {integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==}
     engines: {node: '>= 6'}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
     engines: {node: '>= 6'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -3764,6 +4099,10 @@ packages:
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
   import-fresh@3.3.1:
@@ -3921,6 +4260,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
@@ -3947,6 +4289,12 @@ packages:
 
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@5.6.0:
     resolution: {integrity: sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==}
@@ -4090,6 +4438,11 @@ packages:
   mark.js@8.11.1:
     resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
 
+  marked@18.0.5:
+    resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -4221,6 +4574,10 @@ packages:
     resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
     engines: {node: '>=8'}
 
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minisearch@7.2.0:
     resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
 
@@ -4283,6 +4640,15 @@ packages:
 
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-gyp@8.4.1:
     resolution: {integrity: sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==}
@@ -4371,6 +4737,17 @@ packages:
       zod:
         optional: true
 
+  openai@6.40.0:
+    resolution: {integrity: sha512-MWtTjd/gQt4jpbji61NTgFWJLoY/PdRJ6wG9/ZDRMYNMlBKrCrSlkLI+KgHP1vR1qT6LKSAyAqIxno6lcK9JiA==}
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   opusscript@0.1.1:
     resolution: {integrity: sha512-mL0fZZOUnXdZ78woRXp18lApwpp0lF5tozJOD1Wut0dgrA9WuQTgSels/CSmFleaAZrJi/nci5KOVtbuxeWoQA==}
 
@@ -4409,6 +4786,10 @@ packages:
     resolution: {integrity: sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==}
     engines: {node: '>=20'}
 
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
   p-timeout@7.0.1:
     resolution: {integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==}
     engines: {node: '>=20'}
@@ -4433,6 +4814,9 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  partial-json@0.1.7:
+    resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
+
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
@@ -4451,6 +4835,10 @@ packages:
   path-key@4.0.0:
     resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
     engines: {node: '>=12'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@0.1.13:
     resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
@@ -4561,6 +4949,9 @@ packages:
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
+
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
@@ -4706,6 +5097,10 @@ packages:
     resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
     engines: {node: '>= 4'}
 
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -4761,6 +5156,11 @@ packages:
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -5088,6 +5488,9 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
+  typebox@1.3.7:
+    resolution: {integrity: sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -5117,6 +5520,10 @@ packages:
 
   undici@8.7.0:
     resolution: {integrity: sha512-N7iQtfyLhIMOFgQubvmLV26svHpO0bqKnAiWotTQCVKCmWrcGbBotPuW1x+xwYZ2VHdSTVUfPQQnlEt1/LouTQ==}
+    engines: {node: '>=22.19.0'}
+
+  undici@8.9.0:
+    resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
     engines: {node: '>=22.19.0'}
 
   unicorn-magic@0.3.0:
@@ -5337,6 +5744,10 @@ packages:
       typescript:
         optional: true
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
@@ -5399,6 +5810,11 @@ packages:
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
 
   yocto-spinner@1.2.0:
     resolution: {integrity: sha512-Yw0hUB6UA3o4YUgKy3oSe9a4cxoaZ9sBfYDw+JSxo6Id0KoJGoxzPA24qqUXYKBWABs/zDSGTz9kww7t3F0XGw==}
@@ -5595,7 +6011,227 @@ snapshots:
     optionalDependencies:
       zod: 4.3.6
 
+  '@anthropic-ai/sdk@0.91.1(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
+
   '@apm-js-collab/code-transformer@0.9.0': {}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.974.4
+      '@aws-sdk/util-locate-window': 3.965.10
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.974.4
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.974.4
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-bedrock-runtime@3.1048.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/credential-provider-node': 3.972.80
+      '@aws-sdk/eventstream-handler-node': 3.972.33
+      '@aws-sdk/middleware-eventstream': 3.972.28
+      '@aws-sdk/middleware-websocket': 3.972.51
+      '@aws-sdk/token-providers': 3.1048.0
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.7.3
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.977.8':
+    dependencies:
+      '@aws-sdk/types': 3.974.4
+      '@aws-sdk/xml-builder': 3.972.39
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.33.2
+      '@smithy/signature-v4': 5.7.2
+      '@smithy/types': 4.17.2
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.69':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.71':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.14':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/credential-provider-env': 3.972.69
+      '@aws-sdk/credential-provider-http': 3.972.71
+      '@aws-sdk/credential-provider-login': 3.972.76
+      '@aws-sdk/credential-provider-process': 3.972.69
+      '@aws-sdk/credential-provider-sso': 3.973.13
+      '@aws-sdk/credential-provider-web-identity': 3.972.75
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.76':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.80':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.69
+      '@aws-sdk/credential-provider-http': 3.972.71
+      '@aws-sdk/credential-provider-ini': 3.973.14
+      '@aws-sdk/credential-provider-process': 3.972.69
+      '@aws-sdk/credential-provider-sso': 3.973.13
+      '@aws-sdk/credential-provider-web-identity': 3.972.75
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.69':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.13':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/token-providers': 3.1111.0
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.75':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/eventstream-handler-node@3.972.33':
+    dependencies:
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-eventstream@3.972.28':
+    dependencies:
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-websocket@3.972.51':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/signature-v4': 5.7.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.43':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/signature-v4-multi-region': 3.996.45
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/fetch-http-handler': 5.7.2
+      '@smithy/node-http-handler': 4.11.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.45':
+    dependencies:
+      '@aws-sdk/types': 3.974.4
+      '@smithy/signature-v4': 5.7.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1048.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1111.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.8
+      '@aws-sdk/nested-clients': 3.997.43
+      '@aws-sdk/types': 3.974.4
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.4':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.10':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.39':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -5976,6 +6612,91 @@ snapshots:
 
   '@dotenvx/primitives@0.8.0': {}
 
+  '@earendil-works/pi-agent-core@0.84.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
+    dependencies:
+      '@earendil-works/pi-ai': 0.84.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+      '@earendil-works/pi-telemetry': 0.84.2
+      diff: 8.0.4
+      ignore: 7.0.5
+      typebox: 1.3.7
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-ai@0.84.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.91.1(zod@4.3.6)
+      '@aws-sdk/client-bedrock-runtime': 3.1048.0
+      '@earendil-works/pi-telemetry': 0.84.2
+      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))
+      '@opentelemetry/api': 1.9.0
+      '@smithy/node-http-handler': 4.7.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      openai: 6.40.0(ws@8.21.0)(zod@4.3.6)
+      partial-json: 0.1.7
+      typebox: 1.3.7
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-client@0.84.2':
+    dependencies:
+      '@earendil-works/pi-protocol': 0.84.2
+
+  '@earendil-works/pi-coding-agent@0.84.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)':
+    dependencies:
+      '@earendil-works/pi-agent-core': 0.84.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+      '@earendil-works/pi-ai': 0.84.2(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.21.0)(zod@4.3.6)
+      '@earendil-works/pi-client': 0.84.2
+      '@earendil-works/pi-protocol': 0.84.2
+      '@earendil-works/pi-tui': 0.84.2
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cross-spawn: 7.0.6
+      diff: 8.0.4
+      glob: 13.0.6
+      grok-mermaid: 0.2.2
+      highlight.js: 10.7.3
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
+      jiti: 2.7.0
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      semver: 7.8.0
+      typebox: 1.3.7
+      undici: 8.9.0
+      yaml: 2.9.0
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.9
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@earendil-works/pi-protocol@0.84.2':
+    dependencies:
+      typebox: 1.3.7
+
+  '@earendil-works/pi-telemetry@0.84.2': {}
+
+  '@earendil-works/pi-tui@0.84.2':
+    dependencies:
+      get-east-asian-width: 1.6.0
+      marked: 18.0.5
+
   '@emnapi/core@1.9.1':
     dependencies:
       '@emnapi/wasi-threads': 1.2.0
@@ -6161,6 +6882,19 @@ snapshots:
   '@gar/promisify@1.1.3':
     optional: true
 
+  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))':
+    dependencies:
+      google-auth-library: 10.9.1
+      p-retry: 4.6.2
+      protobufjs: 7.6.1
+      ws: 8.21.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@hapi/boom@9.1.4':
     dependencies:
       '@hapi/hoek': 9.3.0
@@ -6308,6 +7042,50 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
+  '@mariozechner/clipboard-darwin-arm64@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-darwin-universal@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-darwin-x64@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-linux-x64-musl@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.9':
+    optional: true
+
+  '@mariozechner/clipboard@0.3.9':
+    optionalDependencies:
+      '@mariozechner/clipboard-darwin-arm64': 0.3.9
+      '@mariozechner/clipboard-darwin-universal': 0.3.9
+      '@mariozechner/clipboard-darwin-x64': 0.3.9
+      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-arm64-musl': 0.3.9
+      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-x64-gnu': 0.3.9
+      '@mariozechner/clipboard-linux-x64-musl': 0.3.9
+      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.9
+      '@mariozechner/clipboard-win32-x64-msvc': 0.3.9
+    optional: true
+
   '@mixmark-io/domino@2.2.0': {}
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
@@ -6388,6 +7166,8 @@ snapshots:
       mkdirp: 1.0.4
       rimraf: 3.0.2
     optional: true
+
+  '@opentelemetry/api@1.9.0': {}
 
   '@oxc-project/types@0.122.0': {}
 
@@ -7460,7 +8240,62 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@silvia-odwyer/photon-node@0.3.4': {}
+
   '@sindresorhus/merge-streams@4.0.0': {}
+
+  '@smithy/core@3.33.2':
+    dependencies:
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.5.2':
+    dependencies:
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.7.2':
+    dependencies:
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.11.2':
+    dependencies:
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.7.3':
+    dependencies:
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.7.2':
+    dependencies:
+      '@smithy/core': 3.33.2
+      '@smithy/types': 4.17.2
+      tslib: 2.8.1
+
+  '@smithy/types@4.17.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
 
   '@snazzah/davey-android-arm-eabi@0.1.11':
     optional: true
@@ -7600,12 +8435,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
 
-  '@tailwindcss/vite@4.3.1(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0))':
+  '@tailwindcss/vite@4.3.1(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.3.1
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
-      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)
+      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@tokenizer/inflate@0.4.1':
     dependencies:
@@ -7670,6 +8505,8 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/retry@0.12.0': {}
+
   '@types/turndown@5.0.6': {}
 
   '@types/unist@3.0.3': {}
@@ -7715,12 +8552,14 @@ snapshots:
 
   '@ungap/structured-clone@1.3.2': {}
 
-  '@vercel/functions@1.6.0': {}
+  '@vercel/functions@1.6.0(@aws-sdk/credential-provider-web-identity@3.972.75)':
+    optionalDependencies:
+      '@aws-sdk/credential-provider-web-identity': 3.972.75
 
-  '@vitejs/plugin-react@6.0.3(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0))':
+  '@vitejs/plugin-react@6.0.3(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)
+      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitejs/plugin-vue@5.2.4(vite@5.4.21(@types/node@25.5.0)(lightningcss@1.32.0))(vue@3.5.39(typescript@5.9.3))':
     dependencies:
@@ -7736,13 +8575,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.2(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)
+      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.2':
     dependencies:
@@ -7910,6 +8749,8 @@ snapshots:
       - supports-color
     optional: true
 
+  agent-base@7.1.4: {}
+
   agentkeepalive@4.6.0:
     dependencies:
       humanize-ms: 1.2.1
@@ -8062,6 +8903,8 @@ snapshots:
 
   baseline-browser-mapping@2.10.40: {}
 
+  bignumber.js@9.3.1: {}
+
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
@@ -8107,6 +8950,8 @@ snapshots:
 
   boolbase@1.0.0: {}
 
+  bowser@2.14.1: {}
+
   boxen@8.0.1:
     dependencies:
       ansi-align: 3.0.1
@@ -8136,12 +8981,12 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  braintrust@3.7.0(zod@4.3.6):
+  braintrust@3.7.0(@aws-sdk/credential-provider-web-identity@3.972.75)(zod@4.3.6):
     dependencies:
       '@ai-sdk/provider': 1.1.3
       '@apm-js-collab/code-transformer': 0.9.0
       '@next/env': 14.2.35
-      '@vercel/functions': 1.6.0
+      '@vercel/functions': 1.6.0(@aws-sdk/credential-provider-web-identity@3.972.75)
       ajv: 8.18.0
       argparse: 2.0.1
       boxen: 8.0.1
@@ -8178,6 +9023,8 @@ snapshots:
       electron-to-chromium: 1.5.380
       node-releases: 2.0.50
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer@5.7.1:
     dependencies:
@@ -8378,6 +9225,8 @@ snapshots:
 
   curve25519-js@0.0.4: {}
 
+  data-uri-to-buffer@4.0.1: {}
+
   dc-browser@1.0.4: {}
 
   debounce-fn@4.0.0:
@@ -8484,6 +9333,10 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
 
@@ -8729,6 +9582,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  extend@3.0.2: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-fifo@1.3.2: {}
@@ -8752,6 +9607,11 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
 
   figures@6.1.0:
     dependencies:
@@ -8803,6 +9663,10 @@ snapshots:
     dependencies:
       tabbable: 6.5.0
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   forwarded@0.2.0: {}
 
   fresh@0.5.2: {}
@@ -8843,9 +9707,27 @@ snapshots:
       wide-align: 1.1.5
     optional: true
 
+  gaxios@7.3.1:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.3.1
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   gensync@1.0.0-beta.2: {}
 
   get-east-asian-width@1.5.0: {}
+
+  get-east-asian-width@1.6.0: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -8886,6 +9768,12 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -8896,9 +9784,24 @@ snapshots:
       path-is-absolute: 1.0.1
     optional: true
 
+  google-auth-library@10.9.1:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.3.1
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  grok-mermaid@0.2.2: {}
 
   has-flag@4.0.0: {}
 
@@ -8933,6 +9836,8 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  highlight.js@10.7.3: {}
+
   hono@4.12.16: {}
 
   hookable@5.5.3: {}
@@ -8940,6 +9845,10 @@ snapshots:
   hookified@1.15.1: {}
 
   hookified@2.2.0: {}
+
+  hosted-git-info@9.0.3:
+    dependencies:
+      lru-cache: 11.5.0
 
   html-escaper@3.0.3: {}
 
@@ -8972,6 +9881,13 @@ snapshots:
       - supports-color
     optional: true
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
@@ -8979,6 +9895,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
     optional: true
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   human-signals@2.1.0: {}
 
@@ -9005,6 +9928,8 @@ snapshots:
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -9108,6 +10033,10 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-parse-even-better-errors@2.3.1: {}
 
   json-schema-to-ts@3.1.1:
@@ -9130,6 +10059,17 @@ snapshots:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   keyv@5.6.0:
     dependencies:
@@ -9265,6 +10205,8 @@ snapshots:
 
   mark.js@8.11.1: {}
 
+  marked@18.0.5: {}
+
   math-intrinsics@1.1.0: {}
 
   mdast-util-to-hast@13.2.1:
@@ -9387,6 +10329,8 @@ snapshots:
 
   minipass@5.0.0: {}
 
+  minipass@7.1.3: {}
+
   minisearch@7.2.0: {}
 
   minizlib@2.1.2:
@@ -9438,6 +10382,14 @@ snapshots:
       semver: 7.7.4
 
   node-addon-api@7.1.1: {}
+
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-gyp@8.4.1:
     dependencies:
@@ -9536,6 +10488,11 @@ snapshots:
       ws: 8.21.0
       zod: 4.3.6
 
+  openai@6.40.0(ws@8.21.0)(zod@4.3.6):
+    optionalDependencies:
+      ws: 8.21.0
+      zod: 4.3.6
+
   opusscript@0.1.1: {}
 
   ora@8.2.0:
@@ -9614,6 +10571,11 @@ snapshots:
       eventemitter3: 5.0.4
       p-timeout: 7.0.1
 
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
   p-timeout@7.0.1: {}
 
   p-try@2.2.0: {}
@@ -9633,6 +10595,8 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  partial-json@0.1.7: {}
+
   path-browserify@1.0.1: {}
 
   path-exists@3.0.0: {}
@@ -9643,6 +10607,11 @@ snapshots:
   path-key@3.1.1: {}
 
   path-key@4.0.0: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.0
+      minipass: 7.1.3
 
   path-to-regexp@0.1.13: {}
 
@@ -9745,6 +10714,12 @@ snapshots:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
+
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
 
   property-information@7.2.0: {}
 
@@ -9950,8 +10925,9 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
-  retry@0.12.0:
-    optional: true
+  retry@0.12.0: {}
+
+  retry@0.13.1: {}
 
   reusify@1.1.0: {}
 
@@ -10046,6 +11022,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.4: {}
+
+  semver@7.8.0: {}
 
   send@0.19.2:
     dependencies:
@@ -10511,6 +11489,8 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
+  typebox@1.3.7: {}
+
   typescript@5.9.3: {}
 
   uhyphen@0.2.0: {}
@@ -10528,6 +11508,8 @@ snapshots:
   undici@7.28.0: {}
 
   undici@8.7.0: {}
+
+  undici@8.9.0: {}
 
   unicorn-magic@0.3.0: {}
 
@@ -10626,7 +11608,7 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.32.0
 
-  vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0):
+  vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -10639,6 +11621,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.21.0
+      yaml: 2.9.0
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -10692,10 +11675,10 @@ snapshots:
       - typescript
       - universal-cookie
 
-  vitest@4.1.2(@types/node@25.5.0)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)):
+  vitest@4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0))
+      '@vitest/mocker': 4.1.2(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.2
       '@vitest/runner': 4.1.2
       '@vitest/snapshot': 4.1.2
@@ -10712,9 +11695,10 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)
+      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.0
       '@types/node': 25.5.0
     transitivePeerDependencies:
       - msw
@@ -10728,6 +11712,8 @@ snapshots:
       '@vue/shared': 3.5.39
     optionalDependencies:
       typescript: 5.9.3
+
+  web-streams-polyfill@3.3.3: {}
 
   webpack-virtual-modules@0.6.2: {}
 
@@ -10777,6 +11763,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@4.0.0: {}
+
+  yaml@2.9.0: {}
 
   yocto-spinner@1.2.0:
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,8 @@
       ],
       "@exo/codex/app-server": ["./exoharness/typescript/codex/app-server.ts"],
       "@exo/cursor/sdk": ["./exoharness/typescript/cursor/sdk.ts"],
-      "@exo/cursor/protocol": ["./exoharness/typescript/cursor/protocol.ts"]
+      "@exo/cursor/protocol": ["./exoharness/typescript/cursor/protocol.ts"],
+      "@exo/pi/protocol": ["./exoharness/typescript/pi/protocol.ts"]
     },
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,8 @@
       "@exo/codex/app-server": ["./exoharness/typescript/codex/app-server.ts"],
       "@exo/cursor/sdk": ["./exoharness/typescript/cursor/sdk.ts"],
       "@exo/cursor/protocol": ["./exoharness/typescript/cursor/protocol.ts"],
+      "@exo/pi/history": ["./exoharness/typescript/pi/history.ts"],
+      "@exo/pi/projection": ["./exoharness/typescript/pi/projection.ts"],
       "@exo/pi/protocol": ["./exoharness/typescript/pi/protocol.ts"]
     },
     "resolveJsonModule": true,

--- a/website/docs-src/concepts/executors.md
+++ b/website/docs-src/concepts/executors.md
@@ -1,6 +1,6 @@
 ---
 title: Executors & Harnesses
-description: The built-in executor runtimes, from basic to Codex, Claude Code, and Cursor.
+description: The built-in executor runtimes, from basic to Codex, Claude Code, Cursor, and Pi.
 ---
 
 # Executors & Harnesses
@@ -16,6 +16,7 @@ one with `--harness`:
 | `codex` | Backs OpenAI Codex with durable exoharness sessions |
 | `claude-code` | Backs Claude Code with durable exoharness sessions |
 | `cursor` | Backs the Cursor SDK with durable exoharness sessions |
+| `pi` | Backs Pi with durable exoharness sessions |
 | `<module.ts>` | Any TypeScript module path implementing the harness interface |
 
 ## The executor loop
@@ -50,8 +51,8 @@ This is the main extension point for building your own agent — see the
 
 ## Coding-agent harnesses
 
-The `codex`, `claude-code`, and `cursor` harnesses treat exoharness events
-as the canonical conversation state and run the native agent runtimes
+The `codex`, `claude-code`, `cursor`, and `pi` harnesses treat exoharness
+events as the canonical conversation state and run the native agent runtimes
 inside exoharness-managed sandboxes. The payoff: sessions you can stop,
 resume, fork, and rewind across runs, regardless of which coding agent is
 driving.

--- a/website/docs-src/concepts/exoharness-and-executor.md
+++ b/website/docs-src/concepts/exoharness-and-executor.md
@@ -47,7 +47,7 @@ can:
 - **Fork or rewind** at any past event, without losing secrets, sandboxes,
   or history.
 - **Swap executors** — run the same agent via Codex, Claude Code, the
-  Cursor SDK, or your own executor, without rebuilding state.
+  Cursor SDK, Pi, or your own executor, without rebuilding state.
 - **Evolve safely** — change its own policy processes, tools, and even
   harness code, while the exoharness isolates secrets and compute and keeps
   canonical history out of reach.

--- a/website/docs-src/concepts/index.md
+++ b/website/docs-src/concepts/index.md
@@ -21,9 +21,9 @@ rewritten, which is what makes everything else safe to change.
 
 The layer that decides how the agent thinks and acts: prompt assembly,
 model calls, tool dispatch, memory and compaction. It is **fully editable
-and evolvable** — swappable wholesale (Codex, Claude Code, Cursor SDK, your
-own), and modifiable by the agent itself, because nothing durable lives in
-it.
+and evolvable** — swappable wholesale (Codex, Claude Code, Cursor SDK, Pi,
+your own), and modifiable by the agent itself, because nothing durable lives
+in it.
 
 ## Sandbox — the environment
 

--- a/website/docs-src/tutorials/custom-coding-agent.md
+++ b/website/docs-src/tutorials/custom-coding-agent.md
@@ -264,5 +264,5 @@ command confirmed them.
 - Register more built-in tools, or add custom tools for anything the shell
   can't express directly.
 - Read [Executors & Harnesses](../concepts/executors) to see the
-  built-in `codex` / `claude-code` / `cursor` harnesses, which wrap full
-  coding-agent runtimes with durable exoharness state.
+  built-in `codex` / `claude-code` / `cursor` / `pi` harnesses, which wrap
+  full coding-agent runtimes with durable exoharness state.

--- a/website/docs-src/tutorials/index.md
+++ b/website/docs-src/tutorials/index.md
@@ -18,5 +18,5 @@ Step-by-step guides for building on exo:
   ground-truth state, and a small tool surface, shown end to end with a
   Game Boy emulator playing Pokemon Red.
 
-More coming: coding-agent harnesses (Codex, Claude Code, Cursor) and
+More coming: coding-agent harnesses (Codex, Claude Code, Cursor, Pi) and
 canonical-agent setup.


### PR DESCRIPTION
## Summary

Adds a Pi coding-agent harness using the same Exoharness integration pattern as the existing Codex, Claude Code, and Cursor harnesses.

- adds a `--harness pi` TypeScript preset with a default sandbox image and networking
- runs Pi inside the configured Exoharness sandbox
- treats Exoharness events as canonical history and reconstructs context on each turn
- projects Pi text, tool calls/results, retries, compaction, raw messages, per-call usage/timing, and completion into the standard event and trace paths
- bounds history replay and worker lifetime, scopes JSONL events to turn IDs, and forwards agent output/round limits
- adds the sandbox image, CLI/unit coverage, live harness E2E entry, and matching documentation

## Implementation

The implementation follows the existing coding-agent harness structure rather than introducing a new executor path:

- `pi-harness.ts` uses `traceExecutorTurn`, `tracedUnderParent`, `resolveLlmBinding`, `materializePriorConversationMessages`, `WarmJsonlSandboxWorker`, and `WarmResourceCache`, matching the Cursor harness shape.
- A JSONL SDK worker runs inside the sandbox, so Pi's native read/write/edit/bash tools stay within the Exoharness sandbox boundary.
- Each request uses `SessionManager.inMemory()`, similar to Claude Code's `persistSession: false`: Exoharness remains the only durable conversation history.
- The worker uses an explicit resource loader so it does not implicitly load host or project Pi extensions, skills, prompts, settings, context files, or sessions.
- Model secrets and base URLs come from the existing Exoharness LLM binding path. No binding schema or Exoharness API changes are required.

This is additive and does not change Codex, Claude Code, Cursor, or the underlying Exoharness/executor boundary.

## Initial scope

- Model IDs use Pi's `provider/model` form and Pi's built-in model catalog.
- Provider credentials enter the sandbox because Pi makes model requests there, matching the current coding-agent sandbox pattern. The worker removes the credential from its environment before Pi tools run, so tool subprocesses do not inherit it.
- Pi extensions and skills remain disabled by default; exposing additional resources can be considered separately.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 166 passing
- `pnpm format:check`
- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `pnpm docs:build`
- Pi sandbox image built successfully with Docker
- sandbox worker exercised against a mocked Anthropic SSE endpoint, including tools, warm-worker request isolation, limits, usage/timing, and credential non-inheritance
- full two-turn `exo -> Pi sandbox -> mocked provider` run verified canonical Exoharness history replay

The live E2E entry is available as:

```bash
pnpm e2e:agent-harnesses --only pi --build-images
```

