### PR TITLE
cli: accept --provider on conversation create/update

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -824,7 +824,7 @@ struct ProviderConfigureArgs {
 struct ConversationSandboxRuntimeArgs {
     #[arg(long)]
     sandbox_image: Option<String>,
-    #[arg(long, value_enum)]
+    #[arg(long = "provider", value_enum)]
     sandbox_provider: Option<SandboxProviderArg>,
     #[arg(long)]
     shell_program: Option<String>,


### PR DESCRIPTION
Fixing bug in setup introduced in PR #216 – that PR had intended to rename sandbox-provider to provider