### PR TITLE
Protect completed turns and cross-process wakeups

### DIFF
--- a/crates/executor/src/conversation_wakeup.rs
+++ b/crates/executor/src/conversation_wakeup.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::fs::File;
 use std::sync::{Arc, Mutex, OnceLock};
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 use anyhow::Context;
 use exoharness::Result;
@@ -36,7 +36,8 @@ pub async fn send_conversation_wakeup_content(
 }
 
 struct WakeupFileLock {
-    path: PathBuf,
+    // The operating system releases the advisory lock when this handle drops.
+    _file: File,
 }
 
 impl WakeupFileLock {
@@ -44,19 +45,22 @@ impl WakeupFileLock {
         let dir = std::env::temp_dir().join("exo-wakeup-locks");
         tokio::fs::create_dir_all(&dir).await?;
         let path = dir.join(format!("{conversation_id}.lock"));
+        let file = File::options()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)
+            .with_context(|| format!("failed to open wakeup lock {}", path.display()))?;
+        // Keep the path in place: unlinking it could let waiters lock different
+        // inodes and enter the same conversation concurrently.
         loop {
-            match tokio::fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(&path)
-                .await
-            {
-                Ok(_) => return Ok(Self { path }),
-                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-                    remove_stale_lock(&path).await?;
+            match file.try_lock() {
+                Ok(()) => return Ok(Self { _file: file }),
+                Err(std::fs::TryLockError::WouldBlock) => {
                     tokio::time::sleep(Duration::from_millis(100)).await;
                 }
-                Err(error) => {
+                Err(std::fs::TryLockError::Error(error)) => {
                     return Err(error).with_context(|| {
                         format!("failed to acquire wakeup lock {}", path.display())
                     });
@@ -64,39 +68,6 @@ impl WakeupFileLock {
             }
         }
     }
-}
-
-impl Drop for WakeupFileLock {
-    fn drop(&mut self) {
-        if let Err(error) = std::fs::remove_file(&self.path) {
-            tracing::error!(
-                path = %self.path.display(),
-                %error,
-                "failed to remove wakeup lock"
-            );
-        }
-    }
-}
-
-async fn remove_stale_lock(path: &PathBuf) -> Result<()> {
-    const STALE_AFTER: Duration = Duration::from_secs(30 * 60);
-    let Ok(metadata) = tokio::fs::metadata(path).await else {
-        return Ok(());
-    };
-    let Ok(modified) = metadata.modified() else {
-        return Ok(());
-    };
-    if SystemTime::now()
-        .duration_since(modified)
-        .is_ok_and(|age| age > STALE_AFTER)
-    {
-        match tokio::fs::remove_file(path).await {
-            Ok(()) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => return Err(error.into()),
-        }
-    }
-    Ok(())
 }
 
 pub(crate) fn conversation_send_lock(conversation_id: &str) -> Arc<AsyncMutex<()>> {
@@ -115,22 +86,31 @@ pub(crate) fn conversation_send_lock(conversation_id: &str) -> Arc<AsyncMutex<()
 #[cfg(test)]
 mod tests {
     use std::pin::pin;
+    use std::time::{Duration, SystemTime};
 
     use exoharness::Uuid7;
 
     use super::*;
 
     #[tokio::test]
-    async fn wakeup_file_lock_serializes_conversation_ids() {
+    async fn wakeup_file_lock_serializes_live_holders() {
         let conversation_id = format!("test-{}", Uuid7::now());
+        let path = std::env::temp_dir()
+            .join("exo-wakeup-locks")
+            .join(format!("{conversation_id}.lock"));
         let first = WakeupFileLock::acquire(&conversation_id).await.unwrap();
+        let stale_time = SystemTime::now() - Duration::from_secs(31 * 60);
+        first
+            ._file
+            .set_times(std::fs::FileTimes::new().set_modified(stale_time))
+            .unwrap();
         let mut second = pin!(WakeupFileLock::acquire(&conversation_id));
 
         tokio::select! {
             _ = &mut second => {
-                panic!("second lock acquired while first lock was held");
+                panic!("second lock stole an old but actively held lock");
             }
-            _ = tokio::time::sleep(Duration::from_millis(20)) => {}
+            _ = tokio::time::sleep(Duration::from_millis(200)) => {}
         }
 
         drop(first);
@@ -139,5 +119,6 @@ mod tests {
             .unwrap()
             .unwrap();
         drop(second);
+        std::fs::remove_file(path).unwrap();
     }
 }

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -2050,6 +2050,7 @@ impl<'a> BasicScopedSandboxHandle<'a> {
     }
 
     async fn snapshot_sandbox(&self, id: SandboxId) -> Result<SnapshotId> {
+        self.ensure_active_turn()?;
         let (snapshot_id, event) =
             snapshot_sandbox_side_effect(self.harness, &self.owner_dir, id).await?;
         self.append_events(vec![event]).await?;
@@ -2057,6 +2058,7 @@ impl<'a> BasicScopedSandboxHandle<'a> {
     }
 
     async fn start_sandbox(&self, request: StartSandboxRequest) -> Result<()> {
+        self.ensure_active_turn()?;
         let event =
             start_sandbox_side_effect(self.harness, &self.owner_dir, self.owner, request).await?;
         self.append_events(vec![event]).await?;
@@ -2583,7 +2585,11 @@ impl<'a> BasicScopedSandboxHandle<'a> {
                 turn_id,
                 state,
             } => {
-                let expected_head = state.lock().expect("turn state poisoned").latest_event_id;
+                let expected_head = {
+                    let state = state.lock().expect("turn state poisoned");
+                    state.ensure_active(turn_id)?;
+                    state.latest_event_id
+                };
                 let mut record = self
                     .harness
                     .inner
@@ -2611,6 +2617,16 @@ impl<'a> BasicScopedSandboxHandle<'a> {
                 Ok(())
             }
         }
+    }
+
+    fn ensure_active_turn(&self) -> Result<()> {
+        if let BasicSandboxEventSink::Turn { turn_id, state, .. } = self.event_sink {
+            state
+                .lock()
+                .expect("turn state poisoned")
+                .ensure_active(turn_id)?;
+        }
+        Ok(())
     }
 }
 
@@ -2692,7 +2708,7 @@ impl ConversationHandle for BasicConversationHandle {
             record: turn_record,
             state: Mutex::new(BasicTurnState {
                 latest_event_id: Some(add_result.latest_event_id),
-                finished: false,
+                finish_event_id: None,
             }),
         }))
     }
@@ -2700,14 +2716,16 @@ impl ConversationHandle for BasicConversationHandle {
     async fn turn_handle(&self, record: TurnRecord) -> Result<Arc<dyn TurnHandle>> {
         let events = load_events(&self.harness.inner.storage, &self.events_dir()).await?;
         let mut latest_event_id = None;
-        let mut finished = false;
+        let mut finish_event_id = None;
         for event in events
             .into_iter()
             .filter(|event| event.session_id == Some(record.session_id))
             .filter(|event| event.turn_id == Some(record.id))
         {
             latest_event_id = Some(event.id);
-            finished = matches!(event.data, EventData::TurnEnded);
+            if finish_event_id.is_none() && matches!(event.data, EventData::TurnEnded) {
+                finish_event_id = Some(event.id);
+            }
         }
         if latest_event_id.is_none() {
             bail!(
@@ -2723,7 +2741,7 @@ impl ConversationHandle for BasicConversationHandle {
             record,
             state: Mutex::new(BasicTurnState {
                 latest_event_id,
-                finished,
+                finish_event_id,
             }),
         }))
     }
@@ -3664,7 +3682,18 @@ struct BasicTurnHandle {
 
 struct BasicTurnState {
     latest_event_id: Option<EventId>,
-    finished: bool,
+    // Keep the completion boundary itself so rehydration cannot reopen a turn
+    // merely because older data contains a later turn-scoped event.
+    finish_event_id: Option<EventId>,
+}
+
+impl BasicTurnState {
+    fn ensure_active(&self, turn_id: TurnId) -> Result<()> {
+        if self.finish_event_id.is_some() {
+            bail!("turn {turn_id} is already finished");
+        }
+        Ok(())
+    }
 }
 
 impl BasicSandboxScope for BasicTurnHandle {
@@ -3680,6 +3709,15 @@ impl BasicSandboxScope for BasicTurnHandle {
     }
 }
 
+impl BasicTurnHandle {
+    fn ensure_active(&self) -> Result<()> {
+        self.state
+            .lock()
+            .expect("turn state poisoned")
+            .ensure_active(self.record.id)
+    }
+}
+
 #[async_trait]
 impl TurnHandle for BasicTurnHandle {
     fn record(&self) -> &TurnRecord {
@@ -3688,6 +3726,7 @@ impl TurnHandle for BasicTurnHandle {
 
     async fn add_events(&self, data: Vec<EventData>) -> Result<AddEventsResult> {
         let _guard = self.harness.inner.write_lock.lock().await;
+        self.ensure_active()?;
         let mut record = self
             .harness
             .inner
@@ -3720,6 +3759,7 @@ impl TurnHandle for BasicTurnHandle {
 
     async fn write_artifact(&self, request: WriteArtifactRequest) -> Result<ArtifactVersion> {
         let _guard = self.harness.inner.write_lock.lock().await;
+        self.ensure_active()?;
         let mut record = self
             .harness
             .inner
@@ -3764,10 +3804,8 @@ impl TurnHandle for BasicTurnHandle {
         let _guard = self.harness.inner.write_lock.lock().await;
         {
             let state = self.state.lock().expect("turn state poisoned");
-            if state.finished {
-                return state
-                    .latest_event_id
-                    .ok_or_else(|| anyhow!("turn has no latest event id"));
+            if let Some(finish_event_id) = state.finish_event_id {
+                return Ok(finish_event_id);
             }
         }
         let mut record = self
@@ -3796,7 +3834,7 @@ impl TurnHandle for BasicTurnHandle {
         let latest = add_result.latest_event_id;
         let mut state = self.state.lock().expect("turn state poisoned");
         state.latest_event_id = Some(latest);
-        state.finished = true;
+        state.finish_event_id = Some(latest);
         Ok(latest)
     }
 }

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -1054,6 +1054,58 @@ async fn turn_artifact_write_allows_interleaved_conversation_writes() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn finished_turn_rejects_writes_after_rehydration() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let harness = BasicExoHarness::new(local_test_config(tempdir.path()))
+        .await
+        .expect("harness");
+    let conversation = test_conversation(&harness).await;
+    let turn = conversation
+        .begin_turn(BeginTurnRequest {
+            session_id: None,
+            input: vec![user_message("ping")],
+        })
+        .await
+        .expect("turn");
+    let record = turn.record().clone();
+    let finish_event_id = turn.finish().await.expect("finish");
+
+    let event_error = turn
+        .add_events(vec![EventData::Custom {
+            event_type: "too_late".to_string(),
+            payload: Value::Null,
+        }])
+        .await
+        .expect_err("finished turn must reject events");
+    assert!(event_error.to_string().contains("already finished"));
+    let artifact_error = turn
+        .write_artifact(WriteArtifactRequest {
+            path: "too-late.txt".to_string(),
+            contents: Vec::new(),
+        })
+        .await
+        .expect_err("finished turn must reject artifacts");
+    assert!(artifact_error.to_string().contains("already finished"));
+
+    let rehydrated = conversation.turn_handle(record).await.expect("turn handle");
+    assert_eq!(
+        rehydrated.finish().await.expect("idempotent finish"),
+        finish_event_id
+    );
+    assert!(
+        rehydrated
+            .add_events(vec![EventData::Custom {
+                event_type: "still_too_late".to_string(),
+                payload: Value::Null,
+            }])
+            .await
+            .expect_err("rehydrated turn must remain finished")
+            .to_string()
+            .contains("already finished")
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn artifacts_are_versioned_by_path() {
     let tempdir = TempDir::new().expect("tempdir");
     let harness = BasicExoHarness::new(local_test_config(tempdir.path()))

--- a/exoharness/typescript/harness/runner.ts
+++ b/exoharness/typescript/harness/runner.ts
@@ -189,7 +189,9 @@ interface RawAddEventsResult {
 
 interface RawEvent {
   id: string;
-  conversation_id: string;
+  thread_id?: string;
+  // Read events persisted before the thread terminology migration.
+  conversation_id?: string;
   session_id?: string | null;
   turn_id?: string | null;
   created_at: string;
@@ -1002,9 +1004,13 @@ function decodeArtifactJson<T>(artifact: Artifact | null): T | null {
 }
 
 function toEvent(raw: RawEvent): Event {
+  const conversationId = raw.thread_id ?? raw.conversation_id;
+  if (!conversationId) {
+    throw new Error(`event ${raw.id} is missing thread_id`);
+  }
   return {
     id: raw.id,
-    conversationId: raw.conversation_id,
+    conversationId,
     sessionId: raw.session_id ?? null,
     turnId: raw.turn_id ?? null,
     createdAt: raw.created_at,


### PR DESCRIPTION
## Summary

- preserve the first `turn_ended` event as the durable completion boundary and reject later event, artifact, snapshot, or restore writes through that turn handle
- replace timestamp-based wakeup lock stealing with an OS advisory lock that is released automatically when the holder exits
- decode canonical `thread_id` event ownership in the TypeScript runner while retaining support for committed `conversation_id` events

## Why

A completed turn could previously accept new events and artifacts. After rehydration, a later turn-scoped event could also make the handle appear unfinished again, breaking the ordering invariant around `turn_ended`.

Cross-process wakeups used file age as ownership. Any live wakeup older than 30 minutes—or a sleeping machine that resumed later—could have its lock deleted by another process, allowing overlapping turns and duplicate external side effects. The original holder could then delete the replacement holder's lock on drop.

The thread terminology migration changed serialized events to `thread_id`, but the TypeScript runner still read `conversation_id`, leaving `Event.conversationId` undefined for current events.

## Verification

- `pnpm check`
- `pnpm format:check`
- `cargo test -p exoharness --features basic-backend --lib`
- `cargo test -p executor --lib`
- `cargo clippy -p exoharness --features basic-backend --all-targets -- -D warnings`
- `cargo clippy -p executor --all-targets -- -D warnings`
- repository commit and pre-push hooks
