### PR TITLE
fix: resolve DEFERRED_SCRIPT path so rebuild_and_restart_exo can spawn the deferred runner (#214)

### DIFF
--- a/exo/tools/guardian-tools.ts
+++ b/exo/tools/guardian-tools.ts
@@ -22,7 +22,7 @@ const GUARDIAN_SCRIPT = new URL(
   import.meta.url,
 ).pathname;
 const DEFERRED_SCRIPT = new URL(
-  "./scripts/deferred-rebuild-and-restart",
+  "../scripts/deferred-rebuild-and-restart",
   import.meta.url,
 ).pathname;
 const ROOT_DIR = new URL("../..", import.meta.url).pathname;


### PR DESCRIPTION
Closes #214

## Problem
The `DEFERRED_SCRIPT` path in `exo/tools/guardian-tools.ts` was set to `"./scripts/deferred-rebuild-and-restart"` relative to `guardian-tools.ts`. This resolves to `exo/tools/scripts/deferred-rebuild-and-restart`, which does not exist. As a result, the deferred rebuild runner could never be spawned, causing `rebuild_and_restart_exo` to stay in the `"queued"` state forever with an `ENOENT` error.

## Fix
Changed the relative URL to `"../scripts/deferred-rebuild-and-restart"` so it resolves correctly from `exo/tools/` up to `exo/scripts/` where the actual bash script lives.

## Verification
- The path now points at the existing file: `exo/scripts/deferred-rebuild-and-restart`.
- The TypeScript compiles (no new errors).
- The fix is minimal and surgical—one line changed.

Closes #214.
