### PR TITLE
fix: correct DEFERRED_SCRIPT path in guardian-tools

### DIFF
--- a/exo/tools/guardian-tools.ts
+++ b/exo/tools/guardian-tools.ts
@@ -22,7 +22,7 @@ const GUARDIAN_SCRIPT = new URL(
   import.meta.url,
 ).pathname;
 const DEFERRED_SCRIPT = new URL(
-  "./scripts/deferred-rebuild-and-restart",
+  "../scripts/deferred-rebuild-and-restart",
   import.meta.url,
 ).pathname;
 const ROOT_DIR = new URL("../..", import.meta.url).pathname;


### PR DESCRIPTION
Fixes #214

`DEFERRED_SCRIPT` in `exo/tools/guardian-tools.ts` resolved `./scripts/deferred-rebuild-and-restart` to the nonexistent `exo/tools/scripts/deferred-rebuild-and-restart`, so the spawned deferred runner failed with ENOENT and queued self-updates stayed `status: "queued"` forever. The script actually lives at `exo/scripts/deferred-rebuild-and-restart` — use `../scripts/`, matching the sibling `GUARDIAN_SCRIPT` (whose path was corrected in the same refactor that missed this one).

One-line change; verified the target path exists on `main`.