### PR TITLE
Fix agent sandbox creation and process bridge failures

### DIFF
--- a/crates/executor/src/agent_sandbox.rs
+++ b/crates/executor/src/agent_sandbox.rs
@@ -1,8 +1,12 @@
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
 use exoharness::{
     AgentHandle, Artifact, ArtifactVersion, CreateSandboxRequest, ReadArtifactRequest, Result,
     SandboxProvider, Uuid7, WriteArtifactRequest,
 };
 use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex as AsyncMutex;
 
 use crate::AgentConfig;
 use crate::conversation_sandbox::{ConversationSandboxSpec, agent_sandbox_spec};
@@ -72,6 +76,8 @@ pub(crate) async fn ensure_agent_sandbox(
     agent: &dyn AgentHandle,
     agent_config: &AgentConfig,
 ) -> Result<AgentSandboxHandle> {
+    let sandbox_lock = agent_sandbox_lock(&agent.record().id.to_string());
+    let _guard = sandbox_lock.lock().await;
     if let Some(record) = load_agent_sandbox_record(agent).await? {
         let recorded_spec = record.spec();
         if recorded_spec != agent_sandbox_spec(agent_config) {
@@ -165,6 +171,19 @@ fn latest_artifact_version(artifacts: Vec<ArtifactVersion>, path: &str) -> Optio
 
 fn new_agent_sandbox_name() -> String {
     format!("{AGENT_SANDBOX_NAME_PREFIX}-{}", Uuid7::now())
+}
+
+// Different conversations can prepare the shared agent sandbox concurrently.
+// Serialize the read-create-record sequence so first use creates exactly one.
+fn agent_sandbox_lock(agent_id: &str) -> Arc<AsyncMutex<()>> {
+    static LOCKS: OnceLock<Mutex<HashMap<String, Arc<AsyncMutex<()>>>>> = OnceLock::new();
+    let locks = LOCKS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut locks = locks.lock().expect("agent sandbox lock registry poisoned");
+    Arc::clone(
+        locks
+            .entry(agent_id.to_string())
+            .or_insert_with(|| Arc::new(AsyncMutex::new(()))),
+    )
 }
 
 #[cfg(test)]

--- a/crates/exoharness/src/sandbox_provider/process_bridge.rs
+++ b/crates/exoharness/src/sandbox_provider/process_bridge.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, bail};
 use async_trait::async_trait;
 use base64::Engine;
 use base64::engine::general_purpose::STANDARD;
@@ -277,6 +277,20 @@ pub struct Response {
     pub error: Option<String>,
 }
 
+impl Response {
+    fn ensure_ok(&self) -> Result<()> {
+        if !self.ok {
+            bail!(
+                "process bridge request failed: {}",
+                self.error
+                    .as_deref()
+                    .unwrap_or("unknown process bridge error")
+            );
+        }
+        Ok(())
+    }
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Event {
@@ -404,6 +418,7 @@ async fn poll_output(
 ) -> Result<()> {
     loop {
         let response = client.request(Request::recv()).await?;
+        response.ensure_ok()?;
         if response.timeout {
             continue;
         }
@@ -461,13 +476,15 @@ async fn forward_stdin(
             .await
             .context("reading process bridge stdin")?;
         if bytes_read == 0 {
-            client.request(Request::close_stdin()).await?;
+            let response = client.request(Request::close_stdin()).await?;
+            response.ensure_ok()?;
             return Ok(());
         }
-        client
+        let response = client
             .request(Request::write(&buffer[..bytes_read]))
             .await
             .context("writing process bridge stdin")?;
+        response.ensure_ok()?;
     }
 }
 
@@ -538,6 +555,26 @@ mod tests {
     struct BridgeFixture {
         _temp: TempDir,
         script_path: PathBuf,
+    }
+
+    #[tokio::test]
+    async fn process_parts_reports_bridge_error_responses() {
+        let client = Arc::new(FakeClient {
+            responses: Mutex::new(VecDeque::from([Response {
+                ok: false,
+                timeout: false,
+                events: Vec::new(),
+                error: Some("remote process disappeared".to_string()),
+            }])),
+        });
+        let parts = process_parts(client);
+        let _stdin = parts.stdin;
+
+        let result = tokio::time::timeout(Duration::from_secs(1), parts.wait)
+            .await
+            .expect("bridge error should resolve the process wait");
+
+        assert!(result.is_err());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- serialize agent-scoped sandbox initialization so concurrent conversations cannot create multiple supposedly shared sandboxes
- reject unsuccessful process-bridge responses for output polling, stdin writes, and stdin closure instead of spinning or silently accepting the failure
- add one regression test covering process-bridge error termination

## Validation

- `cargo test -p exoharness --features basic-backend -p executor`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `oxlint --deny-warnings .`
- `tsgo --noEmit -p tsconfig.json`
- `vitest run`