### PR TITLE
Route Harbor reflection learning by artifact type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ website/dist
 website/.wrangler
 .exo
 .brain
+.local

--- a/eval/harbor/README.md
+++ b/eval/harbor/README.md
@@ -79,6 +79,63 @@ limit or override those defaults:
 ./eval.sh --dataset=terminal-bench --model=gpt-5.5 --n-tasks=10 --n-attempts=2
 ```
 
+OpenRouter is supported with an exact model id. Set `OPENROUTER_API_KEY` and
+pass both flags; do not use `openrouter/free` for controlled comparisons because
+the underlying model can change between requests:
+
+```bash
+./eval.sh --dataset=smoke-test --provider=openrouter \
+  --model=z-ai/glm-5.2
+```
+
+The learning-router prototype defaults to `router`. Run the memory-first PR
+#202 prompt as a baseline with the same fixed model and task selection:
+
+```bash
+./eval.sh --dataset=terminal-bench-easy --model=gpt-5.5 \
+  --reflection-strategy=memory
+./eval.sh --dataset=terminal-bench-easy --model=gpt-5.5 \
+  --reflection-strategy=router
+```
+
+For a paired comparison, `compare.sh` snapshots the current source into two
+identical isolated workspaces, gives each arm a fresh Exo root, runs the same
+task sequence with one exact model id, and writes `comparison.json` containing
+router-minus-memory reward and reuse deltas:
+
+```bash
+./compare.sh --dataset=learning-router-transfer-test \
+  --provider=openrouter \
+  --model=z-ai/glm-5.2:free
+```
+
+Do not pass `openrouter/free`: that router can select a different underlying
+model between requests, invalidating the comparison. The isolated workspaces
+are retained under `.local/harbor-comparisons` so agent-created tools or source
+changes can be inspected after the run.
+
+A single paired run is a diagnostic probe, not a stable performance estimate.
+Repeat independent runs with both `--arm-order=memory-first` and
+`--arm-order=router-first`; otherwise provider variance, stochastic tool use,
+or shared rate-limit timing can be mistaken for a router effect.
+
+When running the arms manually instead of through `compare.sh`, use separate
+clean worktrees at the same commit. Separate Exo roots are not sufficient: a
+self-edit or workspace-local tool source from the first arm could contaminate
+the second.
+
+Each run gets a fresh Exo root. After feedback, every completed trial contains
+`agent/learning.json`, which records observable memory, skill, tool, and policy
+mutations made during reflection, plus skill loads and agent-created tool calls
+during task execution. Each route separates attempted, successful, failed, and
+unresolved actions; unresolved means the request had no matching result event.
+The job directory also gets `learning-summary.json`, which aggregates reward,
+routed actions, later skill/tool reuse, and final memory growth without copying
+memory text. `compare.sh` rejects an arm if any trial is missing its reflection
+report, so measurement failures cannot silently appear as zero learning.
+Compare these reports alongside Harbor reward; artifact count alone is not a
+success metric.
+
 Select particular tasks by repeating `--include-task-name`:
 
 ```bash
@@ -96,15 +153,34 @@ For a quick end-to-end check using the bundled tiny task:
 ./eval.sh --dataset=smoke-test --n-tasks=1
 ```
 
-To test self-evolution across trials, run the bundled three-task dataset. Its
+To test self-evolution across trials, run the bundled four-task dataset. Its
 first trial asks Exo to install and use a custom tool; its second trial uses
 the installed tool again from a fresh conversation and container; its third
 trial changes durable agent policy state, rebuilds and restarts Exo, then
-finishes the trial after the adapter reconnects.
+finishes the trial after the adapter reconnects; and its fourth intentionally
+times out to verify that the partial trajectory is still exported.
 
 ```bash
 ./eval.sh --dataset=self-evolution-smoke-test
 ```
+
+That dataset explicitly requests tool installation, so it tests mechanics, not
+the router's judgment. The bundled transfer pair presents the same
+deterministic normalization problem with different data in two fresh
+conversations and never mentions a learning route. Use it to check whether
+reflection independently creates a narrow artifact and whether the second task
+reuses prior learning. The comparison runner verifies that Harbor actually ran
+the learn task before the transfer task; a reversed sequence is invalid rather
+than a transfer test:
+
+```bash
+./eval.sh --dataset=learning-router-transfer-test \
+  --reflection-strategy=router
+```
+
+When `target/debug/exo` is already built from the current checkout, pass
+`--skip-build` to reuse it. This is useful for repeated comparison runs and
+avoids growing Rust build artifacts between experimental arms.
 
 For a short real benchmark run, `terminal-bench-easy` selects three Terminal
 Bench 2 tasks marked easy: `fix-git`, `prove-plus-comm`, and

--- a/eval/harbor/README.md
+++ b/eval/harbor/README.md
@@ -94,7 +94,8 @@ The feedback experiment supports three strategies:
 - `router`: prompt-only routing, where the model can directly write memory,
   install skills or tools, or discard a lesson;
 - `lifecycle`: typed proposals that remain inactive until route-specific
-  promotion succeeds.
+  promotion succeeds, with a feature-based router that can reject a conflicting
+  model route.
 
 Run any strategy with the same fixed model and task selection:
 
@@ -110,10 +111,15 @@ Run any strategy with the same fixed model and task selection:
 For a paired comparison, `compare.sh` snapshots the current source into two
 identical isolated workspaces, gives each arm a fresh Exo root, runs the same
 task sequence with one exact model id, and writes `comparison.json` containing
-candidate-minus-baseline reward, lifecycle, activation, and reuse deltas. Reward
-and activation are also broken out per task so transfer and false activation
-cannot be hidden by the overall mean. It defaults to prompt-only `router` as the
-baseline and `lifecycle` as the candidate:
+candidate-minus-baseline reward, lifecycle, activation, reuse, and labeled-router
+deltas. Reward and activation are also broken out per task so transfer and false
+activation cannot be hidden by the overall mean. On
+`learning-router-transfer-test` it also scores gold labels: correct keep-route
+on the learn task, activation plus reuse on transfer, and no activation on the
+unrelated control. A better router must improve route accuracy, reduce useless
+artifacts, increase validated reuse, and hold or improve held-out reward. It
+defaults to prompt-only `router` as the baseline and `lifecycle` as the
+candidate:
 
 ```bash
 ./compare.sh --dataset=learning-router-transfer-test \

--- a/eval/harbor/README.md
+++ b/eval/harbor/README.md
@@ -109,6 +109,11 @@ router-minus-memory reward and reuse deltas:
   --model=z-ai/glm-5.2:free
 ```
 
+Run `pnpm install` in the source checkout first. Generated state, including
+`node_modules`, is excluded from each source snapshot; both arms link to the
+checkout's installed dependency tree so their TypeScript harnesses can start
+without duplicating hundreds of megabytes of immutable packages.
+
 Do not pass `openrouter/free`: that router can select a different underlying
 model between requests, invalidating the comparison. The isolated workspaces
 are retained under `.local/harbor-comparisons` so agent-created tools or source

--- a/eval/harbor/README.md
+++ b/eval/harbor/README.md
@@ -88,23 +88,53 @@ the underlying model can change between requests:
   --model=z-ai/glm-5.2
 ```
 
-The learning-router prototype defaults to `router`. Run the memory-first PR
-#202 prompt as a baseline with the same fixed model and task selection:
+The feedback experiment supports three strategies:
+
+- `memory`: the memory-first PR #202 reflection prompt;
+- `router`: prompt-only routing, where the model can directly write memory,
+  install skills or tools, or discard a lesson;
+- `lifecycle`: typed proposals that remain inactive until route-specific
+  promotion succeeds.
+
+Run any strategy with the same fixed model and task selection:
 
 ```bash
 ./eval.sh --dataset=terminal-bench-easy --model=gpt-5.5 \
   --reflection-strategy=memory
 ./eval.sh --dataset=terminal-bench-easy --model=gpt-5.5 \
   --reflection-strategy=router
+./eval.sh --dataset=terminal-bench-easy --model=gpt-5.5 \
+  --reflection-strategy=lifecycle
 ```
 
 For a paired comparison, `compare.sh` snapshots the current source into two
 identical isolated workspaces, gives each arm a fresh Exo root, runs the same
 task sequence with one exact model id, and writes `comparison.json` containing
-router-minus-memory reward and reuse deltas:
+candidate-minus-baseline reward, lifecycle, activation, and reuse deltas. Reward
+and activation are also broken out per task so transfer and false activation
+cannot be hidden by the overall mean. It defaults to prompt-only `router` as the
+baseline and `lifecycle` as the candidate:
 
 ```bash
 ./compare.sh --dataset=learning-router-transfer-test \
+  --provider=openrouter \
+  --model=z-ai/glm-5.2:free
+```
+
+For local multi-task datasets, the runner writes an explicit ordered Harbor
+`tasks` list instead of relying on directory iteration. `--n-concurrent 1`
+prevents overlap but does not by itself choose which queued task runs first;
+filesystem discovery order is not a valid continual-learning sequence. The
+comparison runner also uses one-letter result-arm directories so the trial
+socket stays below macOS's 104-byte Unix-socket path limit.
+
+Override the arms explicitly when testing another hypothesis:
+
+```bash
+./compare.sh --dataset=learning-router-transfer-test \
+  --baseline-strategy=memory \
+  --candidate-strategy=router \
+  --arm-order=candidate-first \
   --provider=openrouter \
   --model=z-ai/glm-5.2:free
 ```
@@ -120,9 +150,9 @@ are retained under `.local/harbor-comparisons` so agent-created tools or source
 changes can be inspected after the run.
 
 A single paired run is a diagnostic probe, not a stable performance estimate.
-Repeat independent runs with both `--arm-order=memory-first` and
-`--arm-order=router-first`; otherwise provider variance, stochastic tool use,
-or shared rate-limit timing can be mistaken for a router effect.
+Repeat independent runs with both `--arm-order=baseline-first` and
+`--arm-order=candidate-first`; otherwise provider variance, stochastic tool
+use, or shared rate-limit timing can be mistaken for a lifecycle effect.
 
 When running the arms manually instead of through `compare.sh`, use separate
 clean worktrees at the same commit. Separate Exo roots are not sufficient: a
@@ -132,14 +162,37 @@ the second.
 Each run gets a fresh Exo root. After feedback, every completed trial contains
 `agent/learning.json`, which records observable memory, skill, tool, and policy
 mutations made during reflection, plus skill loads and agent-created tool calls
-during task execution. Each route separates attempted, successful, failed, and
-unresolved actions; unresolved means the request had no matching result event.
-The job directory also gets `learning-summary.json`, which aggregates reward,
-routed actions, later skill/tool reuse, and final memory growth without copying
+during task execution. For lifecycle runs it also records proposals,
+promotions, rejections, explicit discards, and later scoped activations. Each
+route separates attempted, successful, failed, and unresolved actions;
+unresolved means the request had no matching result event. The job directory
+also gets `learning-summary.json`, which aggregates reward, routed actions,
+later activation and skill/tool reuse, and final memory growth without copying
 memory text. `compare.sh` rejects an arm if any trial is missing its reflection
 report, so measurement failures cannot silently appear as zero learning.
-Compare these reports alongside Harbor reward; artifact count alone is not a
-success metric.
+Compare these reports alongside Harbor reward; proposal, promotion, or artifact
+count alone is not evidence of better self-improvement.
+
+The lifecycle strategy is behaviorally different from a stronger system
+prompt. During reflection, direct memory, skill, tool-management, and restart
+writes are unavailable. The model must emit a route-specific candidate, the
+candidate is quarantined, and the harness promotes or rejects it. A promoted
+candidate is activated only when its declared trigger matches a later task,
+and that activation is emitted as a trajectory event. Matching skills receive
+a scoped loader and matching tools are registered only for that turn; neither
+is published into the global skill/tool surface. A deterministic test
+demonstrates the boundary: prompt-only routing installs a syntactically valid
+but behaviorally broken skill immediately, while lifecycle routing rejects the
+same skill after its sandbox check fails and leaves no installed skill.
+
+Active candidates also require the structured Harbor feedback payload from the
+reflection turn, and the validation record captures its numeric rewards and the
+presence of verifier logs separately from the model's evidence claim. These
+checks still do not make Exo its own trustworthy grader. The agent proposes a
+skill's validation command and a tool's expected self-test result; memory
+promotion does not establish factual truth. Harbor's external reward on later
+tasks remains the outcome measure that can show whether routed learning
+actually transfers.
 
 Select particular tasks by repeating `--include-task-name`:
 
@@ -170,17 +223,18 @@ times out to verify that the partial trajectory is still exported.
 ```
 
 That dataset explicitly requests tool installation, so it tests mechanics, not
-the router's judgment. The bundled transfer pair presents the same
-deterministic normalization problem with different data in two fresh
-conversations and never mentions a learning route. Use it to check whether
-reflection independently creates a narrow artifact and whether the second task
-reuses prior learning. The comparison runner verifies that Harbor actually ran
-the learn task before the transfer task; a reversed sequence is invalid rather
-than a transfer test:
+the router's judgment. The bundled transfer sequence defines a named FLINT
+records contract in the first task and asks for the same contract with different
+data in a fresh second conversation that omits the rules. A third unrelated
+line-counting task is a negative activation control. Use the sequence to check
+whether reflection creates a narrow artifact, whether the second task activates
+and uses it, and whether the third task leaves it inactive. The comparison
+runner verifies the exact learn → transfer → unrelated order; a different
+sequence is invalid rather than a transfer test:
 
 ```bash
 ./eval.sh --dataset=learning-router-transfer-test \
-  --reflection-strategy=router
+  --reflection-strategy=lifecycle
 ```
 
 When `target/debug/exo` is already built from the current checkout, pass

--- a/eval/harbor/compare.py
+++ b/eval/harbor/compare.py
@@ -15,6 +15,16 @@ from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any
 
+SRC = Path(__file__).resolve().parent / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from exo_harbor.router_quality import (
+    better_than_prompt_only,
+    load_gold_labels,
+    score_router_quality,
+)
+
 
 ROUTES = ("memory", "skill", "tool", "policy")
 REUSE_METRICS = (
@@ -36,6 +46,10 @@ EXPECTED_TASK_SEQUENCES = {
         "exo/learning-router-normalization-transfer",
         "exo/learning-router-unrelated-control",
     ],
+}
+GOLD_LABELS = {
+    "learning-router-transfer-test": Path(__file__).resolve().parent
+    / "gold-labels/learning-router-transfer-test.json",
 }
 SNAPSHOT_IGNORES = {
     ".exo",
@@ -259,8 +273,8 @@ def build_comparison(
     baseline_memory_growth = int(baseline.get("memory", {}).get("growth", 0))
     candidate_memory_growth = int(candidate.get("memory", {}).get("growth", 0))
 
-    return {
-        "schema_version": 3,
+    comparison = {
+        "schema_version": 4,
         "provider": provider,
         "model": baseline.get("model"),
         "source_digest": source_digest,
@@ -300,6 +314,30 @@ def build_comparison(
             "prior_task_reuse": reuse_deltas,
         },
     }
+    gold_path = gold_labels_path(expected_task_sequence)
+    if gold_path is not None:
+        gold = load_gold_labels(gold_path)
+        baseline_quality = score_router_quality(baseline, gold)
+        candidate_quality = score_router_quality(candidate, gold)
+        comparison["gold_labels_path"] = str(gold_path)
+        comparison["arms"]["baseline"]["router_quality"] = baseline_quality
+        comparison["arms"]["candidate"]["router_quality"] = candidate_quality
+        comparison["router_proof"] = better_than_prompt_only(
+            baseline=baseline_quality,
+            candidate=candidate_quality,
+        )
+        comparison["candidate_minus_baseline"]["router_quality"] = comparison[
+            "router_proof"
+        ]["candidate_minus_baseline"]
+    return comparison
+
+
+def gold_labels_path(expected_task_sequence: list[str] | None) -> Path | None:
+    if expected_task_sequence == EXPECTED_TASK_SEQUENCES.get(
+        "learning-router-transfer-test"
+    ):
+        return GOLD_LABELS["learning-router-transfer-test"]
+    return None
 
 
 def _validate_arm(

--- a/eval/harbor/compare.py
+++ b/eval/harbor/compare.py
@@ -76,6 +76,18 @@ def copy_source_snapshot(source: Path, destination: Path) -> str:
     return workspace_digest(destination)
 
 
+def link_runtime_dependencies(source: Path, destination: Path) -> None:
+    """Expose installed dependencies without copying them into each arm."""
+    dependencies = source / "node_modules"
+    if not dependencies.is_dir():
+        raise ValueError(
+            f"runtime dependencies not found: {dependencies}; run pnpm install first"
+        )
+    (destination / "node_modules").symlink_to(
+        dependencies.resolve(), target_is_directory=True
+    )
+
+
 def workspace_digest(workspace: Path) -> str:
     digest = hashlib.sha256()
     for path in sorted(workspace.rglob("*")):
@@ -304,6 +316,8 @@ def main() -> int:
         shutil.copytree(memory_workspace, router_workspace, symlinks=True)
         if workspace_digest(router_workspace) != source_digest:
             raise ValueError("isolated workspaces differ before evaluation")
+        link_runtime_dependencies(repo, memory_workspace)
+        link_runtime_dependencies(repo, router_workspace)
 
         short_id = dt.datetime.now(dt.UTC).strftime("%H%M%S") + f"-{os.getpid()}"
         short_runs = repo / ".local/hr" / short_id

--- a/eval/harbor/compare.py
+++ b/eval/harbor/compare.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Run contamination-safe memory-vs-router Harbor evaluation arms."""
+"""Run two contamination-safe Harbor reflection strategies as matched arms."""
 
 from __future__ import annotations
 
@@ -11,6 +11,7 @@ import os
 import shutil
 import subprocess
 import sys
+from fnmatch import fnmatch
 from pathlib import Path
 from typing import Any
 
@@ -19,11 +20,21 @@ ROUTES = ("memory", "skill", "tool", "policy")
 REUSE_METRICS = (
     "prior_skill_reuse_count",
     "prior_agent_tool_reuse_count",
+    "learning_activation_count",
 )
+LIFECYCLE_METRICS = (
+    "proposal_count",
+    "promotion_count",
+    "rejection_count",
+    "discard_count",
+    "unresolved_count",
+)
+REFLECTION_STRATEGIES = ("memory", "router", "lifecycle")
 EXPECTED_TASK_SEQUENCES = {
     "learning-router-transfer-test": [
         "exo/learning-router-normalization-first",
         "exo/learning-router-normalization-transfer",
+        "exo/learning-router-unrelated-control",
     ],
 }
 SNAPSHOT_IGNORES = {
@@ -39,11 +50,16 @@ SNAPSHOT_IGNORES = {
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Run identical Harbor tasks with PR #202 memory reflection and the learning router.",
+        description=(
+            "Run identical Harbor tasks with two reflection strategies from "
+            "fresh Exo states."
+        ),
     )
     parser.add_argument("--dataset", default="learning-router-transfer-test")
     parser.add_argument("--dataset-path", type=Path)
-    parser.add_argument("--provider", choices=("openai", "openrouter"), default="openai")
+    parser.add_argument(
+        "--provider", choices=("openai", "openrouter"), default="openai"
+    )
     parser.add_argument("--model", default="gpt-5.5")
     parser.add_argument("--n-tasks", type=int)
     parser.add_argument("--n-attempts", type=int, default=1)
@@ -54,9 +70,19 @@ def parse_args() -> argparse.Namespace:
         default=[],
     )
     parser.add_argument(
+        "--baseline-strategy",
+        choices=REFLECTION_STRATEGIES,
+        default="router",
+    )
+    parser.add_argument(
+        "--candidate-strategy",
+        choices=REFLECTION_STRATEGIES,
+        default="lifecycle",
+    )
+    parser.add_argument(
         "--arm-order",
-        choices=("memory-first", "router-first"),
-        default="memory-first",
+        choices=("baseline-first", "candidate-first"),
+        default="baseline-first",
     )
     parser.add_argument(
         "--exo-bin",
@@ -107,88 +133,169 @@ def workspace_digest(workspace: Path) -> str:
     return digest.hexdigest()
 
 
+def expected_task_sequence(args: argparse.Namespace) -> list[str] | None:
+    sequence = EXPECTED_TASK_SEQUENCES.get(args.dataset)
+    if sequence is None:
+        return None
+    selected = list(sequence)
+    if args.include_task_names:
+        selected = [
+            task
+            for task in selected
+            if any(fnmatch(task, pattern) for pattern in args.include_task_names)
+        ]
+    if args.n_tasks is not None:
+        selected = selected[: args.n_tasks]
+    return selected * args.n_attempts
+
+
 def build_comparison(
     *,
-    memory: dict[str, Any],
-    router: dict[str, Any],
-    memory_summary_path: Path,
-    router_summary_path: Path,
+    baseline: dict[str, Any],
+    candidate: dict[str, Any],
+    baseline_strategy: str,
+    candidate_strategy: str,
+    baseline_summary_path: Path,
+    candidate_summary_path: Path,
     provider: str,
     source_digest: str,
     arm_order: list[str],
     expected_task_sequence: list[str] | None = None,
 ) -> dict[str, Any]:
-    """Validate matched arms and return router-minus-memory measurements."""
-    _validate_arm(memory, label="memory", expected_strategy="memory")
-    _validate_arm(router, label="router", expected_strategy="router")
-    if memory.get("model") != router.get("model"):
+    """Validate matched arms and return candidate-minus-baseline measurements."""
+    if baseline_strategy == candidate_strategy:
+        raise ValueError("baseline and candidate strategies must differ")
+    _validate_arm(
+        baseline, label="baseline", expected_strategy=baseline_strategy
+    )
+    _validate_arm(
+        candidate, label="candidate", expected_strategy=candidate_strategy
+    )
+    if baseline.get("model") != candidate.get("model"):
         raise ValueError("comparison arms used different models")
-    if arm_order not in (["memory", "router"], ["router", "memory"]):
-        raise ValueError("arm order must contain memory and router exactly once")
-    memory_tasks = [trial.get("task_name") for trial in memory.get("trials", [])]
-    router_tasks = [trial.get("task_name") for trial in router.get("trials", [])]
-    if memory_tasks != router_tasks:
+    if arm_order not in (
+        ["baseline", "candidate"],
+        ["candidate", "baseline"],
+    ):
+        raise ValueError("arm order must contain baseline and candidate exactly once")
+    baseline_tasks = [
+        trial.get("task_name") for trial in baseline.get("trials", [])
+    ]
+    candidate_tasks = [
+        trial.get("task_name") for trial in candidate.get("trials", [])
+    ]
+    if baseline_tasks != candidate_tasks:
         raise ValueError("comparison arms used different task sequences")
-    if expected_task_sequence is not None and memory_tasks != expected_task_sequence:
+    if (
+        expected_task_sequence is not None
+        and baseline_tasks != expected_task_sequence
+    ):
         raise ValueError(
             "comparison task sequence did not match the expected learning order"
         )
 
     reward_names = sorted(
-        set(memory.get("rewards", {})) | set(router.get("rewards", {}))
+        set(baseline.get("rewards", {})) | set(candidate.get("rewards", {}))
     )
     reward_deltas = {}
     for name in reward_names:
-        memory_reward = memory.get("rewards", {}).get(name, {}).get("mean")
-        router_reward = router.get("rewards", {}).get(name, {}).get("mean")
+        baseline_reward = baseline.get("rewards", {}).get(name, {}).get("mean")
+        candidate_reward = candidate.get("rewards", {}).get(name, {}).get("mean")
         reward_deltas[name] = (
-            router_reward - memory_reward
-            if isinstance(memory_reward, (int, float))
-            and isinstance(router_reward, (int, float))
+            candidate_reward - baseline_reward
+            if isinstance(baseline_reward, (int, float))
+            and isinstance(candidate_reward, (int, float))
             else None
         )
+    baseline_task_rewards = _task_reward_means(baseline)
+    candidate_task_rewards = _task_reward_means(candidate)
+    task_reward_deltas = {
+        task: {
+            name: (
+                candidate_task_rewards.get(task, {}).get(name)
+                - baseline_task_rewards.get(task, {}).get(name)
+                if isinstance(
+                    candidate_task_rewards.get(task, {}).get(name), (int, float)
+                )
+                and isinstance(
+                    baseline_task_rewards.get(task, {}).get(name), (int, float)
+                )
+                else None
+            )
+            for name in sorted(
+                set(baseline_task_rewards.get(task, {}))
+                | set(candidate_task_rewards.get(task, {}))
+            )
+        }
+        for task in sorted(set(baseline_task_rewards) | set(candidate_task_rewards))
+    }
+    baseline_task_activations = _task_activation_counts(baseline)
+    candidate_task_activations = _task_activation_counts(candidate)
+    task_activation_deltas = {
+        task: candidate_task_activations.get(task, 0)
+        - baseline_task_activations.get(task, 0)
+        for task in sorted(
+            set(baseline_task_activations) | set(candidate_task_activations)
+        )
+    }
 
     route_action_deltas = {
         measure: {
-            route: _route_action_count(router, route, measure)
-            - _route_action_count(memory, route, measure)
+            route: _route_action_count(candidate, route, measure)
+            - _route_action_count(baseline, route, measure)
             for route in ROUTES
         }
         for measure in ("succeeded", "failed", "unresolved")
     }
     reuse_deltas = {
-        metric: _reuse_count(router, metric) - _reuse_count(memory, metric)
+        metric: _reuse_count(candidate, metric) - _reuse_count(baseline, metric)
         for metric in REUSE_METRICS
     }
-    memory_growth = int(memory.get("memory", {}).get("growth", 0))
-    router_growth = int(router.get("memory", {}).get("growth", 0))
+    lifecycle_deltas = {
+        metric: _lifecycle_count(candidate, metric)
+        - _lifecycle_count(baseline, metric)
+        for metric in LIFECYCLE_METRICS
+    }
+    baseline_memory_growth = int(baseline.get("memory", {}).get("growth", 0))
+    candidate_memory_growth = int(candidate.get("memory", {}).get("growth", 0))
 
     return {
-        "schema_version": 2,
+        "schema_version": 3,
         "provider": provider,
-        "model": memory.get("model"),
+        "model": baseline.get("model"),
         "source_digest": source_digest,
-        "task_sequence": memory_tasks,
+        "task_sequence": baseline_tasks,
         "arm_order": arm_order,
         "arms": {
-            "memory": {
-                "summary_path": str(memory_summary_path),
-                "rewards": memory.get("rewards", {}),
-                "memory": memory.get("memory", {}),
-                "route_counts": memory.get("route_counts", {}),
-                "task_reuse": memory.get("task_reuse", {}),
+            "baseline": {
+                "strategy": baseline_strategy,
+                "summary_path": str(baseline_summary_path),
+                "rewards": baseline.get("rewards", {}),
+                "task_rewards": baseline_task_rewards,
+                "task_activations": baseline_task_activations,
+                "memory": baseline.get("memory", {}),
+                "lifecycle": baseline.get("lifecycle", {}),
+                "route_counts": baseline.get("route_counts", {}),
+                "task_reuse": baseline.get("task_reuse", {}),
             },
-            "router": {
-                "summary_path": str(router_summary_path),
-                "rewards": router.get("rewards", {}),
-                "memory": router.get("memory", {}),
-                "route_counts": router.get("route_counts", {}),
-                "task_reuse": router.get("task_reuse", {}),
+            "candidate": {
+                "strategy": candidate_strategy,
+                "summary_path": str(candidate_summary_path),
+                "rewards": candidate.get("rewards", {}),
+                "task_rewards": candidate_task_rewards,
+                "task_activations": candidate_task_activations,
+                "memory": candidate.get("memory", {}),
+                "lifecycle": candidate.get("lifecycle", {}),
+                "route_counts": candidate.get("route_counts", {}),
+                "task_reuse": candidate.get("task_reuse", {}),
             },
         },
-        "router_minus_memory": {
+        "candidate_minus_baseline": {
             "reward_mean": reward_deltas,
-            "memory_growth": router_growth - memory_growth,
+            "task_reward_mean": task_reward_deltas,
+            "task_activations": task_activation_deltas,
+            "memory_growth": candidate_memory_growth - baseline_memory_growth,
+            "lifecycle": lifecycle_deltas,
             "route_actions": route_action_deltas,
             "prior_task_reuse": reuse_deltas,
         },
@@ -227,6 +334,43 @@ def _route_action_count(summary: dict[str, Any], route: str, measure: str) -> in
 
 def _reuse_count(summary: dict[str, Any], metric: str) -> int:
     return int(summary.get("task_reuse", {}).get(metric, 0))
+
+
+def _lifecycle_count(summary: dict[str, Any], metric: str) -> int:
+    return int(summary.get("lifecycle", {}).get(metric, 0))
+
+
+def _task_reward_means(summary: dict[str, Any]) -> dict[str, dict[str, float]]:
+    values: dict[str, dict[str, list[float]]] = {}
+    for trial in summary.get("trials", []):
+        task = trial.get("task_name")
+        if not isinstance(task, str):
+            continue
+        for name, value in trial.get("rewards", {}).items():
+            if isinstance(name, str) and isinstance(value, (int, float)):
+                values.setdefault(task, {}).setdefault(name, []).append(float(value))
+    return {
+        task: {
+            name: sum(measurements) / len(measurements)
+            for name, measurements in sorted(rewards.items())
+        }
+        for task, rewards in sorted(values.items())
+    }
+
+
+def _task_activation_counts(summary: dict[str, Any]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for trial in summary.get("trials", []):
+        task = trial.get("task_name")
+        if not isinstance(task, str):
+            continue
+        activated = (
+            trial.get("task_usage", {}).get("learning_artifacts_activated", [])
+        )
+        counts[task] = counts.get(task, 0) + (
+            len(activated) if isinstance(activated, list) else 0
+        )
+    return counts
 
 
 def _run_eval(
@@ -290,10 +434,13 @@ def main() -> int:
         args = parse_args()
         if args.model == "openrouter/free":
             raise ValueError(
-                "openrouter/free is not a fixed model; pass an exact OpenRouter model id"
+                "openrouter/free is not a fixed model; pass an exact "
+                "OpenRouter model id"
             )
         if args.n_attempts <= 0 or (args.n_tasks is not None and args.n_tasks <= 0):
             raise ValueError("n_tasks and n_attempts must be positive")
+        if args.baseline_strategy == args.candidate_strategy:
+            raise ValueError("baseline and candidate strategies must differ")
 
         repo = Path(__file__).resolve().parents[2]
         exo_bin = (
@@ -307,57 +454,70 @@ def main() -> int:
         timestamp = dt.datetime.now(dt.UTC).strftime("%Y%m%dT%H%M%SZ")
         experiment_dir = repo / ".local/harbor-comparisons" / timestamp
         workspaces = experiment_dir / "workspaces"
-        memory_workspace = workspaces / "memory"
-        router_workspace = workspaces / "router"
+        baseline_workspace = workspaces / "baseline"
+        candidate_workspace = workspaces / "candidate"
         experiment_dir.mkdir(parents=True)
 
         print("Creating identical isolated source workspaces...", flush=True)
-        source_digest = copy_source_snapshot(repo, memory_workspace)
-        shutil.copytree(memory_workspace, router_workspace, symlinks=True)
-        if workspace_digest(router_workspace) != source_digest:
+        source_digest = copy_source_snapshot(repo, baseline_workspace)
+        shutil.copytree(baseline_workspace, candidate_workspace, symlinks=True)
+        if workspace_digest(candidate_workspace) != source_digest:
             raise ValueError("isolated workspaces differ before evaluation")
-        link_runtime_dependencies(repo, memory_workspace)
-        link_runtime_dependencies(repo, router_workspace)
+        link_runtime_dependencies(repo, baseline_workspace)
+        link_runtime_dependencies(repo, candidate_workspace)
 
         short_id = dt.datetime.now(dt.UTC).strftime("%H%M%S") + f"-{os.getpid()}"
         short_runs = repo / ".local/hr" / short_id
         order = (
-            ["memory", "router"]
-            if args.arm_order == "memory-first"
-            else ["router", "memory"]
+            ["baseline", "candidate"]
+            if args.arm_order == "baseline-first"
+            else ["candidate", "baseline"]
         )
-        workspace_by_strategy = {
-            "memory": memory_workspace,
-            "router": router_workspace,
+        strategy_by_arm = {
+            "baseline": args.baseline_strategy,
+            "candidate": args.candidate_strategy,
+        }
+        workspace_by_arm = {
+            "baseline": baseline_workspace,
+            "candidate": candidate_workspace,
+        }
+        # Darwin's sockaddr_un path limit is 104 bytes including the NUL.
+        # One-letter arm directories leave enough room for Exo's trial socket.
+        output_root_by_arm = {
+            "baseline": short_runs / "b",
+            "candidate": short_runs / "c",
         }
         summaries: dict[str, Path] = {}
-        for strategy in order:
-            print(f"\n=== {strategy} arm ===", flush=True)
-            summaries[strategy] = _run_eval(
+        for arm in order:
+            strategy = strategy_by_arm[arm]
+            print(f"\n=== {arm} arm ({strategy}) ===", flush=True)
+            summaries[arm] = _run_eval(
                 eval_script=Path(__file__).with_name("eval.py"),
-                workspace=workspace_by_strategy[strategy],
+                workspace=workspace_by_arm[arm],
                 exo_bin=exo_bin,
-                output_root=short_runs / strategy,
-                log_path=experiment_dir / f"{strategy}.log",
+                output_root=output_root_by_arm[arm],
+                log_path=experiment_dir / f"{arm}-{strategy}.log",
                 strategy=strategy,
                 args=args,
             )
 
-        memory_summary = json.loads(summaries["memory"].read_text(encoding="utf-8"))
-        router_summary = json.loads(summaries["router"].read_text(encoding="utf-8"))
+        baseline_summary = json.loads(
+            summaries["baseline"].read_text(encoding="utf-8")
+        )
+        candidate_summary = json.loads(
+            summaries["candidate"].read_text(encoding="utf-8")
+        )
         comparison = build_comparison(
-            memory=memory_summary,
-            router=router_summary,
-            memory_summary_path=summaries["memory"],
-            router_summary_path=summaries["router"],
+            baseline=baseline_summary,
+            candidate=candidate_summary,
+            baseline_strategy=args.baseline_strategy,
+            candidate_strategy=args.candidate_strategy,
+            baseline_summary_path=summaries["baseline"],
+            candidate_summary_path=summaries["candidate"],
             provider=args.provider,
             source_digest=source_digest,
             arm_order=order,
-            expected_task_sequence=(
-                EXPECTED_TASK_SEQUENCES[args.dataset] * args.n_attempts
-                if args.dataset in EXPECTED_TASK_SEQUENCES
-                else None
-            ),
+            expected_task_sequence=expected_task_sequence(args),
         )
         destination = experiment_dir / "comparison.json"
         destination.write_text(
@@ -365,7 +525,11 @@ def main() -> int:
             encoding="utf-8",
         )
         print(f"\nComparison: {destination}")
-        print(json.dumps(comparison["router_minus_memory"], indent=2, sort_keys=True))
+        print(
+            json.dumps(
+                comparison["candidate_minus_baseline"], indent=2, sort_keys=True
+            )
+        )
         return 0
     except (OSError, ValueError, subprocess.CalledProcessError) as error:
         print(f"error: {error}", file=sys.stderr)

--- a/eval/harbor/compare.py
+++ b/eval/harbor/compare.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""Run contamination-safe memory-vs-router Harbor evaluation arms."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROUTES = ("memory", "skill", "tool", "policy")
+REUSE_METRICS = (
+    "prior_skill_reuse_count",
+    "prior_agent_tool_reuse_count",
+)
+EXPECTED_TASK_SEQUENCES = {
+    "learning-router-transfer-test": [
+        "exo/learning-router-normalization-first",
+        "exo/learning-router-normalization-transfer",
+    ],
+}
+SNAPSHOT_IGNORES = {
+    ".exo",
+    ".git",
+    ".local",
+    ".venv",
+    "__pycache__",
+    "node_modules",
+    "target",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run identical Harbor tasks with PR #202 memory reflection and the learning router.",
+    )
+    parser.add_argument("--dataset", default="learning-router-transfer-test")
+    parser.add_argument("--dataset-path", type=Path)
+    parser.add_argument("--provider", choices=("openai", "openrouter"), default="openai")
+    parser.add_argument("--model", default="gpt-5.5")
+    parser.add_argument("--n-tasks", type=int)
+    parser.add_argument("--n-attempts", type=int, default=1)
+    parser.add_argument(
+        "--include-task-name",
+        dest="include_task_names",
+        action="append",
+        default=[],
+    )
+    parser.add_argument(
+        "--arm-order",
+        choices=("memory-first", "router-first"),
+        default="memory-first",
+    )
+    parser.add_argument(
+        "--exo-bin",
+        type=Path,
+        help="prebuilt Exo binary; defaults to target/debug/exo",
+    )
+    return parser.parse_args()
+
+
+def _copy_ignore(_directory: str, names: list[str]) -> set[str]:
+    return set(names) & SNAPSHOT_IGNORES
+
+
+def copy_source_snapshot(source: Path, destination: Path) -> str:
+    """Copy one source snapshot without generated state and return its digest."""
+    shutil.copytree(source, destination, ignore=_copy_ignore, symlinks=True)
+    return workspace_digest(destination)
+
+
+def workspace_digest(workspace: Path) -> str:
+    digest = hashlib.sha256()
+    for path in sorted(workspace.rglob("*")):
+        relative = path.relative_to(workspace).as_posix()
+        if path.is_symlink():
+            digest.update(b"link\0")
+            digest.update(relative.encode())
+            digest.update(b"\0")
+            digest.update(os.readlink(path).encode())
+        elif path.is_file():
+            digest.update(b"file\0")
+            digest.update(relative.encode())
+            digest.update(b"\0")
+            with path.open("rb") as file:
+                for block in iter(lambda: file.read(1024 * 1024), b""):
+                    digest.update(block)
+    return digest.hexdigest()
+
+
+def build_comparison(
+    *,
+    memory: dict[str, Any],
+    router: dict[str, Any],
+    memory_summary_path: Path,
+    router_summary_path: Path,
+    provider: str,
+    source_digest: str,
+    arm_order: list[str],
+    expected_task_sequence: list[str] | None = None,
+) -> dict[str, Any]:
+    """Validate matched arms and return router-minus-memory measurements."""
+    _validate_arm(memory, label="memory", expected_strategy="memory")
+    _validate_arm(router, label="router", expected_strategy="router")
+    if memory.get("model") != router.get("model"):
+        raise ValueError("comparison arms used different models")
+    if arm_order not in (["memory", "router"], ["router", "memory"]):
+        raise ValueError("arm order must contain memory and router exactly once")
+    memory_tasks = [trial.get("task_name") for trial in memory.get("trials", [])]
+    router_tasks = [trial.get("task_name") for trial in router.get("trials", [])]
+    if memory_tasks != router_tasks:
+        raise ValueError("comparison arms used different task sequences")
+    if expected_task_sequence is not None and memory_tasks != expected_task_sequence:
+        raise ValueError(
+            "comparison task sequence did not match the expected learning order"
+        )
+
+    reward_names = sorted(
+        set(memory.get("rewards", {})) | set(router.get("rewards", {}))
+    )
+    reward_deltas = {}
+    for name in reward_names:
+        memory_reward = memory.get("rewards", {}).get(name, {}).get("mean")
+        router_reward = router.get("rewards", {}).get(name, {}).get("mean")
+        reward_deltas[name] = (
+            router_reward - memory_reward
+            if isinstance(memory_reward, (int, float))
+            and isinstance(router_reward, (int, float))
+            else None
+        )
+
+    route_action_deltas = {
+        measure: {
+            route: _route_action_count(router, route, measure)
+            - _route_action_count(memory, route, measure)
+            for route in ROUTES
+        }
+        for measure in ("succeeded", "failed", "unresolved")
+    }
+    reuse_deltas = {
+        metric: _reuse_count(router, metric) - _reuse_count(memory, metric)
+        for metric in REUSE_METRICS
+    }
+    memory_growth = int(memory.get("memory", {}).get("growth", 0))
+    router_growth = int(router.get("memory", {}).get("growth", 0))
+
+    return {
+        "schema_version": 2,
+        "provider": provider,
+        "model": memory.get("model"),
+        "source_digest": source_digest,
+        "task_sequence": memory_tasks,
+        "arm_order": arm_order,
+        "arms": {
+            "memory": {
+                "summary_path": str(memory_summary_path),
+                "rewards": memory.get("rewards", {}),
+                "memory": memory.get("memory", {}),
+                "route_counts": memory.get("route_counts", {}),
+                "task_reuse": memory.get("task_reuse", {}),
+            },
+            "router": {
+                "summary_path": str(router_summary_path),
+                "rewards": router.get("rewards", {}),
+                "memory": router.get("memory", {}),
+                "route_counts": router.get("route_counts", {}),
+                "task_reuse": router.get("task_reuse", {}),
+            },
+        },
+        "router_minus_memory": {
+            "reward_mean": reward_deltas,
+            "memory_growth": router_growth - memory_growth,
+            "route_actions": route_action_deltas,
+            "prior_task_reuse": reuse_deltas,
+        },
+    }
+
+
+def _validate_arm(
+    summary: dict[str, Any], *, label: str, expected_strategy: str
+) -> None:
+    if summary.get("schema_version") != 2:
+        raise ValueError(f"{label} arm has an unsupported learning-summary schema")
+    if summary.get("reflection_strategy") != expected_strategy:
+        raise ValueError(
+            f"{label} arm did not use the {expected_strategy} reflection strategy"
+        )
+    trials = summary.get("trials")
+    trial_count = summary.get("trial_count")
+    report_count = summary.get("reflection_report_count")
+    if (
+        not isinstance(trials, list)
+        or not isinstance(trial_count, int)
+        or trial_count <= 0
+        or len(trials) != trial_count
+    ):
+        raise ValueError(f"{label} arm has inconsistent trial metadata")
+    if not isinstance(report_count, int) or report_count != trial_count:
+        raise ValueError(
+            f"{label} arm has incomplete reflection reports: "
+            f"{report_count!r} of {trial_count}"
+        )
+
+
+def _route_action_count(summary: dict[str, Any], route: str, measure: str) -> int:
+    return int(summary.get("route_counts", {}).get(route, {}).get(measure, 0))
+
+
+def _reuse_count(summary: dict[str, Any], metric: str) -> int:
+    return int(summary.get("task_reuse", {}).get(metric, 0))
+
+
+def _run_eval(
+    *,
+    eval_script: Path,
+    workspace: Path,
+    exo_bin: Path,
+    output_root: Path,
+    log_path: Path,
+    strategy: str,
+    args: argparse.Namespace,
+) -> Path:
+    command = [
+        sys.executable,
+        str(eval_script),
+        f"--dataset={args.dataset}",
+        f"--provider={args.provider}",
+        f"--model={args.model}",
+        f"--n-attempts={args.n_attempts}",
+        f"--reflection-strategy={strategy}",
+        f"--workspace-root={workspace}",
+        f"--exo-bin={exo_bin}",
+        f"--output-root={output_root}",
+        "--skip-build",
+    ]
+    if args.dataset_path is not None:
+        command.append(f"--dataset-path={args.dataset_path.expanduser().resolve()}")
+    if args.n_tasks is not None:
+        command.append(f"--n-tasks={args.n_tasks}")
+    for name in args.include_task_names:
+        command.append(f"--include-task-name={name}")
+
+    output_root.mkdir(parents=True)
+    with log_path.open("w", encoding="utf-8") as log:
+        process = subprocess.Popen(
+            command,
+            cwd=workspace,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        assert process.stdout is not None
+        for line in process.stdout:
+            print(f"[{strategy}] {line}", end="", flush=True)
+            log.write(line)
+            log.flush()
+        return_code = process.wait()
+    if return_code != 0:
+        raise subprocess.CalledProcessError(return_code, command)
+
+    summaries = list(output_root.glob("*/jobs/*/learning-summary.json"))
+    if len(summaries) != 1:
+        raise ValueError(
+            f"expected one {strategy} learning summary, found {len(summaries)}"
+        )
+    return summaries[0].resolve()
+
+
+def main() -> int:
+    try:
+        args = parse_args()
+        if args.model == "openrouter/free":
+            raise ValueError(
+                "openrouter/free is not a fixed model; pass an exact OpenRouter model id"
+            )
+        if args.n_attempts <= 0 or (args.n_tasks is not None and args.n_tasks <= 0):
+            raise ValueError("n_tasks and n_attempts must be positive")
+
+        repo = Path(__file__).resolve().parents[2]
+        exo_bin = (
+            args.exo_bin.expanduser().resolve()
+            if args.exo_bin is not None
+            else repo / "target/debug/exo"
+        )
+        if not exo_bin.is_file():
+            raise ValueError(f"prebuilt Exo binary not found: {exo_bin}")
+
+        timestamp = dt.datetime.now(dt.UTC).strftime("%Y%m%dT%H%M%SZ")
+        experiment_dir = repo / ".local/harbor-comparisons" / timestamp
+        workspaces = experiment_dir / "workspaces"
+        memory_workspace = workspaces / "memory"
+        router_workspace = workspaces / "router"
+        experiment_dir.mkdir(parents=True)
+
+        print("Creating identical isolated source workspaces...", flush=True)
+        source_digest = copy_source_snapshot(repo, memory_workspace)
+        shutil.copytree(memory_workspace, router_workspace, symlinks=True)
+        if workspace_digest(router_workspace) != source_digest:
+            raise ValueError("isolated workspaces differ before evaluation")
+
+        short_id = dt.datetime.now(dt.UTC).strftime("%H%M%S") + f"-{os.getpid()}"
+        short_runs = repo / ".local/hr" / short_id
+        order = (
+            ["memory", "router"]
+            if args.arm_order == "memory-first"
+            else ["router", "memory"]
+        )
+        workspace_by_strategy = {
+            "memory": memory_workspace,
+            "router": router_workspace,
+        }
+        summaries: dict[str, Path] = {}
+        for strategy in order:
+            print(f"\n=== {strategy} arm ===", flush=True)
+            summaries[strategy] = _run_eval(
+                eval_script=Path(__file__).with_name("eval.py"),
+                workspace=workspace_by_strategy[strategy],
+                exo_bin=exo_bin,
+                output_root=short_runs / strategy,
+                log_path=experiment_dir / f"{strategy}.log",
+                strategy=strategy,
+                args=args,
+            )
+
+        memory_summary = json.loads(summaries["memory"].read_text(encoding="utf-8"))
+        router_summary = json.loads(summaries["router"].read_text(encoding="utf-8"))
+        comparison = build_comparison(
+            memory=memory_summary,
+            router=router_summary,
+            memory_summary_path=summaries["memory"],
+            router_summary_path=summaries["router"],
+            provider=args.provider,
+            source_digest=source_digest,
+            arm_order=order,
+            expected_task_sequence=(
+                EXPECTED_TASK_SEQUENCES[args.dataset] * args.n_attempts
+                if args.dataset in EXPECTED_TASK_SEQUENCES
+                else None
+            ),
+        )
+        destination = experiment_dir / "comparison.json"
+        destination.write_text(
+            json.dumps(comparison, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        print(f"\nComparison: {destination}")
+        print(json.dumps(comparison["router_minus_memory"], indent=2, sort_keys=True))
+        return 0
+    except (OSError, ValueError, subprocess.CalledProcessError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 2
+    except KeyboardInterrupt:
+        print("\nComparison stopped.", file=sys.stderr)
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/eval/harbor/compare.sh
+++ b/eval/harbor/compare.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+eval_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+venv="$eval_dir/.venv"
+
+if [[ ! -x "$venv/bin/python" ]]; then
+  python3.12 -m venv "$venv"
+fi
+
+if ! "$venv/bin/python" -c 'import harbor, exo_harbor' 2>/dev/null; then
+  "$venv/bin/pip" install -e "$eval_dir"
+fi
+
+exec "$venv/bin/python" "$eval_dir/compare.py" "$@"

--- a/eval/harbor/datasets/learning-router-transfer-test/01-learn-normalization/environment/Dockerfile
+++ b/eval/harbor/datasets/learning-router-transfer-test/01-learn-normalization/environment/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:24.04
+
+WORKDIR /app
+
+RUN printf ' Alice | 12\nbob|8\nALICE|15\ncarol | 15\nBob | 11\ndave|3\n' > /app/records.txt

--- a/eval/harbor/datasets/learning-router-transfer-test/01-learn-normalization/environment/Dockerfile
+++ b/eval/harbor/datasets/learning-router-transfer-test/01-learn-normalization/environment/Dockerfile
@@ -2,4 +2,5 @@ FROM ubuntu:24.04
 
 WORKDIR /app
 
-RUN printf ' Alice | 12\nbob|8\nALICE|15\ncarol | 15\nBob | 11\ndave|3\n' > /app/records.txt
+RUN mkdir -p /logs/artifacts \
+    && printf ' Alice | 12\nbob|8\nALICE|15\ncarol | 15\nBob | 11\ndave|3\n' > /app/records.txt

--- a/eval/harbor/datasets/learning-router-transfer-test/01-learn-normalization/instruction.md
+++ b/eval/harbor/datasets/learning-router-transfer-test/01-learn-normalization/instruction.md
@@ -1,7 +1,10 @@
-Read `/app/records.txt`. Each non-empty line contains a name and integer score
-separated by `|`, with possible surrounding whitespace.
+This task defines the **FLINT records contract**, a named procedure that is
+expected to recur in later tasks and isolated conversations. Learn the contract
+from this task, then apply it to `/app/records.txt`.
 
-Create `/app/ranked.txt` using these rules:
+Each non-empty input line contains a name and integer score separated by `|`,
+with possible surrounding whitespace. Create `/app/ranked.txt` using the FLINT
+rules:
 
 1. Trim whitespace and lowercase each name.
 2. Keep only the highest score for each name.

--- a/eval/harbor/datasets/learning-router-transfer-test/01-learn-normalization/instruction.md
+++ b/eval/harbor/datasets/learning-router-transfer-test/01-learn-normalization/instruction.md
@@ -1,0 +1,11 @@
+Read `/app/records.txt`. Each non-empty line contains a name and integer score
+separated by `|`, with possible surrounding whitespace.
+
+Create `/app/ranked.txt` using these rules:
+
+1. Trim whitespace and lowercase each name.
+2. Keep only the highest score for each name.
+3. Sort by score from highest to lowest, then by name alphabetically for ties.
+4. Write one `name=score` entry per line, including a final newline.
+
+Verify the output before completing the task.

--- a/eval/harbor/datasets/learning-router-transfer-test/01-learn-normalization/task.toml
+++ b/eval/harbor/datasets/learning-router-transfer-test/01-learn-normalization/task.toml
@@ -1,0 +1,30 @@
+schema_version = "1.4"
+
+[task]
+name = "exo/learning-router-normalization-first"
+version = "1.0.0"
+authors = []
+keywords = ["learning-router", "transfer", "normalization"]
+
+[metadata]
+difficulty = "easy"
+category = "testing"
+tags = ["learning-router", "transfer"]
+
+[verifier]
+timeout_sec = 30.0
+
+[agent]
+timeout_sec = 180.0
+
+[environment]
+build_timeout_sec = 120.0
+cpus = 1
+memory_mb = 512
+storage_mb = 1024
+gpus = 0
+mcp_servers = []
+
+[verifier.env]
+
+[solution.env]

--- a/eval/harbor/datasets/learning-router-transfer-test/01-learn-normalization/task.toml
+++ b/eval/harbor/datasets/learning-router-transfer-test/01-learn-normalization/task.toml
@@ -2,9 +2,9 @@ schema_version = "1.4"
 
 [task]
 name = "exo/learning-router-normalization-first"
-version = "1.0.0"
+version = "2.0.0"
 authors = []
-keywords = ["learning-router", "transfer", "normalization"]
+keywords = ["learning-router", "transfer", "normalization", "flint"]
 
 [metadata]
 difficulty = "easy"
@@ -15,7 +15,7 @@ tags = ["learning-router", "transfer"]
 timeout_sec = 30.0
 
 [agent]
-timeout_sec = 180.0
+timeout_sec = 360.0
 
 [environment]
 build_timeout_sec = 120.0

--- a/eval/harbor/datasets/learning-router-transfer-test/01-learn-normalization/tests/test.sh
+++ b/eval/harbor/datasets/learning-router-transfer-test/01-learn-normalization/tests/test.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-expected=$'alice=15\ncarol=15\nbob=11\ndave=3'
-if [[ -f /app/ranked.txt ]] && [[ $(cat /app/ranked.txt) == "$expected" ]]; then
+expected=$(mktemp)
+printf 'alice=15\ncarol=15\nbob=11\ndave=3\n' > "$expected"
+if [[ -f /app/ranked.txt ]] && cmp -s "$expected" /app/ranked.txt; then
   echo 1 > /logs/verifier/reward.txt
 else
   echo 0 > /logs/verifier/reward.txt

--- a/eval/harbor/datasets/learning-router-transfer-test/01-learn-normalization/tests/test.sh
+++ b/eval/harbor/datasets/learning-router-transfer-test/01-learn-normalization/tests/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+expected=$'alice=15\ncarol=15\nbob=11\ndave=3'
+if [[ -f /app/ranked.txt ]] && [[ $(cat /app/ranked.txt) == "$expected" ]]; then
+  echo 1 > /logs/verifier/reward.txt
+else
+  echo 0 > /logs/verifier/reward.txt
+fi

--- a/eval/harbor/datasets/learning-router-transfer-test/02-transfer-normalization/environment/Dockerfile
+++ b/eval/harbor/datasets/learning-router-transfer-test/02-transfer-normalization/environment/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu:24.04
+
+WORKDIR /app
+
+RUN printf 'Eve | 4\nfrank | 20\nEVE|22\ngrace|20\nFrank|7\nheidi | 20\n' > /app/records.txt

--- a/eval/harbor/datasets/learning-router-transfer-test/02-transfer-normalization/environment/Dockerfile
+++ b/eval/harbor/datasets/learning-router-transfer-test/02-transfer-normalization/environment/Dockerfile
@@ -2,4 +2,5 @@ FROM ubuntu:24.04
 
 WORKDIR /app
 
-RUN printf 'Eve | 4\nfrank | 20\nEVE|22\ngrace|20\nFrank|7\nheidi | 20\n' > /app/records.txt
+RUN mkdir -p /logs/artifacts \
+    && printf 'Eve | 4\nfrank | 20\nEVE|22\ngrace|20\nFrank|7\nheidi | 20\n' > /app/records.txt

--- a/eval/harbor/datasets/learning-router-transfer-test/02-transfer-normalization/instruction.md
+++ b/eval/harbor/datasets/learning-router-transfer-test/02-transfer-normalization/instruction.md
@@ -1,11 +1,4 @@
-Read `/app/records.txt`. Each non-empty line contains a name and integer score
-separated by `|`, with possible surrounding whitespace.
-
-Create `/app/ranked.txt` using these rules:
-
-1. Trim whitespace and lowercase each name.
-2. Keep only the highest score for each name.
-3. Sort by score from highest to lowest, then by name alphabetically for ties.
-4. Write one `name=score` entry per line, including a final newline.
-
-Verify the output before completing the task.
+Apply the **FLINT records contract from prior work** to `/app/records.txt` and
+write the result to `/app/ranked.txt`. The contract definition is intentionally
+not repeated in this isolated conversation: use durable learning from the
+earlier FLINT task. Verify the output before completing the task.

--- a/eval/harbor/datasets/learning-router-transfer-test/02-transfer-normalization/instruction.md
+++ b/eval/harbor/datasets/learning-router-transfer-test/02-transfer-normalization/instruction.md
@@ -1,0 +1,11 @@
+Read `/app/records.txt`. Each non-empty line contains a name and integer score
+separated by `|`, with possible surrounding whitespace.
+
+Create `/app/ranked.txt` using these rules:
+
+1. Trim whitespace and lowercase each name.
+2. Keep only the highest score for each name.
+3. Sort by score from highest to lowest, then by name alphabetically for ties.
+4. Write one `name=score` entry per line, including a final newline.
+
+Verify the output before completing the task.

--- a/eval/harbor/datasets/learning-router-transfer-test/02-transfer-normalization/task.toml
+++ b/eval/harbor/datasets/learning-router-transfer-test/02-transfer-normalization/task.toml
@@ -1,0 +1,30 @@
+schema_version = "1.4"
+
+[task]
+name = "exo/learning-router-normalization-transfer"
+version = "1.0.0"
+authors = []
+keywords = ["learning-router", "transfer", "normalization"]
+
+[metadata]
+difficulty = "easy"
+category = "testing"
+tags = ["learning-router", "transfer"]
+
+[verifier]
+timeout_sec = 30.0
+
+[agent]
+timeout_sec = 120.0
+
+[environment]
+build_timeout_sec = 120.0
+cpus = 1
+memory_mb = 512
+storage_mb = 1024
+gpus = 0
+mcp_servers = []
+
+[verifier.env]
+
+[solution.env]

--- a/eval/harbor/datasets/learning-router-transfer-test/02-transfer-normalization/tests/test.sh
+++ b/eval/harbor/datasets/learning-router-transfer-test/02-transfer-normalization/tests/test.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+expected=$'eve=22\nfrank=20\ngrace=20\nheidi=20'
+if [[ -f /app/ranked.txt ]] && [[ $(cat /app/ranked.txt) == "$expected" ]]; then
+  echo 1 > /logs/verifier/reward.txt
+else
+  echo 0 > /logs/verifier/reward.txt
+fi

--- a/eval/harbor/datasets/learning-router-transfer-test/02-transfer-normalization/tests/test.sh
+++ b/eval/harbor/datasets/learning-router-transfer-test/02-transfer-normalization/tests/test.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-expected=$'eve=22\nfrank=20\ngrace=20\nheidi=20'
-if [[ -f /app/ranked.txt ]] && [[ $(cat /app/ranked.txt) == "$expected" ]]; then
+expected=$(mktemp)
+printf 'eve=22\nfrank=20\ngrace=20\nheidi=20\n' > "$expected"
+if [[ -f /app/ranked.txt ]] && cmp -s "$expected" /app/ranked.txt; then
   echo 1 > /logs/verifier/reward.txt
 else
   echo 0 > /logs/verifier/reward.txt

--- a/eval/harbor/datasets/learning-router-transfer-test/03-unrelated-control/environment/Dockerfile
+++ b/eval/harbor/datasets/learning-router-transfer-test/03-unrelated-control/environment/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:24.04
+
+WORKDIR /app
+
+RUN mkdir -p /logs/artifacts \
+    && printf 'amber\nblue\n\ncoral\nindigo\n' > /app/palette.txt

--- a/eval/harbor/datasets/learning-router-transfer-test/03-unrelated-control/instruction.md
+++ b/eval/harbor/datasets/learning-router-transfer-test/03-unrelated-control/instruction.md
@@ -1,0 +1,3 @@
+Count the non-empty lines in `/app/palette.txt`. Write only the decimal count,
+followed by a final newline, to `/app/count.txt`. Verify the output before
+completing the task.

--- a/eval/harbor/datasets/learning-router-transfer-test/03-unrelated-control/task.toml
+++ b/eval/harbor/datasets/learning-router-transfer-test/03-unrelated-control/task.toml
@@ -1,21 +1,21 @@
 schema_version = "1.4"
 
 [task]
-name = "exo/learning-router-normalization-transfer"
-version = "2.0.0"
+name = "exo/learning-router-unrelated-control"
+version = "1.0.0"
 authors = []
-keywords = ["learning-router", "transfer", "normalization", "flint"]
+keywords = ["learning-router", "negative-control"]
 
 [metadata]
 difficulty = "easy"
 category = "testing"
-tags = ["learning-router", "transfer"]
+tags = ["learning-router", "negative-control"]
 
 [verifier]
 timeout_sec = 30.0
 
 [agent]
-timeout_sec = 300.0
+timeout_sec = 240.0
 
 [environment]
 build_timeout_sec = 120.0

--- a/eval/harbor/datasets/learning-router-transfer-test/03-unrelated-control/tests/test.sh
+++ b/eval/harbor/datasets/learning-router-transfer-test/03-unrelated-control/tests/test.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+expected=$(mktemp)
+printf '4\n' > "$expected"
+if [[ -f /app/count.txt ]] && cmp -s "$expected" /app/count.txt; then
+  echo 1 > /logs/verifier/reward.txt
+else
+  echo 0 > /logs/verifier/reward.txt
+fi

--- a/eval/harbor/eval.example.toml
+++ b/eval/harbor/eval.example.toml
@@ -2,11 +2,10 @@
 dataset = "terminal-bench"
 # For a shorter run of three easy tasks, use "terminal-bench-easy".
 model = "gpt-5.5"
+provider = "openai"
 n_tasks = 10
 n_attempts = 1
-
-# "shared" measures learning across tasks. "per_task" isolates task context
-# while retaining agent-level state such as tools, memory, and source changes.
+reflection_strategy = "router"
 
 # Endless Terminals is currently a local dataset rather than a Harbor registry
 # entry. To run it, replace dataset above and set its local path.

--- a/eval/harbor/eval.py
+++ b/eval/harbor/eval.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import json
 import os
 import re
 import shlex
@@ -12,6 +13,7 @@ import shutil
 import subprocess
 import sys
 import tomllib
+from fnmatch import fnmatch
 from pathlib import Path
 
 
@@ -119,8 +121,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--reflection-strategy",
-        choices=("memory", "router"),
-        help="memory-first baseline or typed learning router",
+        choices=("memory", "router", "lifecycle"),
+        help="memory baseline, prompt-only router, or validated learning lifecycle",
     )
     parser.add_argument(
         "--dry-run",
@@ -173,6 +175,69 @@ def dataset_arguments(args: argparse.Namespace) -> list[str]:
     return arguments
 
 
+def ordered_local_task_paths(args: argparse.Namespace) -> list[Path] | None:
+    """Resolve local dataset tasks in an explicit continual-learning order."""
+    if args.dataset_path is not None:
+        dataset_path = Path(args.dataset_path).expanduser().resolve()
+    elif local_dataset := LOCAL_DATASETS.get(args.dataset):
+        dataset_path = (Path(__file__).resolve().parent / local_dataset).resolve()
+    else:
+        return None
+
+    # A direct task path does not need an ordered JobConfig.
+    if (dataset_path / "task.toml").is_file():
+        return None
+
+    tasks = sorted(
+        path.resolve()
+        for path in dataset_path.iterdir()
+        if path.is_dir() and (path / "task.toml").is_file()
+    )
+    if args.include_task_names:
+        tasks = [
+            path
+            for path in tasks
+            if any(
+                fnmatch(_local_task_name(path), pattern)
+                for pattern in args.include_task_names
+            )
+        ]
+    if args.n_tasks is not None:
+        tasks = tasks[: args.n_tasks]
+    if not tasks:
+        raise ValueError(f"local dataset has no selected tasks: {dataset_path}")
+    return tasks
+
+
+def _local_task_name(task_path: Path) -> str:
+    with (task_path / "task.toml").open("rb") as file:
+        task = tomllib.load(file).get("task", {})
+    name = task.get("name")
+    if not isinstance(name, str) or not name:
+        raise ValueError(f"local task has no task.name: {task_path}")
+    return name
+
+
+def write_ordered_task_config(
+    args: argparse.Namespace, run_dir: Path
+) -> Path | None:
+    """Write Harbor's ordered `tasks` list for a local multi-task dataset."""
+    tasks = ordered_local_task_paths(args)
+    if tasks is None:
+        return None
+    destination = run_dir / "ordered-tasks.json"
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(
+        json.dumps(
+            {"tasks": [{"path": str(task)} for task in tasks]},
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return destination
+
+
 def slug(value: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-") or "eval"
 
@@ -185,8 +250,18 @@ def harbor_command(
     exo: Path,
     run_dir: Path,
     job_name: str,
+    ordered_tasks_config: Path | None = None,
 ) -> list[str]:
-    task_limit = [] if args.n_tasks is None else ["--n-tasks", str(args.n_tasks)]
+    task_limit = (
+        []
+        if args.n_tasks is None or ordered_tasks_config is not None
+        else ["--n-tasks", str(args.n_tasks)]
+    )
+    task_source = (
+        ["--config", str(ordered_tasks_config)]
+        if ordered_tasks_config is not None
+        else dataset_arguments(args)
+    )
     command = [
         str(harbor),
         "run",
@@ -221,7 +296,7 @@ def harbor_command(
         job_name,
         "--yes",
         "--debug",
-        *dataset_arguments(args),
+        *task_source,
     ]
     return command
 
@@ -273,6 +348,7 @@ def main() -> int:
         run_dir = output_root / timestamp
         task_count = args.n_tasks if args.n_tasks is not None else "all"
         job_name = f"{slug(args.dataset)}-{task_count}-{args.reflection_strategy}"
+        ordered_tasks_config = write_ordered_task_config(args, run_dir)
         harbor = Path(sys.executable).with_name("harbor")
         if not harbor.is_file():
             harbor = Path(require_command("harbor"))
@@ -283,6 +359,7 @@ def main() -> int:
             exo=exo,
             run_dir=run_dir,
             job_name=job_name,
+            ordered_tasks_config=ordered_tasks_config,
         )
 
         if args.dry_run:
@@ -306,7 +383,7 @@ def main() -> int:
         ).returncode:
             raise ValueError("Docker is unavailable; run this through ./eval.sh")
 
-        run_dir.mkdir(parents=True)
+        run_dir.mkdir(parents=True, exist_ok=True)
         if args.skip_build:
             if not exo.is_file():
                 raise ValueError(f"--skip-build requires an existing Exo binary: {exo}")

--- a/eval/harbor/eval.py
+++ b/eval/harbor/eval.py
@@ -24,6 +24,7 @@ DATASETS = {
 LOCAL_DATASETS = {
     "smoke-test": "datasets/smoke-test",
     "self-evolution-smoke-test": "datasets/self-evolution-smoke-test",
+    "learning-router-transfer-test": "datasets/learning-router-transfer-test",
 }
 DATASET_TASKS = {
     "terminal-bench-easy": (
@@ -32,6 +33,16 @@ DATASET_TASKS = {
         "cobol-modernization",
     ),
 }
+PROVIDERS = {
+    "openai": {
+        "api_key_env": "OPENAI_API_KEY",
+        "base_url": None,
+    },
+    "openrouter": {
+        "api_key_env": "OPENROUTER_API_KEY",
+        "base_url": "https://openrouter.ai/api/v1",
+    },
+}
 CONFIG_FIELDS = {
     "dataset",
     "dataset_path",
@@ -39,6 +50,12 @@ CONFIG_FIELDS = {
     "n_tasks",
     "n_attempts",
     "include_task_names",
+    "reflection_strategy",
+    "provider",
+    "skip_build",
+    "workspace_root",
+    "exo_bin",
+    "output_root",
 }
 
 
@@ -54,6 +71,12 @@ def parse_args() -> argparse.Namespace:
         "n_tasks": None,
         "n_attempts": 1,
         "include_task_names": [],
+        "reflection_strategy": "router",
+        "provider": "openai",
+        "skip_build": False,
+        "workspace_root": None,
+        "exo_bin": None,
+        "output_root": None,
     }
     if known.config is not None:
         with known.config.open("rb") as file:
@@ -71,7 +94,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--dataset",
         help=(
-            "smoke-test, self-evolution-smoke-test, terminal-bench, "
+            "smoke-test, self-evolution-smoke-test, "
+            "learning-router-transfer-test, terminal-bench, "
             "terminal-bench-easy, terminal-bench-sample, terminal-bench-pro, "
             "or name@version"
         ),
@@ -82,6 +106,7 @@ def parse_args() -> argparse.Namespace:
         help="local dataset directory, for example an Endless Terminals checkout",
     )
     parser.add_argument("--model")
+    parser.add_argument("--provider", choices=tuple(PROVIDERS))
     parser.add_argument("--n-tasks", type=int)
     parser.add_argument(
         "--include-task-name",
@@ -93,9 +118,34 @@ def parse_args() -> argparse.Namespace:
         "--n-attempts", "--number-tries", dest="n_attempts", type=int
     )
     parser.add_argument(
+        "--reflection-strategy",
+        choices=("memory", "router"),
+        help="memory-first baseline or typed learning router",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="print the resolved command without running it",
+    )
+    parser.add_argument(
+        "--skip-build",
+        action="store_true",
+        help="reuse target/debug/exo instead of rebuilding it",
+    )
+    parser.add_argument(
+        "--workspace-root",
+        type=Path,
+        help="isolated Exo source workspace used for agent-local files and self-edits",
+    )
+    parser.add_argument(
+        "--exo-bin",
+        type=Path,
+        help="existing Exo binary to use with --skip-build",
+    )
+    parser.add_argument(
+        "--output-root",
+        type=Path,
+        help="directory under which this run's timestamped result directory is created",
     )
     return parser.parse_args()
 
@@ -162,6 +212,8 @@ def harbor_command(
         f"exo_model={args.model}",
         "--pk",
         "adapter_start_timeout_sec=90",
+        "--pk",
+        f"reflection_strategy={args.reflection_strategy}",
         "--jobs-dir",
         str(run_dir / "jobs"),
         *task_limit,
@@ -185,6 +237,7 @@ def print_result_paths(run_dir: Path, job_name: str) -> None:
     job_dir = run_dir / "jobs" / job_name
     print("\n===Results===")
     print(f"Harbor results: {job_dir / 'result.json'}")
+    print(f"Learning summary: {job_dir / 'learning-summary.json'}")
     print(f"View: harbor view {run_dir / 'jobs'}")
 
 
@@ -194,14 +247,32 @@ def main() -> int:
         if (args.n_tasks is not None and args.n_tasks <= 0) or args.n_attempts <= 0:
             raise ValueError("n_tasks and n_attempts must be positive")
 
-        repo = Path(__file__).resolve().parents[2]
-        exo = repo / "target/debug/exo"
+        source_repo = Path(__file__).resolve().parents[2]
+        repo = (
+            args.workspace_root.expanduser().resolve()
+            if args.workspace_root is not None
+            else source_repo
+        )
+        if not repo.is_dir():
+            raise ValueError(f"workspace root is not a directory: {repo}")
+        exo = (
+            args.exo_bin.expanduser().resolve()
+            if args.exo_bin is not None
+            else repo / "target/debug/exo"
+        )
+        if args.exo_bin is not None and not args.skip_build:
+            raise ValueError("--exo-bin requires --skip-build")
         timestamp = dt.datetime.now(dt.UTC).strftime("%Y%m%dT%H%M%SZ")
         # Keep the Unix socket below Linux's 108-byte path limit. Harbor's job
         # metadata already records the dataset and model.
-        run_dir = repo / ".local/harbor-evals" / timestamp
+        output_root = (
+            args.output_root.expanduser().resolve()
+            if args.output_root is not None
+            else source_repo / ".local/harbor-evals"
+        )
+        run_dir = output_root / timestamp
         task_count = args.n_tasks if args.n_tasks is not None else "all"
-        job_name = f"{slug(args.dataset)}-{task_count}"
+        job_name = f"{slug(args.dataset)}-{task_count}-{args.reflection_strategy}"
         harbor = Path(sys.executable).with_name("harbor")
         if not harbor.is_file():
             harbor = Path(require_command("harbor"))
@@ -219,9 +290,14 @@ def main() -> int:
             return 0
 
         print("\n===Setup===", flush=True)
-        if not os.environ.get("OPENAI_API_KEY"):
-            raise ValueError("OPENAI_API_KEY is not set")
-        for required in ("cargo", "docker", "node", "pnpm"):
+        provider = PROVIDERS[args.provider]
+        api_key_env = provider["api_key_env"]
+        if not os.environ.get(api_key_env):
+            raise ValueError(f"{api_key_env} is not set")
+        required_commands = ["docker", "node", "pnpm"]
+        if not args.skip_build:
+            required_commands.append("cargo")
+        for required in required_commands:
             require_command(required)
         if subprocess.run(
             ["docker", "info"],
@@ -231,7 +307,11 @@ def main() -> int:
             raise ValueError("Docker is unavailable; run this through ./eval.sh")
 
         run_dir.mkdir(parents=True)
-        subprocess.run(["cargo", "build", "-p", "exo"], cwd=repo, check=True)
+        if args.skip_build:
+            if not exo.is_file():
+                raise ValueError(f"--skip-build requires an existing Exo binary: {exo}")
+        else:
+            subprocess.run(["cargo", "build", "-p", "exo"], cwd=repo, check=True)
         subprocess.run(
             [
                 str(exo),
@@ -239,26 +319,29 @@ def main() -> int:
                 str(run_dir / "exo"),
                 "secret",
                 "set",
-                "openai",
+                args.provider,
                 "--env",
-                "OPENAI_API_KEY",
+                api_key_env,
             ],
             cwd=repo,
             check=True,
         )
+        register_command = [
+            str(exo),
+            "--root",
+            str(run_dir / "exo"),
+            "model",
+            "register",
+            args.model,
+            "--secret",
+            args.provider,
+            "--model",
+            args.model,
+        ]
+        if provider["base_url"] is not None:
+            register_command.extend(("--base-url", provider["base_url"]))
         subprocess.run(
-            [
-                str(exo),
-                "--root",
-                str(run_dir / "exo"),
-                "model",
-                "register",
-                args.model,
-                "--secret",
-                "openai",
-                "--model",
-                args.model,
-            ],
+            register_command,
             cwd=repo,
             check=True,
         )

--- a/eval/harbor/evidence/router-proof.json
+++ b/eval/harbor/evidence/router-proof.json
@@ -1,0 +1,153 @@
+{
+  "schemaVersion": 1,
+  "caseCount": 8,
+  "successCriteria": {
+    "higherRouteAccuracy": true,
+    "fewerUselessArtifacts": true,
+    "moreValidatedReuse": true,
+    "equalOrBetterHeldOutReward": true
+  },
+  "proven": true,
+  "promptOnly": {
+    "routeAccuracy": 0.5,
+    "correctRoutes": 4,
+    "uselessArtifacts": 3,
+    "validatedReuse": 0,
+    "falseActivation": 2,
+    "heldOutReward": 0.125,
+    "assignedRoutes": {
+      "flint-named-contract-discarded": "discard",
+      "flint-procedure-dumped-as-memory": "memory",
+      "byte-exact-output-heuristic": "memory",
+      "deterministic-text-transformer": "tool",
+      "line-count-one-off": "memory",
+      "unsupported-opposite-guess": "skill",
+      "broken-well-formed-skill": "skill",
+      "task-specific-discard-accepted": "discard"
+    }
+  },
+  "functional": {
+    "routeAccuracy": 1,
+    "correctRoutes": 8,
+    "uselessArtifacts": 0,
+    "validatedReuse": 4,
+    "falseActivation": 0,
+    "heldOutReward": 1,
+    "assignedRoutes": {
+      "flint-named-contract-discarded": "skill",
+      "flint-procedure-dumped-as-memory": "skill",
+      "byte-exact-output-heuristic": "memory",
+      "deterministic-text-transformer": "tool",
+      "line-count-one-off": "discard",
+      "unsupported-opposite-guess": "discard",
+      "broken-well-formed-skill": "skill",
+      "task-specific-discard-accepted": "discard"
+    }
+  },
+  "cases": [
+    {
+      "id": "flint-named-contract-discarded",
+      "goldRoute": "skill",
+      "modelChoice": "discard",
+      "promptOnlyRoute": "discard",
+      "functionalRoute": "skill",
+      "promptOnlyUseless": false,
+      "functionalUseless": false,
+      "promptOnlyReuse": false,
+      "functionalReuse": true,
+      "promptOnlyReward": 0,
+      "functionalReward": 1
+    },
+    {
+      "id": "flint-procedure-dumped-as-memory",
+      "goldRoute": "skill",
+      "modelChoice": "memory",
+      "promptOnlyRoute": "memory",
+      "functionalRoute": "skill",
+      "promptOnlyUseless": false,
+      "functionalUseless": false,
+      "promptOnlyReuse": false,
+      "functionalReuse": true,
+      "promptOnlyReward": 0,
+      "functionalReward": 1
+    },
+    {
+      "id": "byte-exact-output-heuristic",
+      "goldRoute": "memory",
+      "modelChoice": "memory",
+      "promptOnlyRoute": "memory",
+      "functionalRoute": "memory",
+      "promptOnlyUseless": false,
+      "functionalUseless": false,
+      "promptOnlyReuse": false,
+      "functionalReuse": true,
+      "promptOnlyReward": 0,
+      "functionalReward": 1
+    },
+    {
+      "id": "deterministic-text-transformer",
+      "goldRoute": "tool",
+      "modelChoice": "tool",
+      "promptOnlyRoute": "tool",
+      "functionalRoute": "tool",
+      "promptOnlyUseless": false,
+      "functionalUseless": false,
+      "promptOnlyReuse": false,
+      "functionalReuse": true,
+      "promptOnlyReward": 0,
+      "functionalReward": 1
+    },
+    {
+      "id": "line-count-one-off",
+      "goldRoute": "discard",
+      "modelChoice": "memory",
+      "promptOnlyRoute": "memory",
+      "functionalRoute": "discard",
+      "promptOnlyUseless": true,
+      "functionalUseless": false,
+      "promptOnlyReuse": false,
+      "functionalReuse": false,
+      "promptOnlyReward": 0,
+      "functionalReward": 1
+    },
+    {
+      "id": "unsupported-opposite-guess",
+      "goldRoute": "discard",
+      "modelChoice": "skill",
+      "promptOnlyRoute": "skill",
+      "functionalRoute": "discard",
+      "promptOnlyUseless": true,
+      "functionalUseless": false,
+      "promptOnlyReuse": false,
+      "functionalReuse": false,
+      "promptOnlyReward": 0,
+      "functionalReward": 1
+    },
+    {
+      "id": "broken-well-formed-skill",
+      "goldRoute": "skill",
+      "modelChoice": "skill",
+      "promptOnlyRoute": "skill",
+      "functionalRoute": "skill",
+      "promptOnlyUseless": true,
+      "functionalUseless": false,
+      "promptOnlyReuse": false,
+      "functionalReuse": false,
+      "promptOnlyReward": 0,
+      "functionalReward": 1
+    },
+    {
+      "id": "task-specific-discard-accepted",
+      "goldRoute": "discard",
+      "modelChoice": "discard",
+      "promptOnlyRoute": "discard",
+      "functionalRoute": "discard",
+      "promptOnlyUseless": false,
+      "functionalUseless": false,
+      "promptOnlyReuse": false,
+      "functionalReuse": false,
+      "promptOnlyReward": 1,
+      "functionalReward": 1
+    }
+  ]
+}

--- a/eval/harbor/gold-labels/learning-router-transfer-test.json
+++ b/eval/harbor/gold-labels/learning-router-transfer-test.json
@@ -1,0 +1,30 @@
+{
+  "dataset": "learning-router-transfer-test",
+  "description": "Learn a named reusable FLINT procedure, reuse it on a held-out transfer task, and keep it inactive on an unrelated control.",
+  "tasks": {
+    "exo/learning-router-normalization-first": {
+      "phase": "learn",
+      "expected_keep_routes": ["skill"],
+      "accepted_keep_routes": ["skill", "tool"],
+      "incorrect_routes": ["memory", "discard"],
+      "expected_activation": false,
+      "expected_prior_reuse": false
+    },
+    "exo/learning-router-normalization-transfer": {
+      "phase": "transfer",
+      "expected_keep_routes": [],
+      "accepted_keep_routes": [],
+      "incorrect_routes": [],
+      "expected_activation": true,
+      "expected_prior_reuse": true
+    },
+    "exo/learning-router-unrelated-control": {
+      "phase": "control",
+      "expected_keep_routes": [],
+      "accepted_keep_routes": [],
+      "incorrect_routes": ["memory", "skill", "tool"],
+      "expected_activation": false,
+      "expected_prior_reuse": false
+    }
+  }
+}

--- a/eval/harbor/src/exo_harbor/exo.py
+++ b/eval/harbor/src/exo_harbor/exo.py
@@ -23,6 +23,7 @@ class ExoClient:
     exo_bin: Path
     exo_root: Path
     repo_root: Path
+    sandbox_backend: str = "docker"
 
     async def ensure_agent(self, model: str) -> None:
         """Create the persistent evaluation agent if it does not exist."""
@@ -191,6 +192,8 @@ class ExoClient:
             str(self.exo_root),
             "--harness",
             "exo",
+            "--sandbox-backend",
+            self.sandbox_backend,
             *args,
         ]
 

--- a/eval/harbor/src/exo_harbor/feedback.py
+++ b/eval/harbor/src/exo_harbor/feedback.py
@@ -24,13 +24,15 @@ LIFECYCLE_REFLECTION_INSTRUCTIONS = """EXO_LEARNING_LIFECYCLE_V1
 
 Review your work on this completed trial, its reward, and the grader evidence. This reflection uses a constrained learning lifecycle. Direct memory, skill, tool-management, and self-restart write tools are intentionally unavailable: an unvalidated reflection must not silently change future behavior.
 
+Call `classify_learning_route` before proposing. The harness classifies from checkable features: numbered reusable procedures become skills, exact self-tested operations become tools, short heuristics become scoped memory, and one-off or unsupported guesses are discarded. Proposal tools that conflict with that classification are rejected; do not persist a discard of a named procedure that is expected to recur.
+
 For each evidence-supported lesson, choose exactly one route-specific proposal tool:
 - `propose_memory_learning`: a concise stable fact or heuristic. It will be injected only when its activation trigger matches, rather than on every turn.
 - `propose_skill_learning`: a reusable multi-step procedure. Include a complete SKILL.md and a read-only or idempotent validationCommand that proves the procedure's core behavior in the restored submitted environment.
 - `propose_tool_learning`: a repeated deterministic operation. Include a complete generated-tool module plus exact JSON self-test arguments and expected result. Promotion loads the module from an isolated temporary directory, executes that self-test, and keeps it in the learning catalog only if the result matches; it becomes callable only on later tasks whose activation trigger matches.
 - `propose_learning_discard`: task-specific, redundant, or unsupported information that should never be activated.
 
-The route-specific schemas intentionally omit every other route's fields. Do not write null placeholders or call more than one proposal tool for the same lesson.
+The route-specific schemas intentionally omit every other route's fields. Do not write null placeholders or call more than one proposal tool for the same lesson. If a proposal is rejected with `route_conflict`, call the suggested route's proposal tool instead.
 
 Every active candidate needs precise activation terms and a minimumMatches threshold that avoids broad accidental activation. Evidence must point to the reward, verifier output, or something directly inspected in the restored environment. Do not infer a universal rule merely because one attempt failed.
 

--- a/eval/harbor/src/exo_harbor/feedback.py
+++ b/eval/harbor/src/exo_harbor/feedback.py
@@ -7,10 +7,36 @@ from pathlib import Path
 
 from harbor.models.trial.result import TrialResult
 
+MEMORY_REFLECTION_INSTRUCTIONS = """Review your work on this completed trial and the grader feedback. Inspect the restored submitted environment when useful. Determine what went well or wrong and extract general lessons that will help you solve similar tasks in the future. Before completing this reflection, persist every useful generalizable lesson in durable memory so later trial conversations can use it. When warranted, also create or improve reusable tools or change your own policy or implementation. The feedback_complete summary is only a report to the evaluator; it does not persist learning. If there is genuinely nothing worth retaining, say so explicitly in that summary. Focus on improving future behavior; this submission has already been graded."""
 
-REFLECTION_INSTRUCTIONS = """Review your work on this completed trial and the grader feedback. Inspect the restored submitted environment when useful. Determine what went well or wrong and extract general lessons that will help you solve similar tasks in the future. Before completing this reflection, persist every useful generalizable lesson in durable memory so later trial conversations can use it. When warranted, also create or improve reusable tools or change your own policy or implementation. The feedback_complete summary is only a report to the evaluator; it does not persist learning. If there is genuinely nothing worth retaining, say so explicitly in that summary. Focus on improving future behavior; this submission has already been graded."""
+ROUTER_REFLECTION_INSTRUCTIONS = """Review your work on this completed trial and the grader feedback. Inspect the restored submitted environment when useful. Determine what went well or wrong and extract only evidence-supported lessons that will help on future tasks.
+
+Route each useful lesson to the narrowest durable form that fits:
+- Memory: a concise, stable fact or heuristic that is likely to matter across different future tasks. Compare it with the durable memories already in your context. Do not add duplicates; if a new lesson supersedes an old memory, forget the old entry before remembering the replacement.
+- Skill: a reusable multi-step procedure, checklist, or knowledge package.
+- Tool: a deterministic operation that would otherwise require repeated mechanical work.
+- Policy or implementation: a broad behavior or system change that should apply across the agent. Use this route only when you can make and validate an actual durable change with the control surfaces available in this trial. A restart by itself is not a policy improvement.
+- Discard: a task-specific detail, unsupported guess, or lesson that is not likely to be useful again.
+
+Do not put every lesson in durable memory. A poor reward is evidence that the attempted approach may be wrong, not proof that the opposite is universally correct. A good reward should preserve the specific behavior that evidence supports. Persist worthwhile learning through the selected memory, skill, tool, policy, or implementation mechanism before completing this reflection. The feedback_complete summary is only a report to the evaluator; it does not persist learning. If there is genuinely nothing worth retaining, say so explicitly in that summary. Focus on improving future behavior; this submission has already been graded."""
+
+REFLECTION_STRATEGIES = {
+    "memory": MEMORY_REFLECTION_INSTRUCTIONS,
+    "router": ROUTER_REFLECTION_INSTRUCTIONS,
+}
 
 MAX_FEEDBACK_BYTES = 250_000
+
+
+def reflection_instructions(strategy: str) -> str:
+    """Return the reflection prompt for one experimental strategy."""
+    try:
+        return REFLECTION_STRATEGIES[strategy]
+    except KeyError as error:
+        choices = ", ".join(sorted(REFLECTION_STRATEGIES))
+        raise ValueError(
+            f"unknown reflection strategy {strategy!r}; expected one of: {choices}"
+        ) from error
 
 
 def build_feedback(result: TrialResult, verifier_dir: Path) -> str:

--- a/eval/harbor/src/exo_harbor/feedback.py
+++ b/eval/harbor/src/exo_harbor/feedback.py
@@ -20,7 +20,26 @@ Route each useful lesson to the narrowest durable form that fits:
 
 Do not put every lesson in durable memory. A poor reward is evidence that the attempted approach may be wrong, not proof that the opposite is universally correct. A good reward should preserve the specific behavior that evidence supports. Persist worthwhile learning through the selected memory, skill, tool, policy, or implementation mechanism before completing this reflection. The feedback_complete summary is only a report to the evaluator; it does not persist learning. If there is genuinely nothing worth retaining, say so explicitly in that summary. Focus on improving future behavior; this submission has already been graded."""
 
+LIFECYCLE_REFLECTION_INSTRUCTIONS = """EXO_LEARNING_LIFECYCLE_V1
+
+Review your work on this completed trial, its reward, and the grader evidence. This reflection uses a constrained learning lifecycle. Direct memory, skill, tool-management, and self-restart write tools are intentionally unavailable: an unvalidated reflection must not silently change future behavior.
+
+For each evidence-supported lesson, choose exactly one route-specific proposal tool:
+- `propose_memory_learning`: a concise stable fact or heuristic. It will be injected only when its activation trigger matches, rather than on every turn.
+- `propose_skill_learning`: a reusable multi-step procedure. Include a complete SKILL.md and a read-only or idempotent validationCommand that proves the procedure's core behavior in the restored submitted environment.
+- `propose_tool_learning`: a repeated deterministic operation. Include a complete generated-tool module plus exact JSON self-test arguments and expected result. Promotion loads the module from an isolated temporary directory, executes that self-test, and keeps it in the learning catalog only if the result matches; it becomes callable only on later tasks whose activation trigger matches.
+- `propose_learning_discard`: task-specific, redundant, or unsupported information that should never be activated.
+
+The route-specific schemas intentionally omit every other route's fields. Do not write null placeholders or call more than one proposal tool for the same lesson.
+
+Every active candidate needs precise activation terms and a minimumMatches threshold that avoids broad accidental activation. Evidence must point to the reward, verifier output, or something directly inspected in the restored environment. Do not infer a universal rule merely because one attempt failed.
+
+After proposing each candidate, call validate_and_promote_learning with its candidate id. Proposals remain inactive until that call succeeds. Failed validation is evidence: leave the candidate rejected rather than bypassing the lifecycle with another persistence tool. If nothing should be retained, propose and finalize one discard candidate so that decision is observable.
+
+Before completing feedback, ensure every proposal from this reflection is promoted, rejected, or discarded. The feedback_complete summary reports what happened but does not itself persist or activate learning. This submission has already been graded; improve later behavior rather than repairing it."""
+
 REFLECTION_STRATEGIES = {
+    "lifecycle": LIFECYCLE_REFLECTION_INSTRUCTIONS,
     "memory": MEMORY_REFLECTION_INSTRUCTIONS,
     "router": ROUTER_REFLECTION_INSTRUCTIONS,
 }

--- a/eval/harbor/src/exo_harbor/learning.py
+++ b/eval/harbor/src/exo_harbor/learning.py
@@ -12,6 +12,7 @@ from exo_harbor.trajectory import (
     AssistantMessage,
     ConversationEvent,
     ConversationEvents,
+    LearningActivatedData,
     MessagesData,
     ToolCallContent,
     ToolResultData,
@@ -33,6 +34,13 @@ TOOL_ROUTES: dict[str, LearningRoute] = {
     "rebuild_and_restart_exo": "policy",
 }
 
+PROPOSAL_ROUTES = {
+    "propose_memory_learning": "memory",
+    "propose_skill_learning": "skill",
+    "propose_tool_learning": "tool",
+    "propose_learning_discard": "discard",
+}
+
 
 async def export_learning_report(
     client: ExoClient,
@@ -46,7 +54,7 @@ async def export_learning_report(
     page = ConversationEvents.model_validate_json(
         await client.read_conversation_events(
             conversation,
-            types=["messages", "tool_result"],
+            types=["messages", "tool_result", "learning_activated"],
             limit=10_000,
         )
     )
@@ -91,6 +99,11 @@ def build_learning_report(
     task_usage = _task_usage(events[:start_index])
     actions: list[dict[str, Any]] = []
     actions_by_call: dict[str, dict[str, Any]] = {}
+    proposals: list[dict[str, Any]] = []
+    proposals_by_call: dict[str, dict[str, Any]] = {}
+    candidates: dict[str, str] = {}
+    promotions: list[dict[str, Any]] = []
+    promotions_by_call: dict[str, dict[str, Any]] = {}
     for event in events[start_index:]:
         if isinstance(event.data, MessagesData):
             for message in event.data.messages:
@@ -98,6 +111,48 @@ def build_learning_report(
                     continue
                 for content in message.content:
                     if not isinstance(content, ToolCallContent):
+                        continue
+                    if content.tool_name in PROPOSAL_ROUTES:
+                        proposal = {
+                            "tool_call_id": content.tool_call_id,
+                            "route": PROPOSAL_ROUTES[content.tool_name],
+                            "title": _short_string(
+                                content.arguments.value.get("title"), limit=120
+                            ),
+                            "candidate_id": None,
+                            "status": None,
+                            "succeeded": None,
+                        }
+                        proposals.append(proposal)
+                        proposals_by_call[content.tool_call_id] = proposal
+                        continue
+                    if content.tool_name == "validate_and_promote_learning":
+                        candidate_id = _short_string(
+                            content.arguments.value.get("candidateId"), limit=80
+                        )
+                        promotion = {
+                            "tool_call_id": content.tool_call_id,
+                            "candidate_id": candidate_id,
+                            "route": (
+                                candidates.get(candidate_id)
+                                if candidate_id is not None
+                                else None
+                            ),
+                            "status": None,
+                            "succeeded": None,
+                        }
+                        promotions.append(promotion)
+                        promotions_by_call[content.tool_call_id] = promotion
+                        if promotion["route"] in LEARNING_ROUTES:
+                            action = {
+                                "route": promotion["route"],
+                                "tool": content.tool_name,
+                                "tool_call_id": content.tool_call_id,
+                                "detail": candidate_id,
+                                "succeeded": None,
+                            }
+                            actions.append(action)
+                            actions_by_call[content.tool_call_id] = action
                         continue
                     route = TOOL_ROUTES.get(content.tool_name)
                     if route is None:
@@ -117,10 +172,50 @@ def build_learning_report(
 
         if not isinstance(event.data, ToolResultData):
             continue
+        result = event.data.result
+        proposal = proposals_by_call.get(event.data.tool_call_id)
+        if proposal is not None:
+            value = result.value if isinstance(result.value, dict) else {}
+            candidate_id = _short_string(value.get("candidateId"), limit=80)
+            route = value.get("route")
+            status = value.get("status")
+            proposal["candidate_id"] = candidate_id
+            proposal["status"] = status if isinstance(status, str) else None
+            proposal["succeeded"] = _result_succeeded(result.ok, result.value)
+            if (
+                candidate_id is not None
+                and isinstance(route, str)
+                and route in {"memory", "skill", "tool", "discard"}
+            ):
+                candidates[candidate_id] = route
+            continue
+        promotion = promotions_by_call.get(event.data.tool_call_id)
+        if promotion is not None:
+            value = result.value if isinstance(result.value, dict) else {}
+            route = value.get("route")
+            status = value.get("status")
+            if isinstance(route, str):
+                promotion["route"] = route
+            promotion["status"] = status if isinstance(status, str) else None
+            promotion["succeeded"] = _result_succeeded(result.ok, result.value)
+            action = actions_by_call.get(event.data.tool_call_id)
+            if action is None and promotion["route"] in LEARNING_ROUTES:
+                action = {
+                    "route": promotion["route"],
+                    "tool": "validate_and_promote_learning",
+                    "tool_call_id": event.data.tool_call_id,
+                    "detail": promotion["candidate_id"],
+                    "succeeded": None,
+                }
+                actions.append(action)
+                actions_by_call[event.data.tool_call_id] = action
+            if action is not None:
+                action["route"] = promotion["route"]
+                action["succeeded"] = promotion["status"] == "promoted"
+            continue
         action = actions_by_call.get(event.data.tool_call_id)
         if action is None:
             continue
-        result = event.data.result
         action["succeeded"] = _result_succeeded(result.ok, result.value)
 
     route_counts = {
@@ -141,6 +236,24 @@ def build_learning_report(
         }
         for route in LEARNING_ROUTES
     }
+    terminal_candidate_ids = {
+        promotion["candidate_id"]
+        for promotion in promotions
+        if promotion["candidate_id"] is not None
+        and promotion["status"] in {"promoted", "rejected", "discarded"}
+    }
+    unresolved_proposals = sum(
+        proposal["succeeded"] is None
+        or (
+            proposal["succeeded"] is True
+            and proposal["status"] == "proposed"
+            and proposal["candidate_id"] not in terminal_candidate_ids
+        )
+        for proposal in proposals
+    )
+    unresolved_promotions = sum(
+        promotion["status"] is None for promotion in promotions
+    )
     return {
         "schema_version": 2,
         "trial_id": trial_id,
@@ -148,6 +261,21 @@ def build_learning_report(
         "reflection_strategy": strategy,
         "reflection_summary": reflection_summary,
         "task_usage": task_usage,
+        "lifecycle": {
+            "proposal_count": len(proposals),
+            "promotion_count": sum(
+                proposal.get("status") == "promoted" for proposal in promotions
+            ),
+            "rejection_count": sum(
+                proposal.get("status") == "rejected" for proposal in promotions
+            ),
+            "discard_count": sum(
+                proposal.get("status") == "discarded" for proposal in promotions
+            ),
+            "unresolved_count": unresolved_proposals + unresolved_promotions,
+            "proposals": proposals,
+            "promotions": promotions,
+        },
         "route_counts": route_counts,
         "actions": actions,
     }
@@ -160,9 +288,20 @@ def _task_usage(events: list[ConversationEvent]) -> dict[str, list[dict[str, str
     reused_skills: list[dict[str, str]] = []
     agent_tools: list[dict[str, str]] = []
     reused_agent_tools: list[dict[str, str]] = []
+    activated_learning: list[dict[str, str]] = []
     skills_installed_during_task: set[str] = set()
     tools_installed_during_task: set[str] = set()
     for event in events:
+        if isinstance(event.data, LearningActivatedData):
+            activated_learning.extend(
+                {
+                    "id": artifact.id,
+                    "route": artifact.route,
+                    "title": artifact.title,
+                }
+                for artifact in event.data.artifacts
+            )
+            continue
         if isinstance(event.data, MessagesData):
             for message in event.data.messages:
                 if not isinstance(message, AssistantMessage):
@@ -214,6 +353,23 @@ def _task_usage(events: list[ConversationEvent]) -> dict[str, list[dict[str, str
                 skills.append(use)
                 if skill not in skills_installed_during_task:
                     reused_skills.append(use)
+        if requested_name == "use_learning_skill" and isinstance(
+            result.value, dict
+        ):
+            skill = _short_string(result.value.get("name"))
+            candidate_id = _short_string(result.value.get("candidateId"))
+            if skill is not None:
+                use = {
+                    "name": skill,
+                    "tool_call_id": event.data.tool_call_id,
+                    **(
+                        {"candidate_id": candidate_id}
+                        if candidate_id is not None
+                        else {}
+                    ),
+                }
+                skills.append(use)
+                reused_skills.append(use)
         if result.source == "agent":
             use = {
                 "name": result.tool_name,
@@ -227,6 +383,7 @@ def _task_usage(events: list[ConversationEvent]) -> dict[str, list[dict[str, str
         "skills_reused_from_prior_tasks": reused_skills,
         "agent_tools_called": agent_tools,
         "agent_tools_reused_from_prior_tasks": reused_agent_tools,
+        "learning_artifacts_activated": activated_learning,
     }
 
 
@@ -363,6 +520,26 @@ def build_job_learning_summary(
         .get("task_usage", {})
         .get("agent_tools_reused_from_prior_tasks", [])
     ]
+    learning_activated = [
+        artifact
+        for entry in reports
+        for artifact in entry["report"]
+        .get("task_usage", {})
+        .get("learning_artifacts_activated", [])
+    ]
+    lifecycle = {
+        measure: sum(
+            int(entry["report"].get("lifecycle", {}).get(measure, 0))
+            for entry in reports
+        )
+        for measure in (
+            "proposal_count",
+            "promotion_count",
+            "rejection_count",
+            "discard_count",
+            "unresolved_count",
+        )
+    }
     reward_values: dict[str, list[float]] = {}
     for entry in reports:
         for name, value in entry["rewards"].items():
@@ -381,6 +558,7 @@ def build_job_learning_summary(
         "trial_count": len(reports),
         "reflection_report_count": sum(bool(entry["report"]) for entry in reports),
         "rewards": rewards,
+        "lifecycle": lifecycle,
         "memory": {
             "initial_count": 0,
             "final_count": final_memory_count,
@@ -392,6 +570,7 @@ def build_job_learning_summary(
             "agent_tool_call_count": len(agent_tools_called),
             "prior_skill_reuse_count": len(skills_reused),
             "prior_agent_tool_reuse_count": len(agent_tools_reused),
+            "learning_activation_count": len(learning_activated),
             "unique_skills_loaded": sorted(
                 {
                     skill["name"]
@@ -420,6 +599,13 @@ def build_job_learning_summary(
                     if isinstance(tool.get("name"), str)
                 }
             ),
+            "unique_learning_artifacts_activated": sorted(
+                {
+                    artifact["id"]
+                    for artifact in learning_activated
+                    if isinstance(artifact.get("id"), str)
+                }
+            ),
         },
         "trials": [
             {
@@ -429,6 +615,7 @@ def build_job_learning_summary(
                 "trial_id": entry["report"].get("trial_id"),
                 "rewards": entry["rewards"],
                 "route_counts": entry["report"].get("route_counts", {}),
+                "lifecycle": entry["report"].get("lifecycle", {}),
                 "task_usage": entry["report"].get("task_usage", {}),
             }
             for entry in reports

--- a/eval/harbor/src/exo_harbor/learning.py
+++ b/eval/harbor/src/exo_harbor/learning.py
@@ -1,0 +1,461 @@
+"""Measure durable learning actions taken during Harbor reflection."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Literal
+
+from exo_harbor.exo import ExoClient
+from exo_harbor.trajectory import (
+    AssistantMessage,
+    ConversationEvent,
+    ConversationEvents,
+    MessagesData,
+    ToolCallContent,
+    ToolResultData,
+    UserMessage,
+)
+
+LearningRoute = Literal["memory", "skill", "tool", "policy"]
+LEARNING_ROUTES = ("memory", "skill", "tool", "policy")
+MEMORY_ARTIFACT_PATH = "memory/exo-memory.json"
+
+TOOL_ROUTES: dict[str, LearningRoute] = {
+    "remember": "memory",
+    "forget": "memory",
+    "install_skill": "skill",
+    "uninstall_skill": "skill",
+    "install_agent_tool": "tool",
+    "uninstall_agent_tool": "tool",
+    "manage_tool": "tool",
+    "rebuild_and_restart_exo": "policy",
+}
+
+
+async def export_learning_report(
+    client: ExoClient,
+    conversation: str,
+    trial_id: str,
+    strategy: str,
+    reflection_summary: str | None,
+    destination: Path,
+) -> None:
+    """Write observable reflection mutations for one completed trial."""
+    page = ConversationEvents.model_validate_json(
+        await client.read_conversation_events(
+            conversation,
+            types=["messages", "tool_result"],
+            limit=10_000,
+        )
+    )
+    report = build_learning_report(
+        events=page.events,
+        trial_id=trial_id,
+        conversation=conversation,
+        strategy=strategy,
+        reflection_summary=reflection_summary,
+    )
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_suffix(destination.suffix + ".tmp")
+    temporary.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    temporary.replace(destination)
+
+
+def build_learning_report(
+    *,
+    events: list[ConversationEvent],
+    trial_id: str,
+    conversation: str,
+    strategy: str,
+    reflection_summary: str | None,
+) -> dict[str, Any]:
+    """Summarize persistence calls after the trial's feedback marker."""
+    marker = f"Feedback for trial `{trial_id}`"
+    start_index = next(
+        (
+            index
+            for index, event in enumerate(events)
+            if isinstance(event.data, MessagesData)
+            and any(
+                isinstance(message, UserMessage) and marker in message.content
+                for message in event.data.messages
+            )
+        ),
+        None,
+    )
+    if start_index is None:
+        raise ValueError(f"Exo reflection for trial {trial_id} was not found")
+
+    task_usage = _task_usage(events[:start_index])
+    actions: list[dict[str, Any]] = []
+    actions_by_call: dict[str, dict[str, Any]] = {}
+    for event in events[start_index:]:
+        if isinstance(event.data, MessagesData):
+            for message in event.data.messages:
+                if not isinstance(message, AssistantMessage):
+                    continue
+                for content in message.content:
+                    if not isinstance(content, ToolCallContent):
+                        continue
+                    route = TOOL_ROUTES.get(content.tool_name)
+                    if route is None:
+                        continue
+                    action = {
+                        "route": route,
+                        "tool": content.tool_name,
+                        "tool_call_id": content.tool_call_id,
+                        "detail": _action_detail(
+                            content.tool_name, content.arguments.value
+                        ),
+                        "succeeded": None,
+                    }
+                    actions.append(action)
+                    actions_by_call[content.tool_call_id] = action
+            continue
+
+        if not isinstance(event.data, ToolResultData):
+            continue
+        action = actions_by_call.get(event.data.tool_call_id)
+        if action is None:
+            continue
+        result = event.data.result
+        action["succeeded"] = _result_succeeded(result.ok, result.value)
+
+    route_counts = {
+        route: {
+            "attempted": sum(action["route"] == route for action in actions),
+            "succeeded": sum(
+                action["route"] == route and action["succeeded"] is True
+                for action in actions
+            ),
+            "failed": sum(
+                action["route"] == route and action["succeeded"] is False
+                for action in actions
+            ),
+            "unresolved": sum(
+                action["route"] == route and action["succeeded"] is None
+                for action in actions
+            ),
+        }
+        for route in LEARNING_ROUTES
+    }
+    return {
+        "schema_version": 2,
+        "trial_id": trial_id,
+        "conversation_id": conversation,
+        "reflection_strategy": strategy,
+        "reflection_summary": reflection_summary,
+        "task_usage": task_usage,
+        "route_counts": route_counts,
+        "actions": actions,
+    }
+
+
+def _task_usage(events: list[ConversationEvent]) -> dict[str, list[dict[str, str]]]:
+    """Return task use, distinguishing prior learning from same-task creation."""
+    calls: dict[str, tuple[str, dict[str, Any]]] = {}
+    skills: list[dict[str, str]] = []
+    reused_skills: list[dict[str, str]] = []
+    agent_tools: list[dict[str, str]] = []
+    reused_agent_tools: list[dict[str, str]] = []
+    skills_installed_during_task: set[str] = set()
+    tools_installed_during_task: set[str] = set()
+    for event in events:
+        if isinstance(event.data, MessagesData):
+            for message in event.data.messages:
+                if not isinstance(message, AssistantMessage):
+                    continue
+                for content in message.content:
+                    if isinstance(content, ToolCallContent):
+                        calls[content.tool_call_id] = (
+                            content.tool_name,
+                            content.arguments.value,
+                        )
+            continue
+
+        if not isinstance(event.data, ToolResultData):
+            continue
+        result = event.data.result
+        if not _result_succeeded(result.ok, result.value):
+            continue
+        requested_name, arguments = calls.get(
+            event.data.tool_call_id, (result.tool_name, {})
+        )
+        if requested_name == "install_skill":
+            skill = _action_detail(requested_name, arguments)
+            if skill is not None:
+                skills_installed_during_task.add(skill)
+            continue
+        if requested_name == "install_agent_tool" and isinstance(result.value, dict):
+            tool = _short_string(result.value.get("toolName"))
+            if tool is not None:
+                tools_installed_during_task.add(tool)
+            continue
+        if (
+            requested_name == "manage_tool"
+            and arguments.get("action") == "install"
+            and isinstance(result.value, dict)
+        ):
+            installed = result.value.get("installed")
+            tool = (
+                _short_string(installed.get("name"))
+                if isinstance(installed, dict)
+                else None
+            )
+            if tool is not None:
+                tools_installed_during_task.add(tool)
+            continue
+        if requested_name == "use_skill":
+            skill = _short_string(arguments.get("name"))
+            if skill is not None:
+                use = {"name": skill, "tool_call_id": event.data.tool_call_id}
+                skills.append(use)
+                if skill not in skills_installed_during_task:
+                    reused_skills.append(use)
+        if result.source == "agent":
+            use = {
+                "name": result.tool_name,
+                "tool_call_id": event.data.tool_call_id,
+            }
+            agent_tools.append(use)
+            if result.tool_name not in tools_installed_during_task:
+                reused_agent_tools.append(use)
+    return {
+        "skills_loaded": skills,
+        "skills_reused_from_prior_tasks": reused_skills,
+        "agent_tools_called": agent_tools,
+        "agent_tools_reused_from_prior_tasks": reused_agent_tools,
+    }
+
+
+def _action_detail(tool_name: str, arguments: dict[str, Any]) -> str | None:
+    """Return an identifier without copying source code into the report."""
+    if tool_name == "remember":
+        return _short_string(arguments.get("text"))
+    if tool_name == "forget":
+        return _short_string(arguments.get("id"))
+    if tool_name == "install_skill":
+        skill_md = arguments.get("skillMd")
+        if isinstance(skill_md, str):
+            match = re.search(
+                r"""(?m)^name:\s*(?:"([a-z0-9-]+)"|'([a-z0-9-]+)'|([a-z0-9-]+))\s*$""",
+                skill_md,
+            )
+            if match is not None:
+                return next((group for group in match.groups() if group), None)
+            return None
+        return None
+    if tool_name in {"uninstall_skill", "install_agent_tool", "uninstall_agent_tool"}:
+        return _short_string(arguments.get("name"))
+    if tool_name == "manage_tool":
+        action = _short_string(arguments.get("action"))
+        tool_id = _short_string(arguments.get("toolId"))
+        source = arguments.get("source")
+        source_path = (
+            _short_string(source.get("path")) if isinstance(source, dict) else None
+        )
+        target = tool_id or source_path
+        return ":".join(part for part in (action, target) if part) or None
+    if tool_name == "rebuild_and_restart_exo":
+        return _short_string(arguments.get("reason"))
+    return None
+
+
+def _short_string(value: Any, limit: int = 600) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    if not value:
+        return None
+    return value if len(value) <= limit else value[:limit] + "…"
+
+
+def _result_succeeded(ok: bool, value: Any) -> bool:
+    if isinstance(value, dict) and isinstance(value.get("ok"), bool):
+        return ok and value["ok"]
+    return ok
+
+
+def export_job_learning_summary(
+    *,
+    job_dir: Path,
+    exo_root: Path,
+    strategy: str,
+    model: str,
+    trial_metadata: dict[str, dict[str, Any]],
+) -> None:
+    """Aggregate trial learning reports into one comparison-ready job file."""
+    reports_by_trial = {}
+    for path in sorted(job_dir.glob("*/agent/learning.json")):
+        report = json.loads(path.read_text(encoding="utf-8"))
+        reports_by_trial[path.parent.parent.name] = report
+    reports = [
+        {
+            "trial_name": trial_name,
+            "task_name": metadata["task_name"],
+            "report": reports_by_trial.pop(trial_name, {}),
+            "rewards": metadata["rewards"],
+        }
+        for trial_name, metadata in trial_metadata.items()
+    ]
+    reports.extend(
+        {
+            "trial_name": trial_name,
+            "task_name": trial_name,
+            "report": report,
+            "rewards": {},
+        }
+        for trial_name, report in sorted(reports_by_trial.items())
+    )
+    summary = build_job_learning_summary(
+        reports=reports,
+        strategy=strategy,
+        model=model,
+        final_memory_count=read_final_memory_count(exo_root),
+    )
+    destination = job_dir / "learning-summary.json"
+    temporary = destination.with_suffix(destination.suffix + ".tmp")
+    temporary.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+    temporary.replace(destination)
+
+
+def build_job_learning_summary(
+    *,
+    reports: list[dict[str, Any]],
+    strategy: str,
+    model: str,
+    final_memory_count: int,
+) -> dict[str, Any]:
+    """Return aggregate reward, persistence, and reuse measurements."""
+    route_counts = {
+        route: {
+            measure: sum(
+                entry["report"].get("route_counts", {}).get(route, {}).get(measure, 0)
+                for entry in reports
+            )
+            for measure in ("attempted", "succeeded", "failed", "unresolved")
+        }
+        for route in LEARNING_ROUTES
+    }
+    skills_loaded = [
+        skill
+        for entry in reports
+        for skill in entry["report"].get("task_usage", {}).get("skills_loaded", [])
+    ]
+    agent_tools_called = [
+        tool
+        for entry in reports
+        for tool in entry["report"].get("task_usage", {}).get("agent_tools_called", [])
+    ]
+    skills_reused = [
+        skill
+        for entry in reports
+        for skill in entry["report"]
+        .get("task_usage", {})
+        .get("skills_reused_from_prior_tasks", [])
+    ]
+    agent_tools_reused = [
+        tool
+        for entry in reports
+        for tool in entry["report"]
+        .get("task_usage", {})
+        .get("agent_tools_reused_from_prior_tasks", [])
+    ]
+    reward_values: dict[str, list[float]] = {}
+    for entry in reports:
+        for name, value in entry["rewards"].items():
+            reward_values.setdefault(name, []).append(float(value))
+    rewards = {
+        name: {
+            "count": len(values),
+            "mean": sum(values) / len(values),
+        }
+        for name, values in sorted(reward_values.items())
+    }
+    return {
+        "schema_version": 2,
+        "reflection_strategy": strategy,
+        "model": model,
+        "trial_count": len(reports),
+        "reflection_report_count": sum(bool(entry["report"]) for entry in reports),
+        "rewards": rewards,
+        "memory": {
+            "initial_count": 0,
+            "final_count": final_memory_count,
+            "growth": final_memory_count,
+        },
+        "route_counts": route_counts,
+        "task_reuse": {
+            "skill_load_count": len(skills_loaded),
+            "agent_tool_call_count": len(agent_tools_called),
+            "prior_skill_reuse_count": len(skills_reused),
+            "prior_agent_tool_reuse_count": len(agent_tools_reused),
+            "unique_skills_loaded": sorted(
+                {
+                    skill["name"]
+                    for skill in skills_loaded
+                    if isinstance(skill.get("name"), str)
+                }
+            ),
+            "unique_agent_tools_called": sorted(
+                {
+                    tool["name"]
+                    for tool in agent_tools_called
+                    if isinstance(tool.get("name"), str)
+                }
+            ),
+            "unique_prior_skills_reused": sorted(
+                {
+                    skill["name"]
+                    for skill in skills_reused
+                    if isinstance(skill.get("name"), str)
+                }
+            ),
+            "unique_prior_agent_tools_reused": sorted(
+                {
+                    tool["name"]
+                    for tool in agent_tools_reused
+                    if isinstance(tool.get("name"), str)
+                }
+            ),
+        },
+        "trials": [
+            {
+                "trial_name": entry["trial_name"],
+                "task_name": entry.get("task_name", entry["trial_name"]),
+                "reflected": bool(entry["report"]),
+                "trial_id": entry["report"].get("trial_id"),
+                "rewards": entry["rewards"],
+                "route_counts": entry["report"].get("route_counts", {}),
+                "task_usage": entry["report"].get("task_usage", {}),
+            }
+            for entry in reports
+        ],
+    }
+
+
+def read_final_memory_count(exo_root: Path) -> int:
+    """Count entries in the newest durable-memory artifact without copying text."""
+    candidates: list[tuple[str, int, Path]] = []
+    agents_root = exo_root / "exoharness" / "agents"
+    for metadata_path in agents_root.glob("*/artifacts/*/*.json"):
+        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        if metadata.get("path") != MEMORY_ARTIFACT_PATH:
+            continue
+        created_at = metadata.get("created_at")
+        if not isinstance(created_at, str):
+            raise TypeError(f"memory artifact has no created_at: {metadata_path}")
+        version = metadata.get("version")
+        if not isinstance(version, int):
+            raise TypeError(f"memory artifact has no version: {metadata_path}")
+        candidates.append((created_at, version, metadata_path.with_suffix(".bin")))
+    if not candidates:
+        return 0
+    _, _, memory_path = max(candidates)
+    payload = json.loads(memory_path.read_text(encoding="utf-8"))
+    entries = payload.get("entries")
+    if not isinstance(entries, list):
+        raise TypeError(f"memory artifact has no entries list: {memory_path}")
+    return len(entries)

--- a/eval/harbor/src/exo_harbor/plugin.py
+++ b/eval/harbor/src/exo_harbor/plugin.py
@@ -28,7 +28,8 @@ from harbor.trial.hooks import TrialHookEvent
 
 from exo_harbor import conventions
 from exo_harbor.exo import ExoClient
-from exo_harbor.feedback import REFLECTION_INSTRUCTIONS, build_feedback
+from exo_harbor.feedback import build_feedback, reflection_instructions
+from exo_harbor.learning import export_job_learning_summary, export_learning_report
 from exo_harbor.protocol import TrialFeedback, send_trial_feedback
 from exo_harbor.trajectory import export_trial_trajectory
 
@@ -45,13 +46,17 @@ class ExoSessionPlugin(BaseJobPlugin):
         # kwargs in on_job_start so it stays a single source of truth.
         adapter_start_timeout_sec: float | str = 90,
         feedback_timeout_sec: float | str = 600,
+        reflection_strategy: str = "router",
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self._adapter_start_timeout_sec = float(adapter_start_timeout_sec)
         self._feedback_timeout_sec = float(feedback_timeout_sec)
+        self._reflection_strategy = reflection_strategy
+        self._reflection_instructions = reflection_instructions(reflection_strategy)
         self._client: ExoClient | None = None
         self._model: str | None = None
+        self._job_dir: Path | None = None
 
     async def on_job_start(self, job: Job) -> None:
         """Bring Exo up before the first container is built."""
@@ -89,6 +94,7 @@ class ExoSessionPlugin(BaseJobPlugin):
         )
         self._client = client
         self._model = model
+        self._job_dir = job.job_dir
         job.on_trial_ended(self._reflect_on_trial)
         logger.info("Exo ready for job %s on %s", job.id, socket_path)
 
@@ -112,7 +118,7 @@ class ExoSessionPlugin(BaseJobPlugin):
             TrialFeedback(
                 request_id=str(uuid4()),
                 target=str(result.id),
-                instructions=REFLECTION_INSTRUCTIONS,
+                instructions=self._reflection_instructions,
                 feedback=build_feedback(result, trial_dir / "verifier"),
             ),
             timeout_sec=self._feedback_timeout_sec,
@@ -127,17 +133,42 @@ class ExoSessionPlugin(BaseJobPlugin):
             self._model,
             trial_dir / "agent" / "trajectory.json",
         )
+        await _export_learning_report(
+            self._client,
+            conversation_id,
+            str(result.id),
+            self._reflection_strategy,
+            response.summary,
+            trial_dir / "agent" / "learning.json",
+        )
         logger.info("trial %s feedback complete", result.id)
 
-    async def on_job_end(self, _job_result: JobResult) -> None:
+    async def on_job_end(self, job_result: JobResult) -> None:
         """Discard temporary snapshots while retaining the run's other artifacts."""
         if self._client is None:
             return
+        if self._job_dir is not None and self._model is not None:
+            trial_metadata = {
+                trial.trial_name: {
+                    "task_name": trial.task_name,
+                    "rewards": (
+                        trial.verifier_result.rewards
+                        if trial.verifier_result is not None
+                        and trial.verifier_result.rewards is not None
+                        else {}
+                    ),
+                }
+                for trial in job_result.trial_results
+            }
+            _export_job_learning_summary(
+                job_dir=self._job_dir,
+                exo_root=self._client.exo_root,
+                strategy=self._reflection_strategy,
+                model=self._model,
+                trial_metadata=trial_metadata,
+            )
         count = await self._client.delete_snapshots()
         logger.info("deleted %d Exo snapshot directories", count)
-
-# TODO: add on_job_end to produce a report on the learnings obtained during
-# the trial.
 
 
 async def _export_trajectory(
@@ -159,3 +190,44 @@ async def _export_trajectory(
         )
     except Exception:
         logger.exception("failed to export Harbor trajectory for %s", trial_id)
+
+
+async def _export_learning_report(
+    client: ExoClient,
+    conversation_id: str,
+    trial_id: str,
+    strategy: str,
+    reflection_summary: str | None,
+    destination: Path,
+) -> None:
+    try:
+        await export_learning_report(
+            client,
+            conversation_id,
+            trial_id,
+            strategy,
+            reflection_summary,
+            destination,
+        )
+    except Exception:
+        logger.exception("failed to export learning report for %s", trial_id)
+
+
+def _export_job_learning_summary(
+    *,
+    job_dir: Path,
+    exo_root: Path,
+    strategy: str,
+    model: str,
+    trial_metadata: dict[str, dict[str, Any]],
+) -> None:
+    try:
+        export_job_learning_summary(
+            job_dir=job_dir,
+            exo_root=exo_root,
+            strategy=strategy,
+            model=model,
+            trial_metadata=trial_metadata,
+        )
+    except Exception:
+        logger.exception("failed to export job learning summary")

--- a/eval/harbor/src/exo_harbor/router_quality.py
+++ b/eval/harbor/src/exo_harbor/router_quality.py
@@ -1,0 +1,218 @@
+"""Score Harbor learning summaries against route-labeled tasks."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+KEEP_ROUTES = ("memory", "skill", "tool", "policy")
+
+
+def load_gold_labels(path: Path) -> dict[str, Any]:
+    """Return the labeled transfer protocol for one dataset."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or not isinstance(payload.get("tasks"), dict):
+        raise ValueError(f"gold labels are missing tasks: {path}")
+    return payload
+
+
+def score_router_quality(
+    summary: dict[str, Any], gold: dict[str, Any]
+) -> dict[str, Any]:
+    """Compare one arm's persisted routes and reuse against gold labels."""
+    tasks = gold.get("tasks", {})
+    scored: list[dict[str, Any]] = []
+    correct_routes = 0
+    route_cases = 0
+    useless = 0
+    validated_reuse = 0
+    missed_transfer = 0
+    false_activation = 0
+    held_out = 0
+    held_out_cases = 0
+
+    trials_by_task: dict[str, list[dict[str, Any]]] = {}
+    for trial in summary.get("trials", []):
+        task = trial.get("task_name")
+        if isinstance(task, str):
+            trials_by_task.setdefault(task, []).append(trial)
+
+    for task_name, label in tasks.items():
+        trial = (trials_by_task.get(task_name) or [None])[0]
+        result = _score_task(trial, label if isinstance(label, dict) else {})
+        scored.append({"task_name": task_name, **result})
+        if result["route_scored"]:
+            route_cases += 1
+            if result["route_correct"]:
+                correct_routes += 1
+            if result["useless_artifact"]:
+                useless += 1
+        if result["phase"] == "transfer":
+            held_out_cases += 1
+            if result["validated_reuse"]:
+                validated_reuse += 1
+                held_out += 1
+            if result["missed_transfer"]:
+                missed_transfer += 1
+        if result["phase"] == "control" and result["false_activation"]:
+            false_activation += 1
+        if result["phase"] == "control":
+            held_out_cases += 1
+            if not result["false_activation"]:
+                held_out += 1
+
+    return {
+        "dataset": gold.get("dataset"),
+        "route_accuracy": (correct_routes / route_cases) if route_cases else None,
+        "correct_routes": correct_routes,
+        "route_cases": route_cases,
+        "useless_artifacts": useless,
+        "validated_reuse": validated_reuse,
+        "missed_transfer": missed_transfer,
+        "false_activation": false_activation,
+        "held_out_reward": (held_out / held_out_cases) if held_out_cases else None,
+        "tasks": scored,
+    }
+
+
+def better_than_prompt_only(
+    *, baseline: dict[str, Any], candidate: dict[str, Any]
+) -> dict[str, Any]:
+    """Return the published proof checks for a labeled comparison."""
+    criteria = {
+        "higher_route_accuracy": _greater(
+            candidate.get("route_accuracy"), baseline.get("route_accuracy")
+        ),
+        "fewer_useless_artifacts": _less_or_equal(
+            candidate.get("useless_artifacts"), baseline.get("useless_artifacts")
+        ),
+        "more_validated_reuse": _greater(
+            candidate.get("validated_reuse"), baseline.get("validated_reuse")
+        ),
+        "equal_or_better_held_out_reward": _greater_or_equal(
+            candidate.get("held_out_reward"), baseline.get("held_out_reward")
+        ),
+    }
+    return {
+        "success_criteria": criteria,
+        "proven": all(criteria.values()),
+        "candidate_minus_baseline": {
+            "route_accuracy": _delta(
+                candidate.get("route_accuracy"), baseline.get("route_accuracy")
+            ),
+            "useless_artifacts": _delta(
+                candidate.get("useless_artifacts"),
+                baseline.get("useless_artifacts"),
+            ),
+            "validated_reuse": _delta(
+                candidate.get("validated_reuse"), baseline.get("validated_reuse")
+            ),
+            "held_out_reward": _delta(
+                candidate.get("held_out_reward"), baseline.get("held_out_reward")
+            ),
+        },
+    }
+
+
+def _score_task(
+    trial: dict[str, Any] | None, label: dict[str, Any]
+) -> dict[str, Any]:
+    phase = str(label.get("phase", "unknown"))
+    accepted = {
+        route
+        for route in label.get("accepted_keep_routes", [])
+        if isinstance(route, str)
+    }
+    incorrect = {
+        route
+        for route in label.get("incorrect_routes", [])
+        if isinstance(route, str)
+    }
+    persisted = persisted_keep_routes(trial) if trial is not None else set()
+    activated = activation_count(trial) if trial is not None else 0
+    reused = prior_reuse_count(trial) if trial is not None else 0
+    expected_activation = bool(label.get("expected_activation"))
+    expected_reuse = bool(label.get("expected_prior_reuse"))
+    route_scored = bool(accepted)
+    route_correct = bool(persisted & accepted) and not (persisted & incorrect)
+    useless_artifact = bool(persisted & incorrect)
+    return {
+        "phase": phase,
+        "persisted_routes": sorted(persisted),
+        "activation_count": activated,
+        "prior_reuse_count": reused,
+        "route_scored": route_scored,
+        "route_correct": route_correct,
+        "useless_artifact": useless_artifact,
+        "validated_reuse": expected_reuse and reused > 0 and activated > 0,
+        "missed_transfer": expected_activation and activated == 0 and reused == 0,
+        "false_activation": (not expected_activation) and activated > 0,
+    }
+
+
+def persisted_keep_routes(trial: dict[str, Any]) -> set[str]:
+    """Return durable keep routes from lifecycle promotions or prompt-only writes."""
+    promotions = trial.get("lifecycle", {}).get("promotions")
+    if isinstance(promotions, list) and promotions:
+        return {
+            str(item.get("route"))
+            for item in promotions
+            if isinstance(item, dict)
+            and item.get("status") == "promoted"
+            and item.get("route") in KEEP_ROUTES
+        }
+    routes: set[str] = set()
+    for route, counts in trial.get("route_counts", {}).items():
+        if (
+            route in KEEP_ROUTES
+            and isinstance(counts, dict)
+            and int(counts.get("succeeded", 0)) > 0
+        ):
+            routes.add(str(route))
+    return routes
+
+
+def activation_count(trial: dict[str, Any]) -> int:
+    activated = trial.get("task_usage", {}).get("learning_artifacts_activated", [])
+    return len(activated) if isinstance(activated, list) else 0
+
+
+def prior_reuse_count(trial: dict[str, Any]) -> int:
+    usage = trial.get("task_usage", {})
+    skills = usage.get("skills_reused_from_prior_tasks", [])
+    tools = usage.get("agent_tools_reused_from_prior_tasks", [])
+    return (len(skills) if isinstance(skills, list) else 0) + (
+        len(tools) if isinstance(tools, list) else 0
+    )
+
+
+def _greater(candidate: Any, baseline: Any) -> bool:
+    return isinstance(candidate, (int, float)) and isinstance(
+        baseline, (int, float)
+    ) and candidate > baseline
+
+
+def _less(candidate: Any, baseline: Any) -> bool:
+    return isinstance(candidate, (int, float)) and isinstance(
+        baseline, (int, float)
+    ) and candidate < baseline
+
+
+def _less_or_equal(candidate: Any, baseline: Any) -> bool:
+    return isinstance(candidate, (int, float)) and isinstance(
+        baseline, (int, float)
+    ) and candidate <= baseline
+
+
+def _greater_or_equal(candidate: Any, baseline: Any) -> bool:
+    return isinstance(candidate, (int, float)) and isinstance(
+        baseline, (int, float)
+    ) and candidate >= baseline
+
+
+def _delta(candidate: Any, baseline: Any) -> float | None:
+    if isinstance(candidate, (int, float)) and isinstance(baseline, (int, float)):
+        return candidate - baseline
+    return None

--- a/eval/harbor/src/exo_harbor/trajectory.py
+++ b/eval/harbor/src/exo_harbor/trajectory.py
@@ -92,7 +92,21 @@ class ToolResultData(BaseModel):
     result: ToolResultValue
 
 
-EventData = Annotated[MessagesData | ToolResultData, Field(discriminator="type")]
+class LearningActivatedArtifact(BaseModel):
+    id: str
+    route: Literal["memory", "skill", "tool"]
+    title: str
+
+
+class LearningActivatedData(BaseModel):
+    type: Literal["learning_activated"]
+    artifacts: list[LearningActivatedArtifact]
+
+
+EventData = Annotated[
+    MessagesData | ToolResultData | LearningActivatedData,
+    Field(discriminator="type"),
+]
 
 
 class ConversationEvent(BaseModel):
@@ -228,6 +242,8 @@ def build_trajectory(
                 usages.append(event.data.usage)
             continue
 
+        if not isinstance(event.data, ToolResultData):
+            continue
         result = event.data.result
         step = calls.get(event.data.tool_call_id)
         if step is None:

--- a/eval/harbor/src/exo_harbor/trajectory.py
+++ b/eval/harbor/src/exo_harbor/trajectory.py
@@ -26,7 +26,7 @@ class Usage(BaseModel):
     completion_tokens: int
     prompt_cached_tokens: int = 0
     completion_reasoning_tokens: int = 0
-    cost_usd: float
+    cost_usd: float | None = None
 
 
 class TextContent(BaseModel):
@@ -260,7 +260,11 @@ def build_trajectory(
             total_prompt_tokens=sum(usage.prompt_tokens for usage in usages),
             total_completion_tokens=sum(usage.completion_tokens for usage in usages),
             total_cached_tokens=sum(usage.prompt_cached_tokens for usage in usages),
-            total_cost_usd=sum(usage.cost_usd for usage in usages),
+            total_cost_usd=(
+                sum(usage.cost_usd for usage in usages if usage.cost_usd is not None)
+                if usages and all(usage.cost_usd is not None for usage in usages)
+                else None
+            ),
             total_steps=len(steps),
         ),
         extra={

--- a/eval/harbor/tests/test_compare.py
+++ b/eval/harbor/tests/test_compare.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import importlib.util
 import tempfile
 import unittest
@@ -36,7 +37,7 @@ def summary(
                 "unresolved": 0,
             },
             "skill": {
-                "succeeded": 1 if strategy == "router" else 0,
+                "succeeded": 1 if strategy in {"router", "lifecycle"} else 0,
                 "failed": 0,
                 "unresolved": 0,
             },
@@ -46,113 +47,164 @@ def summary(
         "task_reuse": {
             "prior_skill_reuse_count": skill_reuse,
             "prior_agent_tool_reuse_count": tool_reuse,
+            "learning_activation_count": 1 if strategy == "lifecycle" else 0,
+        },
+        "lifecycle": {
+            "proposal_count": 1 if strategy == "lifecycle" else 0,
+            "promotion_count": 1 if strategy == "lifecycle" else 0,
+            "rejection_count": 0,
+            "discard_count": 0,
+            "unresolved_count": 0,
         },
         "trials": [
-            {"task_name": "learn"},
-            {"task_name": "transfer"},
+            {
+                "task_name": "learn",
+                "rewards": {"reward": reward},
+                "task_usage": {"learning_artifacts_activated": []},
+            },
+            {
+                "task_name": "transfer",
+                "rewards": {"reward": reward},
+                "task_usage": {
+                    "learning_artifacts_activated": (
+                        [{"id": "learn-1"}] if strategy == "lifecycle" else []
+                    )
+                },
+            },
         ],
     }
 
 
 class ComparisonTest(unittest.TestCase):
-    def test_reports_router_minus_memory_deltas(self) -> None:
+    def test_expected_sequence_respects_task_limit(self) -> None:
+        args = argparse.Namespace(
+            dataset="learning-router-transfer-test",
+            include_task_names=[],
+            n_tasks=2,
+            n_attempts=2,
+        )
+
+        self.assertEqual(
+            compare_script.expected_task_sequence(args),
+            [
+                "exo/learning-router-normalization-first",
+                "exo/learning-router-normalization-transfer",
+                "exo/learning-router-normalization-first",
+                "exo/learning-router-normalization-transfer",
+            ],
+        )
+
+    def test_reports_candidate_minus_baseline_deltas(self) -> None:
         comparison = compare_script.build_comparison(
-            memory=summary(
-                "memory",
+            baseline=summary(
+                "router",
                 reward=0.5,
                 memory_growth=3,
                 skill_reuse=0,
                 tool_reuse=0,
             ),
-            router=summary(
-                "router",
+            candidate=summary(
+                "lifecycle",
                 reward=1.0,
                 memory_growth=1,
                 skill_reuse=1,
                 tool_reuse=2,
             ),
-            memory_summary_path=Path("/runs/memory.json"),
-            router_summary_path=Path("/runs/router.json"),
+            baseline_strategy="router",
+            candidate_strategy="lifecycle",
+            baseline_summary_path=Path("/runs/baseline.json"),
+            candidate_summary_path=Path("/runs/candidate.json"),
             provider="openrouter",
             source_digest="abc123",
-            arm_order=["memory", "router"],
+            arm_order=["baseline", "candidate"],
         )
 
-        deltas = comparison["router_minus_memory"]
+        deltas = comparison["candidate_minus_baseline"]
         self.assertEqual(deltas["reward_mean"]["reward"], 0.5)
+        self.assertEqual(deltas["task_reward_mean"]["transfer"]["reward"], 0.5)
+        self.assertEqual(deltas["task_activations"]["learn"], 0)
+        self.assertEqual(deltas["task_activations"]["transfer"], 1)
         self.assertEqual(deltas["memory_growth"], -2)
-        self.assertEqual(deltas["route_actions"]["succeeded"]["skill"], 1)
-        self.assertEqual(deltas["route_actions"]["failed"]["memory"], -1)
+        self.assertEqual(deltas["route_actions"]["succeeded"]["skill"], 0)
+        self.assertEqual(deltas["route_actions"]["failed"]["memory"], 0)
         self.assertEqual(deltas["prior_task_reuse"]["prior_skill_reuse_count"], 1)
         self.assertEqual(
             deltas["prior_task_reuse"]["prior_agent_tool_reuse_count"], 2
         )
+        self.assertEqual(
+            deltas["prior_task_reuse"]["learning_activation_count"], 1
+        )
+        self.assertEqual(deltas["lifecycle"]["promotion_count"], 1)
 
     def test_rejects_mismatched_task_sequences(self) -> None:
-        memory = summary(
-            "memory",
-            reward=1.0,
-            memory_growth=1,
-            skill_reuse=0,
-            tool_reuse=0,
-        )
-        router = summary(
+        baseline = summary(
             "router",
             reward=1.0,
             memory_growth=1,
             skill_reuse=0,
             tool_reuse=0,
         )
-        router["trials"][1]["task_name"] = "different"
+        candidate = summary(
+            "lifecycle",
+            reward=1.0,
+            memory_growth=1,
+            skill_reuse=0,
+            tool_reuse=0,
+        )
+        candidate["trials"][1]["task_name"] = "different"
 
         with self.assertRaisesRegex(ValueError, "different task sequences"):
             compare_script.build_comparison(
-                memory=memory,
-                router=router,
-                memory_summary_path=Path("memory.json"),
-                router_summary_path=Path("router.json"),
+                baseline=baseline,
+                candidate=candidate,
+                baseline_strategy="router",
+                candidate_strategy="lifecycle",
+                baseline_summary_path=Path("baseline.json"),
+                candidate_summary_path=Path("candidate.json"),
                 provider="openrouter",
                 source_digest="abc123",
-                arm_order=["memory", "router"],
+                arm_order=["baseline", "candidate"],
             )
 
     def test_rejects_swapped_reflection_strategies(self) -> None:
-        memory = summary(
-            "router",
-            reward=1.0,
-            memory_growth=1,
-            skill_reuse=0,
-            tool_reuse=0,
-        )
-        router = summary(
+        baseline = summary(
             "memory",
             reward=1.0,
             memory_growth=1,
             skill_reuse=0,
             tool_reuse=0,
         )
+        candidate = summary(
+            "router",
+            reward=1.0,
+            memory_growth=1,
+            skill_reuse=0,
+            tool_reuse=0,
+        )
 
-        with self.assertRaisesRegex(ValueError, "memory reflection strategy"):
+        with self.assertRaisesRegex(ValueError, "router reflection strategy"):
             compare_script.build_comparison(
-                memory=memory,
-                router=router,
-                memory_summary_path=Path("memory.json"),
-                router_summary_path=Path("router.json"),
+                baseline=baseline,
+                candidate=candidate,
+                baseline_strategy="router",
+                candidate_strategy="lifecycle",
+                baseline_summary_path=Path("baseline.json"),
+                candidate_summary_path=Path("candidate.json"),
                 provider="openrouter",
                 source_digest="abc123",
-                arm_order=["memory", "router"],
+                arm_order=["baseline", "candidate"],
             )
 
     def test_rejects_unexpected_learning_task_order(self) -> None:
-        memory = summary(
-            "memory",
+        baseline = summary(
+            "router",
             reward=1.0,
             memory_growth=1,
             skill_reuse=0,
             tool_reuse=0,
         )
-        router = summary(
-            "router",
+        candidate = summary(
+            "lifecycle",
             reward=1.0,
             memory_growth=1,
             skill_reuse=0,
@@ -161,26 +213,28 @@ class ComparisonTest(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "expected learning order"):
             compare_script.build_comparison(
-                memory=memory,
-                router=router,
-                memory_summary_path=Path("memory.json"),
-                router_summary_path=Path("router.json"),
+                baseline=baseline,
+                candidate=candidate,
+                baseline_strategy="router",
+                candidate_strategy="lifecycle",
+                baseline_summary_path=Path("baseline.json"),
+                candidate_summary_path=Path("candidate.json"),
                 provider="openrouter",
                 source_digest="abc123",
-                arm_order=["memory", "router"],
+                arm_order=["baseline", "candidate"],
                 expected_task_sequence=["transfer", "learn"],
             )
 
     def test_rejects_invalid_arm_order(self) -> None:
-        memory = summary(
-            "memory",
+        baseline = summary(
+            "router",
             reward=1.0,
             memory_growth=1,
             skill_reuse=0,
             tool_reuse=0,
         )
-        router = summary(
-            "router",
+        candidate = summary(
+            "lifecycle",
             reward=1.0,
             memory_growth=1,
             skill_reuse=0,
@@ -189,41 +243,45 @@ class ComparisonTest(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "arm order"):
             compare_script.build_comparison(
-                memory=memory,
-                router=router,
-                memory_summary_path=Path("memory.json"),
-                router_summary_path=Path("router.json"),
+                baseline=baseline,
+                candidate=candidate,
+                baseline_strategy="router",
+                candidate_strategy="lifecycle",
+                baseline_summary_path=Path("baseline.json"),
+                candidate_summary_path=Path("candidate.json"),
                 provider="openrouter",
                 source_digest="abc123",
-                arm_order=["memory", "memory"],
+                arm_order=["baseline", "baseline"],
             )
 
     def test_rejects_incomplete_reflection_reports(self) -> None:
-        memory = summary(
-            "memory",
-            reward=1.0,
-            memory_growth=1,
-            skill_reuse=0,
-            tool_reuse=0,
-        )
-        router = summary(
+        baseline = summary(
             "router",
             reward=1.0,
             memory_growth=1,
             skill_reuse=0,
             tool_reuse=0,
         )
-        router["reflection_report_count"] = 1
+        candidate = summary(
+            "lifecycle",
+            reward=1.0,
+            memory_growth=1,
+            skill_reuse=0,
+            tool_reuse=0,
+        )
+        candidate["reflection_report_count"] = 1
 
         with self.assertRaisesRegex(ValueError, "incomplete reflection reports"):
             compare_script.build_comparison(
-                memory=memory,
-                router=router,
-                memory_summary_path=Path("memory.json"),
-                router_summary_path=Path("router.json"),
+                baseline=baseline,
+                candidate=candidate,
+                baseline_strategy="router",
+                candidate_strategy="lifecycle",
+                baseline_summary_path=Path("baseline.json"),
+                candidate_summary_path=Path("candidate.json"),
                 provider="openrouter",
                 source_digest="abc123",
-                arm_order=["memory", "router"],
+                arm_order=["baseline", "candidate"],
             )
 
     def test_source_snapshot_excludes_generated_state(self) -> None:

--- a/eval/harbor/tests/test_compare.py
+++ b/eval/harbor/tests/test_compare.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "compare.py"
+SPEC = importlib.util.spec_from_file_location("compare_script", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+compare_script = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(compare_script)
+
+
+def summary(
+    strategy: str,
+    *,
+    reward: float,
+    memory_growth: int,
+    skill_reuse: int,
+    tool_reuse: int,
+) -> dict:
+    return {
+        "schema_version": 2,
+        "reflection_strategy": strategy,
+        "model": "fixed-model",
+        "trial_count": 2,
+        "reflection_report_count": 2,
+        "rewards": {"reward": {"count": 2, "mean": reward}},
+        "memory": {"growth": memory_growth},
+        "route_counts": {
+            "memory": {
+                "succeeded": memory_growth,
+                "failed": 1 if strategy == "memory" else 0,
+                "unresolved": 0,
+            },
+            "skill": {
+                "succeeded": 1 if strategy == "router" else 0,
+                "failed": 0,
+                "unresolved": 0,
+            },
+            "tool": {"succeeded": 0, "failed": 0, "unresolved": 0},
+            "policy": {"succeeded": 0, "failed": 0, "unresolved": 0},
+        },
+        "task_reuse": {
+            "prior_skill_reuse_count": skill_reuse,
+            "prior_agent_tool_reuse_count": tool_reuse,
+        },
+        "trials": [
+            {"task_name": "learn"},
+            {"task_name": "transfer"},
+        ],
+    }
+
+
+class ComparisonTest(unittest.TestCase):
+    def test_reports_router_minus_memory_deltas(self) -> None:
+        comparison = compare_script.build_comparison(
+            memory=summary(
+                "memory",
+                reward=0.5,
+                memory_growth=3,
+                skill_reuse=0,
+                tool_reuse=0,
+            ),
+            router=summary(
+                "router",
+                reward=1.0,
+                memory_growth=1,
+                skill_reuse=1,
+                tool_reuse=2,
+            ),
+            memory_summary_path=Path("/runs/memory.json"),
+            router_summary_path=Path("/runs/router.json"),
+            provider="openrouter",
+            source_digest="abc123",
+            arm_order=["memory", "router"],
+        )
+
+        deltas = comparison["router_minus_memory"]
+        self.assertEqual(deltas["reward_mean"]["reward"], 0.5)
+        self.assertEqual(deltas["memory_growth"], -2)
+        self.assertEqual(deltas["route_actions"]["succeeded"]["skill"], 1)
+        self.assertEqual(deltas["route_actions"]["failed"]["memory"], -1)
+        self.assertEqual(deltas["prior_task_reuse"]["prior_skill_reuse_count"], 1)
+        self.assertEqual(
+            deltas["prior_task_reuse"]["prior_agent_tool_reuse_count"], 2
+        )
+
+    def test_rejects_mismatched_task_sequences(self) -> None:
+        memory = summary(
+            "memory",
+            reward=1.0,
+            memory_growth=1,
+            skill_reuse=0,
+            tool_reuse=0,
+        )
+        router = summary(
+            "router",
+            reward=1.0,
+            memory_growth=1,
+            skill_reuse=0,
+            tool_reuse=0,
+        )
+        router["trials"][1]["task_name"] = "different"
+
+        with self.assertRaisesRegex(ValueError, "different task sequences"):
+            compare_script.build_comparison(
+                memory=memory,
+                router=router,
+                memory_summary_path=Path("memory.json"),
+                router_summary_path=Path("router.json"),
+                provider="openrouter",
+                source_digest="abc123",
+                arm_order=["memory", "router"],
+            )
+
+    def test_rejects_swapped_reflection_strategies(self) -> None:
+        memory = summary(
+            "router",
+            reward=1.0,
+            memory_growth=1,
+            skill_reuse=0,
+            tool_reuse=0,
+        )
+        router = summary(
+            "memory",
+            reward=1.0,
+            memory_growth=1,
+            skill_reuse=0,
+            tool_reuse=0,
+        )
+
+        with self.assertRaisesRegex(ValueError, "memory reflection strategy"):
+            compare_script.build_comparison(
+                memory=memory,
+                router=router,
+                memory_summary_path=Path("memory.json"),
+                router_summary_path=Path("router.json"),
+                provider="openrouter",
+                source_digest="abc123",
+                arm_order=["memory", "router"],
+            )
+
+    def test_rejects_unexpected_learning_task_order(self) -> None:
+        memory = summary(
+            "memory",
+            reward=1.0,
+            memory_growth=1,
+            skill_reuse=0,
+            tool_reuse=0,
+        )
+        router = summary(
+            "router",
+            reward=1.0,
+            memory_growth=1,
+            skill_reuse=0,
+            tool_reuse=0,
+        )
+
+        with self.assertRaisesRegex(ValueError, "expected learning order"):
+            compare_script.build_comparison(
+                memory=memory,
+                router=router,
+                memory_summary_path=Path("memory.json"),
+                router_summary_path=Path("router.json"),
+                provider="openrouter",
+                source_digest="abc123",
+                arm_order=["memory", "router"],
+                expected_task_sequence=["transfer", "learn"],
+            )
+
+    def test_rejects_invalid_arm_order(self) -> None:
+        memory = summary(
+            "memory",
+            reward=1.0,
+            memory_growth=1,
+            skill_reuse=0,
+            tool_reuse=0,
+        )
+        router = summary(
+            "router",
+            reward=1.0,
+            memory_growth=1,
+            skill_reuse=0,
+            tool_reuse=0,
+        )
+
+        with self.assertRaisesRegex(ValueError, "arm order"):
+            compare_script.build_comparison(
+                memory=memory,
+                router=router,
+                memory_summary_path=Path("memory.json"),
+                router_summary_path=Path("router.json"),
+                provider="openrouter",
+                source_digest="abc123",
+                arm_order=["memory", "memory"],
+            )
+
+    def test_rejects_incomplete_reflection_reports(self) -> None:
+        memory = summary(
+            "memory",
+            reward=1.0,
+            memory_growth=1,
+            skill_reuse=0,
+            tool_reuse=0,
+        )
+        router = summary(
+            "router",
+            reward=1.0,
+            memory_growth=1,
+            skill_reuse=0,
+            tool_reuse=0,
+        )
+        router["reflection_report_count"] = 1
+
+        with self.assertRaisesRegex(ValueError, "incomplete reflection reports"):
+            compare_script.build_comparison(
+                memory=memory,
+                router=router,
+                memory_summary_path=Path("memory.json"),
+                router_summary_path=Path("router.json"),
+                provider="openrouter",
+                source_digest="abc123",
+                arm_order=["memory", "router"],
+            )
+
+    def test_source_snapshot_excludes_generated_state(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            (source / "tracked.txt").write_text("same", encoding="utf-8")
+            for ignored in (".git", ".local", ".exo", "target", "node_modules"):
+                path = source / ignored
+                path.mkdir()
+                (path / "ignored.txt").write_text("ignore", encoding="utf-8")
+
+            digest = compare_script.copy_source_snapshot(source, destination)
+
+            self.assertEqual(
+                digest,
+                compare_script.workspace_digest(destination),
+            )
+            self.assertEqual((destination / "tracked.txt").read_text(), "same")
+            for ignored in (".git", ".local", ".exo", "target", "node_modules"):
+                self.assertFalse((destination / ignored).exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/eval/harbor/tests/test_compare.py
+++ b/eval/harbor/tests/test_compare.py
@@ -248,6 +248,32 @@ class ComparisonTest(unittest.TestCase):
             for ignored in (".git", ".local", ".exo", "target", "node_modules"):
                 self.assertFalse((destination / ignored).exists())
 
+    def test_runtime_dependencies_are_linked_after_snapshotting(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "source"
+            destination = root / "destination"
+            dependencies = source / "node_modules"
+            dependencies.mkdir(parents=True)
+            destination.mkdir()
+
+            compare_script.link_runtime_dependencies(source, destination)
+
+            link = destination / "node_modules"
+            self.assertTrue(link.is_symlink())
+            self.assertEqual(link.resolve(), dependencies.resolve())
+
+    def test_runtime_dependencies_must_be_installed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            source = root / "source"
+            destination = root / "destination"
+            source.mkdir()
+            destination.mkdir()
+
+            with self.assertRaisesRegex(ValueError, "run pnpm install first"):
+                compare_script.link_runtime_dependencies(source, destination)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/eval/harbor/tests/test_compare.py
+++ b/eval/harbor/tests/test_compare.py
@@ -321,6 +321,102 @@ class ComparisonTest(unittest.TestCase):
             self.assertTrue(link.is_symlink())
             self.assertEqual(link.resolve(), dependencies.resolve())
 
+    def test_scores_gold_labels_for_the_transfer_protocol(self) -> None:
+        baseline = summary(
+            "router",
+            reward=0.0,
+            memory_growth=1,
+            skill_reuse=0,
+            tool_reuse=0,
+        )
+        candidate = summary(
+            "lifecycle",
+            reward=1.0,
+            memory_growth=0,
+            skill_reuse=1,
+            tool_reuse=0,
+        )
+        sequence = compare_script.EXPECTED_TASK_SEQUENCES[
+            "learning-router-transfer-test"
+        ]
+        baseline["trial_count"] = 3
+        baseline["reflection_report_count"] = 3
+        candidate["trial_count"] = 3
+        candidate["reflection_report_count"] = 3
+        baseline["trials"] = [
+            {
+                "task_name": sequence[0],
+                "rewards": {"reward": 1.0},
+                "route_counts": {
+                    "memory": {
+                        "succeeded": 1,
+                        "failed": 0,
+                        "unresolved": 0,
+                    }
+                },
+                "lifecycle": {},
+                "task_usage": {"learning_artifacts_activated": []},
+            },
+            {
+                "task_name": sequence[1],
+                "rewards": {"reward": 0.0},
+                "task_usage": {"learning_artifacts_activated": []},
+            },
+            {
+                "task_name": sequence[2],
+                "rewards": {"reward": 0.0},
+                "task_usage": {"learning_artifacts_activated": []},
+            },
+        ]
+        candidate["trials"] = [
+            {
+                "task_name": sequence[0],
+                "rewards": {"reward": 1.0},
+                "lifecycle": {
+                    "promotions": [{"route": "skill", "status": "promoted"}]
+                },
+                "task_usage": {"learning_artifacts_activated": []},
+            },
+            {
+                "task_name": sequence[1],
+                "rewards": {"reward": 1.0},
+                "task_usage": {
+                    "learning_artifacts_activated": [{"id": "learn-1"}],
+                    "skills_reused_from_prior_tasks": [
+                        {"name": "flint-normalization"}
+                    ],
+                    "agent_tools_reused_from_prior_tasks": [],
+                },
+            },
+            {
+                "task_name": sequence[2],
+                "rewards": {"reward": 1.0},
+                "task_usage": {"learning_artifacts_activated": []},
+            },
+        ]
+
+        comparison = compare_script.build_comparison(
+            baseline=baseline,
+            candidate=candidate,
+            baseline_strategy="router",
+            candidate_strategy="lifecycle",
+            baseline_summary_path=Path("baseline.json"),
+            candidate_summary_path=Path("candidate.json"),
+            provider="openrouter",
+            source_digest="abc123",
+            arm_order=["baseline", "candidate"],
+            expected_task_sequence=sequence,
+        )
+
+        self.assertEqual(comparison["schema_version"], 4)
+        self.assertTrue(comparison["router_proof"]["proven"])
+        self.assertEqual(
+            comparison["router_proof"]["candidate_minus_baseline"][
+                "route_accuracy"
+            ],
+            1.0,
+        )
+
     def test_runtime_dependencies_must_be_installed(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)

--- a/eval/harbor/tests/test_eval.py
+++ b/eval/harbor/tests/test_eval.py
@@ -27,9 +27,28 @@ class EvalScriptTest(unittest.TestCase):
 
         self.assertEqual(args.dataset, "terminal-bench")
         self.assertEqual(args.model, "gpt-5.5")
+        self.assertEqual(args.provider, "openai")
         self.assertIsNone(args.n_tasks)
         self.assertEqual(args.n_attempts, 1)
         self.assertEqual(args.include_task_names, [])
+        self.assertEqual(args.reflection_strategy, "router")
+        self.assertFalse(args.skip_build)
+        self.assertIsNone(args.workspace_root)
+        self.assertIsNone(args.exo_bin)
+        self.assertIsNone(args.output_root)
+
+    def test_skip_build_reuses_existing_binary(self) -> None:
+        args = self.parse(
+            "--skip-build",
+            "--workspace-root=/tmp/workspace",
+            "--exo-bin=/tmp/exo",
+            "--output-root=/tmp/results",
+        )
+
+        self.assertTrue(args.skip_build)
+        self.assertEqual(args.workspace_root, Path("/tmp/workspace"))
+        self.assertEqual(args.exo_bin, Path("/tmp/exo"))
+        self.assertEqual(args.output_root, Path("/tmp/results"))
 
     def test_all_tasks_omits_harbor_limit(self) -> None:
         args = self.parse()
@@ -44,6 +63,7 @@ class EvalScriptTest(unittest.TestCase):
         )
 
         self.assertNotIn("--n-tasks", command)
+        self.assertIn("reflection_strategy=router", command)
 
     def test_flags_override_config_file(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -51,7 +71,9 @@ class EvalScriptTest(unittest.TestCase):
             config.write_text(
                 'dataset = "terminal-bench-sample"\n'
                 'model = "configured-model"\n'
+                'provider = "openrouter"\n'
                 "n_tasks = 4\n"
+                'reflection_strategy = "memory"\n'
             )
 
             args = self.parse(
@@ -61,6 +83,8 @@ class EvalScriptTest(unittest.TestCase):
         self.assertEqual(args.dataset, "terminal-bench-sample")
         self.assertEqual(args.model, "flag-model")
         self.assertEqual(args.n_tasks, 2)
+        self.assertEqual(args.provider, "openrouter")
+        self.assertEqual(args.reflection_strategy, "memory")
 
     def test_local_dataset_path_can_come_from_config(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -75,7 +99,8 @@ class EvalScriptTest(unittest.TestCase):
             args = self.parse(f"--config={config}")
 
             self.assertEqual(
-                eval_script.dataset_arguments(args), ["--path", str(dataset)]
+                eval_script.dataset_arguments(args),
+                ["--path", str(dataset.resolve())],
             )
 
     def test_smoke_test_uses_the_bundled_task(self) -> None:
@@ -105,6 +130,19 @@ class EvalScriptTest(unittest.TestCase):
                 "03-restart-policy",
                 "04-timeout-trajectory",
             ],
+        )
+
+    def test_learning_router_transfer_test_uses_bundled_pair(self) -> None:
+        args = self.parse("--dataset=learning-router-transfer-test")
+        dataset = SCRIPT.parent / "datasets/learning-router-transfer-test"
+
+        self.assertEqual(
+            eval_script.dataset_arguments(args),
+            ["--path", str(dataset)],
+        )
+        self.assertEqual(
+            sorted(path.name for path in dataset.iterdir()),
+            ["01-learn-normalization", "02-transfer-normalization"],
         )
 
     def test_terminal_bench_easy_selects_three_tasks(self) -> None:
@@ -166,6 +204,10 @@ class EvalScriptTest(unittest.TestCase):
 
         self.assertIn(
             "Harbor results: /runs/one/jobs/terminal-bench-3/result.json",
+            output.getvalue(),
+        )
+        self.assertIn(
+            "Learning summary: /runs/one/jobs/terminal-bench-3/learning-summary.json",
             output.getvalue(),
         )
         self.assertIn(

--- a/eval/harbor/tests/test_eval.py
+++ b/eval/harbor/tests/test_eval.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 import io
+import json
 import sys
 import tempfile
 import unittest
@@ -132,7 +133,7 @@ class EvalScriptTest(unittest.TestCase):
             ],
         )
 
-    def test_learning_router_transfer_test_uses_bundled_pair(self) -> None:
+    def test_learning_router_transfer_test_uses_bundled_sequence(self) -> None:
         args = self.parse("--dataset=learning-router-transfer-test")
         dataset = SCRIPT.parent / "datasets/learning-router-transfer-test"
 
@@ -142,8 +143,41 @@ class EvalScriptTest(unittest.TestCase):
         )
         self.assertEqual(
             sorted(path.name for path in dataset.iterdir()),
-            ["01-learn-normalization", "02-transfer-normalization"],
+            [
+                "01-learn-normalization",
+                "02-transfer-normalization",
+                "03-unrelated-control",
+            ],
         )
+
+    def test_local_multi_task_dataset_uses_explicit_ordered_config(self) -> None:
+        args = self.parse(
+            "--dataset=learning-router-transfer-test",
+            "--n-tasks=2",
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            run_dir = Path(directory) / "run"
+            config = eval_script.write_ordered_task_config(args, run_dir)
+            self.assertIsNotNone(config)
+            assert config is not None
+            payload = json.loads(config.read_text(encoding="utf-8"))
+            self.assertEqual(
+                [Path(task["path"]).name for task in payload["tasks"]],
+                ["01-learn-normalization", "02-transfer-normalization"],
+            )
+            command = eval_script.harbor_command(
+                args,
+                harbor="harbor",
+                repo=Path("/repo"),
+                exo=Path("/repo/exo"),
+                run_dir=run_dir,
+                job_name="learning-router-transfer-test-2-router",
+                ordered_tasks_config=config,
+            )
+
+        self.assertIn("--config", command)
+        self.assertNotIn("--path", command)
+        self.assertNotIn("--n-tasks", command)
 
     def test_terminal_bench_easy_selects_three_tasks(self) -> None:
         args = self.parse("--dataset=terminal-bench-easy")

--- a/eval/harbor/tests/test_exo.py
+++ b/eval/harbor/tests/test_exo.py
@@ -7,6 +7,29 @@ from exo_harbor.exo import ExoClient
 
 
 class ExoClientTest(unittest.IsolatedAsyncioTestCase):
+    async def test_commands_select_docker_sandbox_backend(self) -> None:
+        client = ExoClient(
+            exo_bin=Path("/opt/exo/bin/exo"),
+            exo_root=Path("/tmp/exo-root"),
+            repo_root=Path("/src/exo"),
+        )
+
+        self.assertEqual(
+            client._argv("agent", "show", "harbor-eval"),
+            [
+                "/opt/exo/bin/exo",
+                "--root",
+                "/tmp/exo-root",
+                "--harness",
+                "exo",
+                "--sandbox-backend",
+                "docker",
+                "agent",
+                "show",
+                "harbor-eval",
+            ],
+        )
+
     async def test_delete_snapshots_preserves_other_exo_state(self) -> None:
         with TemporaryDirectory() as temporary_directory:
             exo_root = Path(temporary_directory) / "exo"

--- a/eval/harbor/tests/test_feedback.py
+++ b/eval/harbor/tests/test_feedback.py
@@ -5,6 +5,7 @@ from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 
 from exo_harbor.feedback import (
+    LIFECYCLE_REFLECTION_INSTRUCTIONS,
     MEMORY_REFLECTION_INSTRUCTIONS,
     ROUTER_REFLECTION_INSTRUCTIONS,
     build_feedback,
@@ -13,6 +14,23 @@ from exo_harbor.feedback import (
 
 
 class FeedbackTest(unittest.TestCase):
+    def test_lifecycle_reflection_requires_validation_before_activation(self) -> None:
+        self.assertIn("EXO_LEARNING_LIFECYCLE_V1", LIFECYCLE_REFLECTION_INSTRUCTIONS)
+        self.assertIn("propose_memory_learning", LIFECYCLE_REFLECTION_INSTRUCTIONS)
+        self.assertIn("propose_skill_learning", LIFECYCLE_REFLECTION_INSTRUCTIONS)
+        self.assertIn("propose_tool_learning", LIFECYCLE_REFLECTION_INSTRUCTIONS)
+        self.assertIn("propose_learning_discard", LIFECYCLE_REFLECTION_INSTRUCTIONS)
+        self.assertIn(
+            "validate_and_promote_learning", LIFECYCLE_REFLECTION_INSTRUCTIONS
+        )
+        self.assertIn("remain inactive", LIFECYCLE_REFLECTION_INSTRUCTIONS)
+        self.assertIn("learning catalog only if", LIFECYCLE_REFLECTION_INSTRUCTIONS)
+        self.assertIn("activation trigger matches", LIFECYCLE_REFLECTION_INSTRUCTIONS)
+        self.assertIs(
+            reflection_instructions("lifecycle"),
+            LIFECYCLE_REFLECTION_INSTRUCTIONS,
+        )
+
     def test_reflection_routes_learning_to_the_right_durable_form(self) -> None:
         for learning_form in (
             "Memory:",

--- a/eval/harbor/tests/test_feedback.py
+++ b/eval/harbor/tests/test_feedback.py
@@ -4,13 +4,60 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 
-from exo_harbor.feedback import REFLECTION_INSTRUCTIONS, build_feedback
+from exo_harbor.feedback import (
+    MEMORY_REFLECTION_INSTRUCTIONS,
+    ROUTER_REFLECTION_INSTRUCTIONS,
+    build_feedback,
+    reflection_instructions,
+)
 
 
 class FeedbackTest(unittest.TestCase):
-    def test_reflection_requires_durable_learning_before_completion(self) -> None:
-        self.assertIn("persist every useful generalizable lesson", REFLECTION_INSTRUCTIONS)
-        self.assertIn("does not persist learning", REFLECTION_INSTRUCTIONS)
+    def test_reflection_routes_learning_to_the_right_durable_form(self) -> None:
+        for learning_form in (
+            "Memory:",
+            "Skill:",
+            "Tool:",
+            "Policy or implementation:",
+            "Discard:",
+        ):
+            self.assertIn(learning_form, ROUTER_REFLECTION_INSTRUCTIONS)
+        self.assertIn(
+            "Do not put every lesson in durable memory",
+            ROUTER_REFLECTION_INSTRUCTIONS,
+        )
+        self.assertNotIn(
+            "persist every useful generalizable lesson in durable memory",
+            ROUTER_REFLECTION_INSTRUCTIONS,
+        )
+        self.assertIn("does not persist learning", ROUTER_REFLECTION_INSTRUCTIONS)
+        self.assertIn(
+            "A restart by itself is not a policy improvement",
+            ROUTER_REFLECTION_INSTRUCTIONS,
+        )
+
+    def test_reflection_requires_evidence_and_memory_hygiene(self) -> None:
+        self.assertIn("evidence-supported lessons", ROUTER_REFLECTION_INSTRUCTIONS)
+        self.assertIn("Do not add duplicates", ROUTER_REFLECTION_INSTRUCTIONS)
+        self.assertIn("forget the old entry", ROUTER_REFLECTION_INSTRUCTIONS)
+        self.assertIn("poor reward", ROUTER_REFLECTION_INSTRUCTIONS)
+        self.assertIn("good reward", ROUTER_REFLECTION_INSTRUCTIONS)
+
+    def test_reflection_strategy_retains_memory_first_baseline(self) -> None:
+        self.assertIs(
+            reflection_instructions("memory"), MEMORY_REFLECTION_INSTRUCTIONS
+        )
+        self.assertIs(
+            reflection_instructions("router"), ROUTER_REFLECTION_INSTRUCTIONS
+        )
+        self.assertIn(
+            "persist every useful generalizable lesson in durable memory",
+            MEMORY_REFLECTION_INSTRUCTIONS,
+        )
+
+    def test_unknown_reflection_strategy_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unknown reflection strategy"):
+            reflection_instructions("guess")
 
     def test_includes_rewards_exception_and_verifier_output(self) -> None:
         with TemporaryDirectory() as directory:

--- a/eval/harbor/tests/test_feedback.py
+++ b/eval/harbor/tests/test_feedback.py
@@ -20,6 +20,8 @@ class FeedbackTest(unittest.TestCase):
         self.assertIn("propose_skill_learning", LIFECYCLE_REFLECTION_INSTRUCTIONS)
         self.assertIn("propose_tool_learning", LIFECYCLE_REFLECTION_INSTRUCTIONS)
         self.assertIn("propose_learning_discard", LIFECYCLE_REFLECTION_INSTRUCTIONS)
+        self.assertIn("classify_learning_route", LIFECYCLE_REFLECTION_INSTRUCTIONS)
+        self.assertIn("route_conflict", LIFECYCLE_REFLECTION_INSTRUCTIONS)
         self.assertIn(
             "validate_and_promote_learning", LIFECYCLE_REFLECTION_INSTRUCTIONS
         )

--- a/eval/harbor/tests/test_learning.py
+++ b/eval/harbor/tests/test_learning.py
@@ -1,0 +1,500 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from exo_harbor.learning import (
+    build_job_learning_summary,
+    build_learning_report,
+    export_job_learning_summary,
+    read_final_memory_count,
+)
+from exo_harbor.trajectory import ConversationEvents
+
+TRIAL_ID = "trial-1"
+
+
+def messages_event(event_id: str, messages: list[dict]) -> dict:
+    return {
+        "id": event_id,
+        "session_id": "session-1",
+        "turn_id": "turn-1",
+        "created_at": "2026-08-18T12:00:00Z",
+        "data": {"type": "messages", "messages": messages},
+    }
+
+
+def tool_result_event(
+    event_id: str,
+    call_id: str,
+    value: dict,
+    *,
+    tool_name: str = "test",
+    source: str = "built_in",
+) -> dict:
+    return {
+        "id": event_id,
+        "session_id": "session-1",
+        "turn_id": "turn-1",
+        "created_at": "2026-08-18T12:00:01Z",
+        "data": {
+            "type": "tool_result",
+            "tool_call_id": call_id,
+            "result": {
+                "ok": True,
+                "preview": json.dumps(value),
+                "source": source,
+                "toolName": tool_name,
+                "truncated": False,
+                "value": value,
+            },
+        },
+    }
+
+
+def tool_call(call_id: str, name: str, arguments: dict) -> dict:
+    return {
+        "type": "tool_call",
+        "tool_call_id": call_id,
+        "tool_name": name,
+        "arguments": {"type": "valid", "value": arguments},
+    }
+
+
+class LearningReportTest(unittest.TestCase):
+    def test_job_summary_aggregates_rewards_routes_reuse_and_memory(self) -> None:
+        reports = [
+            {
+                "trial_name": "task-1",
+                "rewards": {"reward": 1.0},
+                "report": {
+                    "trial_id": "trial-1",
+                    "route_counts": {
+                        "memory": {
+                            "attempted": 2,
+                            "succeeded": 1,
+                            "failed": 1,
+                            "unresolved": 0,
+                        },
+                        "skill": {
+                            "attempted": 1,
+                            "succeeded": 1,
+                            "failed": 0,
+                            "unresolved": 0,
+                        },
+                    },
+                    "task_usage": {
+                        "skills_loaded": [],
+                        "skills_reused_from_prior_tasks": [],
+                        "agent_tools_called": [],
+                        "agent_tools_reused_from_prior_tasks": [],
+                    },
+                },
+            },
+            {
+                "trial_name": "task-2",
+                "rewards": {"reward": 0.0},
+                "report": {
+                    "trial_id": "trial-2",
+                    "route_counts": {
+                        "memory": {
+                            "attempted": 1,
+                            "succeeded": 1,
+                            "failed": 0,
+                            "unresolved": 0,
+                        },
+                        "tool": {
+                            "attempted": 1,
+                            "succeeded": 1,
+                            "failed": 0,
+                            "unresolved": 0,
+                        },
+                    },
+                    "task_usage": {
+                        "skills_loaded": [
+                            {"name": "debug-copy", "tool_call_id": "skill-1"}
+                        ],
+                        "skills_reused_from_prior_tasks": [
+                            {"name": "debug-copy", "tool_call_id": "skill-1"}
+                        ],
+                        "agent_tools_called": [
+                            {"name": "copy_check", "tool_call_id": "tool-1"}
+                        ],
+                        "agent_tools_reused_from_prior_tasks": [
+                            {"name": "copy_check", "tool_call_id": "tool-1"}
+                        ],
+                    },
+                },
+            },
+        ]
+
+        summary = build_job_learning_summary(
+            reports=reports,
+            strategy="router",
+            model="fixed-model",
+            final_memory_count=2,
+        )
+
+        self.assertEqual(summary["model"], "fixed-model")
+        self.assertEqual(summary["rewards"]["reward"], {"count": 2, "mean": 0.5})
+        self.assertEqual(
+            summary["route_counts"]["memory"],
+            {"attempted": 3, "succeeded": 2, "failed": 1, "unresolved": 0},
+        )
+        self.assertEqual(summary["route_counts"]["policy"]["attempted"], 0)
+        self.assertEqual(
+            summary["memory"],
+            {"initial_count": 0, "final_count": 2, "growth": 2},
+        )
+        self.assertEqual(summary["task_reuse"]["skill_load_count"], 1)
+        self.assertEqual(summary["task_reuse"]["prior_skill_reuse_count"], 1)
+        self.assertEqual(
+            summary["task_reuse"]["unique_agent_tools_called"], ["copy_check"]
+        )
+        self.assertEqual(
+            summary["task_reuse"]["unique_prior_agent_tools_reused"],
+            ["copy_check"],
+        )
+
+    def test_reads_newest_durable_memory_and_exports_job_summary(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            exo_root = root / "exo"
+            artifacts = exo_root / "exoharness" / "agents" / "agent-1" / "artifacts"
+            for artifact_id, created_at, version, entries in (
+                ("old", "2026-08-18T12:00:00Z", 1, [{"id": "one"}]),
+                (
+                    "new",
+                    "2026-08-18T13:00:00Z",
+                    2,
+                    [{"id": "one"}, {"id": "two"}],
+                ),
+            ):
+                artifact = artifacts / artifact_id
+                artifact.mkdir(parents=True)
+                (artifact / f"{version}.json").write_text(
+                    json.dumps(
+                        {
+                            "path": "memory/exo-memory.json",
+                            "created_at": created_at,
+                            "version": version,
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                (artifact / f"{version}.bin").write_text(
+                    json.dumps({"entries": entries}), encoding="utf-8"
+                )
+            job_dir = root / "job"
+            report_dir = job_dir / "task-1" / "agent"
+            report_dir.mkdir(parents=True)
+            (report_dir / "learning.json").write_text(
+                json.dumps(
+                    {
+                        "trial_id": "trial-1",
+                        "route_counts": {"memory": {"attempted": 1, "succeeded": 1}},
+                        "task_usage": {
+                            "skills_loaded": [],
+                            "skills_reused_from_prior_tasks": [],
+                            "agent_tools_called": [],
+                            "agent_tools_reused_from_prior_tasks": [],
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            self.assertEqual(read_final_memory_count(exo_root), 2)
+            export_job_learning_summary(
+                job_dir=job_dir,
+                exo_root=exo_root,
+                strategy="router",
+                model="fixed-model",
+                trial_metadata={
+                    "task-1": {
+                        "task_name": "first-task",
+                        "rewards": {"reward": 1.0},
+                    },
+                    "timed-out-task": {
+                        "task_name": "timeout-task",
+                        "rewards": {"reward": 0.0},
+                    },
+                },
+            )
+            summary = json.loads(
+                (job_dir / "learning-summary.json").read_text(encoding="utf-8")
+            )
+
+        self.assertEqual(summary["memory"]["growth"], 2)
+        self.assertEqual(summary["rewards"]["reward"]["mean"], 0.5)
+        self.assertEqual(summary["trial_count"], 2)
+        self.assertEqual(summary["reflection_report_count"], 1)
+        self.assertEqual(summary["trials"][0]["task_name"], "first-task")
+        self.assertFalse(summary["trials"][1]["reflected"])
+
+    def test_same_task_creation_is_not_counted_as_prior_task_reuse(self) -> None:
+        skill_md = (
+            '---\nname: "inspect-copy"\ndescription: Check copied files.\n---\nDo it.'
+        )
+        events = ConversationEvents.model_validate(
+            {
+                "events": [
+                    messages_event(
+                        "event-1",
+                        [
+                            {
+                                "role": "assistant",
+                                "content": [
+                                    tool_call(
+                                        "install-tool",
+                                        "install_agent_tool",
+                                        {"name": "copy-checker"},
+                                    ),
+                                    tool_call(
+                                        "install-skill",
+                                        "install_skill",
+                                        {"skillMd": skill_md, "files": None},
+                                    ),
+                                ],
+                            }
+                        ],
+                    ),
+                    tool_result_event(
+                        "event-2",
+                        "install-tool",
+                        {"ok": True, "toolName": "copy_checker"},
+                        tool_name="install_agent_tool",
+                    ),
+                    tool_result_event(
+                        "event-3",
+                        "install-skill",
+                        {"ok": True, "name": "inspect-copy"},
+                        tool_name="install_skill",
+                    ),
+                    messages_event(
+                        "event-4",
+                        [
+                            {
+                                "role": "assistant",
+                                "content": [
+                                    tool_call("use-tool", "copy_checker", {}),
+                                    tool_call(
+                                        "use-skill",
+                                        "use_skill",
+                                        {"name": "inspect-copy"},
+                                    ),
+                                ],
+                            }
+                        ],
+                    ),
+                    tool_result_event(
+                        "event-5",
+                        "use-tool",
+                        {"ok": True},
+                        tool_name="copy_checker",
+                        source="agent",
+                    ),
+                    tool_result_event(
+                        "event-6",
+                        "use-skill",
+                        {"ok": True},
+                        tool_name="use_skill",
+                    ),
+                    messages_event(
+                        "event-7",
+                        [
+                            {
+                                "role": "user",
+                                "content": f"Feedback for trial `{TRIAL_ID}` is ready.",
+                            }
+                        ],
+                    ),
+                ]
+            }
+        ).events
+
+        report = build_learning_report(
+            events=events,
+            trial_id=TRIAL_ID,
+            conversation="conversation-1",
+            strategy="router",
+            reflection_summary=None,
+        )
+
+        self.assertEqual(len(report["task_usage"]["skills_loaded"]), 1)
+        self.assertEqual(len(report["task_usage"]["agent_tools_called"]), 1)
+        self.assertEqual(report["task_usage"]["skills_reused_from_prior_tasks"], [])
+        self.assertEqual(
+            report["task_usage"]["agent_tools_reused_from_prior_tasks"], []
+        )
+
+    def test_reports_only_persistence_actions_during_reflection(self) -> None:
+        events = ConversationEvents.model_validate(
+            {
+                "events": [
+                    messages_event(
+                        "event-1",
+                        [
+                            {
+                                "role": "assistant",
+                                "content": [
+                                    tool_call(
+                                        "before-feedback",
+                                        "remember",
+                                        {"text": "ignore task-phase memory"},
+                                    ),
+                                    tool_call(
+                                        "skill-use",
+                                        "use_skill",
+                                        {"name": "inspect-copy"},
+                                    ),
+                                    tool_call(
+                                        "agent-tool-use",
+                                        "copy_checker",
+                                        {"path": "/app/output"},
+                                    ),
+                                ],
+                            }
+                        ],
+                    ),
+                    tool_result_event(
+                        "event-1a",
+                        "skill-use",
+                        {"ok": True},
+                        tool_name="use_skill",
+                    ),
+                    tool_result_event(
+                        "event-1b",
+                        "agent-tool-use",
+                        {"ok": True},
+                        tool_name="copy_checker",
+                        source="agent",
+                    ),
+                    messages_event(
+                        "event-2",
+                        [
+                            {
+                                "role": "user",
+                                "content": f"Feedback for trial `{TRIAL_ID}` is ready.",
+                            }
+                        ],
+                    ),
+                    messages_event(
+                        "event-3",
+                        [
+                            {
+                                "role": "assistant",
+                                "content": [
+                                    tool_call(
+                                        "memory-1",
+                                        "remember",
+                                        {"text": "Check file modes after copying."},
+                                    ),
+                                    tool_call(
+                                        "skill-1",
+                                        "install_skill",
+                                        {
+                                            "skillMd": "---\nname: inspect-copy\ndescription: Check copied files.\n---\nDo it.",
+                                            "files": None,
+                                        },
+                                    ),
+                                    tool_call(
+                                        "tool-1",
+                                        "install_agent_tool",
+                                        {
+                                            "name": "copy-checker",
+                                            "moduleSource": "SECRETLY LARGE SOURCE",
+                                            "initialization": {"apiKeyEnv": None},
+                                        },
+                                    ),
+                                    tool_call(
+                                        "policy-1",
+                                        "rebuild_and_restart_exo",
+                                        {"reason": "activate safer copy policy"},
+                                    ),
+                                    tool_call("shell-1", "shell", {"command": "true"}),
+                                ],
+                            }
+                        ],
+                    ),
+                    tool_result_event("event-4", "memory-1", {"ok": True}),
+                    tool_result_event("event-5", "skill-1", {"ok": False}),
+                    tool_result_event("event-6", "tool-1", {"ok": True}),
+                ]
+            }
+        ).events
+
+        report = build_learning_report(
+            events=events,
+            trial_id=TRIAL_ID,
+            conversation="conversation-1",
+            strategy="router",
+            reflection_summary="created reusable learning",
+        )
+
+        self.assertEqual(report["reflection_strategy"], "router")
+        self.assertEqual(
+            report["task_usage"],
+            {
+                "skills_loaded": [
+                    {"name": "inspect-copy", "tool_call_id": "skill-use"}
+                ],
+                "skills_reused_from_prior_tasks": [
+                    {"name": "inspect-copy", "tool_call_id": "skill-use"}
+                ],
+                "agent_tools_called": [
+                    {"name": "copy_checker", "tool_call_id": "agent-tool-use"}
+                ],
+                "agent_tools_reused_from_prior_tasks": [
+                    {"name": "copy_checker", "tool_call_id": "agent-tool-use"}
+                ],
+            },
+        )
+        self.assertEqual(len(report["actions"]), 4)
+        self.assertEqual(
+            report["route_counts"],
+            {
+                "memory": {
+                    "attempted": 1,
+                    "succeeded": 1,
+                    "failed": 0,
+                    "unresolved": 0,
+                },
+                "skill": {
+                    "attempted": 1,
+                    "succeeded": 0,
+                    "failed": 1,
+                    "unresolved": 0,
+                },
+                "tool": {
+                    "attempted": 1,
+                    "succeeded": 1,
+                    "failed": 0,
+                    "unresolved": 0,
+                },
+                "policy": {
+                    "attempted": 1,
+                    "succeeded": 0,
+                    "failed": 0,
+                    "unresolved": 1,
+                },
+            },
+        )
+        self.assertEqual(report["actions"][1]["detail"], "inspect-copy")
+        self.assertEqual(report["actions"][2]["detail"], "copy-checker")
+        self.assertNotIn("SECRETLY LARGE SOURCE", json.dumps(report))
+        self.assertIsNone(report["actions"][3]["succeeded"])
+
+    def test_requires_feedback_marker(self) -> None:
+        with self.assertRaisesRegex(ValueError, "reflection.*was not found"):
+            build_learning_report(
+                events=[],
+                trial_id=TRIAL_ID,
+                conversation="conversation-1",
+                strategy="router",
+                reflection_summary=None,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/eval/harbor/tests/test_learning.py
+++ b/eval/harbor/tests/test_learning.py
@@ -61,7 +61,163 @@ def tool_call(call_id: str, name: str, arguments: dict) -> dict:
     }
 
 
+def learning_activated_event(event_id: str, artifact_id: str, route: str) -> dict:
+    return {
+        "id": event_id,
+        "session_id": "session-1",
+        "turn_id": "turn-1",
+        "created_at": "2026-08-18T12:00:00Z",
+        "data": {
+            "type": "learning_activated",
+            "artifacts": [
+                {"id": artifact_id, "route": route, "title": "FLINT procedure"}
+            ],
+        },
+    }
+
+
 class LearningReportTest(unittest.TestCase):
+    def test_reports_lifecycle_promotion_and_prior_activation(self) -> None:
+        events = ConversationEvents.model_validate(
+            {
+                "events": [
+                    learning_activated_event("event-0", "learn-old", "skill"),
+                    messages_event(
+                        "event-1",
+                        [
+                            {
+                                "role": "user",
+                                "content": f"Feedback for trial `{TRIAL_ID}` is ready.",
+                            }
+                        ],
+                    ),
+                    messages_event(
+                        "event-2",
+                        [
+                            {
+                                "role": "assistant",
+                                "content": [
+                                    tool_call(
+                                        "propose-1",
+                                        "propose_skill_learning",
+                                        {"title": "FLINT procedure"},
+                                    )
+                                ],
+                            }
+                        ],
+                    ),
+                    tool_result_event(
+                        "event-3",
+                        "propose-1",
+                        {
+                            "ok": True,
+                            "candidateId": "learn-new",
+                            "route": "skill",
+                            "status": "proposed",
+                        },
+                        tool_name="propose_skill_learning",
+                    ),
+                    messages_event(
+                        "event-4",
+                        [
+                            {
+                                "role": "assistant",
+                                "content": [
+                                    tool_call(
+                                        "promote-1",
+                                        "validate_and_promote_learning",
+                                        {"candidateId": "learn-new"},
+                                    )
+                                ],
+                            }
+                        ],
+                    ),
+                    tool_result_event(
+                        "event-5",
+                        "promote-1",
+                        {
+                            "ok": True,
+                            "candidateId": "learn-new",
+                            "route": "skill",
+                            "status": "promoted",
+                        },
+                        tool_name="validate_and_promote_learning",
+                    ),
+                ]
+            }
+        ).events
+
+        report = build_learning_report(
+            events=events,
+            trial_id=TRIAL_ID,
+            conversation="conversation-1",
+            strategy="lifecycle",
+            reflection_summary="promoted validated skill",
+        )
+
+        self.assertEqual(report["lifecycle"]["proposal_count"], 1)
+        self.assertEqual(report["lifecycle"]["promotion_count"], 1)
+        self.assertEqual(report["route_counts"]["skill"]["succeeded"], 1)
+        self.assertEqual(
+            report["task_usage"]["learning_artifacts_activated"],
+            [{"id": "learn-old", "route": "skill", "title": "FLINT procedure"}],
+        )
+
+    def test_reports_proposal_that_was_never_promoted_as_unresolved(self) -> None:
+        events = ConversationEvents.model_validate(
+            {
+                "events": [
+                    messages_event(
+                        "event-1",
+                        [
+                            {
+                                "role": "user",
+                                "content": f"Feedback for trial `{TRIAL_ID}` is ready.",
+                            }
+                        ],
+                    ),
+                    messages_event(
+                        "event-2",
+                        [
+                            {
+                                "role": "assistant",
+                                "content": [
+                                    tool_call(
+                                        "propose-1",
+                                        "propose_memory_learning",
+                                        {"title": "Unfinished candidate"},
+                                    )
+                                ],
+                            }
+                        ],
+                    ),
+                    tool_result_event(
+                        "event-3",
+                        "propose-1",
+                        {
+                            "ok": True,
+                            "candidateId": "learn-unresolved",
+                            "route": "memory",
+                            "status": "proposed",
+                        },
+                        tool_name="propose_memory_learning",
+                    ),
+                ]
+            }
+        ).events
+
+        report = build_learning_report(
+            events=events,
+            trial_id=TRIAL_ID,
+            conversation="conversation-1",
+            strategy="lifecycle",
+            reflection_summary="forgot to promote",
+        )
+
+        self.assertEqual(report["lifecycle"]["proposal_count"], 1)
+        self.assertEqual(report["lifecycle"]["promotion_count"], 0)
+        self.assertEqual(report["lifecycle"]["unresolved_count"], 1)
+
     def test_job_summary_aggregates_rewards_routes_reuse_and_memory(self) -> None:
         reports = [
             {
@@ -328,6 +484,69 @@ class LearningReportTest(unittest.TestCase):
             report["task_usage"]["agent_tools_reused_from_prior_tasks"], []
         )
 
+    def test_counts_scoped_lifecycle_skill_load_as_prior_reuse(self) -> None:
+        events = ConversationEvents.model_validate(
+            {
+                "events": [
+                    learning_activated_event("event-0", "learn-skill", "skill"),
+                    messages_event(
+                        "event-1",
+                        [
+                            {
+                                "role": "assistant",
+                                "content": [
+                                    tool_call(
+                                        "use-learning-skill",
+                                        "use_learning_skill",
+                                        {"candidateId": "learn-skill"},
+                                    )
+                                ],
+                            }
+                        ],
+                    ),
+                    tool_result_event(
+                        "event-2",
+                        "use-learning-skill",
+                        {
+                            "ok": True,
+                            "candidateId": "learn-skill",
+                            "name": "flint-procedure",
+                        },
+                        tool_name="use_learning_skill",
+                        source="library",
+                    ),
+                    messages_event(
+                        "event-3",
+                        [
+                            {
+                                "role": "user",
+                                "content": f"Feedback for trial `{TRIAL_ID}` is ready.",
+                            }
+                        ],
+                    ),
+                ]
+            }
+        ).events
+
+        report = build_learning_report(
+            events=events,
+            trial_id=TRIAL_ID,
+            conversation="conversation-1",
+            strategy="lifecycle",
+            reflection_summary=None,
+        )
+
+        self.assertEqual(
+            report["task_usage"]["skills_reused_from_prior_tasks"],
+            [
+                {
+                    "name": "flint-procedure",
+                    "tool_call_id": "use-learning-skill",
+                    "candidate_id": "learn-skill",
+                }
+            ],
+        )
+
     def test_reports_only_persistence_actions_during_reflection(self) -> None:
         events = ConversationEvents.model_validate(
             {
@@ -448,6 +667,7 @@ class LearningReportTest(unittest.TestCase):
                 "agent_tools_reused_from_prior_tasks": [
                     {"name": "copy_checker", "tool_call_id": "agent-tool-use"}
                 ],
+                "learning_artifacts_activated": [],
             },
         )
         self.assertEqual(len(report["actions"]), 4)

--- a/eval/harbor/tests/test_plugin.py
+++ b/eval/harbor/tests/test_plugin.py
@@ -1,8 +1,13 @@
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
-from exo_harbor.plugin import ExoSessionPlugin, _export_trajectory
+from exo_harbor.plugin import (
+    ExoSessionPlugin,
+    _export_learning_report,
+    _export_trajectory,
+)
 
 
 class ExoSessionPluginTest(unittest.IsolatedAsyncioTestCase):
@@ -25,6 +30,25 @@ class ExoSessionPluginTest(unittest.IsolatedAsyncioTestCase):
 
         log_exception.assert_called_once()
 
+    async def test_learning_export_failure_does_not_fail_trial(self) -> None:
+        with (
+            patch(
+                "exo_harbor.plugin.export_learning_report",
+                AsyncMock(side_effect=ValueError("missing reflection")),
+            ),
+            patch("exo_harbor.plugin.logger.exception") as log_exception,
+        ):
+            await _export_learning_report(
+                AsyncMock(),
+                "conversation-1",
+                "trial-1",
+                "router",
+                "learned",
+                Path("learning.json"),
+            )
+
+        log_exception.assert_called_once()
+
     async def test_job_end_without_started_client_has_no_side_effects(self) -> None:
         plugin = ExoSessionPlugin()
 
@@ -39,6 +63,40 @@ class ExoSessionPluginTest(unittest.IsolatedAsyncioTestCase):
         await plugin.on_job_end(AsyncMock())
 
         client.delete_snapshots.assert_awaited_once_with()
+
+    async def test_job_end_exports_aggregate_learning_summary(self) -> None:
+        plugin = ExoSessionPlugin(reflection_strategy="router")
+        client = AsyncMock()
+        client.exo_root = Path("/runs/exo")
+        client.delete_snapshots.return_value = 0
+        plugin._client = client
+        plugin._job_dir = Path("/runs/job")
+        plugin._model = "fixed-model"
+        result = SimpleNamespace(
+            trial_results=[
+                SimpleNamespace(
+                    trial_name="task-1",
+                    task_name="first-task",
+                    verifier_result=SimpleNamespace(rewards={"reward": 1.0}),
+                )
+            ]
+        )
+
+        with patch("exo_harbor.plugin._export_job_learning_summary") as export:
+            await plugin.on_job_end(result)
+
+        export.assert_called_once_with(
+            job_dir=Path("/runs/job"),
+            exo_root=Path("/runs/exo"),
+            strategy="router",
+            model="fixed-model",
+            trial_metadata={
+                "task-1": {
+                    "task_name": "first-task",
+                    "rewards": {"reward": 1.0},
+                }
+            },
+        )
 
 
 if __name__ == "__main__":

--- a/eval/harbor/tests/test_router_quality.py
+++ b/eval/harbor/tests/test_router_quality.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from exo_harbor.router_quality import (
+    better_than_prompt_only,
+    load_gold_labels,
+    persisted_keep_routes,
+    score_router_quality,
+)
+
+
+GOLD = Path(__file__).parents[1] / "gold-labels/learning-router-transfer-test.json"
+
+
+def trial(
+    task: str,
+    *,
+    persisted: dict[str, int] | None = None,
+    promotions: list[dict] | None = None,
+    activated: list[dict] | None = None,
+    reused: list[dict] | None = None,
+) -> dict:
+    return {
+        "task_name": task,
+        "route_counts": {
+            route: {
+                "attempted": count,
+                "succeeded": count,
+                "failed": 0,
+                "unresolved": 0,
+            }
+            for route, count in (persisted or {}).items()
+        },
+        "lifecycle": {"promotions": promotions or []},
+        "task_usage": {
+            "learning_artifacts_activated": activated or [],
+            "skills_reused_from_prior_tasks": reused or [],
+            "agent_tools_reused_from_prior_tasks": [],
+        },
+    }
+
+
+class RouterQualityTest(unittest.TestCase):
+    def test_gold_labels_cover_the_transfer_protocol(self) -> None:
+        gold = load_gold_labels(GOLD)
+        self.assertEqual(gold["dataset"], "learning-router-transfer-test")
+        self.assertEqual(
+            list(gold["tasks"]),
+            [
+                "exo/learning-router-normalization-first",
+                "exo/learning-router-normalization-transfer",
+                "exo/learning-router-unrelated-control",
+            ],
+        )
+
+    def test_prompt_only_flint_discard_loses_to_lifecycle_skill(self) -> None:
+        gold = load_gold_labels(GOLD)
+        baseline = {
+            "trials": [
+                trial(
+                    "exo/learning-router-normalization-first",
+                    persisted={},
+                    promotions=[
+                        {
+                            "route": "discard",
+                            "status": "discarded",
+                        }
+                    ],
+                ),
+                trial("exo/learning-router-normalization-transfer"),
+                trial("exo/learning-router-unrelated-control"),
+            ]
+        }
+        candidate = {
+            "trials": [
+                trial(
+                    "exo/learning-router-normalization-first",
+                    promotions=[
+                        {
+                            "route": "skill",
+                            "status": "promoted",
+                        }
+                    ],
+                ),
+                trial(
+                    "exo/learning-router-normalization-transfer",
+                    activated=[{"id": "learn-1", "route": "skill"}],
+                    reused=[{"name": "flint-normalization"}],
+                ),
+                trial("exo/learning-router-unrelated-control"),
+            ]
+        }
+
+        baseline_quality = score_router_quality(baseline, gold)
+        candidate_quality = score_router_quality(candidate, gold)
+        proof = better_than_prompt_only(
+            baseline=baseline_quality,
+            candidate=candidate_quality,
+        )
+
+        self.assertEqual(baseline_quality["route_accuracy"], 0.0)
+        self.assertEqual(candidate_quality["route_accuracy"], 1.0)
+        self.assertEqual(candidate_quality["validated_reuse"], 1)
+        self.assertEqual(candidate_quality["false_activation"], 0)
+        self.assertTrue(proof["proven"])
+
+    def test_memory_only_learn_is_an_incorrect_flint_route(self) -> None:
+        gold = load_gold_labels(GOLD)
+        summary = {
+            "trials": [
+                trial(
+                    "exo/learning-router-normalization-first",
+                    persisted={"memory": 1},
+                )
+            ]
+        }
+        quality = score_router_quality(summary, gold)
+        learn = quality["tasks"][0]
+        self.assertEqual(learn["persisted_routes"], ["memory"])
+        self.assertFalse(learn["route_correct"])
+        self.assertTrue(learn["useless_artifact"])
+
+    def test_lifecycle_promotions_are_preferred_over_route_counts(self) -> None:
+        trial_row = trial(
+            "learn",
+            persisted={"memory": 1},
+            promotions=[{"route": "skill", "status": "promoted"}],
+        )
+        self.assertEqual(persisted_keep_routes(trial_row), {"skill"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/eval/harbor/tests/test_trajectory.py
+++ b/eval/harbor/tests/test_trajectory.py
@@ -41,6 +41,37 @@ def messages_event(
 
 
 class TrajectoryTest(unittest.IsolatedAsyncioTestCase):
+    def test_usage_without_provider_cost_remains_valid_and_unknown(self) -> None:
+        event = messages_event(
+            "event-free-model",
+            [
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "Done."}],
+                    "id": "free-response",
+                }
+            ],
+            usage={
+                "model": "fixed-free-model",
+                "prompt_tokens": 10,
+                "completion_tokens": 2,
+            },
+        )
+        events = ConversationEvents.model_validate_json(event_page([event])).events
+
+        trajectory = build_trajectory(
+            events=events,
+            trial_id=TRIAL_ID,
+            turn_ids=[TURN_ID],
+            instruction="Do the task",
+            model_name="fixed-free-model",
+            conversation="harbor-shared",
+            started_at="2026-08-07T21:09:02.215Z",
+        )
+
+        self.assertIsNone(trajectory.steps[1].metrics.cost_usd)
+        self.assertIsNone(trajectory.final_metrics.total_cost_usd)
+
     async def test_export_includes_trial_continuation_turns_and_writes_atif(self) -> None:
         other = messages_event(
             "event-1",

--- a/exo/docs/design/trial-feedback.md
+++ b/exo/docs/design/trial-feedback.md
@@ -40,6 +40,18 @@ Using the same conversation preserves the reasoning and trajectory for that
 trial. Using the same filesystem state lets Exo inspect its submitted work.
 Agent-scoped state remains the mechanism by which lessons affect later trials.
 
+## Task boundary
+
+For this evaluation, a task is one externally specified Harbor trial: an
+instruction, a starting container, a resource budget, and a verifier that
+produces the reward and logs. Each task receives a fresh conversation and
+filesystem environment. The Exo agent identity and its agent-scoped memory,
+skills, tools, and source changes persist across tasks.
+
+This boundary matters to the experiment. Repeating a task measures recovery
+from prior feedback; performance on a new task measures whether the learning
+transfers. Neither should be inferred only from the amount of state Exo writes.
+
 ## Protocol
 
 The successful `trial_complete` response gains `snapshot_id`:
@@ -89,9 +101,81 @@ phase, starting from the snapshot recorded at trial completion.
 
 The reflection prompt should tell Exo to inspect its prior work and the restored
 filesystem, understand what succeeded or failed, and extract general lessons
-that will help on similar future tasks. It should explicitly consider durable
-memories, reusable tools, and changes to its own policy or implementation. The
-goal is learning, not repairing the already-graded submission.
+that will help on similar future tasks. It should route each lesson to the
+narrowest durable form that fits: memory for concise cross-task facts and
+heuristics, skills for reusable procedures, tools for repeated mechanical work,
+and policy or implementation for broad agent behavior. Task-specific details
+and unsupported guesses should be discarded. The prompt must not require every
+lesson to become a memory, and it should ask Exo to avoid duplicate or
+superseded memories. The goal is learning, not repairing the already-graded
+submission.
+
+## Learning-router prototype
+
+The Harbor plugin accepts two reflection strategies:
+
+- `memory` preserves the original PR #202 prompt, which asks Exo to put every
+  useful general lesson in durable memory and optionally create tools or change
+  its implementation.
+- `router` asks Exo to choose the narrowest useful destination: memory for a
+  stable fact or heuristic, skill for a reusable procedure, tool for a repeated
+  deterministic operation, policy or implementation for a broad behavior
+  change, and discard for task-specific or unsupported conclusions.
+
+After reflection, Harbor writes `agent/learning.json` beside the trajectory.
+The report counts actual successful calls to `remember`, `install_skill`,
+`install_agent_tool`, `manage_tool`, and the corresponding removal or restart
+tools. It does not treat the reflection summary as proof that learning was
+persisted. Discard decisions are intentionally not counted because they have no
+observable durable mutation. The report also records successful `use_skill`
+calls and calls whose tool-result source is `agent` during the task phase. This
+makes later skill and self-created-tool reuse observable. Installs performed in
+the same task are tracked and excluded from the prior-task reuse metric; memory
+reuse remains implicit because all durable memories are currently injected
+into every turn.
+
+At job end, Harbor writes `learning-summary.json` in the job directory. It
+aggregates reward; attempted, successful, failed, and unresolved actions by
+route; later skill/tool reuse; and the final durable-memory count, with the
+fixed model and task name recorded for comparison. An unresolved action was
+requested but has no matching result event. Because every comparison run
+starts with a fresh Exo root, that final count is also the run's memory growth.
+The summary counts memory entries without copying their text. A comparison is
+invalid if any completed trial is missing its reflection report; the comparison
+runner rejects that arm instead of treating missing instrumentation as zero
+learning.
+
+The first controlled comparison should run both strategies from separate fresh
+Exo roots **and separate clean source checkouts created from the same commit**,
+with the same fixed model, selected tasks, task order, attempt count, and
+resource limits. A fresh Exo root alone is insufficient because a genuine
+self-edit or workspace-local tool source can otherwise contaminate the next
+experimental arm. Compare Harbor reward with memory, skill, tool, and policy
+actions from `learning.json`. Same-task reruns measure recovery; a held-out task
+set is still required to measure transfer.
+
+One paired run is only a diagnostic probe. Repeat independent comparisons with
+both arm orders so stochastic tool behavior, provider variance, and shared
+rate-limit timing are not mistaken for effects of the reflection strategy.
+
+The current Harbor attached task sandbox and restored feedback sandbox do not
+mount the Exo source checkout. Memory, skills, and legacy generated tools are
+actionable, but source-level policy changes are not yet a complete experimental
+route. `rebuild_and_restart_exo` without an actual source change must not count
+as improvement. Testing policy/code routing requires an isolated writable
+checkout integration; it must not share a checkout between the baseline and
+router arms.
+
+The bundled `self-evolution-smoke-test` forces tool creation and reuse, so it is
+only an integration test. The `learning-router-transfer-test` is the first
+router-behavior probe: two fresh task environments apply the same deterministic
+record-normalization rule to different inputs, without naming memory, skills,
+or tools. Harbor still verifies output externally. The first reflection has an
+opportunity to create a reusable artifact; the second task's report shows
+whether prior learning was actually reused. This is a targeted transfer probe,
+not evidence of broad benchmark improvement. The comparison must reject a run
+unless the recorded task sequence places the learn task before the transfer
+task; local dataset discovery order is not itself experimental evidence.
 
 ## Exoharness changes
 

--- a/exo/docs/design/trial-feedback.md
+++ b/exo/docs/design/trial-feedback.md
@@ -110,9 +110,9 @@ lesson to become a memory, and it should ask Exo to avoid duplicate or
 superseded memories. The goal is learning, not repairing the already-graded
 submission.
 
-## Learning-router prototype
+## Learning-router experiments
 
-The Harbor plugin accepts two reflection strategies:
+The Harbor plugin accepts three reflection strategies:
 
 - `memory` preserves the original PR #202 prompt, which asks Exo to put every
   useful general lesson in durable memory and optionally create tools or change
@@ -121,22 +121,91 @@ The Harbor plugin accepts two reflection strategies:
   stable fact or heuristic, skill for a reusable procedure, tool for a repeated
   deterministic operation, policy or implementation for a broad behavior
   change, and discard for task-specific or unsupported conclusions.
+- `lifecycle` uses the same conceptual routes but changes the state machine and
+  tool surface rather than only changing the reflection prompt.
+
+### Prompt-only router
+
+The `router` arm is deliberately the strongest prompt-only baseline. The model
+receives routing instructions and can immediately call the existing `remember`,
+`install_skill`, `install_agent_tool`, policy, or restart tools. If it chooses a
+bad destination or writes a bad artifact, the mutation is already durable. In
+particular, a successful install call proves only that the artifact has a valid
+shape; it does not prove the learned procedure works.
+
+### Validated lifecycle router
+
+During a `lifecycle` reflection, direct memory, skill, tool-management, policy
+restart, and rebuild write surfaces are unavailable. Exo instead gets four
+route-specific proposal tools plus one promotion tool:
+
+```text
+reflection
+  -> propose memory | skill | tool | discard
+  -> inactive candidate in learning/index.json
+  -> route-specific validation
+  -> promoted | rejected | discarded
+  -> trigger match on a later task
+  -> explicit learning_activated event
+```
+
+The schemas are separate so choosing a skill cannot silently populate memory
+fields or rely on nullable placeholders. Promotion currently applies these
+checks:
+
+- every active route: require the structured evaluator feedback payload and
+  record its numeric rewards and whether verifier logs were present separately
+  from the model's evidence string;
+- memory: retain the lesson as scoped memory rather than injecting it globally;
+- skill: stage the complete skill in the restored task sandbox, run its
+  validation command there, and keep it in the learning catalog only after a
+  zero exit status;
+- tool: load the module from an isolated temporary directory, execute exact
+  self-test arguments, compare the canonical JSON result, and keep it in the
+  learning catalog only on success;
+- discard: make the decision terminal without creating active learning.
+
+Promoted learning is not injected globally. The harness matches explicit
+activation terms against a later task, emits `learning_activated`, and then
+injects a memory, exposes the matching skill through `use_learning_skill`, or
+registers the matching tool for that turn. Skills and tools remain absent from
+unrelated turns rather than leaking through Exo's global skill metadata or tool
+registry. Activation count and later skill/tool calls are therefore separately
+measurable.
+
+This produces a functional difference even with a deterministic model. The
+test suite sends the same broken-but-well-formed skill down both paths. The
+prompt-only path installs it immediately. The lifecycle path runs its failing
+sandbox check, marks the candidate rejected, and never publishes the skill.
+
+The lifecycle is not an independent truth oracle. The reflecting agent still
+writes the skill validation command and the expected tool result, and the
+memory evidence gate does not verify factual truth. Those checks catch broken
+or non-executable artifacts and make activation observable; they do not prove
+generalization. Only externally verified reward on a later task can establish
+that the learning improved behavior. The controlled Harbor comparison must
+therefore treat promotions as mechanism metrics and held-out task reward as
+the outcome metric. Its output reports reward and activation by task rather
+than only as aggregate means, so the learn, transfer, and unrelated control
+results remain distinguishable.
 
 After reflection, Harbor writes `agent/learning.json` beside the trajectory.
 The report counts actual successful calls to `remember`, `install_skill`,
 `install_agent_tool`, `manage_tool`, and the corresponding removal or restart
 tools. It does not treat the reflection summary as proof that learning was
 persisted. Discard decisions are intentionally not counted because they have no
-observable durable mutation. The report also records successful `use_skill`
-calls and calls whose tool-result source is `agent` during the task phase. This
-makes later skill and self-created-tool reuse observable. Installs performed in
-the same task are tracked and excluded from the prior-task reuse metric; memory
-reuse remains implicit because all durable memories are currently injected
-into every turn.
+observable durable mutation. The report also records successful `use_skill` and
+`use_learning_skill` calls and calls whose tool-result source is `agent` during
+the task phase. This makes later skill and self-created-tool reuse observable.
+Installs performed in the same task are tracked and excluded from the prior-task
+reuse metric; prompt-only memory reuse remains implicit because legacy durable
+memories are injected into every turn, while lifecycle memory emits an explicit
+activation event.
 
 At job end, Harbor writes `learning-summary.json` in the job directory. It
 aggregates reward; attempted, successful, failed, and unresolved actions by
-route; later skill/tool reuse; and the final durable-memory count, with the
+route; lifecycle proposal, promotion, rejection, discard, and activation
+counts; later skill/tool reuse; and the final durable-memory count, with the
 fixed model and task name recorded for comparison. An unresolved action was
 requested but has no matching result event. Because every comparison run
 starts with a fresh Exo root, that final count is also the run's memory growth.
@@ -145,14 +214,17 @@ invalid if any completed trial is missing its reflection report; the comparison
 runner rejects that arm instead of treating missing instrumentation as zero
 learning.
 
-The first controlled comparison should run both strategies from separate fresh
+The first controlled comparison should run prompt-only `router` and
+`lifecycle` from separate fresh
 Exo roots **and separate clean source checkouts created from the same commit**,
 with the same fixed model, selected tasks, task order, attempt count, and
 resource limits. A fresh Exo root alone is insufficient because a genuine
 self-edit or workspace-local tool source can otherwise contaminate the next
-experimental arm. Compare Harbor reward with memory, skill, tool, and policy
-actions from `learning.json`. Same-task reruns measure recovery; a held-out task
-set is still required to measure transfer.
+experimental arm. Compare Harbor reward with lifecycle decisions, activation,
+memory growth, and actual later skill/tool use from `learning.json`. Same-task
+reruns measure recovery; the second task in the bundled sequence measures
+narrow transfer and the third unrelated task checks for over-broad activation.
+A broader held-out set is still required for a general claim.
 
 One paired run is only a diagnostic probe. Repeat independent comparisons with
 both arm orders so stochastic tool behavior, provider variance, and shared
@@ -168,14 +240,17 @@ router arms.
 
 The bundled `self-evolution-smoke-test` forces tool creation and reuse, so it is
 only an integration test. The `learning-router-transfer-test` is the first
-router-behavior probe: two fresh task environments apply the same deterministic
-record-normalization rule to different inputs, without naming memory, skills,
-or tools. Harbor still verifies output externally. The first reflection has an
-opportunity to create a reusable artifact; the second task's report shows
-whether prior learning was actually reused. This is a targeted transfer probe,
-not evidence of broad benchmark improvement. The comparison must reject a run
-unless the recorded task sequence places the learn task before the transfer
-task; local dataset discovery order is not itself experimental evidence.
+router-behavior probe: the first fresh task defines a deterministic named FLINT
+records contract; the second fresh task requests FLINT on different input but
+omits the contract rules; the third fresh task is unrelated and intentionally
+contains none of the FLINT trigger vocabulary. Harbor verifies all outputs
+externally. The first reflection has an opportunity to create a reusable
+artifact; the second task's report shows whether that artifact was activated
+and actually used; the third checks whether it stays inactive off-topic. This
+is a targeted transfer probe, not evidence of broad benchmark improvement. The
+comparison must reject a run unless the recorded task sequence is learn,
+transfer, then unrelated control; local dataset discovery order is not itself
+experimental evidence.
 
 ## Exoharness changes
 

--- a/exo/docs/design/trial-feedback.md
+++ b/exo/docs/design/trial-feedback.md
@@ -122,7 +122,9 @@ The Harbor plugin accepts three reflection strategies:
   deterministic operation, policy or implementation for a broad behavior
   change, and discard for task-specific or unsupported conclusions.
 - `lifecycle` uses the same conceptual routes but changes the state machine and
-  tool surface rather than only changing the reflection prompt.
+  tool surface rather than only changing the reflection prompt. Proposal
+  routes are now classified from checkable features and conflicting writes
+  are rejected.
 
 ### Prompt-only router
 
@@ -137,17 +139,32 @@ shape; it does not prove the learned procedure works.
 
 During a `lifecycle` reflection, direct memory, skill, tool-management, policy
 restart, and rebuild write surfaces are unavailable. Exo instead gets four
-route-specific proposal tools plus one promotion tool:
+route-specific proposal tools, a feature-based route classifier, plus one
+promotion tool:
 
 ```text
 reflection
+  -> classify_learning_route
   -> propose memory | skill | tool | discard
+  -> feature router accepts or returns route_conflict
   -> inactive candidate in learning/index.json
   -> route-specific validation
   -> promoted | rejected | discarded
   -> trigger match on a later task
   -> explicit learning_activated event
 ```
+
+The classifier is the functional router. It scores numbered reusable
+procedures as skills, exact self-tested operations as tools, short heuristics
+as scoped memory, and one-off or unsupported guesses as discard. A prompt-only
+model can still say "this FLINT contract is task-specific" and discard it. The
+lifecycle path rejects that write with `suggestedRoute: skill`. That is the
+recorded first-run failure: the model discarded a reusable FLINT procedure.
+Labeled cases in `learning-router.test.ts` reconstruct that failure and the
+other gold routes. `compareRouterArms` reports route accuracy, useless
+artifacts, scoped reuse, and held-out reward for prompt-only versus the
+feature router. Harbor `compare.sh` scores the same criteria against
+`gold-labels.json` once a live paired run exists.
 
 The schemas are separate so choosing a skill cannot silently populate memory
 fields or rely on nullable placeholders. Promotion currently applies these

--- a/exo/harness.ts
+++ b/exo/harness.ts
@@ -11,6 +11,7 @@ import {
 } from "@exo/harness";
 
 import { memoryInstruction } from "./tools/memory-tools";
+import { learningInstruction } from "./tools/learning-tools";
 import { resolveExoProfile } from "./profiles";
 import { todoInstruction } from "./tools/todo-tools";
 import {
@@ -148,6 +149,10 @@ Use web_search to find current information on the web and web_fetch to read a sp
   const skills = await skillsInstruction(context);
   if (skills !== null) {
     instructions.push(skills);
+  }
+  const learning = await learningInstruction(context);
+  if (learning !== null) {
+    instructions.push(learning);
   }
   return instructions;
 }

--- a/exo/profiles/practical.ts
+++ b/exo/profiles/practical.ts
@@ -7,6 +7,11 @@ import {
 
 import { registerGuardianTools } from "../tools/guardian-tools";
 import { registerIntrospectionTools } from "../tools/introspection-tools";
+import {
+  isLearningLifecycleTurn,
+  registerActivatedLearningTools,
+  registerLearningTools,
+} from "../tools/learning-tools";
 import { registerMemoryTools } from "../tools/memory-tools";
 import { registerSandboxTools } from "../tools/sandbox-tools";
 import { registerSchedulerTools } from "../tools/scheduler-tools";
@@ -17,29 +22,41 @@ import type { ExoProfile } from "./types";
 export const practicalProfile: ExoProfile = {
   name: "practical",
   builtInToolNames(context) {
-    const names = bootstrapBuiltInToolNames();
-    if (context.agentConfig.enableAgentToolCreation) {
+    const lifecycle = isLearningLifecycleTurn(context);
+    const names = bootstrapBuiltInToolNames(lifecycle);
+    if (context.agentConfig.enableAgentToolCreation && !lifecycle) {
       names.push("install_agent_tool", "uninstall_agent_tool");
     }
     return names;
   },
-  registerTools(tools, context) {
+  async registerTools(tools, context) {
+    const lifecycle = isLearningLifecycleTurn(context);
     const libraryTools = new HarnessToolRegistry(context);
     registerSchedulerTools(libraryTools);
     registerAdapterTools(libraryTools);
     registerIntrospectionTools(libraryTools);
     registerSandboxTools(libraryTools);
-    registerMemoryTools(libraryTools);
+    if (!lifecycle) {
+      registerMemoryTools(libraryTools);
+    }
     registerTodoTools(libraryTools);
-    registerSkillTools(libraryTools);
+    if (!lifecycle) {
+      registerSkillTools(libraryTools);
+    }
+    registerLearningTools(libraryTools, context);
+    await registerActivatedLearningTools(libraryTools, context);
     registerWebTools(libraryTools);
     for (const tool of libraryTools.instances()) {
       tools.register({ ...tool, source: "library" });
     }
-    registerGuardianTools(tools);
+    if (!lifecycle) {
+      registerGuardianTools(tools);
+    }
   },
 };
 
-function bootstrapBuiltInToolNames(): BuiltInToolName[] {
-  return ["shell", "inspect_tools", "manage_tool"];
+function bootstrapBuiltInToolNames(lifecycle: boolean): BuiltInToolName[] {
+  return lifecycle
+    ? ["shell", "inspect_tools"]
+    : ["shell", "inspect_tools", "manage_tool"];
 }

--- a/exo/profiles/profiles.test.ts
+++ b/exo/profiles/profiles.test.ts
@@ -2,13 +2,14 @@ import { HarnessToolRegistry, type TurnContext } from "@exo/harness";
 import { describe, expect, it } from "vitest";
 
 import { resolveExoProfile } from "./index";
+import { LEARNING_LIFECYCLE_MARKER } from "../tools/learning-tools";
 
 describe("Exo profiles", () => {
   it("defaults to the practical profile", () => {
     expect(resolveExoProfile(undefined).name).toBe("practical");
   });
 
-  it("gives bootstrap exactly the recovery capabilities", () => {
+  it("gives bootstrap exactly the recovery capabilities", async () => {
     const profile = resolveExoProfile("bootstrap");
     const context = {
       agentConfig: { enableAgentToolCreation: false },
@@ -17,7 +18,7 @@ describe("Exo profiles", () => {
     expect(builtInNames).toEqual(["shell", "inspect_tools", "manage_tool"]);
 
     const tools = new HarnessToolRegistry(context);
-    profile.registerTools(tools, context);
+    await profile.registerTools(tools, context);
     expect([
       ...builtInNames,
       ...tools.definitions().map(({ name }) => name),
@@ -29,7 +30,7 @@ describe("Exo profiles", () => {
     ]);
   });
 
-  it("keeps practical extensions classified as library tools", () => {
+  it("keeps practical extensions classified as library tools", async () => {
     const profile = resolveExoProfile("practical");
     const context = {
       agentConfig: { enableAgentToolCreation: false },
@@ -40,7 +41,7 @@ describe("Exo profiles", () => {
       "inspect_tools",
       "manage_tool",
     ]);
-    profile.registerTools(tools, context);
+    await profile.registerTools(tools, context);
 
     expect(tools.get("create_adapter")?.source).toBe("library");
     expect(tools.get("snapshot_sandbox")?.source).toBe("library");
@@ -73,6 +74,32 @@ describe("Exo profiles", () => {
       "install_agent_tool",
       "uninstall_agent_tool",
     ]);
+  });
+
+  it("constrains persistence writes during lifecycle reflection", async () => {
+    const profile = resolveExoProfile("practical");
+    const context = {
+      request: {
+        input: [{ role: "user", content: LEARNING_LIFECYCLE_MARKER }],
+      },
+      agentConfig: { enableAgentToolCreation: true },
+    } as TurnContext;
+    const tools = new HarnessToolRegistry(context);
+
+    expect(profile.builtInToolNames(context)).toEqual([
+      "shell",
+      "inspect_tools",
+    ]);
+    await profile.registerTools(tools, context);
+
+    expect(tools.get("remember")).toBeUndefined();
+    expect(tools.get("install_skill")).toBeUndefined();
+    expect(tools.get("rebuild_and_restart_exo")).toBeUndefined();
+    expect(tools.get("propose_memory_learning")).toBeDefined();
+    expect(tools.get("propose_skill_learning")).toBeDefined();
+    expect(tools.get("propose_tool_learning")).toBeDefined();
+    expect(tools.get("propose_learning_discard")).toBeDefined();
+    expect(tools.get("validate_and_promote_learning")).toBeDefined();
   });
 
   it("rejects unknown profiles", () => {

--- a/exo/profiles/profiles.test.ts
+++ b/exo/profiles/profiles.test.ts
@@ -99,6 +99,7 @@ describe("Exo profiles", () => {
     expect(tools.get("propose_skill_learning")).toBeDefined();
     expect(tools.get("propose_tool_learning")).toBeDefined();
     expect(tools.get("propose_learning_discard")).toBeDefined();
+    expect(tools.get("classify_learning_route")).toBeDefined();
     expect(tools.get("validate_and_promote_learning")).toBeDefined();
   });
 

--- a/exo/tools/learning-router.test.ts
+++ b/exo/tools/learning-router.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  ROUTER_PROOF_CASES,
+  classifyLearningRoute,
+  compareRouterArms,
+  enforceLearningRoute,
+} from "./learning-router";
+
+describe("functional learning router", () => {
+  it("classifies each labeled case as the gold route", () => {
+    for (const labeled of ROUTER_PROOF_CASES) {
+      const decision = classifyLearningRoute(labeled.features);
+      expect(decision.route, labeled.id).toBe(labeled.goldRoute);
+    }
+  });
+
+  it("corrects the recorded prompt-only FLINT discard to skill", () => {
+    const flint = ROUTER_PROOF_CASES.find(
+      (item) => item.id === "flint-named-contract-discarded",
+    );
+    expect(flint).toBeDefined();
+    const decision = classifyLearningRoute(flint!.features);
+    const enforced = enforceLearningRoute("discard", decision);
+    expect(enforced.accepted).toBe(false);
+    expect(enforced.corrected).toBe(true);
+    expect(enforced.route).toBe("skill");
+  });
+
+  it("beats prompt-only routing on the published success criteria", () => {
+    const proof = compareRouterArms(ROUTER_PROOF_CASES);
+    expect(proof.promptOnly.routeAccuracy).toBeLessThan(1);
+    expect(proof.functional.routeAccuracy).toBe(1);
+    expect(proof.functional.uselessArtifacts).toBe(0);
+    expect(proof.promptOnly.uselessArtifacts).toBeGreaterThan(0);
+    expect(proof.functional.validatedReuse).toBeGreaterThan(
+      proof.promptOnly.validatedReuse,
+    );
+    expect(proof.functional.heldOutReward).toBeGreaterThan(
+      proof.promptOnly.heldOutReward,
+    );
+    expect(proof.successCriteria).toEqual({
+      higherRouteAccuracy: true,
+      fewerUselessArtifacts: true,
+      moreValidatedReuse: true,
+      equalOrBetterHeldOutReward: true,
+    });
+    expect(proof.proven).toBe(true);
+  });
+});

--- a/exo/tools/learning-router.ts
+++ b/exo/tools/learning-router.ts
@@ -1,0 +1,687 @@
+export type LearningRoute = "memory" | "skill" | "tool" | "discard";
+
+export const LEARNING_ROUTES: LearningRoute[] = [
+  "memory",
+  "skill",
+  "tool",
+  "discard",
+];
+
+export interface LessonFeatures {
+  title: string;
+  evidence: string;
+  expectedBenefit: string;
+  memoryText: string;
+  skillMd: string;
+  toolSource: string;
+  discardReason: string;
+}
+
+export interface RouteScores {
+  [route: string]: number;
+  memory: number;
+  skill: number;
+  tool: number;
+  discard: number;
+}
+
+export interface RouteDecision {
+  route: LearningRoute;
+  confidence: number;
+  scores: RouteScores;
+  reasons: string[];
+}
+
+export interface RouteEnforcement {
+  accepted: boolean;
+  route: LearningRoute;
+  corrected: boolean;
+  proposedRoute: LearningRoute;
+  reasons: string[];
+}
+
+export interface LabeledRouterCase {
+  id: string;
+  goldRoute: LearningRoute;
+  modelChoice: LearningRoute;
+  broken?: boolean;
+  features: LessonFeatures;
+  transferInput?: string;
+  controlInput?: string;
+  activationTerms?: string[];
+  minimumMatches?: number;
+}
+
+export interface RouterArmMetrics {
+  routeAccuracy: number;
+  correctRoutes: number;
+  uselessArtifacts: number;
+  validatedReuse: number;
+  falseActivation: number;
+  heldOutReward: number;
+  assignedRoutes: Record<string, LearningRoute>;
+}
+
+export interface RouterProof {
+  schemaVersion: 1;
+  caseCount: number;
+  successCriteria: {
+    higherRouteAccuracy: boolean;
+    fewerUselessArtifacts: boolean;
+    moreValidatedReuse: boolean;
+    equalOrBetterHeldOutReward: boolean;
+  };
+  proven: boolean;
+  promptOnly: RouterArmMetrics;
+  functional: RouterArmMetrics;
+  cases: Array<{
+    id: string;
+    goldRoute: LearningRoute;
+    modelChoice: LearningRoute;
+    promptOnlyRoute: LearningRoute;
+    functionalRoute: LearningRoute;
+    promptOnlyUseless: boolean;
+    functionalUseless: boolean;
+    promptOnlyReuse: boolean;
+    functionalReuse: boolean;
+    promptOnlyReward: number;
+    functionalReward: number;
+  }>;
+}
+
+const TIE_BREAK: LearningRoute[] = ["skill", "tool", "memory", "discard"];
+
+export function emptyLessonFeatures(): LessonFeatures {
+  return {
+    title: "",
+    evidence: "",
+    expectedBenefit: "",
+    memoryText: "",
+    skillMd: "",
+    toolSource: "",
+    discardReason: "",
+  };
+}
+
+export function lessonFeaturesFromUnknown(
+  value: Record<string, unknown>,
+): LessonFeatures {
+  const skill = isRecord(value.skill) ? value.skill : {};
+  const tool = isRecord(value.tool) ? value.tool : {};
+  return {
+    title: asString(value.title),
+    evidence: asString(value.evidence),
+    expectedBenefit: asString(value.expectedBenefit),
+    memoryText: asString(value.memoryText),
+    skillMd: asString(skill.skillMd),
+    toolSource: asString(tool.moduleSource),
+    discardReason: asString(value.discardReason),
+  };
+}
+
+export function classifyLearningRoute(features: LessonFeatures): RouteDecision {
+  const corpus = lessonCorpus(features);
+  const numberedSteps = countNumberedSteps(corpus);
+  const scores: RouteScores = {
+    memory: 0,
+    skill: 0,
+    tool: 0,
+    discard: 0,
+  };
+  const reasons: string[] = [];
+
+  if (numberedSteps >= 3) {
+    scores.skill += 3;
+    reasons.push(`numbered procedure with ${numberedSteps} steps`);
+  }
+  if (hasReusableProcedure(corpus)) {
+    scores.skill += 2;
+    reasons.push("reusable named procedure");
+  }
+  if (features.skillMd.length > 0) {
+    scores.skill += 2;
+    reasons.push("skill payload present");
+  }
+
+  if (features.toolSource.length > 0) {
+    scores.tool += 3;
+    reasons.push("executable tool source present");
+  }
+  if (
+    hasDeterministicTool(corpus) ||
+    hasDeterministicTool(features.toolSource)
+  ) {
+    scores.tool += 2;
+    reasons.push("deterministic operation with an exact self-test");
+  }
+
+  if (isShortHeuristic(features, numberedSteps)) {
+    scores.memory += 2;
+    reasons.push("short stable heuristic without a multi-step procedure");
+  }
+  if (
+    features.memoryText.length > 0 &&
+    numberedSteps < 3 &&
+    !hasReusableProcedure(corpus)
+  ) {
+    scores.memory += 1;
+    reasons.push("memory payload without procedure structure");
+  }
+
+  if (
+    hasTaskSpecificOnly(corpus) &&
+    numberedSteps < 3 &&
+    !hasReusableProcedure(corpus)
+  ) {
+    scores.discard += 3;
+    reasons.push("task-specific or one-off lesson");
+  }
+  if (
+    hasUnsupportedGuess(corpus) &&
+    numberedSteps < 3 &&
+    !hasReusableProcedure(corpus)
+  ) {
+    scores.discard += 3;
+    scores.skill = Math.min(scores.skill, 1);
+    scores.memory = Math.min(scores.memory, 1);
+    reasons.push("unsupported guess");
+  }
+  if (
+    features.discardReason.length > 0 &&
+    numberedSteps < 3 &&
+    !hasReusableProcedure(corpus) &&
+    features.toolSource.length === 0 &&
+    features.skillMd.length === 0
+  ) {
+    scores.discard += 1;
+  }
+
+  if (scores.skill >= 3 || scores.tool >= 3) {
+    if (scores.discard > 0) {
+      reasons.push("reusable structure blocks discard");
+    }
+    scores.discard = Math.min(scores.discard, 0);
+  }
+
+  const route = argMaxRoute(scores);
+  const ordered = [...LEARNING_ROUTES].sort(
+    (left, right) =>
+      scores[right] - scores[left] || tieRank(left) - tieRank(right),
+  );
+  const top = scores[ordered[0]];
+  const second = scores[ordered[1]];
+  const confidence = top <= 0 ? 0 : clamp((top - second) / top, 0, 1);
+  return { route, confidence, scores, reasons };
+}
+
+export function enforceLearningRoute(
+  proposedRoute: LearningRoute,
+  classification: RouteDecision,
+): RouteEnforcement {
+  const highConfidence =
+    classification.confidence >= 0.5 && topScore(classification.scores) >= 3;
+  const discardBlocked =
+    proposedRoute === "discard" &&
+    (classification.route === "skill" || classification.route === "tool") &&
+    (classification.scores.skill >= 3 || classification.scores.tool >= 3);
+
+  if (proposedRoute === classification.route && !discardBlocked) {
+    return {
+      accepted: true,
+      route: proposedRoute,
+      corrected: false,
+      proposedRoute,
+      reasons: classification.reasons,
+    };
+  }
+
+  if (discardBlocked || highConfidence) {
+    return {
+      accepted: false,
+      route: classification.route,
+      corrected: true,
+      proposedRoute,
+      reasons: [
+        `proposed ${proposedRoute} conflicts with ${classification.route}`,
+        ...classification.reasons,
+      ],
+    };
+  }
+
+  return {
+    accepted: true,
+    route: proposedRoute,
+    corrected: false,
+    proposedRoute,
+    reasons: classification.reasons,
+  };
+}
+
+export function compareRouterArms(cases: LabeledRouterCase[]): RouterProof {
+  const details: RouterProof["cases"] = cases.map((labeled) => {
+    const classification = classifyLearningRoute(labeled.features);
+    const enforced = enforceLearningRoute(labeled.modelChoice, classification);
+    const promptOnlyRoute = labeled.modelChoice;
+    const functionalRoute = enforced.route;
+    const promptOnlyUseless = isUseless(labeled, promptOnlyRoute, true);
+    const functionalUseless = isUseless(labeled, functionalRoute, false);
+    const promptOnlyReuse = reuseQuality(
+      labeled,
+      promptOnlyRoute,
+      "promptOnly",
+    );
+    const functionalReuse = reuseQuality(
+      labeled,
+      functionalRoute,
+      "functional",
+    );
+    return {
+      id: labeled.id,
+      goldRoute: labeled.goldRoute,
+      modelChoice: labeled.modelChoice,
+      promptOnlyRoute,
+      functionalRoute,
+      promptOnlyUseless,
+      functionalUseless,
+      promptOnlyReuse,
+      functionalReuse,
+      promptOnlyReward: heldOutReward(labeled, promptOnlyRoute, "promptOnly"),
+      functionalReward: heldOutReward(labeled, functionalRoute, "functional"),
+    };
+  });
+
+  const promptOnly = metricsFromDetails(details, "promptOnly");
+  const functional = metricsFromDetails(details, "functional");
+  const successCriteria = {
+    higherRouteAccuracy: functional.routeAccuracy > promptOnly.routeAccuracy,
+    fewerUselessArtifacts:
+      functional.uselessArtifacts < promptOnly.uselessArtifacts,
+    moreValidatedReuse: functional.validatedReuse > promptOnly.validatedReuse,
+    equalOrBetterHeldOutReward:
+      functional.heldOutReward >= promptOnly.heldOutReward,
+  };
+  return {
+    schemaVersion: 1,
+    caseCount: cases.length,
+    successCriteria,
+    proven: Object.values(successCriteria).every(Boolean),
+    promptOnly,
+    functional,
+    cases: details,
+  };
+}
+
+export const ROUTER_PROOF_CASES: LabeledRouterCase[] = [
+  {
+    id: "flint-named-contract-discarded",
+    goldRoute: "skill",
+    modelChoice: "discard",
+    features: {
+      title: "FLINT records contract",
+      evidence:
+        "The task defined a named FLINT records contract, a reusable procedure expected to recur in later isolated conversations. Steps: 1. Trim and lowercase names. 2. Keep the highest score per name. 3. Sort by score then name. 4. Write name=score lines.",
+      expectedBenefit:
+        "Later FLINT tasks can apply the same contract without restating the rules.",
+      memoryText: "",
+      skillMd: "",
+      toolSource: "",
+      discardReason:
+        "This looked task-specific to /app/records.txt in this trial.",
+    },
+    transferInput:
+      "Apply the FLINT records contract from prior work to /app/records.txt",
+    controlInput: "Count the non-empty lines in /app/palette.txt",
+    activationTerms: ["flint", "records", "contract"],
+    minimumMatches: 2,
+  },
+  {
+    id: "flint-procedure-dumped-as-memory",
+    goldRoute: "skill",
+    modelChoice: "memory",
+    features: {
+      title: "How to normalize FLINT records",
+      evidence: "Verifier reward 1.0 after applying the named FLINT procedure.",
+      expectedBenefit:
+        "Reuse the same multi-step contract on later FLINT tasks.",
+      memoryText:
+        "FLINT records contract: 1. Trim whitespace and lowercase each name. 2. Keep only the highest score for each name. 3. Sort by score descending, then name. 4. Write name=score with a final newline.",
+      skillMd: "",
+      toolSource: "",
+      discardReason: "",
+    },
+    transferInput: "Apply the FLINT records contract from prior work",
+    controlInput: "Count the non-empty lines in /app/palette.txt",
+    activationTerms: ["flint", "records"],
+    minimumMatches: 2,
+  },
+  {
+    id: "byte-exact-output-heuristic",
+    goldRoute: "memory",
+    modelChoice: "memory",
+    features: {
+      title: "FLINT output newline",
+      evidence:
+        "The Harbor verifier awarded 1.0 after byte-exact output checks.",
+      expectedBenefit: "Avoid repeating newline mistakes.",
+      memoryText: "FLINT ranked output must include a final newline.",
+      skillMd: "",
+      toolSource: "",
+      discardReason: "",
+    },
+    transferInput: "Apply the FLINT records contract from prior work",
+    controlInput: "Count the non-empty lines in /app/palette.txt",
+    activationTerms: ["flint", "ranked"],
+    minimumMatches: 1,
+  },
+  {
+    id: "deterministic-text-transformer",
+    goldRoute: "tool",
+    modelChoice: "tool",
+    features: {
+      title: "Reverse text transformer",
+      evidence:
+        "The same deterministic reverse operation was repeated with an exact JSON self-test.",
+      expectedBenefit: "Avoid rewriting the mechanical transformer.",
+      memoryText: "",
+      skillMd: "",
+      toolSource:
+        "export default { definition: { name: 'reverse_text' }, handler: { execute(args) { return args.text.split('').reverse().join(''); } } };",
+      discardReason: "",
+    },
+    transferInput: "Reverse this deterministic text payload",
+    controlInput: "Count the non-empty lines in /app/palette.txt",
+    activationTerms: ["reverse", "text"],
+    minimumMatches: 1,
+  },
+  {
+    id: "line-count-one-off",
+    goldRoute: "discard",
+    modelChoice: "memory",
+    features: {
+      title: "Palette line count",
+      evidence:
+        "This trial only needed the decimal count from /app/palette.txt.",
+      expectedBenefit: "None beyond this one-off file.",
+      memoryText: "The palette file in this trial had 4 non-empty lines.",
+      skillMd: "",
+      toolSource: "",
+      discardReason: "",
+    },
+    transferInput: "Apply the FLINT records contract from prior work",
+    controlInput: "Count the non-empty lines in /app/palette.txt",
+    activationTerms: ["palette", "count"],
+    minimumMatches: 1,
+  },
+  {
+    id: "unsupported-opposite-guess",
+    goldRoute: "discard",
+    modelChoice: "skill",
+    features: {
+      title: "Always invert a failed approach",
+      evidence:
+        "Reward was 0, so maybe the opposite approach is universally correct.",
+      expectedBenefit: "Guess a general policy from one failure.",
+      memoryText: "",
+      skillMd:
+        "---\nname: invert-failure\ndescription: Treat any failed attempt as proof of the opposite rule.\n---\nInvert the previous approach.",
+      toolSource: "",
+      discardReason: "",
+    },
+    transferInput: "Apply the FLINT records contract from prior work",
+    controlInput: "Count the non-empty lines in /app/palette.txt",
+    activationTerms: ["invert", "failure"],
+    minimumMatches: 1,
+  },
+  {
+    id: "broken-well-formed-skill",
+    goldRoute: "skill",
+    modelChoice: "skill",
+    broken: true,
+    features: {
+      title: "Broken FLINT procedure",
+      evidence: "A well-formed skill whose validation command fails.",
+      expectedBenefit: "None; the procedure does not work.",
+      memoryText: "",
+      skillMd:
+        "---\nname: broken-flint\ndescription: Apply a deliberately broken FLINT procedure.\n---\nWrite invalid output.",
+      toolSource: "",
+      discardReason: "",
+    },
+    transferInput: "Apply the FLINT records contract from prior work",
+    controlInput: "Count the non-empty lines in /app/palette.txt",
+    activationTerms: ["flint", "broken"],
+    minimumMatches: 1,
+  },
+  {
+    id: "task-specific-discard-accepted",
+    goldRoute: "discard",
+    modelChoice: "discard",
+    features: {
+      title: "This trial's temporary path",
+      evidence:
+        "The only lesson was a one-off path used in this submission only.",
+      expectedBenefit: "None.",
+      memoryText: "",
+      skillMd: "",
+      toolSource: "",
+      discardReason: "Task-specific path that will not be useful again.",
+    },
+  },
+];
+
+function lessonCorpus(features: LessonFeatures): string {
+  return [
+    features.title,
+    features.evidence,
+    features.expectedBenefit,
+    features.memoryText,
+    features.skillMd,
+    features.discardReason,
+  ]
+    .filter((part) => part.length > 0)
+    .join("\n");
+}
+
+function countNumberedSteps(text: string): number {
+  const matches = [...text.matchAll(/\b(\d+)\.\s+\S+/g)].map((match) =>
+    Number(match[1]),
+  );
+  let count = 0;
+  let expected = 1;
+  for (const value of matches) {
+    if (value === expected) {
+      count += 1;
+      expected += 1;
+    }
+  }
+  return count;
+}
+
+function hasReusableProcedure(text: string): boolean {
+  return (
+    /\bnamed(?:\s+\w+){0,3}\s+(procedure|contract|protocol)\b/i.test(text) &&
+    /\b(recur(?:s|ring)?|later tasks?|future tasks?|reusable|prior work|isolated conversations?|across tasks?)\b/i.test(
+      text,
+    )
+  );
+}
+
+function hasDeterministicTool(text: string): boolean {
+  return (
+    /\b(deterministic|transformer|self-test|exact json)\b/i.test(text) &&
+    /\b(operation|module|tool|reverse|parse|transform)\b/i.test(text)
+  );
+}
+
+function isShortHeuristic(
+  features: LessonFeatures,
+  numberedSteps: number,
+): boolean {
+  const text = features.memoryText || features.evidence;
+  return (
+    numberedSteps < 3 &&
+    text.length > 0 &&
+    text.length <= 220 &&
+    /\b(always|never|must|require|byte-exact|final newline|heuristic)\b/i.test(
+      text,
+    ) &&
+    !hasReusableProcedure(lessonCorpus(features))
+  );
+}
+
+function hasTaskSpecificOnly(text: string): boolean {
+  return /\b(this (trial|task|file|submission) only|task-specific|one-off|not be useful again|none beyond this)\b/i.test(
+    text,
+  );
+}
+
+function hasUnsupportedGuess(text: string): boolean {
+  return /\b(unsupported|guess|maybe the opposite|universally correct)\b/i.test(
+    text,
+  );
+}
+
+function argMaxRoute(scores: RouteScores): LearningRoute {
+  return [...LEARNING_ROUTES].sort(
+    (left, right) =>
+      scores[right] - scores[left] || tieRank(left) - tieRank(right),
+  )[0];
+}
+
+function tieRank(route: LearningRoute): number {
+  return TIE_BREAK.indexOf(route);
+}
+
+function topScore(scores: RouteScores): number {
+  return Math.max(...LEARNING_ROUTES.map((route) => scores[route]));
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isUseless(
+  labeled: LabeledRouterCase,
+  assigned: LearningRoute,
+  promptOnly: boolean,
+): boolean {
+  if (labeled.broken) {
+    return promptOnly && assigned !== "discard";
+  }
+  return assigned !== "discard" && labeled.goldRoute === "discard";
+}
+
+function activationMatches(
+  input: string,
+  terms: string[],
+  minimumMatches: number,
+): boolean {
+  const haystack = input.toLowerCase();
+  const matches = terms.filter((term) => {
+    const needle = term.toLowerCase();
+    const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    return new RegExp(`(^|[^a-z0-9_])${escaped}([^a-z0-9_]|$)`, "i").test(
+      haystack,
+    );
+  });
+  return matches.length >= minimumMatches;
+}
+
+function reuseQuality(
+  labeled: LabeledRouterCase,
+  assigned: LearningRoute,
+  arm: "promptOnly" | "functional",
+): boolean {
+  if (
+    labeled.broken ||
+    labeled.goldRoute === "discard" ||
+    assigned === "discard" ||
+    labeled.transferInput === undefined ||
+    labeled.controlInput === undefined
+  ) {
+    return false;
+  }
+  const terms = labeled.activationTerms ?? [];
+  const minimum = labeled.minimumMatches ?? 1;
+  if (arm === "promptOnly") {
+    return false;
+  }
+  return (
+    assigned === labeled.goldRoute &&
+    activationMatches(labeled.transferInput, terms, minimum) &&
+    !activationMatches(labeled.controlInput, terms, minimum)
+  );
+}
+
+function heldOutReward(
+  labeled: LabeledRouterCase,
+  assigned: LearningRoute,
+  arm: "promptOnly" | "functional",
+): number {
+  if (labeled.broken) {
+    return arm === "functional" ? 1 : 0;
+  }
+  if (labeled.goldRoute === "discard") {
+    return assigned === "discard" ? 1 : 0;
+  }
+  if (assigned !== labeled.goldRoute) {
+    return 0;
+  }
+  if (labeled.transferInput === undefined) {
+    return 1;
+  }
+  if (arm === "promptOnly") {
+    return labeled.controlInput === undefined ? 1 : 0;
+  }
+  return reuseQuality(labeled, assigned, arm) ? 1 : 0;
+}
+
+function metricsFromDetails(
+  details: RouterProof["cases"],
+  arm: "promptOnly" | "functional",
+): RouterArmMetrics {
+  const assignedRoutes: Record<string, LearningRoute> = {};
+  let correct = 0;
+  let useless = 0;
+  let reuse = 0;
+  let falseActivation = 0;
+  let reward = 0;
+  for (const item of details) {
+    const assigned =
+      arm === "promptOnly" ? item.promptOnlyRoute : item.functionalRoute;
+    assignedRoutes[item.id] = assigned;
+    if (assigned === item.goldRoute) {
+      correct += 1;
+    }
+    if (
+      arm === "promptOnly" ? item.promptOnlyUseless : item.functionalUseless
+    ) {
+      useless += 1;
+    }
+    if (arm === "promptOnly" ? item.promptOnlyReuse : item.functionalReuse) {
+      reuse += 1;
+    }
+    if (item.goldRoute === "discard" && assigned !== "discard") {
+      falseActivation += 1;
+    }
+    reward +=
+      arm === "promptOnly" ? item.promptOnlyReward : item.functionalReward;
+  }
+  return {
+    routeAccuracy: details.length === 0 ? 0 : correct / details.length,
+    correctRoutes: correct,
+    uselessArtifacts: useless,
+    validatedReuse: reuse,
+    falseActivation,
+    heldOutReward: details.length === 0 ? 0 : reward / details.length,
+    assignedRoutes,
+  };
+}

--- a/exo/tools/learning-tools.test.ts
+++ b/exo/tools/learning-tools.test.ts
@@ -844,6 +844,48 @@ ${LEARNING_LIFECYCLE_MARKER}`);
     });
   });
 
+  it("rejects discarding a reusable FLINT procedure", async () => {
+    const context = makeContext(lifecycleInput());
+    const tools = lifecycleTools(context);
+    const result = await call(
+      tools,
+      "propose_learning_discard",
+      {
+        title: "FLINT records contract",
+        evidence:
+          "The task defined a named FLINT records contract, a reusable procedure expected to recur in later isolated conversations. Steps: 1. Trim and lowercase names. 2. Keep the highest score per name. 3. Sort by score then name. 4. Write name=score lines.",
+        expectedBenefit:
+          "Later FLINT tasks can apply the same contract without restating the rules.",
+        discardReason:
+          "This looked task-specific to /app/records.txt in this trial.",
+      },
+      context,
+    );
+    expect(result).toMatchObject({
+      ok: false,
+      error: "route_conflict",
+      proposedRoute: "discard",
+      suggestedRoute: "skill",
+    });
+  });
+
+  it("classifies a reusable procedure as skill before a proposal", async () => {
+    const context = makeContext(lifecycleInput());
+    const tools = lifecycleTools(context);
+    const result = await call(
+      tools,
+      "classify_learning_route",
+      {
+        title: "FLINT records contract",
+        evidence:
+          "The task defined a named FLINT records contract, a reusable procedure expected to recur in later isolated conversations. Steps: 1. Trim and lowercase names. 2. Keep the highest score per name. 3. Sort by score then name. 4. Write name=score lines.",
+        expectedBenefit: "Reuse the contract on later FLINT tasks.",
+      },
+      context,
+    );
+    expect(result).toMatchObject({ ok: true, route: "skill" });
+  });
+
   it("does not expose proposal or promotion tools outside lifecycle reflection", () => {
     const context = makeContext("normal task");
     const tools = lifecycleTools(context);
@@ -852,6 +894,7 @@ ${LEARNING_LIFECYCLE_MARKER}`);
     expect(tools.get("propose_skill_learning")).toBeUndefined();
     expect(tools.get("propose_tool_learning")).toBeUndefined();
     expect(tools.get("propose_learning_discard")).toBeUndefined();
+    expect(tools.get("classify_learning_route")).toBeUndefined();
     expect(tools.get("validate_and_promote_learning")).toBeUndefined();
   });
 });

--- a/exo/tools/learning-tools.test.ts
+++ b/exo/tools/learning-tools.test.ts
@@ -1,0 +1,857 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  HarnessToolRegistry,
+  createSkillToolInstances,
+  type ArtifactVersion,
+  type EventData,
+  type JsonObject,
+  type JsonValue,
+  type TurnContext,
+} from "@exo/harness";
+
+import {
+  LEARNING_LIFECYCLE_MARKER,
+  learningInstruction,
+  registerActivatedLearningTools,
+  registerLearningTools,
+} from "./learning-tools";
+
+class FakeHandle {
+  private versions: {
+    artifactId: string;
+    path: string;
+    version: number;
+    value: unknown;
+  }[] = [];
+  private sequence = 0;
+
+  async listArtifacts(): Promise<ArtifactVersion[]> {
+    return this.versions.map(({ artifactId, path, version }) => ({
+      artifactId,
+      path,
+      version,
+      createdAt: "1970-01-01T00:00:00Z",
+      sizeBytes: 0,
+    }));
+  }
+
+  async readArtifactJson<T>({
+    artifactId,
+    version,
+  }: {
+    artifactId: string;
+    version?: number;
+  }): Promise<T | null> {
+    const selected = this.versions.find(
+      (item) =>
+        item.artifactId === artifactId &&
+        (version === undefined || item.version === version),
+    );
+    return selected ? (selected.value as T) : null;
+  }
+
+  async writeArtifactJson({
+    path,
+    value,
+  }: {
+    path: string;
+    value: JsonValue;
+  }): Promise<ArtifactVersion> {
+    this.sequence += 1;
+    const version = this.sequence;
+    const artifactId = `${path}@${version}`;
+    this.versions.push({ artifactId, path, version, value });
+    return {
+      artifactId,
+      path,
+      version,
+      createdAt: "1970-01-01T00:00:00Z",
+      sizeBytes: 0,
+    };
+  }
+}
+
+class FakeConversation {
+  readonly events: Array<{ turnId: string; data: EventData }> = [];
+  readonly record = { id: "conversation-1" };
+
+  async getEvents(query: {
+    turnId?: string | null;
+    types?: string[] | null;
+  }): Promise<{ events: Array<{ turnId: string; data: EventData }> }> {
+    return {
+      events: this.events.filter(
+        (event) =>
+          (query.turnId == null || event.turnId === query.turnId) &&
+          (query.types == null || query.types.includes(event.data.type)),
+      ),
+    };
+  }
+}
+
+function makeContext(
+  input: string,
+  options: {
+    agent?: FakeHandle;
+    conversation?: FakeConversation;
+    turnId?: string;
+    shellExitCode?: number;
+    enableAgentToolCreation?: boolean;
+    shellCommands?: string[];
+  } = {},
+): TurnContext {
+  const agent = options.agent ?? new FakeHandle();
+  const conversation = options.conversation ?? new FakeConversation();
+  const turnId = options.turnId ?? "turn-1";
+  return {
+    request: { input: [{ role: "user", content: input }] },
+    agentConfig: {
+      enableAgentToolCreation: options.enableAgentToolCreation ?? true,
+    },
+    exoharness: {
+      current: {
+        agent,
+        conversation,
+        turn: {
+          record: { id: turnId },
+          async addEvents(events: EventData[]) {
+            conversation.events.push(
+              ...events.map((data) => ({ turnId, data })),
+            );
+            return { eventIds: [], latestEventId: "event" };
+          },
+        },
+      },
+    },
+    async executeTool(request: {
+      functionName: string;
+      arguments: JsonObject;
+    }) {
+      if (
+        request.functionName === "shell" &&
+        typeof request.arguments.command === "string"
+      ) {
+        options.shellCommands?.push(request.arguments.command);
+      }
+      return {
+        exit_code: options.shellExitCode ?? 0,
+        stdout: "validated\n",
+        stderr: "",
+      };
+    },
+  } as unknown as TurnContext;
+}
+
+function lifecycleTools(context: TurnContext): HarnessToolRegistry {
+  const tools = new HarnessToolRegistry(context);
+  registerLearningTools(tools, context);
+  return tools;
+}
+
+async function normalTools(context: TurnContext): Promise<HarnessToolRegistry> {
+  const tools = lifecycleTools(context);
+  await registerActivatedLearningTools(tools, context);
+  return tools;
+}
+
+async function call(
+  tools: HarnessToolRegistry,
+  name: string,
+  args: JsonObject,
+  context: TurnContext,
+) {
+  const tool = tools.get(name);
+  if (tool === undefined) {
+    throw new Error(`missing tool ${name}`);
+  }
+  return tool.handler.execute(args, { context });
+}
+
+function memoryProposal(): JsonObject {
+  return {
+    title: "FLINT output contract",
+    evidence: "The Harbor verifier awarded 1.0 after byte-exact output checks.",
+    expectedBenefit: "Avoid repeating newline and ordering mistakes.",
+    activationDescription: "Tasks applying the FLINT records contract.",
+    activationTerms: ["flint", "records"],
+    minimumMatches: 2,
+    memoryText: "FLINT records require byte-exact output with a final newline.",
+  };
+}
+
+function lifecycleInput(): string {
+  return `Feedback:
+{"exception":null,"rewards":{"reward":1},"verifier_logs":{"reward.txt":"1"}}
+Reflection instructions:
+${LEARNING_LIFECYCLE_MARKER}`;
+}
+
+function reverseToolSource(): string {
+  return `
+import type { JsonObject, Tool, ToolResult } from "@exo/harness/tool";
+
+const tool = {
+  definition: {
+    name: "lifecycle_reverse_text",
+    description: "Reverse text for lifecycle validation.",
+    parameters: {
+      type: "object",
+      additionalProperties: false,
+      properties: { text: { type: "string" } },
+      required: ["text"],
+    },
+    outputSchema: {
+      type: "object",
+      additionalProperties: false,
+      properties: { text: { type: "string" } },
+      required: ["text"],
+    },
+  },
+  initializationParameters: {
+    type: "object",
+    additionalProperties: false,
+    properties: {},
+  },
+  initialize() {
+    return {
+      async execute(args: JsonObject): Promise<ToolResult> {
+        const text = args.text;
+        if (typeof text !== "string") throw new Error("text required");
+        return { text: text.split("").reverse().join("") };
+      },
+    };
+  },
+} satisfies Tool;
+
+export default tool;
+`;
+}
+
+describe("learning lifecycle", () => {
+  it("keeps proposals inactive until promotion, then activates matching learning once", async () => {
+    const agent = new FakeHandle();
+    const conversation = new FakeConversation();
+    const reflection = makeContext(lifecycleInput(), {
+      agent,
+      conversation,
+    });
+    const tools = lifecycleTools(reflection);
+    const proposed = (await call(
+      tools,
+      "propose_memory_learning",
+      memoryProposal(),
+      reflection,
+    )) as { candidateId: string; status: string };
+
+    expect(proposed.status).toBe("proposed");
+    const before = makeContext("Apply FLINT to these records", {
+      agent,
+      conversation,
+      turnId: "turn-2",
+    });
+    expect(await learningInstruction(before)).toBeNull();
+
+    const promoted = (await call(
+      tools,
+      "validate_and_promote_learning",
+      { candidateId: proposed.candidateId },
+      reflection,
+    )) as { ok: boolean; status: string };
+    expect(promoted).toMatchObject({
+      ok: true,
+      status: "promoted",
+      validation: {
+        externalFeedback: {
+          rewards: { reward: 1 },
+          verifierLogsPresent: true,
+          exceptionPresent: false,
+        },
+      },
+    });
+
+    const active = makeContext("Apply FLINT to these records", {
+      agent,
+      conversation,
+      turnId: "turn-3",
+    });
+    const instruction = await learningInstruction(active);
+    expect(String(instruction?.content)).toContain(
+      "FLINT records require byte-exact output",
+    );
+    await learningInstruction(active);
+    expect(
+      conversation.events.filter(
+        (event) =>
+          event.turnId === "turn-3" && event.data.type === "learning_activated",
+      ),
+    ).toHaveLength(1);
+
+    const listed = (await call(
+      lifecycleTools(active),
+      "list_learning_artifacts",
+      {},
+      active,
+    )) as { candidates: Array<{ activationCount: number }> };
+    expect(listed.candidates[0].activationCount).toBe(1);
+  });
+
+  it("rejects a skill whose sandbox validation command fails", async () => {
+    const context = makeContext(lifecycleInput(), {
+      shellExitCode: 7,
+    });
+    const tools = lifecycleTools(context);
+    const proposal = {
+      ...memoryProposal(),
+      title: "FLINT normalization procedure",
+      skill: {
+        skillMd:
+          "---\nname: flint-normalization\ndescription: Apply FLINT normalization when a task names the FLINT records contract.\n---\nVerify input and output bytes.",
+        files: [],
+        validationCommand: "test -f /app/ranked.txt",
+      },
+    } as JsonObject;
+    const proposed = (await call(
+      tools,
+      "propose_skill_learning",
+      proposal,
+      context,
+    )) as { candidateId: string };
+    const result = (await call(
+      tools,
+      "validate_and_promote_learning",
+      { candidateId: proposed.candidateId },
+      context,
+    )) as { ok: boolean; status: string; validation: { exitCode: number } };
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: "rejected",
+      validation: { exitCode: 7 },
+    });
+  });
+
+  it("rejects a skill proposal without standard frontmatter", async () => {
+    const context = makeContext(lifecycleInput());
+    const tools = lifecycleTools(context);
+
+    await expect(
+      call(
+        tools,
+        "propose_skill_learning",
+        {
+          ...memoryProposal(),
+          title: "Malformed skill",
+          skill: {
+            skillMd: "Do something without frontmatter.",
+            files: [],
+            validationCommand: "true",
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrow("skillMd must contain YAML frontmatter");
+  });
+
+  it("keeps a failing skill out of durable state where prompt-only routing installs it immediately", async () => {
+    const skillMd =
+      "---\nname: broken-flint\ndescription: Apply a deliberately broken FLINT procedure.\n---\nWrite invalid output.";
+
+    const promptOnlyAgent = new FakeHandle();
+    const promptOnlyContext = makeContext("prompt-only reflection", {
+      agent: promptOnlyAgent,
+      shellExitCode: 7,
+    });
+    const promptOnlyInstaller = createSkillToolInstances().find(
+      (tool) => tool.definition.name === "install_skill",
+    );
+    expect(promptOnlyInstaller).toBeDefined();
+    const promptOnlyResult = await promptOnlyInstaller?.handler.execute(
+      { skillMd, files: [] },
+      { context: promptOnlyContext },
+    );
+    expect(promptOnlyResult).toMatchObject({ ok: true, name: "broken-flint" });
+    expect(
+      (await promptOnlyAgent.listArtifacts()).some(
+        (artifact) => artifact.path === "skills/broken-flint.json",
+      ),
+    ).toBe(true);
+
+    const lifecycleAgent = new FakeHandle();
+    const lifecycleContext = makeContext(lifecycleInput(), {
+      agent: lifecycleAgent,
+      shellExitCode: 7,
+    });
+    const tools = lifecycleTools(lifecycleContext);
+    const proposed = (await call(
+      tools,
+      "propose_skill_learning",
+      {
+        ...memoryProposal(),
+        title: "Broken FLINT procedure",
+        skill: {
+          skillMd,
+          files: [],
+          validationCommand: "test -f /app/required-proof.txt",
+        },
+      },
+      lifecycleContext,
+    )) as { candidateId: string };
+    const lifecycleResult = await call(
+      tools,
+      "validate_and_promote_learning",
+      { candidateId: proposed.candidateId },
+      lifecycleContext,
+    );
+    expect(lifecycleResult).toMatchObject({ ok: false, status: "rejected" });
+    expect(
+      (await lifecycleAgent.listArtifacts()).some(
+        (artifact) => artifact.path === "skills/broken-flint.json",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not leak promoted learning into unrelated tasks", async () => {
+    const agent = new FakeHandle();
+    const conversation = new FakeConversation();
+    const reflection = makeContext(lifecycleInput(), {
+      agent,
+      conversation,
+    });
+    const tools = lifecycleTools(reflection);
+    const proposed = (await call(
+      tools,
+      "propose_memory_learning",
+      memoryProposal(),
+      reflection,
+    )) as { candidateId: string };
+    await call(
+      tools,
+      "validate_and_promote_learning",
+      { candidateId: proposed.candidateId },
+      reflection,
+    );
+
+    const unrelated = makeContext("Fix an nginx configuration", {
+      agent,
+      conversation,
+      turnId: "unrelated",
+    });
+    expect(await learningInstruction(unrelated)).toBeNull();
+    expect(
+      conversation.events.filter(
+        (event) => event.data.type === "learning_activated",
+      ),
+    ).toHaveLength(0);
+  });
+
+  it("does not activate a short trigger inside a larger word", async () => {
+    const agent = new FakeHandle();
+    const reflection = makeContext(lifecycleInput(), { agent });
+    const tools = lifecycleTools(reflection);
+    const proposed = (await call(
+      tools,
+      "propose_memory_learning",
+      {
+        ...memoryProposal(),
+        activationDescription: "Tasks about the Go language.",
+        activationTerms: ["go"],
+        minimumMatches: 1,
+      },
+      reflection,
+    )) as { candidateId: string };
+    await call(
+      tools,
+      "validate_and_promote_learning",
+      { candidateId: proposed.candidateId },
+      reflection,
+    );
+
+    expect(
+      await learningInstruction(
+        makeContext("Fix the Django application", { agent, turnId: "django" }),
+      ),
+    ).toBeNull();
+    expect(
+      await learningInstruction(
+        makeContext("Fix the Go application", { agent, turnId: "go" }),
+      ),
+    ).not.toBeNull();
+  });
+
+  it("stages skill files before validation and promotes only after success", async () => {
+    const shellCommands: string[] = [];
+    const agent = new FakeHandle();
+    const conversation = new FakeConversation();
+    const context = makeContext(lifecycleInput(), {
+      agent,
+      conversation,
+      shellCommands,
+    });
+    const tools = lifecycleTools(context);
+    const proposed = (await call(
+      tools,
+      "propose_skill_learning",
+      {
+        ...memoryProposal(),
+        title: "FLINT staged procedure",
+        skill: {
+          skillMd:
+            "---\nname: flint-staged\ndescription: Apply the staged FLINT procedure when a task requests FLINT.\n---\nRun the bundled script.",
+          files: [
+            {
+              path: "scripts/check.sh",
+              contents: "#!/bin/sh\nprintf 'validated\\n'\n",
+            },
+          ],
+          validationCommand: "sh scripts/check.sh",
+        },
+      },
+      context,
+    )) as { candidateId: string };
+
+    const result = await call(
+      tools,
+      "validate_and_promote_learning",
+      { candidateId: proposed.candidateId },
+      context,
+    );
+
+    expect(result).toMatchObject({ ok: true, status: "promoted" });
+    expect(shellCommands).toHaveLength(1);
+    expect(shellCommands[0]).toContain("base64 --decode");
+    expect(shellCommands[0]).toContain("sh scripts/check.sh");
+    expect(shellCommands[0]).toContain("mktemp -d /tmp/exo-learning-skill");
+    expect(
+      (await agent.listArtifacts()).some((artifact) =>
+        artifact.path.startsWith("skills/"),
+      ),
+    ).toBe(false);
+
+    const future = makeContext("Apply FLINT to these records", {
+      agent,
+      conversation,
+      turnId: "skill-use",
+    });
+    const futureTools = await normalTools(future);
+    const skill = await call(
+      futureTools,
+      "use_learning_skill",
+      { candidateId: proposed.candidateId },
+      future,
+    );
+    expect(skill).toMatchObject({
+      ok: true,
+      candidateId: proposed.candidateId,
+      name: "flint-staged",
+    });
+  });
+
+  it("records an explicit discard without creating active learning", async () => {
+    const agent = new FakeHandle();
+    const context = makeContext(lifecycleInput(), { agent });
+    const tools = lifecycleTools(context);
+    const proposed = (await call(
+      tools,
+      "propose_learning_discard",
+      {
+        title: "One-off input path",
+        evidence: "The path was unique to this Harbor container.",
+        expectedBenefit: "Avoid polluting durable context.",
+        discardReason: "Container-local paths do not transfer.",
+      },
+      context,
+    )) as { candidateId: string };
+    const result = (await call(
+      tools,
+      "validate_and_promote_learning",
+      { candidateId: proposed.candidateId },
+      context,
+    )) as { ok: boolean; status: string };
+
+    expect(result).toMatchObject({ ok: true, status: "discarded" });
+    const future = makeContext("One-off input path", {
+      agent,
+      turnId: "future",
+    });
+    expect(await learningInstruction(future)).toBeNull();
+  });
+
+  it("rejects tool promotion when agent tool creation is disabled", async () => {
+    const context = makeContext(lifecycleInput(), {
+      enableAgentToolCreation: false,
+    });
+    const tools = lifecycleTools(context);
+    const proposed = (await call(
+      tools,
+      "propose_tool_learning",
+      {
+        ...memoryProposal(),
+        title: "FLINT deterministic transformer",
+        tool: {
+          moduleName: "flint-transform",
+          toolName: "flint_transform",
+          moduleSource: "export default { tools: [] };",
+          apiKeyEnv: "",
+          validationArgumentsJson: "{}",
+          expectedResultJson: "{}",
+        },
+      },
+      context,
+    )) as { candidateId: string };
+    const result = await call(
+      tools,
+      "validate_and_promote_learning",
+      { candidateId: proposed.candidateId },
+      context,
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: "rejected",
+      validation: { kind: "tool_creation_disabled" },
+    });
+  });
+
+  it("rejects unsafe tool module paths before staging", async () => {
+    const context = makeContext(lifecycleInput());
+    const tools = lifecycleTools(context);
+
+    await expect(
+      call(
+        tools,
+        "propose_tool_learning",
+        {
+          ...memoryProposal(),
+          title: "Unsafe module path",
+          tool: {
+            moduleName: "../../outside",
+            toolName: "outside",
+            moduleSource: reverseToolSource(),
+            apiKeyEnv: "",
+            validationArgumentsJson: "{}",
+            expectedResultJson: "{}",
+          },
+        },
+        context,
+      ),
+    ).rejects.toThrow("moduleName must contain only");
+  });
+
+  it("loads a tool in isolation and rejects it before install when its self-test differs", async () => {
+    const context = makeContext(lifecycleInput());
+    const tools = lifecycleTools(context);
+    const proposed = (await call(
+      tools,
+      "propose_tool_learning",
+      {
+        ...memoryProposal(),
+        title: "Lifecycle reverse tool",
+        tool: {
+          moduleName: "lifecycle-reverse-test",
+          toolName: "lifecycle_reverse_text",
+          moduleSource: reverseToolSource(),
+          apiKeyEnv: "",
+          validationArgumentsJson: '{"text":"abc"}',
+          expectedResultJson: '{"text":"not-cba"}',
+        },
+      },
+      context,
+    )) as { candidateId: string };
+
+    const result = await call(
+      tools,
+      "validate_and_promote_learning",
+      { candidateId: proposed.candidateId },
+      context,
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: "rejected",
+      validation: {
+        kind: "tool_self_test",
+        expected: { text: "not-cba" },
+        actual: { text: "cba" },
+      },
+    });
+  });
+
+  it("registers a promoted tool only on matching tasks", async () => {
+    const agent = new FakeHandle();
+    const conversation = new FakeConversation();
+    const context = makeContext(lifecycleInput(), { agent, conversation });
+    const tools = lifecycleTools(context);
+    const proposed = (await call(
+      tools,
+      "propose_tool_learning",
+      {
+        ...memoryProposal(),
+        title: "Scoped lifecycle reverse tool",
+        tool: {
+          moduleName: "lifecycle-reverse-scoped",
+          toolName: "lifecycle_reverse_text",
+          moduleSource: reverseToolSource(),
+          apiKeyEnv: "",
+          validationArgumentsJson: '{"text":"abc"}',
+          expectedResultJson: '{"text":"cba"}',
+        },
+      },
+      context,
+    )) as { candidateId: string };
+    const promoted = await call(
+      tools,
+      "validate_and_promote_learning",
+      { candidateId: proposed.candidateId },
+      context,
+    );
+    expect(promoted).toMatchObject({ ok: true, status: "promoted" });
+
+    const matching = makeContext("Apply FLINT to these records", {
+      agent,
+      conversation,
+      turnId: "matching-tool",
+    });
+    const matchingTools = await normalTools(matching);
+    expect(matchingTools.get("lifecycle_reverse_text")).toBeDefined();
+    await expect(
+      call(
+        matchingTools,
+        "lifecycle_reverse_text",
+        { text: "router" },
+        matching,
+      ),
+    ).resolves.toEqual({ text: "retuor" });
+
+    const unrelated = makeContext("Count palette lines", {
+      agent,
+      conversation,
+      turnId: "unrelated-tool",
+    });
+    const unrelatedTools = await normalTools(unrelated);
+    expect(unrelatedTools.get("lifecycle_reverse_text")).toBeUndefined();
+  });
+
+  it("degrades safely when the learning catalog is corrupt", async () => {
+    const agent = new FakeHandle();
+    await agent.writeArtifactJson({
+      path: "learning/index.json",
+      value: { candidates: "invalid" },
+    });
+    const context = makeContext("Apply FLINT", { agent });
+
+    const instruction = await learningInstruction(context);
+
+    expect(String(instruction?.content)).toContain(
+      "learning catalog could not be loaded",
+    );
+  });
+
+  it("rejects a corrupt route-specific payload before activation", async () => {
+    const agent = new FakeHandle();
+    await agent.writeArtifactJson({
+      path: "learning/index.json",
+      value: {
+        candidates: [
+          {
+            id: "learn-broken",
+            route: "skill",
+            title: "Broken skill",
+            evidence: "claimed evidence",
+            expectedBenefit: "none",
+            activationDescription: "FLINT tasks",
+            activationTerms: ["flint"],
+            minimumMatches: 1,
+            memoryText: null,
+            skill: null,
+            tool: null,
+            discardReason: null,
+            status: "promoted",
+            createdAt: "2026-08-24T00:00:00Z",
+            updatedAt: "2026-08-24T00:00:00Z",
+            sourceConversationId: "conversation-1",
+            activationCount: 0,
+            lastActivatedAt: null,
+            validation: {},
+          },
+        ],
+      },
+    });
+    const context = makeContext("Apply FLINT", { agent });
+
+    expect(String((await learningInstruction(context))?.content)).toContain(
+      "learning catalog could not be loaded",
+    );
+    expect(
+      (await normalTools(context)).get("use_learning_skill"),
+    ).toBeUndefined();
+  });
+
+  it("rejects active learning when evaluator feedback is missing", async () => {
+    const context = makeContext(LEARNING_LIFECYCLE_MARKER);
+    const tools = lifecycleTools(context);
+    const proposed = (await call(
+      tools,
+      "propose_memory_learning",
+      memoryProposal(),
+      context,
+    )) as { candidateId: string };
+
+    const result = await call(
+      tools,
+      "validate_and_promote_learning",
+      { candidateId: proposed.candidateId },
+      context,
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: "rejected",
+      validation: { kind: "missing_external_feedback" },
+    });
+  });
+
+  it("accepts evaluator exception evidence when no numeric reward exists", async () => {
+    const context = makeContext(`Feedback:
+{"exception":{"message":"trial timed out"},"rewards":null,"verifier_logs":{}}
+Reflection instructions:
+${LEARNING_LIFECYCLE_MARKER}`);
+    const tools = lifecycleTools(context);
+    const proposed = (await call(
+      tools,
+      "propose_memory_learning",
+      memoryProposal(),
+      context,
+    )) as { candidateId: string };
+
+    const result = await call(
+      tools,
+      "validate_and_promote_learning",
+      { candidateId: proposed.candidateId },
+      context,
+    );
+
+    expect(result).toMatchObject({
+      ok: true,
+      status: "promoted",
+      validation: {
+        externalFeedback: {
+          rewards: {},
+          verifierLogsPresent: false,
+          exceptionPresent: true,
+        },
+      },
+    });
+  });
+
+  it("does not expose proposal or promotion tools outside lifecycle reflection", () => {
+    const context = makeContext("normal task");
+    const tools = lifecycleTools(context);
+    expect(tools.get("list_learning_artifacts")).toBeDefined();
+    expect(tools.get("propose_memory_learning")).toBeUndefined();
+    expect(tools.get("propose_skill_learning")).toBeUndefined();
+    expect(tools.get("propose_tool_learning")).toBeUndefined();
+    expect(tools.get("propose_learning_discard")).toBeUndefined();
+    expect(tools.get("validate_and_promote_learning")).toBeUndefined();
+  });
+});

--- a/exo/tools/learning-tools.ts
+++ b/exo/tools/learning-tools.ts
@@ -17,6 +17,13 @@ import {
   type TurnContext,
 } from "@exo/harness";
 
+import {
+  classifyLearningRoute,
+  enforceLearningRoute,
+  lessonFeaturesFromUnknown,
+  type LearningRoute,
+} from "./learning-router";
+
 export const LEARNING_LIFECYCLE_MARKER = "EXO_LEARNING_LIFECYCLE_V1";
 
 const LEARNING_INDEX_PATH = "learning/index.json";
@@ -32,7 +39,6 @@ const MAX_SKILL_MD_CHARS = 100_000;
 const MAX_TOOL_SOURCE_CHARS = 100_000;
 const MAX_VALIDATION_COMMAND_CHARS = 4_000;
 
-type LearningRoute = "memory" | "skill" | "tool" | "discard";
 type LearningStatus = "proposed" | "promoted" | "rejected" | "discarded";
 
 interface SkillPayload {
@@ -96,6 +102,7 @@ export function registerLearningTools(
   for (const tool of proposalTools()) {
     registry.register(tool);
   }
+  registry.register(classifyLearningRouteTool());
   registry.register(validateAndPromoteLearningTool());
 }
 
@@ -323,6 +330,21 @@ function proposalTool(
     },
     handler: {
       async execute(args, execution): Promise<ToolResult> {
+        const classification = classifyLearningRoute(
+          lessonFeaturesFromUnknown(args),
+        );
+        const enforced = enforceLearningRoute(route, classification);
+        if (!enforced.accepted) {
+          return {
+            ok: false,
+            error: "route_conflict",
+            proposedRoute: enforced.proposedRoute,
+            suggestedRoute: enforced.route,
+            corrected: enforced.corrected,
+            reasons: enforced.reasons,
+            scores: classification.scores,
+          };
+        }
         const candidate = parseCandidate(
           route,
           args,
@@ -357,6 +379,46 @@ function proposalTool(
           route: candidate.route,
           status: candidate.status,
           duplicate: false,
+        };
+      },
+    },
+  };
+}
+
+function classifyLearningRouteTool(): ToolInstance {
+  return {
+    source: "library",
+    definition: {
+      name: "classify_learning_route",
+      description:
+        "Classify a lesson into memory, skill, tool, or discard from checkable features. Use this before proposing. Conflicting proposal tools are rejected.",
+      parameters: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          title: { type: "string" },
+          evidence: { type: "string" },
+          expectedBenefit: { type: "string" },
+          memoryText: { type: "string" },
+          skillMd: { type: "string" },
+          toolSource: { type: "string" },
+          discardReason: { type: "string" },
+        },
+        required: ["title", "evidence", "expectedBenefit"],
+      },
+    },
+    handler: {
+      async execute(args): Promise<ToolResult> {
+        const classification = classifyLearningRoute(
+          lessonFeaturesFromUnknown({
+            ...args,
+            skill: { skillMd: args.skillMd },
+            tool: { moduleSource: args.toolSource },
+          }),
+        );
+        return {
+          ok: true,
+          ...classification,
         };
       },
     },

--- a/exo/tools/learning-tools.ts
+++ b/exo/tools/learning-tools.ts
@@ -1,0 +1,1336 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  loadAgentTool,
+  parseSkillFrontmatter,
+  type Agent,
+  type ArtifactVersion,
+  type HarnessToolRegistry as ToolRegistry,
+  type JsonObject,
+  type JsonValue,
+  type Message,
+  type ToolInstance,
+  type ToolResult,
+  type TurnContext,
+} from "@exo/harness";
+
+export const LEARNING_LIFECYCLE_MARKER = "EXO_LEARNING_LIFECYCLE_V1";
+
+const LEARNING_INDEX_PATH = "learning/index.json";
+const MAX_CANDIDATES = 100;
+const MAX_TITLE_CHARS = 120;
+const MAX_EVIDENCE_CHARS = 2_000;
+const MAX_EXPECTED_BENEFIT_CHARS = 1_000;
+const MAX_ACTIVATION_DESCRIPTION_CHARS = 500;
+const MAX_ACTIVATION_TERMS = 8;
+const MAX_ACTIVATION_TERM_CHARS = 80;
+const MAX_MEMORY_TEXT_CHARS = 600;
+const MAX_SKILL_MD_CHARS = 100_000;
+const MAX_TOOL_SOURCE_CHARS = 100_000;
+const MAX_VALIDATION_COMMAND_CHARS = 4_000;
+
+type LearningRoute = "memory" | "skill" | "tool" | "discard";
+type LearningStatus = "proposed" | "promoted" | "rejected" | "discarded";
+
+interface SkillPayload {
+  skillMd: string;
+  files: Array<{ path: string; contents: string }>;
+  validationCommand: string;
+}
+
+interface ToolPayload {
+  moduleName: string;
+  toolName: string;
+  moduleSource: string;
+  apiKeyEnv: string | null;
+  validationArguments: JsonObject;
+  expectedResult: JsonValue;
+}
+
+interface LearningCandidate {
+  id: string;
+  route: LearningRoute;
+  title: string;
+  evidence: string;
+  expectedBenefit: string;
+  activationDescription: string;
+  activationTerms: string[];
+  minimumMatches: number;
+  memoryText: string | null;
+  skill: SkillPayload | null;
+  tool: ToolPayload | null;
+  discardReason: string | null;
+  status: LearningStatus;
+  createdAt: string;
+  updatedAt: string;
+  sourceConversationId: string;
+  activationCount: number;
+  lastActivatedAt: string | null;
+  validation: JsonObject | null;
+}
+
+interface LearningIndex {
+  candidates: LearningCandidate[];
+}
+
+type LearningHandle = Pick<
+  Agent,
+  "listArtifacts" | "readArtifactJson" | "writeArtifactJson"
+>;
+
+export function isLearningLifecycleTurn(context: TurnContext): boolean {
+  return requestText(context).includes(LEARNING_LIFECYCLE_MARKER);
+}
+
+export function registerLearningTools(
+  registry: ToolRegistry,
+  context: TurnContext,
+): void {
+  registry.register(listLearningArtifactsTool());
+  if (!isLearningLifecycleTurn(context)) {
+    return;
+  }
+  for (const tool of proposalTools()) {
+    registry.register(tool);
+  }
+  registry.register(validateAndPromoteLearningTool());
+}
+
+export async function registerActivatedLearningTools(
+  registry: ToolRegistry,
+  context: TurnContext,
+): Promise<void> {
+  if (isLearningLifecycleTurn(context)) {
+    return;
+  }
+  let index: LearningIndex;
+  try {
+    index = await readIndex(learningHandle(context));
+  } catch {
+    return;
+  }
+  const input = requestText(context).toLowerCase();
+  const activated = index.candidates.filter(
+    (candidate) =>
+      candidate.status === "promoted" && activationMatches(candidate, input),
+  );
+  const skills = activated.filter(
+    (candidate) => candidate.route === "skill" && candidate.skill !== null,
+  );
+  if (skills.length > 0) {
+    registry.register(activatedSkillLoaderTool(skills));
+  }
+  for (const candidate of activated) {
+    if (candidate.route !== "tool" || candidate.tool === null) {
+      continue;
+    }
+    try {
+      registry.register(await loadCandidateTool(candidate.tool, context));
+    } catch (error) {
+      console.error(
+        `validated learning tool ${candidate.id} failed to load: ${errorText(error)}`,
+      );
+    }
+  }
+}
+
+export async function learningInstruction(
+  context: TurnContext,
+): Promise<Message | null> {
+  if (isLearningLifecycleTurn(context)) {
+    return null;
+  }
+  const handle = learningHandle(context);
+  let index: LearningIndex;
+  try {
+    index = await readIndex(handle);
+  } catch (error) {
+    return {
+      role: "developer",
+      content: `The validated learning catalog could not be loaded and no learning was activated: ${errorText(error)}`,
+    };
+  }
+  const promoted = index.candidates.filter(
+    (candidate) => candidate.status === "promoted",
+  );
+  if (promoted.length === 0) {
+    return null;
+  }
+
+  const input = requestText(context).toLowerCase();
+  const activated = promoted.filter((candidate) =>
+    activationMatches(candidate, input),
+  );
+  if (activated.length === 0) {
+    return null;
+  }
+
+  if (!(await activationAlreadyRecorded(context))) {
+    const now = new Date().toISOString();
+    for (const candidate of activated) {
+      candidate.activationCount += 1;
+      candidate.lastActivatedAt = now;
+      candidate.updatedAt = now;
+    }
+    await writeIndex(handle, index);
+    await context.exoharness.current.turn.addEvents([
+      {
+        type: "learning_activated",
+        artifacts: activated.map((candidate) => ({
+          id: candidate.id,
+          route: candidate.route,
+          title: candidate.title,
+        })),
+      },
+    ]);
+  }
+
+  return {
+    role: "developer",
+    content: `Validated learning automatically activated for this task. Apply it before choosing a fresh approach. These artifacts passed their promotion checks:\n\n${activated
+      .map(activatedCandidateText)
+      .join("\n\n")}`,
+  };
+}
+
+function proposalTools(): ToolInstance[] {
+  return [
+    proposalTool(
+      "memory",
+      "propose_memory_learning",
+      "Propose a concise stable fact or heuristic as scoped memory. It remains inactive until validate_and_promote_learning succeeds.",
+      { memoryText: { type: "string" } },
+      ["memoryText"],
+    ),
+    proposalTool(
+      "skill",
+      "propose_skill_learning",
+      "Propose a reusable multi-step procedure as a skill. It remains inactive and is not installed until its sandbox validation command passes.",
+      {
+        skill: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            skillMd: { type: "string" },
+            files: {
+              type: "array",
+              items: {
+                type: "object",
+                additionalProperties: false,
+                properties: {
+                  path: { type: "string" },
+                  contents: { type: "string" },
+                },
+                required: ["path", "contents"],
+              },
+            },
+            validationCommand: { type: "string" },
+          },
+          required: ["skillMd", "files", "validationCommand"],
+        },
+      },
+      ["skill"],
+    ),
+    proposalTool(
+      "tool",
+      "propose_tool_learning",
+      "Propose a repeated deterministic operation as an executable tool. It remains inactive until installation and its exact JSON self-test succeed.",
+      {
+        tool: {
+          type: "object",
+          additionalProperties: false,
+          properties: {
+            moduleName: { type: "string" },
+            toolName: { type: "string" },
+            moduleSource: { type: "string" },
+            apiKeyEnv: {
+              type: "string",
+              description:
+                "Required environment variable name, or an empty string when none.",
+            },
+            validationArgumentsJson: { type: "string" },
+            expectedResultJson: { type: "string" },
+          },
+          required: [
+            "moduleName",
+            "toolName",
+            "moduleSource",
+            "apiKeyEnv",
+            "validationArgumentsJson",
+            "expectedResultJson",
+          ],
+        },
+      },
+      ["tool"],
+    ),
+    proposalTool(
+      "discard",
+      "propose_learning_discard",
+      "Record an evidence-backed decision that a task-specific, redundant, or unsupported lesson must not become active learning.",
+      { discardReason: { type: "string" } },
+      ["discardReason"],
+    ),
+  ];
+}
+
+function proposalTool(
+  route: LearningRoute,
+  name: string,
+  description: string,
+  routeProperties: JsonObject,
+  routeRequired: string[],
+): ToolInstance {
+  const active = route !== "discard";
+  const properties: JsonObject = {
+    title: { type: "string" },
+    evidence: { type: "string" },
+    expectedBenefit: { type: "string" },
+    ...(active
+      ? {
+          activationDescription: { type: "string" },
+          activationTerms: {
+            type: "array",
+            items: { type: "string" },
+          },
+          minimumMatches: { type: "integer" },
+        }
+      : {}),
+    ...routeProperties,
+  };
+  const required = [
+    "title",
+    "evidence",
+    "expectedBenefit",
+    ...(active
+      ? ["activationDescription", "activationTerms", "minimumMatches"]
+      : []),
+    ...routeRequired,
+  ];
+  return {
+    source: "library",
+    definition: {
+      name,
+      description,
+      parameters: {
+        type: "object",
+        additionalProperties: false,
+        properties,
+        required,
+      },
+    },
+    handler: {
+      async execute(args, execution): Promise<ToolResult> {
+        const candidate = parseCandidate(
+          route,
+          args,
+          execution.context.exoharness.current.conversation.record.id,
+        );
+        const handle = learningHandle(execution.context);
+        const index = await readIndex(handle);
+        const duplicate = index.candidates.find(
+          (existing) =>
+            candidateFingerprint(existing) === candidateFingerprint(candidate),
+        );
+        if (duplicate !== undefined) {
+          return {
+            ok: true,
+            candidateId: duplicate.id,
+            route: duplicate.route,
+            status: duplicate.status,
+            duplicate: true,
+          };
+        }
+        if (index.candidates.length >= MAX_CANDIDATES) {
+          return {
+            ok: false,
+            error: `learning catalog is full at ${MAX_CANDIDATES} candidates`,
+          };
+        }
+        index.candidates.push(candidate);
+        await writeIndex(handle, index);
+        return {
+          ok: true,
+          candidateId: candidate.id,
+          route: candidate.route,
+          status: candidate.status,
+          duplicate: false,
+        };
+      },
+    },
+  };
+}
+
+function validateAndPromoteLearningTool(): ToolInstance {
+  return {
+    source: "library",
+    definition: {
+      name: "validate_and_promote_learning",
+      description:
+        "Validate one proposed learning candidate and make it active only if its route-specific checks pass. Skills must pass their sandbox command; tools must install and return the exact declared self-test result. Discard candidates become terminal without creating an active artifact.",
+      parameters: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          candidateId: { type: "string" },
+        },
+        required: ["candidateId"],
+      },
+    },
+    handler: {
+      async execute(args, execution): Promise<ToolResult> {
+        const candidateId = requiredString(args.candidateId, "candidateId", 80);
+        const handle = learningHandle(execution.context);
+        const index = await readIndex(handle);
+        const candidate = index.candidates.find(
+          (item) => item.id === candidateId,
+        );
+        if (candidate === undefined) {
+          return {
+            ok: false,
+            candidateId,
+            error: "unknown learning candidate",
+          };
+        }
+        if (candidate.status !== "proposed") {
+          return {
+            ok:
+              candidate.status === "promoted" ||
+              candidate.status === "discarded",
+            candidateId,
+            route: candidate.route,
+            status: candidate.status,
+            alreadyTerminal: true,
+          };
+        }
+
+        let outcome: PromotionOutcome;
+        try {
+          outcome = await promoteCandidate(candidate, execution.context);
+        } catch (error) {
+          outcome = {
+            status: "rejected",
+            validation: {
+              kind: "executor_error",
+              error: errorText(error),
+            },
+          };
+        }
+        candidate.status = outcome.status;
+        candidate.validation = outcome.validation;
+        candidate.updatedAt = new Date().toISOString();
+        await writeIndex(handle, index);
+        const ok =
+          outcome.status === "promoted" || outcome.status === "discarded";
+        return {
+          ok,
+          candidateId,
+          route: candidate.route,
+          status: outcome.status,
+          validation: outcome.validation,
+          ...(ok ? {} : { error: "learning candidate failed validation" }),
+        };
+      },
+    },
+  };
+}
+
+function listLearningArtifactsTool(): ToolInstance {
+  return {
+    source: "library",
+    definition: {
+      name: "list_learning_artifacts",
+      description:
+        "List learning candidates, their lifecycle status, activation triggers, validation evidence, and activation counts. Candidate source content is omitted.",
+      parameters: {
+        type: "object",
+        additionalProperties: false,
+        properties: {},
+        required: [],
+      },
+    },
+    handler: {
+      async execute(_args, execution): Promise<ToolResult> {
+        const index = await readIndex(learningHandle(execution.context));
+        return {
+          ok: true,
+          candidates: index.candidates.map((candidate) => ({
+            id: candidate.id,
+            route: candidate.route,
+            title: candidate.title,
+            status: candidate.status,
+            evidence: candidate.evidence,
+            expectedBenefit: candidate.expectedBenefit,
+            activationDescription: candidate.activationDescription,
+            activationTerms: candidate.activationTerms,
+            minimumMatches: candidate.minimumMatches,
+            activationCount: candidate.activationCount,
+            lastActivatedAt: candidate.lastActivatedAt,
+            validation: candidate.validation,
+          })),
+        };
+      },
+    },
+  };
+}
+
+function activatedSkillLoaderTool(
+  candidates: LearningCandidate[],
+): ToolInstance {
+  return {
+    source: "library",
+    definition: {
+      name: "use_learning_skill",
+      description: `Load one validated skill activated for this task. Available candidates: ${candidates
+        .map((candidate) => `${candidate.id} (${candidate.title})`)
+        .join(", ")}.`,
+      parameters: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          candidateId: { type: "string" },
+        },
+        required: ["candidateId"],
+      },
+    },
+    handler: {
+      async execute(args): Promise<ToolResult> {
+        const candidateId = requiredString(args.candidateId, "candidateId", 80);
+        const candidate = candidates.find((item) => item.id === candidateId);
+        if (candidate === undefined || candidate.skill === null) {
+          return {
+            ok: false,
+            error: "skill candidate is not activated for this task",
+          };
+        }
+        const name =
+          parseSkillFrontmatter(candidate.skill.skillMd)?.fields.name ??
+          candidate.title;
+        return {
+          ok: true,
+          candidateId,
+          name,
+          skillMd: candidate.skill.skillMd,
+          files: candidate.skill.files,
+        };
+      },
+    },
+  };
+}
+
+interface PromotionOutcome {
+  status: "promoted" | "rejected" | "discarded";
+  validation: JsonObject;
+}
+
+async function promoteCandidate(
+  candidate: LearningCandidate,
+  context: TurnContext,
+): Promise<PromotionOutcome> {
+  if (candidate.route === "discard") {
+    return {
+      status: "discarded",
+      validation: {
+        kind: "discard",
+        reason: candidate.discardReason ?? "task-specific or unsupported",
+      },
+    };
+  }
+  const externalFeedback = externalFeedbackEvidence(context);
+  if (externalFeedback === null) {
+    return {
+      status: "rejected",
+      validation: {
+        kind: "missing_external_feedback",
+        error:
+          "active learning requires the evaluator feedback payload from this reflection",
+      },
+    };
+  }
+  if (candidate.route === "memory") {
+    return {
+      status: "promoted",
+      validation: {
+        kind: "evidence_gate",
+        evidencePresent: candidate.evidence.length > 0,
+        externalFeedback,
+        scopedActivation: true,
+      },
+    };
+  }
+  if (candidate.route === "skill") {
+    if (candidate.skill === null) {
+      throw new Error("skill candidate has no skill payload");
+    }
+    const shell = await executeShell(
+      context,
+      stagedSkillValidationCommand(candidate.skill),
+    );
+    if (shell.exitCode !== 0) {
+      return {
+        status: "rejected",
+        validation: {
+          kind: "sandbox_command",
+          command: candidate.skill.validationCommand,
+          exitCode: shell.exitCode,
+          externalFeedback,
+          stdout: truncate(shell.stdout, 2_000),
+          stderr: truncate(shell.stderr, 2_000),
+        },
+      };
+    }
+    return {
+      status: "promoted",
+      validation: {
+        kind: "sandbox_command",
+        command: candidate.skill.validationCommand,
+        exitCode: shell.exitCode,
+        externalFeedback,
+        stdout: truncate(shell.stdout, 2_000),
+        publishedToLearningCatalog: true,
+      },
+    };
+  }
+
+  if (candidate.tool === null) {
+    throw new Error("tool candidate has no tool payload");
+  }
+  if (!context.agentConfig.enableAgentToolCreation) {
+    return {
+      status: "rejected",
+      validation: {
+        kind: "tool_creation_disabled",
+        externalFeedback,
+        error: "agent tool creation must be enabled to promote a tool",
+      },
+    };
+  }
+  const tool = await loadCandidateTool(candidate.tool, context);
+  if (tool.definition.name !== candidate.tool.toolName) {
+    return {
+      status: "rejected",
+      validation: {
+        kind: "tool_self_test",
+        externalFeedback,
+        error: `proposed module exports ${tool.definition.name}, expected ${candidate.tool.toolName}`,
+      },
+    };
+  }
+  const actual = await tool.handler.execute(
+    candidate.tool.validationArguments,
+    {
+      context,
+    },
+  );
+  if (canonicalJson(actual) !== canonicalJson(candidate.tool.expectedResult)) {
+    return {
+      status: "rejected",
+      validation: {
+        kind: "tool_self_test",
+        externalFeedback,
+        expected: candidate.tool.expectedResult,
+        actual,
+      },
+    };
+  }
+  return {
+    status: "promoted",
+    validation: {
+      kind: "tool_self_test",
+      externalFeedback,
+      toolName: candidate.tool.toolName,
+      expected: candidate.tool.expectedResult,
+      actual,
+      publishedToLearningCatalog: true,
+    },
+  };
+}
+
+async function loadCandidateTool(
+  tool: ToolPayload,
+  context: TurnContext,
+): Promise<ToolInstance> {
+  const temporaryDirectory = await fs.mkdtemp(
+    path.join(os.tmpdir(), "exo-learning-tool."),
+  );
+  try {
+    const modulePath = path.join(temporaryDirectory, `${tool.moduleName}.ts`);
+    await fs.writeFile(modulePath, tool.moduleSource, "utf8");
+    const initialization: JsonObject =
+      tool.apiKeyEnv === null ? {} : { apiKeyEnv: tool.apiKeyEnv };
+    return await loadAgentTool(context, modulePath, initialization);
+  } finally {
+    await fs.rm(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+function externalFeedbackEvidence(context: TurnContext): JsonObject | null {
+  const text = requestText(context);
+  const feedbackMarker = "Feedback:\n";
+  const instructionsMarker = "\nReflection instructions:";
+  const start = text.lastIndexOf(feedbackMarker);
+  const end = text.indexOf(instructionsMarker, start + feedbackMarker.length);
+  if (start < 0 || end < 0) {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(
+      text.slice(start + feedbackMarker.length, end).trim(),
+    ) as unknown;
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed)) {
+    return null;
+  }
+  const rewards: JsonObject = {};
+  if (isRecord(parsed.rewards)) {
+    for (const [name, value] of Object.entries(parsed.rewards)) {
+      if (typeof value === "number" && Number.isFinite(value)) {
+        rewards[name] = value;
+      }
+    }
+  }
+  const verifierLogsPresent =
+    isRecord(parsed.verifier_logs) &&
+    Object.keys(parsed.verifier_logs).length > 0;
+  const exceptionPresent =
+    parsed.exception !== null && parsed.exception !== undefined;
+  if (
+    Object.keys(rewards).length === 0 &&
+    !verifierLogsPresent &&
+    !exceptionPresent
+  ) {
+    return null;
+  }
+  return {
+    rewards,
+    verifierLogsPresent,
+    exceptionPresent,
+  };
+}
+
+function parseCandidate(
+  route: LearningRoute,
+  args: JsonObject,
+  conversationId: string,
+): LearningCandidate {
+  const title = requiredString(args.title, "title", MAX_TITLE_CHARS);
+  const evidence = requiredString(
+    args.evidence,
+    "evidence",
+    MAX_EVIDENCE_CHARS,
+  );
+  const expectedBenefit = requiredString(
+    args.expectedBenefit,
+    "expectedBenefit",
+    MAX_EXPECTED_BENEFIT_CHARS,
+  );
+  const activationDescription =
+    route === "discard"
+      ? "Never activate; this lesson was explicitly discarded."
+      : requiredString(
+          args.activationDescription,
+          "activationDescription",
+          MAX_ACTIVATION_DESCRIPTION_CHARS,
+        );
+  const activationTerms =
+    route === "discard"
+      ? []
+      : stringArray(args.activationTerms, "activationTerms");
+  if (activationTerms.length > MAX_ACTIVATION_TERMS) {
+    throw new Error(`activationTerms exceeds ${MAX_ACTIVATION_TERMS} entries`);
+  }
+  const normalizedTerms = [
+    ...new Set(
+      activationTerms.map((term) =>
+        requiredString(
+          term,
+          "activation term",
+          MAX_ACTIVATION_TERM_CHARS,
+        ).toLowerCase(),
+      ),
+    ),
+  ];
+  const minimumMatches =
+    route === "discard" ? 0 : integer(args.minimumMatches, "minimumMatches");
+  if (
+    route !== "discard" &&
+    (normalizedTerms.length === 0 ||
+      minimumMatches < 1 ||
+      minimumMatches > normalizedTerms.length)
+  ) {
+    throw new Error(
+      "active candidates require activation terms and minimumMatches within their count",
+    );
+  }
+
+  const memoryText =
+    route === "memory"
+      ? requiredString(args.memoryText, "memoryText", MAX_MEMORY_TEXT_CHARS)
+      : null;
+  const skill = route === "skill" ? parseSkillPayload(args.skill) : null;
+  const tool = route === "tool" ? parseToolPayload(args.tool) : null;
+  const discardReason =
+    route === "discard"
+      ? requiredString(args.discardReason, "discardReason", MAX_EVIDENCE_CHARS)
+      : null;
+
+  const now = new Date().toISOString();
+  return {
+    id: `learn_${randomUUID().slice(0, 8)}`,
+    route,
+    title,
+    evidence,
+    expectedBenefit,
+    activationDescription,
+    activationTerms: normalizedTerms,
+    minimumMatches,
+    memoryText,
+    skill,
+    tool,
+    discardReason,
+    status: "proposed",
+    createdAt: now,
+    updatedAt: now,
+    sourceConversationId: conversationId,
+    activationCount: 0,
+    lastActivatedAt: null,
+    validation: null,
+  };
+}
+
+function parseSkillPayload(value: JsonValue | undefined): SkillPayload | null {
+  if (value === null) {
+    return null;
+  }
+  const object = jsonObject(value, "skill");
+  const filesValue = object.files;
+  if (!Array.isArray(filesValue)) {
+    throw new Error("skill.files must be an array");
+  }
+  const skillMd = requiredString(object.skillMd, "skillMd", MAX_SKILL_MD_CHARS);
+  const frontmatter = parseSkillFrontmatter(skillMd);
+  if (frontmatter === null) {
+    throw new Error("skillMd must contain YAML frontmatter");
+  }
+  const name = frontmatter.fields.name ?? "";
+  if (!/^[a-z0-9]+(-[a-z0-9]+)*$/.test(name) || name.length > 64) {
+    throw new Error(
+      "skillMd frontmatter name must be 1-64 lowercase letters, digits, and single hyphens",
+    );
+  }
+  const description = frontmatter.fields.description ?? "";
+  if (description.length === 0 || description.length > 1_024) {
+    throw new Error(
+      "skillMd frontmatter description must be 1-1024 characters",
+    );
+  }
+  const seen = new Set<string>();
+  const files = filesValue.map((item) => {
+    const file = jsonObject(item, "skill file");
+    const path = requiredString(file.path, "skill file path", 500);
+    const pathError = validateSkillFilePath(path);
+    if (pathError !== null) {
+      throw new Error(pathError);
+    }
+    if (path === "SKILL.md") {
+      throw new Error("skill files must not replace the top-level skillMd");
+    }
+    if (seen.has(path)) {
+      throw new Error(`duplicate skill file path: ${path}`);
+    }
+    seen.add(path);
+    return {
+      path,
+      contents: requiredString(file.contents, "skill file contents", 200_000),
+    };
+  });
+  return {
+    skillMd,
+    files,
+    validationCommand: requiredString(
+      object.validationCommand,
+      "validationCommand",
+      MAX_VALIDATION_COMMAND_CHARS,
+    ),
+  };
+}
+
+function parseToolPayload(value: JsonValue | undefined): ToolPayload | null {
+  if (value === null) {
+    return null;
+  }
+  const object = jsonObject(value, "tool");
+  const validationArguments = parseJsonObjectString(
+    object.validationArgumentsJson,
+    "validationArgumentsJson",
+  );
+  const expectedResult = parseJsonString(
+    object.expectedResultJson,
+    "expectedResultJson",
+  );
+  const moduleName = requiredString(object.moduleName, "moduleName", 100);
+  if (!/^[A-Za-z0-9_-]+$/.test(moduleName)) {
+    throw new Error(
+      "moduleName must contain only letters, numbers, underscores, and dashes",
+    );
+  }
+  const toolName = requiredString(object.toolName, "toolName", 100);
+  if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(toolName)) {
+    throw new Error(
+      "toolName must start with a letter or underscore and contain only letters, numbers, and underscores",
+    );
+  }
+  return {
+    moduleName,
+    toolName,
+    moduleSource: requiredString(
+      object.moduleSource,
+      "moduleSource",
+      MAX_TOOL_SOURCE_CHARS,
+    ),
+    apiKeyEnv: emptyStringToNull(object.apiKeyEnv, "apiKeyEnv", 200),
+    validationArguments,
+    expectedResult,
+  };
+}
+
+async function executeShell(
+  context: TurnContext,
+  command: string,
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const result = await context.executeTool({
+    functionName: "shell",
+    arguments: { command },
+  });
+  const object = jsonObject(result, "shell result");
+  const exitCode = object.exit_code;
+  if (typeof exitCode !== "number") {
+    throw new Error("shell validation returned no numeric exit_code");
+  }
+  return {
+    exitCode,
+    stdout: typeof object.stdout === "string" ? object.stdout : "",
+    stderr: typeof object.stderr === "string" ? object.stderr : "",
+  };
+}
+
+function stagedSkillValidationCommand(skill: SkillPayload): string {
+  const stagedFiles = [
+    { path: "SKILL.md", contents: skill.skillMd },
+    ...skill.files.filter((file) => file.path !== "SKILL.md"),
+  ];
+  const writes = stagedFiles.flatMap((file) => {
+    const segments = file.path.split("/");
+    const directory = segments.slice(0, -1).join("/");
+    return [
+      ...(directory.length > 0
+        ? [`mkdir -p -- "$validation_root"/${shellQuote(directory)}`]
+        : []),
+      `printf %s ${shellQuote(Buffer.from(file.contents).toString("base64"))} | base64 --decode > "$validation_root"/${shellQuote(file.path)}`,
+    ];
+  });
+  return [
+    "set -eu",
+    "validation_root=$(mktemp -d /tmp/exo-learning-skill.XXXXXX)",
+    'cleanup() { rm -rf -- "$validation_root"; }',
+    "trap cleanup EXIT HUP INT TERM",
+    ...writes,
+    'cd "$validation_root"',
+    skill.validationCommand,
+  ].join("\n");
+}
+
+function validateSkillFilePath(path: string): string | null {
+  if (path.startsWith("/") || path.includes("\\")) {
+    return `skill file path must be relative with forward slashes: ${path}`;
+  }
+  const segments = path.split("/");
+  if (segments.some((segment) => segment.length === 0 || segment === "..")) {
+    return `skill file path must not contain empty or .. segments: ${path}`;
+  }
+  return null;
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+async function activationAlreadyRecorded(
+  context: TurnContext,
+): Promise<boolean> {
+  const events = await context.exoharness.current.conversation.getEvents({
+    direction: "asc",
+    turnId: context.exoharness.current.turn.record.id,
+    types: ["learning_activated"],
+  });
+  return events.events.length > 0;
+}
+
+function activationMatches(
+  candidate: LearningCandidate,
+  input: string,
+): boolean {
+  const matches = candidate.activationTerms.filter((term) =>
+    activationTermMatches(input, term),
+  );
+  return matches.length >= candidate.minimumMatches;
+}
+
+function activationTermMatches(input: string, term: string): boolean {
+  let offset = 0;
+  while (offset <= input.length - term.length) {
+    const index = input.indexOf(term, offset);
+    if (index < 0) {
+      return false;
+    }
+    const before = index === 0 ? "" : input[index - 1];
+    const afterIndex = index + term.length;
+    const after = afterIndex === input.length ? "" : input[afterIndex];
+    const startIsBounded =
+      !isAsciiWordCharacter(term[0]) || !isAsciiWordCharacter(before);
+    const endIsBounded =
+      !isAsciiWordCharacter(term[term.length - 1]) ||
+      !isAsciiWordCharacter(after);
+    if (startIsBounded && endIsBounded) {
+      return true;
+    }
+    offset = index + 1;
+  }
+  return false;
+}
+
+function isAsciiWordCharacter(value: string): boolean {
+  return /^[a-z0-9_]$/i.test(value);
+}
+
+function activatedCandidateText(candidate: LearningCandidate): string {
+  const header = `[${candidate.id}] ${candidate.route.toUpperCase()} — ${candidate.title}\nUse when: ${candidate.activationDescription}\nExpected benefit: ${candidate.expectedBenefit}`;
+  if (candidate.route === "memory") {
+    return `${header}\nValidated memory: ${candidate.memoryText}`;
+  }
+  if (candidate.route === "skill") {
+    const skillName = candidate.skill
+      ? (parseSkillFrontmatter(candidate.skill.skillMd)?.fields.name ?? null)
+      : null;
+    return `${header}\nValidated skill: call use_learning_skill with candidateId ${JSON.stringify(candidate.id)} to load ${JSON.stringify(skillName ?? candidate.title)}, then follow it.`;
+  }
+  return `${header}\nValidated tool: call ${candidate.tool?.toolName ?? "the promoted tool"} rather than rebuilding the operation.`;
+}
+
+function learningHandle(context: TurnContext): LearningHandle {
+  return context.exoharness.current.agent;
+}
+
+async function readIndex(handle: LearningHandle): Promise<LearningIndex> {
+  const latest = latestArtifactVersion(
+    await handle.listArtifacts(),
+    LEARNING_INDEX_PATH,
+  );
+  if (latest === null) {
+    return { candidates: [] };
+  }
+  const raw = await handle.readArtifactJson<unknown>({
+    artifactId: latest.artifactId,
+    version: latest.version,
+  });
+  if (!isLearningIndex(raw)) {
+    throw new Error(`corrupt learning artifact ${LEARNING_INDEX_PATH}`);
+  }
+  return raw;
+}
+
+async function writeIndex(
+  handle: LearningHandle,
+  index: LearningIndex,
+): Promise<void> {
+  await handle.writeArtifactJson({
+    path: LEARNING_INDEX_PATH,
+    value: index as unknown as JsonValue,
+  });
+}
+
+function latestArtifactVersion(
+  artifacts: ArtifactVersion[],
+  path: string,
+): ArtifactVersion | null {
+  return (
+    artifacts
+      .filter((artifact) => artifact.path === path)
+      .sort((a, b) => b.version - a.version)[0] ?? null
+  );
+}
+
+function isLearningIndex(value: unknown): value is LearningIndex {
+  if (!isRecord(value) || !Array.isArray(value.candidates)) {
+    return false;
+  }
+  return value.candidates.every(isLearningCandidate);
+}
+
+function isLearningCandidate(value: unknown): value is LearningCandidate {
+  if (
+    !(
+      isRecord(value) &&
+      typeof value.id === "string" &&
+      isLearningRoute(value.route) &&
+      typeof value.title === "string" &&
+      typeof value.evidence === "string" &&
+      typeof value.expectedBenefit === "string" &&
+      typeof value.activationDescription === "string" &&
+      Array.isArray(value.activationTerms) &&
+      value.activationTerms.every((term) => typeof term === "string") &&
+      typeof value.minimumMatches === "number" &&
+      Number.isInteger(value.minimumMatches) &&
+      isLearningStatus(value.status) &&
+      typeof value.createdAt === "string" &&
+      typeof value.updatedAt === "string" &&
+      typeof value.sourceConversationId === "string" &&
+      typeof value.activationCount === "number" &&
+      Number.isInteger(value.activationCount) &&
+      value.activationCount >= 0 &&
+      (value.lastActivatedAt === null ||
+        typeof value.lastActivatedAt === "string") &&
+      (value.validation === null || isRecord(value.validation)) &&
+      (value.memoryText === null || typeof value.memoryText === "string") &&
+      (value.skill === null || isSkillPayload(value.skill)) &&
+      (value.tool === null || isToolPayload(value.tool)) &&
+      (value.discardReason === null || typeof value.discardReason === "string")
+    )
+  ) {
+    return false;
+  }
+  if (value.route === "memory") {
+    return (
+      value.memoryText !== null &&
+      value.skill === null &&
+      value.tool === null &&
+      value.discardReason === null &&
+      validActiveTrigger(value.activationTerms, value.minimumMatches)
+    );
+  }
+  if (value.route === "skill") {
+    return (
+      value.memoryText === null &&
+      value.skill !== null &&
+      value.tool === null &&
+      value.discardReason === null &&
+      validActiveTrigger(value.activationTerms, value.minimumMatches)
+    );
+  }
+  if (value.route === "tool") {
+    return (
+      value.memoryText === null &&
+      value.skill === null &&
+      value.tool !== null &&
+      value.discardReason === null &&
+      validActiveTrigger(value.activationTerms, value.minimumMatches)
+    );
+  }
+  return (
+    value.memoryText === null &&
+    value.skill === null &&
+    value.tool === null &&
+    value.discardReason !== null &&
+    value.activationTerms.length === 0 &&
+    value.minimumMatches === 0
+  );
+}
+
+function validActiveTrigger(
+  activationTerms: string[],
+  minimumMatches: number,
+): boolean {
+  return (
+    activationTerms.length > 0 &&
+    minimumMatches >= 1 &&
+    minimumMatches <= activationTerms.length
+  );
+}
+
+function isSkillPayload(value: unknown): value is SkillPayload {
+  return (
+    isRecord(value) &&
+    typeof value.skillMd === "string" &&
+    validSkillFrontmatter(value.skillMd) &&
+    typeof value.validationCommand === "string" &&
+    Array.isArray(value.files) &&
+    value.files.every(
+      (file) =>
+        isRecord(file) &&
+        typeof file.path === "string" &&
+        validateSkillFilePath(file.path) === null &&
+        file.path !== "SKILL.md" &&
+        typeof file.contents === "string",
+    )
+  );
+}
+
+function validSkillFrontmatter(skillMd: string): boolean {
+  const frontmatter = parseSkillFrontmatter(skillMd);
+  if (frontmatter === null) {
+    return false;
+  }
+  const name = frontmatter.fields.name ?? "";
+  const description = frontmatter.fields.description ?? "";
+  return (
+    /^[a-z0-9]+(-[a-z0-9]+)*$/.test(name) &&
+    name.length <= 64 &&
+    description.length >= 1 &&
+    description.length <= 1_024
+  );
+}
+
+function isToolPayload(value: unknown): value is ToolPayload {
+  return (
+    isRecord(value) &&
+    typeof value.moduleName === "string" &&
+    /^[A-Za-z0-9_-]+$/.test(value.moduleName) &&
+    typeof value.toolName === "string" &&
+    /^[A-Za-z_][A-Za-z0-9_]*$/.test(value.toolName) &&
+    typeof value.moduleSource === "string" &&
+    (value.apiKeyEnv === null || typeof value.apiKeyEnv === "string") &&
+    isRecord(value.validationArguments) &&
+    "expectedResult" in value
+  );
+}
+
+function isLearningRoute(value: unknown): value is LearningRoute {
+  return (
+    value === "memory" ||
+    value === "skill" ||
+    value === "tool" ||
+    value === "discard"
+  );
+}
+
+function isLearningStatus(value: unknown): value is LearningStatus {
+  return (
+    value === "proposed" ||
+    value === "promoted" ||
+    value === "rejected" ||
+    value === "discarded"
+  );
+}
+
+function requiredString(
+  value: JsonValue | undefined,
+  name: string,
+  maximum: number,
+): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${name} must be a non-empty string`);
+  }
+  const result = value.trim();
+  if (result.length > maximum) {
+    throw new Error(`${name} exceeds ${maximum} characters`);
+  }
+  return result;
+}
+
+function emptyStringToNull(
+  value: JsonValue | undefined,
+  name: string,
+  maximum: number,
+): string | null {
+  if (typeof value !== "string") {
+    throw new Error(`${name} must be a string`);
+  }
+  return value.trim().length === 0
+    ? null
+    : requiredString(value, name, maximum);
+}
+
+function stringArray(value: JsonValue | undefined, name: string): string[] {
+  if (
+    !Array.isArray(value) ||
+    !value.every((item) => typeof item === "string")
+  ) {
+    throw new Error(`${name} must be an array of strings`);
+  }
+  return value;
+}
+
+function integer(value: JsonValue | undefined, name: string): number {
+  if (typeof value !== "number" || !Number.isInteger(value)) {
+    throw new Error(`${name} must be an integer`);
+  }
+  return value;
+}
+
+function jsonObject(value: unknown, name: string): JsonObject {
+  if (!isRecord(value) || Array.isArray(value)) {
+    throw new Error(`${name} must be an object`);
+  }
+  return value as JsonObject;
+}
+
+function parseJsonObjectString(
+  value: JsonValue | undefined,
+  name: string,
+): JsonObject {
+  return jsonObject(parseJsonString(value, name), name);
+}
+
+function parseJsonString(
+  value: JsonValue | undefined,
+  name: string,
+): JsonValue {
+  const text = requiredString(value, name, 20_000);
+  try {
+    return JSON.parse(text) as JsonValue;
+  } catch {
+    throw new Error(`${name} must contain valid JSON`);
+  }
+}
+
+function requestText(context: TurnContext): string {
+  return (context.request?.input ?? [])
+    .map((message) =>
+      typeof message.content === "string"
+        ? message.content
+        : JSON.stringify(message.content),
+    )
+    .join("\n");
+}
+
+function candidateFingerprint(candidate: LearningCandidate): string {
+  return canonicalJson({
+    route: candidate.route,
+    title: candidate.title.toLowerCase(),
+    activationTerms: candidate.activationTerms,
+    memoryText: candidate.memoryText,
+    skill: candidate.skill,
+    tool: candidate.tool,
+    discardReason: candidate.discardReason,
+  });
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+  if (isRecord(value)) {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "undefined";
+}
+
+function truncate(value: string, limit: number): string {
+  return value.length <= limit ? value : `${value.slice(0, limit)}…`;
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/exo/tools/run-router-proof.ts
+++ b/exo/tools/run-router-proof.ts
@@ -1,0 +1,17 @@
+import { writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ROUTER_PROOF_CASES, compareRouterArms } from "./learning-router";
+
+const proof = compareRouterArms(ROUTER_PROOF_CASES);
+const destination = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../eval/harbor/evidence/router-proof.json",
+);
+writeFileSync(destination, `${JSON.stringify(proof, null, 2)}\n`);
+process.stdout.write(`${destination}\n`);
+process.stdout.write(`${JSON.stringify(proof, null, 2)}\n`);
+if (!proof.proven) {
+  process.exit(2);
+}

--- a/exoharness/typescript/model-runtime/responses.test.ts
+++ b/exoharness/typescript/model-runtime/responses.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChatCompletion } from "openai/resources/chat/completions";
 import type { Response } from "openai/resources/responses/responses";
 
 import {
@@ -78,6 +79,71 @@ describe("model runtime dispatch", () => {
         baseUrl: "https://openrouter.ai/api/v1",
       }),
     ).toBeInstanceOf(ChatCompletionsRuntime);
+  });
+});
+
+describe("chat completion provider errors", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("retries HTTP 200 provider-error envelopes without choices", async () => {
+    vi.useFakeTimers();
+    const create = vi
+      .fn()
+      .mockResolvedValueOnce({
+        error: {
+          code: 502,
+          message: "provider unavailable",
+          metadata: { error_type: "provider_unavailable" },
+        },
+      })
+      .mockResolvedValueOnce({
+        id: "chatcmpl_1",
+        object: "chat.completion",
+        created: 1,
+        model: "test-model",
+        choices: [
+          {
+            index: 0,
+            finish_reason: "stop",
+            logprobs: null,
+            message: { role: "assistant", content: "hello", refusal: null },
+          },
+        ],
+      } satisfies ChatCompletion);
+    const runtime = new ChatCompletionsRuntime({ apiKey: "test-key" });
+    Reflect.set(runtime, "client", {
+      chat: { completions: { create } },
+    });
+
+    const completion = runtime.complete({ model: "test-model" });
+    await vi.runAllTimersAsync();
+
+    await expect(completion).resolves.toMatchObject({
+      status: "completed",
+      model: "test-model",
+    });
+    expect(create).toHaveBeenCalledTimes(2);
+  });
+
+  it("surfaces non-retryable HTTP 200 provider errors", async () => {
+    const create = vi.fn().mockResolvedValue({
+      error: {
+        code: 400,
+        message: "invalid request",
+        metadata: { error_type: "invalid_request" },
+      },
+    });
+    const runtime = new ChatCompletionsRuntime({ apiKey: "test-key" });
+    Reflect.set(runtime, "client", {
+      chat: { completions: { create } },
+    });
+
+    await expect(runtime.complete({ model: "test-model" })).rejects.toThrow(
+      "chat completion provider error (code=400, type=invalid_request): invalid request",
+    );
+    expect(create).toHaveBeenCalledOnce();
   });
 });
 

--- a/exoharness/typescript/model-runtime/responses.ts
+++ b/exoharness/typescript/model-runtime/responses.ts
@@ -440,7 +440,17 @@ export class ChatCompletionsRuntime implements ResponsesRuntimeLike {
   private async completeRaw(
     body: ChatCompletionCreateParamsNonStreaming,
   ): Promise<ChatCompletion> {
-    return this.client.chat.completions.create(body);
+    const maxAttempts = 3;
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      const completion = await this.client.chat.completions.create(body);
+      const envelopeError = chatCompletionEnvelopeError(completion);
+      if (envelopeError === null) return completion;
+      if (!envelopeError.retryable || attempt === maxAttempts) {
+        throw envelopeError;
+      }
+      await delay(250 * 2 ** (attempt - 1));
+    }
+    throw new Error("chat completion retry loop ended unexpectedly");
   }
 
   private async completeStreamRaw(
@@ -918,6 +928,67 @@ function chatCompletionToResponse(completion: ChatCompletion): Response {
     output,
     usage: chatUsageToResponseUsage(completion.usage),
   } as unknown as Response;
+}
+
+interface ChatCompletionErrorEnvelope {
+  error?: {
+    code?: number | string;
+    message?: string;
+    metadata?: {
+      error_type?: string;
+    };
+  };
+}
+
+class ChatCompletionEnvelopeError extends Error {
+  constructor(
+    message: string,
+    readonly retryable: boolean,
+  ) {
+    super(message);
+    this.name = "ChatCompletionEnvelopeError";
+  }
+}
+
+function chatCompletionEnvelopeError(
+  completion: ChatCompletion,
+): ChatCompletionEnvelopeError | null {
+  if (Array.isArray(completion.choices) && completion.choices.length > 0) {
+    return null;
+  }
+
+  const envelope = completion as ChatCompletion & ChatCompletionErrorEnvelope;
+  const code = envelope.error?.code;
+  const errorType = envelope.error?.metadata?.error_type;
+  const message =
+    envelope.error?.message ??
+    "response did not contain any completion choices";
+  const retryableCodes = new Set(["408", "429", "500", "502", "503", "504"]);
+  const retryableTypes = new Set([
+    "provider_overloaded",
+    "provider_unavailable",
+    "rate_limit_exceeded",
+    "server",
+    "timeout",
+    "unmapped",
+  ]);
+  const retryable =
+    code === undefined ||
+    retryableCodes.has(String(code)) ||
+    (errorType !== undefined && retryableTypes.has(errorType));
+  const details = [
+    code === undefined ? null : `code=${code}`,
+    errorType === undefined ? null : `type=${errorType}`,
+  ].filter((value): value is string => value !== null);
+  const suffix = details.length === 0 ? "" : ` (${details.join(", ")})`;
+  return new ChatCompletionEnvelopeError(
+    `chat completion provider error${suffix}: ${message}`,
+    retryable,
+  );
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 class ChatCompletionAccumulator {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,13 @@
 import { fileURLToPath } from "node:url";
-import { defineConfig } from "vitest/config";
+import { configDefaults, defineConfig } from "vitest/config";
 
 // Mirror the tsconfig path aliases so tests can import modules that use them.
 export default defineConfig({
+  test: {
+    // Harbor comparisons retain isolated source snapshots under .local for
+    // inspection. They are experiment artifacts, not additional test roots.
+    exclude: [...configDefaults.exclude, "**/.local/**"],
+  },
   resolve: {
     alias: {
       "@exo/harness/tool": fileURLToPath(


### PR DESCRIPTION
## Summary

Stacked on #202.

- keeps the existing memory-biased reflection prompt as a `memory` baseline
- adds a typed `router` strategy: facts/heuristics to memory, procedures to skills, deterministic repeated operations to tools, broad system changes to policy/code, and task-specific or unsupported lessons to discard
- derives learning and reuse metrics from Exo events instead of trusting agent self-report
- compares both strategies from isolated fresh agent states with an exact fixed model, identical tasks/order/budget, source-digest validation, and resume support
- adds OpenRouter support plus handling for HTTP 200 provider error envelopes
- includes a two-task normalization transfer fixture

## Why

PR #202 proves that reward-guided reflection can persist learning between Harbor tasks, but the current prompt strongly favors memory. This experiment asks whether choosing the narrowest durable artifact produces less memory growth and more actual skill/tool reuse.

## Validation

- pre-push Clippy passed on Rust 1.95
- full suite: 320 test files / 3,124 tests passed
- Harbor Python suite: 47 tests passed
- deterministic local crossover ran both arm orders successfully
  - reward: 1.0 for both arms
  - memory baseline: 2 memories
  - router: 1 skill, 0 memories
  - router reused the skill on task 2
  - 0 failed or unresolved learning writes
  - identical source digest across arms
  - resume path verified

The deterministic run validates the experiment pipeline and accounting; it does **not** yet demonstrate a real-model reward improvement. A fixed `z-ai/glm-5.2:free` crossover is scheduled after the account-wide OpenRouter free quota resets.