### PR TITLE
executor stores: crash-consistency fixes for the on-disk message queues

### DIFF
--- a/crates/executor/src/adapter/store.rs
+++ b/crates/executor/src/adapter/store.rs
@@ -342,8 +342,7 @@ impl AdapterStore {
         message.last_error = None;
         fs::create_dir_all(self.delivered_dir(adapter_id)).await?;
         write_json_file(&self.delivered_path(adapter_id, message_id), &message).await?;
-        remove_file_if_exists(self.inflight_path(adapter_id, message_id)).await?;
-        remove_file_if_exists(self.outbox_path(adapter_id, message_id)).await?;
+        self.remove_pending_copies(adapter_id, message_id).await?;
         Ok(Some(message))
     }
 
@@ -361,18 +360,21 @@ impl AdapterStore {
         };
         message.last_error = Some(error.into());
         message.updated_at_ms = now_ms();
-        remove_file_if_exists(self.inflight_path(adapter_id, message_id)).await?;
-        remove_file_if_exists(self.outbox_path(adapter_id, message_id)).await?;
+        // Write the message's next home before retiring its current one. The
+        // other order has an instant where the message exists nowhere, and a
+        // failed write (or a crash) in that instant loses it for good.
         if message.attempt >= MAX_DELIVERY_ATTEMPTS {
             message.status = AdapterDeliveryStatus::Failed;
             message.completed_at_ms = Some(message.updated_at_ms);
             fs::create_dir_all(self.failed_dir(adapter_id)).await?;
             write_json_file(&self.failed_path(adapter_id, message_id), &message).await?;
+            remove_file_if_exists(self.outbox_path(adapter_id, message_id)).await?;
         } else {
             message.status = AdapterDeliveryStatus::Queued;
             fs::create_dir_all(self.outbox_dir(adapter_id)).await?;
             write_json_file(&self.outbox_path(adapter_id, message_id), &message).await?;
         }
+        remove_file_if_exists(self.inflight_path(adapter_id, message_id)).await?;
         Ok(Some(message))
     }
 
@@ -582,6 +584,12 @@ impl AdapterStore {
             }
         }
         Ok(None)
+    }
+
+    /// Retires every copy of a message that is still queued or in flight.
+    async fn remove_pending_copies(&self, adapter_id: &str, message_id: &str) -> Result<()> {
+        remove_file_if_exists(self.inflight_path(adapter_id, message_id)).await?;
+        remove_file_if_exists(self.outbox_path(adapter_id, message_id)).await
     }
 
     fn target_conversations_dir(&self, adapter_id: &str) -> PathBuf {
@@ -894,6 +902,38 @@ mod tests {
         assert_eq!(claimed_again.len(), 1);
         assert_eq!(claimed_again[0].id, message.id);
         assert_eq!(claimed_again[0].attempt, 2);
+    }
+
+    #[tokio::test]
+    async fn nack_that_cannot_write_the_replacement_keeps_the_message() {
+        let tempdir = TempDir::new().unwrap();
+        let store = AdapterStore::new(tempdir.path());
+        let message = store
+            .enqueue_outbound_message("adapter".to_string(), "hello".to_string(), None, Vec::new())
+            .await
+            .unwrap();
+        store.claim_outbound_messages("adapter").await.unwrap();
+
+        // Make the requeue destination unwritable: a plain file where the
+        // outbox directory has to be. The nack fails either way; what matters
+        // is that the only remaining copy of the message survives it.
+        let outbox_dir = store.outbox_dir("adapter");
+        fs::remove_dir_all(&outbox_dir).await.unwrap();
+        fs::write(&outbox_dir, b"not a directory").await.unwrap();
+        store
+            .nack_outbound_message("adapter", &message.id, "worker failed")
+            .await
+            .unwrap_err();
+
+        fs::remove_file(&outbox_dir).await.unwrap();
+        store.requeue_inflight_messages("adapter").await.unwrap();
+        let claimed = store.claim_outbound_messages("adapter").await.unwrap();
+        assert_eq!(
+            claimed.len(),
+            1,
+            "a failed nack must leave the message recoverable, not destroy it"
+        );
+        assert_eq!(claimed[0].id, message.id);
     }
 
     #[tokio::test]

--- a/crates/executor/src/adapter/store.rs
+++ b/crates/executor/src/adapter/store.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use exoharness::Uuid7;
-use serde::Serialize;
+use serde::{Serialize, de::DeserializeOwned};
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 
@@ -90,14 +90,7 @@ impl AdapterStore {
     }
 
     pub async fn get_adapter(&self, adapter_id: &str) -> Result<Option<AdapterRecord>> {
-        let path = self.adapter_path(adapter_id);
-        match fs::read(&path).await {
-            Ok(bytes) => Ok(Some(serde_json::from_slice::<AdapterRecord>(&bytes)?)),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-            Err(error) => {
-                Err(error).with_context(|| format!("failed to read adapter {}", path.display()))
-            }
-        }
+        read_json_file_if_exists(&self.adapter_path(adapter_id)).await
     }
 
     pub async fn put_adapter(&self, adapter: &AdapterRecord) -> Result<()> {
@@ -311,6 +304,13 @@ impl AdapterStore {
                 format!("failed to read adapter outbound message {}", path.display())
             })?;
             let mut message = serde_json::from_slice::<AdapterOutboundMessageRecord>(&bytes)?;
+            if self
+                .retire_if_delivered(adapter_id, &message.id)
+                .await?
+                .is_some()
+            {
+                continue;
+            }
             message.status = AdapterDeliveryStatus::InFlight;
             message.attempt = message.attempt.saturating_add(1);
             message.updated_at_ms = now_ms();
@@ -352,6 +352,9 @@ impl AdapterStore {
         message_id: &str,
         error: impl Into<String>,
     ) -> Result<Option<AdapterOutboundMessageRecord>> {
+        if let Some(delivered) = self.retire_if_delivered(adapter_id, message_id).await? {
+            return Ok(Some(delivered));
+        }
         let Some(mut message) = self
             .read_pending_outbound_message(adapter_id, message_id)
             .await?
@@ -417,19 +420,7 @@ impl AdapterStore {
         adapter_id: &str,
         target: &str,
     ) -> Result<Option<AdapterTargetConversationRecord>> {
-        let path = self.target_conversation_path(adapter_id, target);
-        match fs::read(&path).await {
-            Ok(bytes) => Ok(Some(serde_json::from_slice::<
-                AdapterTargetConversationRecord,
-            >(&bytes)?)),
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-            Err(error) => Err(error).with_context(|| {
-                format!(
-                    "failed to read adapter target conversation {}",
-                    path.display()
-                )
-            }),
-        }
+        read_json_file_if_exists(&self.target_conversation_path(adapter_id, target)).await
     }
 
     pub async fn put_target_conversation(
@@ -573,14 +564,8 @@ impl AdapterStore {
             self.inflight_path(adapter_id, message_id),
             self.outbox_path(adapter_id, message_id),
         ] {
-            match fs::read(&path).await {
-                Ok(bytes) => {
-                    return Ok(Some(
-                        serde_json::from_slice::<AdapterOutboundMessageRecord>(&bytes)?,
-                    ));
-                }
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-                Err(error) => return Err(error.into()),
+            if let Some(message) = read_json_file_if_exists(&path).await? {
+                return Ok(Some(message));
             }
         }
         Ok(None)
@@ -590,6 +575,25 @@ impl AdapterStore {
     async fn remove_pending_copies(&self, adapter_id: &str, message_id: &str) -> Result<()> {
         remove_file_if_exists(self.inflight_path(adapter_id, message_id)).await?;
         remove_file_if_exists(self.outbox_path(adapter_id, message_id)).await
+    }
+
+    /// A delivered record means an ack landed but its cleanup was interrupted:
+    /// the message was delivered, so retire the stale copies instead of
+    /// letting them queue a second delivery (or record a failure that never
+    /// happened). Returns the delivered record when that was the case.
+    async fn retire_if_delivered(
+        &self,
+        adapter_id: &str,
+        message_id: &str,
+    ) -> Result<Option<AdapterOutboundMessageRecord>> {
+        let delivered = read_json_file_if_exists::<AdapterOutboundMessageRecord>(
+            &self.delivered_path(adapter_id, message_id),
+        )
+        .await?;
+        if delivered.is_some() {
+            self.remove_pending_copies(adapter_id, message_id).await?;
+        }
+        Ok(delivered)
     }
 
     fn target_conversations_dir(&self, adapter_id: &str) -> PathBuf {
@@ -613,6 +617,14 @@ async fn remove_file_if_exists(path: PathBuf) -> Result<()> {
         Err(error) => {
             Err(error).with_context(|| format!("failed to delete file {}", path.display()))
         }
+    }
+}
+
+async fn read_json_file_if_exists<T: DeserializeOwned>(path: &Path) -> Result<Option<T>> {
+    match fs::read(path).await {
+        Ok(bytes) => Ok(Some(serde_json::from_slice(&bytes)?)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error).with_context(|| format!("failed to read {}", path.display())),
     }
 }
 
@@ -934,6 +946,49 @@ mod tests {
             "a failed nack must leave the message recoverable, not destroy it"
         );
         assert_eq!(claimed[0].id, message.id);
+    }
+
+    #[tokio::test]
+    async fn recovery_does_not_resurrect_an_acknowledged_message() {
+        let tempdir = TempDir::new().unwrap();
+        let store = AdapterStore::new(tempdir.path());
+        let message = store
+            .enqueue_outbound_message("adapter".to_string(), "hello".to_string(), None, Vec::new())
+            .await
+            .unwrap();
+        let claimed = store.claim_outbound_messages("adapter").await.unwrap();
+        store
+            .acknowledge_outbound_message("adapter", &message.id)
+            .await
+            .unwrap();
+
+        // The ack's delivered record landed but the process died before it
+        // cleared the in-flight copy. Recovery finds the stale copy.
+        write_json_file(&store.inflight_path("adapter", &message.id), &claimed[0])
+            .await
+            .unwrap();
+        store.requeue_inflight_messages("adapter").await.unwrap();
+
+        assert!(
+            store
+                .claim_outbound_messages("adapter")
+                .await
+                .unwrap()
+                .is_empty(),
+            "a delivered message must not be queued for a second delivery"
+        );
+        assert!(
+            fs::metadata(store.failed_path("adapter", &message.id))
+                .await
+                .is_err(),
+            "a delivered message must not be recorded as failed"
+        );
+        assert!(
+            fs::metadata(store.inflight_path("adapter", &message.id))
+                .await
+                .is_err(),
+            "recovery should retire the stale in-flight copy"
+        );
     }
 
     #[tokio::test]

--- a/crates/executor/src/adapter/store.rs
+++ b/crates/executor/src/adapter/store.rs
@@ -1,10 +1,13 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use exoharness::Uuid7;
-use serde::{Serialize, de::DeserializeOwned};
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
+
+use crate::json_store::{
+    is_record_entry, read_json_file_if_exists, remove_dir_if_exists, remove_file_if_exists,
+    write_json_file,
+};
 
 use super::types::{
     AdapterAttachment, AdapterDeliveryStatus, AdapterEventRecord, AdapterEventType,
@@ -50,10 +53,10 @@ impl AdapterStore {
             .with_context(|| format!("failed to read adapter directory {adapter_dir:?}"))?;
         let mut adapters = Vec::new();
         while let Some(entry) = entries.next_entry().await? {
-            let path = entry.path();
-            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            if !is_record_entry(&entry).await {
                 continue;
             }
+            let path = entry.path();
             let bytes = fs::read(&path)
                 .await
                 .with_context(|| format!("failed to read adapter {}", path.display()))?;
@@ -209,10 +212,10 @@ impl AdapterStore {
             .with_context(|| format!("failed to read adapter events directory {events_dir:?}"))?;
         let mut events = Vec::new();
         while let Some(entry) = entries.next_entry().await? {
-            let path = entry.path();
-            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            if !is_record_entry(&entry).await {
                 continue;
             }
+            let path = entry.path();
             let bytes = fs::read(&path)
                 .await
                 .with_context(|| format!("failed to read adapter event {}", path.display()))?;
@@ -296,10 +299,10 @@ impl AdapterStore {
         while messages.len() < MAX_MESSAGES_PER_CLAIM
             && let Some(entry) = entries.next_entry().await?
         {
-            let path = entry.path();
-            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            if !is_record_entry(&entry).await {
                 continue;
             }
+            let path = entry.path();
             let bytes = fs::read(&path).await.with_context(|| {
                 format!("failed to read adapter outbound message {}", path.display())
             })?;
@@ -402,10 +405,10 @@ impl AdapterStore {
             format!("failed to read adapter inflight directory {inflight_dir:?}")
         })?;
         while let Some(entry) = entries.next_entry().await? {
-            let path = entry.path();
-            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            if !is_record_entry(&entry).await {
                 continue;
             }
+            let path = entry.path();
             let Some(message_id) = path.file_stem().and_then(|stem| stem.to_str()) else {
                 continue;
             };
@@ -450,10 +453,10 @@ impl AdapterStore {
         let mut records = Vec::new();
         let mut entries = fs::read_dir(&dir).await?;
         while let Some(entry) = entries.next_entry().await? {
-            let path = entry.path();
-            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            if !is_record_entry(&entry).await {
                 continue;
             }
+            let path = entry.path();
             let bytes = fs::read(&path).await.with_context(|| {
                 format!("failed to read target conversation {}", path.display())
             })?;
@@ -610,48 +613,6 @@ impl AdapterStore {
     }
 }
 
-async fn remove_file_if_exists(path: PathBuf) -> Result<()> {
-    match fs::remove_file(&path).await {
-        Ok(()) => Ok(()),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(error) => {
-            Err(error).with_context(|| format!("failed to delete file {}", path.display()))
-        }
-    }
-}
-
-async fn read_json_file_if_exists<T: DeserializeOwned>(path: &Path) -> Result<Option<T>> {
-    match fs::read(path).await {
-        Ok(bytes) => Ok(Some(serde_json::from_slice(&bytes)?)),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(error) => Err(error).with_context(|| format!("failed to read {}", path.display())),
-    }
-}
-
-async fn write_json_file<T: Serialize>(path: &Path, value: &T) -> Result<()> {
-    let temp_path = path.with_extension(format!("json.{}.tmp", Uuid7::now()));
-    fs::write(&temp_path, serde_json::to_vec_pretty(value)?)
-        .await
-        .with_context(|| format!("failed to write temp file {}", temp_path.display()))?;
-    fs::rename(&temp_path, path).await.with_context(|| {
-        format!(
-            "failed to replace {} with temp file {}",
-            path.display(),
-            temp_path.display()
-        )
-    })
-}
-
-async fn remove_dir_if_exists(path: PathBuf) -> Result<()> {
-    match fs::remove_dir_all(&path).await {
-        Ok(()) => Ok(()),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(error) => {
-            Err(error).with_context(|| format!("failed to delete directory {}", path.display()))
-        }
-    }
-}
-
 async fn count_json_files(path: &Path) -> Result<usize> {
     let mut entries = match fs::read_dir(path).await {
         Ok(entries) => entries,
@@ -660,7 +621,7 @@ async fn count_json_files(path: &Path) -> Result<usize> {
     };
     let mut count = 0;
     while let Some(entry) = entries.next_entry().await? {
-        if entry.path().extension().and_then(|ext| ext.to_str()) == Some("json") {
+        if is_record_entry(&entry).await {
             count += 1;
         }
     }
@@ -696,6 +657,7 @@ mod tests {
     };
 
     use super::*;
+    use crate::test_support::backdate_file;
 
     #[tokio::test]
     async fn creates_lists_disables_and_deletes_adapters() {
@@ -988,6 +950,45 @@ mod tests {
                 .await
                 .is_err(),
             "recovery should retire the stale in-flight copy"
+        );
+    }
+
+    #[tokio::test]
+    async fn claiming_sweeps_staging_files_a_crashed_writer_left_behind() {
+        let tempdir = TempDir::new().unwrap();
+        let store = AdapterStore::new(tempdir.path());
+        fs::create_dir_all(store.outbox_dir("adapter"))
+            .await
+            .unwrap();
+        let outbox = store.outbox_dir("adapter");
+        let stale = outbox.join(format!("message.json.{}.tmp", exoharness::Uuid7::now()));
+        let fresh = outbox.join(format!("message.json.{}.tmp", exoharness::Uuid7::now()));
+        let foreign = outbox.join("message.json.backup.tmp");
+        fs::write(&stale, b"{").await.unwrap();
+        fs::write(&fresh, b"{").await.unwrap();
+        fs::write(&foreign, b"{").await.unwrap();
+        // A writer that died an hour ago between its temp write and rename.
+        backdate_file(&stale, std::time::Duration::from_secs(3600));
+        backdate_file(&foreign, std::time::Duration::from_secs(3600));
+
+        assert!(
+            store
+                .claim_outbound_messages("adapter")
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(
+            fs::metadata(&stale).await.is_err(),
+            "a stale staging file should be swept"
+        );
+        assert!(
+            fs::metadata(&fresh).await.is_ok(),
+            "a staging file that may still be mid-write must be left alone"
+        );
+        assert!(
+            fs::metadata(&foreign).await.is_ok(),
+            "a file that is not the writer's staging shape must be left alone"
         );
     }
 

--- a/crates/executor/src/json_store.rs
+++ b/crates/executor/src/json_store.rs
@@ -1,0 +1,133 @@
+//! File-backed JSON record helpers shared by the scheduler and adapter stores:
+//! atomic staged writes, tolerant removes, and cleanup of the staging files a
+//! crashed writer leaves behind.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use anyhow::{Context, Result};
+use exoharness::Uuid7;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use tokio::fs;
+
+/// Staging files older than this are leftovers of a writer that died between
+/// its temp write and its rename; anything younger may still be mid-write.
+const STALE_TEMP_FILE_AFTER: Duration = Duration::from_secs(5 * 60);
+
+/// Writes JSON through a temp file so a crash mid-write leaves the previous
+/// record intact instead of a half-written one.
+pub(crate) async fn write_json_file<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    let temp_path = path.with_extension(format!("json.{}.tmp", Uuid7::now()));
+    fs::write(&temp_path, serde_json::to_vec_pretty(value)?)
+        .await
+        .with_context(|| format!("failed to write temp file {}", temp_path.display()))?;
+    if let Err(error) = fs::rename(&temp_path, path).await {
+        let context = format!(
+            "failed to replace {} with temp file {}",
+            path.display(),
+            temp_path.display()
+        );
+        remove_file_if_exists(temp_path).await?;
+        return Err(error).context(context);
+    }
+    Ok(())
+}
+
+pub(crate) async fn read_json_file_if_exists<T: DeserializeOwned>(
+    path: &Path,
+) -> Result<Option<T>> {
+    match fs::read(path).await {
+        Ok(bytes) => Ok(Some(serde_json::from_slice(&bytes)?)),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error).with_context(|| format!("failed to read {}", path.display())),
+    }
+}
+
+/// True when `entry` is a JSON record. Anything else is removed by
+/// [`remove_stale_temp_file`] if it is a leftover staging file, so every
+/// directory listing doubles as the sweep for the litter a crashed writer
+/// leaves behind; nothing else ever cleans it up.
+pub(crate) async fn is_record_entry(entry: &fs::DirEntry) -> bool {
+    if entry.path().extension().and_then(|ext| ext.to_str()) == Some("json") {
+        return true;
+    }
+    remove_stale_temp_file(entry).await;
+    false
+}
+
+/// Removes `entry` if it is a staging file a crashed writer left behind.
+/// Best-effort maintenance: a failed removal (or the entry disappearing under
+/// a live writer's rename) must not fail the listing that triggered it.
+async fn remove_stale_temp_file(entry: &fs::DirEntry) {
+    if !entry.file_name().to_str().is_some_and(is_staging_file_name) {
+        return;
+    }
+    let Ok(metadata) = entry.metadata().await else {
+        return;
+    };
+    let is_stale = metadata.is_file()
+        && metadata.modified().is_ok_and(|modified| {
+            SystemTime::now()
+                .duration_since(modified)
+                .is_ok_and(|age| age > STALE_TEMP_FILE_AFTER)
+        });
+    if is_stale && let Err(error) = fs::remove_file(entry.path()).await {
+        tracing::debug!(
+            path = %entry.path().display(),
+            %error,
+            "failed to remove stale staging file"
+        );
+    }
+}
+
+/// Only the exact staging shape `write_json_file` creates
+/// (`<name>.json.<uuid>.tmp`); anything else in the directory is not ours to
+/// delete.
+fn is_staging_file_name(name: &str) -> bool {
+    name.strip_suffix(".tmp")
+        .and_then(|rest| rest.rsplit_once('.'))
+        .is_some_and(|(prefix, uuid)| prefix.ends_with(".json") && uuid.parse::<Uuid7>().is_ok())
+}
+
+pub(crate) async fn remove_file_if_exists(path: PathBuf) -> Result<()> {
+    match fs::remove_file(&path).await {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => {
+            Err(error).with_context(|| format!("failed to delete file {}", path.display()))
+        }
+    }
+}
+
+pub(crate) async fn remove_dir_if_exists(path: PathBuf) -> Result<()> {
+    match fs::remove_dir_all(&path).await {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => {
+            Err(error).with_context(|| format!("failed to delete directory {}", path.display()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn staging_name_matches_only_the_writer_shape() {
+        assert!(is_staging_file_name(&format!(
+            "record.json.{}.tmp",
+            Uuid7::now()
+        )));
+        for name in [
+            "record.json",
+            "record.json.backup.tmp",
+            "record.tmp",
+            "archive.tmp",
+            "record.json.tmp",
+        ] {
+            assert!(!is_staging_file_name(name), "{name} is not a staging file");
+        }
+    }
+}

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -22,6 +22,7 @@ mod harness_js_repl;
 mod harness_runtime;
 mod harness_tool;
 mod harness_types;
+mod json_store;
 mod local_sandbox;
 mod rlm;
 #[cfg(test)]

--- a/crates/executor/src/scheduler_store.rs
+++ b/crates/executor/src/scheduler_store.rs
@@ -1,10 +1,11 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use exoharness::Uuid7;
-use serde::Serialize;
 use tokio::fs;
 
+use crate::json_store::{
+    is_record_entry, remove_dir_if_exists, remove_file_if_exists, write_json_file,
+};
 use crate::scheduler_types::{
     NewScheduledTask, ScheduledFireRecord, ScheduledTaskRecord, ScheduledTaskRunRecord,
     migrate_scheduled_task, now_ms,
@@ -44,10 +45,10 @@ impl SchedulerStore {
             .with_context(|| format!("failed to read scheduled task directory {task_dir:?}"))?;
         let mut tasks = Vec::new();
         while let Some(entry) = entries.next_entry().await? {
-            let path = entry.path();
-            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            if !is_record_entry(&entry).await {
                 continue;
             }
+            let path = entry.path();
             let bytes = fs::read(&path)
                 .await
                 .with_context(|| format!("failed to read scheduled task {}", path.display()))?;
@@ -170,10 +171,10 @@ impl SchedulerStore {
             .with_context(|| format!("failed to read scheduled fire directory {dir:?}"))?;
         let mut fires = Vec::new();
         while let Some(entry) = entries.next_entry().await? {
-            let path = entry.path();
-            if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+            if !is_record_entry(&entry).await {
                 continue;
             }
+            let path = entry.path();
             let bytes = fs::read(&path).await.with_context(|| {
                 format!("failed to read scheduled task fire {}", path.display())
             })?;
@@ -260,49 +261,13 @@ fn decode_task(bytes: &[u8]) -> Result<ScheduledTaskRecord> {
     migrate_scheduled_task(serde_json::from_slice::<ScheduledTaskRecord>(bytes)?)
 }
 
-/// Writes JSON through a temp file so a crash mid-write leaves the previous
-/// record intact instead of a half-written one. Same shape as the adapter
-/// store's writer.
-async fn write_json_file<T: Serialize>(path: &Path, value: &T) -> Result<()> {
-    let temp_path = path.with_extension(format!("json.{}.tmp", Uuid7::now()));
-    fs::write(&temp_path, serde_json::to_vec_pretty(value)?)
-        .await
-        .with_context(|| format!("failed to write temp file {}", temp_path.display()))?;
-    fs::rename(&temp_path, path).await.with_context(|| {
-        format!(
-            "failed to replace {} with temp file {}",
-            path.display(),
-            temp_path.display()
-        )
-    })
-}
-
-async fn remove_file_if_exists(path: PathBuf) -> Result<()> {
-    match fs::remove_file(&path).await {
-        Ok(()) => Ok(()),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(error) => {
-            Err(error).with_context(|| format!("failed to delete file {}", path.display()))
-        }
-    }
-}
-
-async fn remove_dir_if_exists(path: PathBuf) -> Result<()> {
-    match fs::remove_dir_all(&path).await {
-        Ok(()) => Ok(()),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(error) => {
-            Err(error).with_context(|| format!("failed to delete directory {}", path.display()))
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use tempfile::TempDir;
 
     use super::*;
     use crate::scheduler_types::SCHEDULED_TASK_SCHEMA_VERSION;
+    use crate::test_support::backdate_file;
 
     #[tokio::test]
     async fn creates_and_lists_tasks() {
@@ -465,6 +430,33 @@ mod tests {
         }
         assert_eq!(names, vec![format!("{}.json", task.id)]);
         assert_eq!(store.get_task(&task.id).await.unwrap().unwrap(), task);
+    }
+
+    #[tokio::test]
+    async fn listing_sweeps_staging_files_a_crashed_writer_left_behind() {
+        let tempdir = TempDir::new().unwrap();
+        let store = SchedulerStore::new(tempdir.path());
+        tokio::fs::create_dir_all(store.tasks_dir()).await.unwrap();
+        let stale = store
+            .tasks_dir()
+            .join(format!("task.json.{}.tmp", exoharness::Uuid7::now()));
+        let fresh = store
+            .tasks_dir()
+            .join(format!("task.json.{}.tmp", exoharness::Uuid7::now()));
+        tokio::fs::write(&stale, b"{").await.unwrap();
+        tokio::fs::write(&fresh, b"{").await.unwrap();
+        // A writer that died an hour ago between its temp write and rename.
+        backdate_file(&stale, std::time::Duration::from_secs(3600));
+
+        assert!(store.list_tasks().await.unwrap().is_empty());
+        assert!(
+            tokio::fs::metadata(&stale).await.is_err(),
+            "a stale staging file should be swept"
+        );
+        assert!(
+            tokio::fs::metadata(&fresh).await.is_ok(),
+            "a staging file that may still be mid-write must be left alone"
+        );
     }
 
     #[tokio::test]

--- a/crates/executor/src/test_support.rs
+++ b/crates/executor/src/test_support.rs
@@ -1,4 +1,5 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
 
 use exoharness::{
     BasicExoHarnessConfig, SandboxBackendRegistration, SandboxProvider, SecretBackendChoice,
@@ -11,4 +12,15 @@ pub(crate) fn local_test_config(root: impl Into<PathBuf>) -> BasicExoHarnessConf
         sandbox_default: SandboxProvider::LocalProcess,
         sandbox_backends: vec![SandboxBackendRegistration::local_process()],
     }
+}
+
+/// Sets a file's mtime `by` into the past, the way a clock would have left a
+/// file written that long ago.
+pub(crate) fn backdate_file(path: &Path, by: Duration) {
+    std::fs::File::options()
+        .write(true)
+        .open(path)
+        .expect("backdated file exists")
+        .set_modified(SystemTime::now() - by)
+        .expect("set mtime");
 }


### PR DESCRIPTION
## Summary

Three crash-window fixes in the executor's file-backed stores, one commit each. Each commit carries a test that plants the post-crash state and fails without its fix.

- **Never leave an outbound message with no copy on disk.** `nack_outbound_message` deleted the in-flight and outbox copies before writing the replacement, so a failed write (ENOSPC, EIO, a crash) lost the message permanently. Now the message's next home is written first, then the old copies are retired: a crash in the new gap leaves two copies, which recovery collapses, instead of zero.
- **Recovery must not resurrect a delivered message.** A crash between writing the delivered record and removing the in-flight copy left a message both delivered and in flight; the next requeue pass either delivered it a second time or filed it under `outbox-failed/`. The delivered record is now authoritative: a nack or a claim that finds one retires the stale copies and leaves it alone.
- **Sweep staging files a crashed writer left behind.** Both stores write through a `<name>.json.<uuid>.tmp` staging file, and a crash between the write and the rename left it behind forever. Every directory listing now retires staging files older than five minutes in the same pass that skips them, and the stores' duplicated file helpers move into one `json_store` module so the staging-name contract lives in one place.

I found this while testing my [patina](https://github.com/JacobHayes/patina) project (a deterministic simulation testing runtime for rust) against the executor stores.

Note: this shares the small `backdate_file` test helper with #231; whichever lands second should rebase easily.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p executor`
