### PR TITLE
Fix broken RSI.md link in README (#217)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ In short, we think this is the best way to take advantage of the growing power
 of AI models when building long-lived agents.
 
 For a more complete description of the architectural philosophy read
-[A Systems View of Recursive Self Improvement](exo/docs/RSI.md)
+[A Systems View of Recursive Self Improvement](docs/RSI.md)
 
 <!-- ![Exo playinb pokemon go](docs/images/exo_playing.gif) -->
 


### PR DESCRIPTION
Closes #217

The README linked to `exo/docs/RSI.md` which does not exist.
Corrected to `docs/RSI.md` after confirming the actual file location in the repo.