### PR TITLE
guardian-tools: resolve the deferred restart script from exo/scripts

### DIFF
--- a/exo/tools/guardian-tools.test.ts
+++ b/exo/tools/guardian-tools.test.ts
@@ -1,7 +1,11 @@
+import { accessSync, constants } from "node:fs";
+
 import { HarnessToolRegistry, type TurnContext } from "@exo/harness";
 import { describe, expect, it } from "vitest";
 
 import {
+  DEFERRED_SCRIPT,
+  GUARDIAN_SCRIPT,
   parseRebuildReason,
   rebuildAndRestartExoTool,
   registerGuardianTools,
@@ -35,6 +39,14 @@ describe("guardian tools", () => {
       },
       required: ["reason"],
     });
+  });
+
+  it("resolves host scripts that exist and are executable", () => {
+    // A wrong relative path here is invisible until a self-update is queued:
+    // the spawn fails with ENOENT and the update record stays "queued".
+    for (const script of [GUARDIAN_SCRIPT, DEFERRED_SCRIPT]) {
+      expect(() => accessSync(script, constants.X_OK)).not.toThrow();
+    }
   });
 
   it("parses rebuild reasons for the durable update record", () => {

--- a/exo/tools/guardian-tools.ts
+++ b/exo/tools/guardian-tools.ts
@@ -17,12 +17,14 @@ import type {
   ToolResult,
 } from "@exo/harness";
 
-const GUARDIAN_SCRIPT = new URL(
+// Both scripts live in exo/scripts/, one level up from this file. Exported so
+// tests can assert they are still spawnable from here.
+export const GUARDIAN_SCRIPT = new URL(
   "../scripts/exo-service-guardian",
   import.meta.url,
 ).pathname;
-const DEFERRED_SCRIPT = new URL(
-  "./scripts/deferred-rebuild-and-restart",
+export const DEFERRED_SCRIPT = new URL(
+  "../scripts/deferred-rebuild-and-restart",
   import.meta.url,
 ).pathname;
 const ROOT_DIR = new URL("../..", import.meta.url).pathname;


### PR DESCRIPTION
Fixes #214, reported by @XtendedSystems with the diagnosis and the fix already in the issue. This adds the regression test that would have caught it.

## The bug

`DEFERRED_SCRIPT` resolved `./scripts/deferred-rebuild-and-restart` against `exo/tools/`, giving `exo/tools/scripts/…`. The script is at `exo/scripts/`. `GUARDIAN_SCRIPT`, four lines above, already used `../scripts/`.

The spawn in `runGuardianDeferredWithOutcome` therefore fails with `ENOENT`, the deferred runner never reaches `restart-all --build`, and the durable record written by `queueRebuildAndRestart` stays `status: "queued"` indefinitely — so `list_conversation_events` never sees the rebuild complete.

## The change

One-character path fix, plus a test.

`guardian-tools.test.ts` covered registration, schema, and reason parsing, but nothing asserted that the process being spawned exists — which is why a path typo could sit on `main`. Both script constants are now exported and the test checks each one resolves to a file that exists and is executable:

```ts
it("resolves host scripts that exist and are executable", () => {
  for (const script of [GUARDIAN_SCRIPT, DEFERRED_SCRIPT]) {
    expect(() => accessSync(script, constants.X_OK)).not.toThrow();
  }
});
```

Reverting the path change alone fails it with exactly the error from the issue:

```
Error: ENOENT: no such file or directory, access
  '…/exo/exo/tools/scripts/deferred-rebuild-and-restart'
```

The executable check is deliberate too — a lost `+x` bit fails the spawn the same silent way a wrong path does.

## Verification

`pnpm check` clean locally: 0 lint warnings, typecheck passes, 147 tests across 14 files. `pnpm format:check` clean.

## One thing I left alone

All four path constants here use `new URL(…).pathname`, which percent-encodes — a checkout under a path with a space would give the spawn a `%20` and fail in a similarly quiet way. `vitest.config.ts` already uses `fileURLToPath` for this. It's a separate concern from #214 and I didn't want to widen the diff; happy to send it as its own PR if you'd like it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
