### PR TITLE
fix: stop losing handle in active_sandbox_handle race (#110)

### DIFF
--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -3488,6 +3488,17 @@ async fn active_sandbox_handle(
     }
     let mut running = harness.inner.running_sandboxes.lock().await;
     if let Some(existing) = running.get(sandbox_id) {
+        // Another concurrent caller already acquired this sandbox while we
+        // were provisioning (check-then-act race): stop the handle we just
+        // created so the remote sandbox isn't leaked untracked, then return
+        // the winner's handle.
+        tracing::warn!(
+            sandbox_id,
+            "sandbox already active; stopping the handle provisioned by this caller"
+        );
+        if let Err(stop_error) = handle.stop().await {
+            tracing::warn!(%stop_error, sandbox_id, "failed to stop the losing sandbox handle");
+        }
         return Ok((Arc::clone(existing), None));
     }
     running.insert(sandbox_id.clone(), Arc::clone(&handle));


### PR DESCRIPTION
Closes #110

## Problem
`active_sandbox_handle` in `crates/exoharness/src/basic.rs` had a check-then-act race: two concurrent first-acquires for the same `sandbox_id` could both miss the initial `running_sandboxes` lookup, both run `create_sandbox_handle` (each provisioning a remote sandbox), and then the second `insert` would overwrite the first — leaving one provisioned sandbox untracked and never `stop()`ed. For a remote provider (Daytona/E2B) that is a leaked remote sandbox.

## Fix
When the dedup check at insertion time finds another caller already registered the sandbox, we now **stop the handle we just provisioned** (the loser) so the remote sandbox cannot leak, log a warning, and return the winner's handle. This mirrors the issue's suggested approach of "dedup on insert and stop() the loser."

## Verification
- `cargo check -p exoharness` passes
- `cargo test -p exoharness` passes (9/9 unit tests)

Let me know if you'd prefer the per-`sandbox_id` lock approach instead; I can adjust.
