### PR TITLE
feat: durable ordered Agent Inbox for conversation wakeups (#207)

### DIFF
--- a/crates/executor/src/conversation_wakeup.rs
+++ b/crates/executor/src/conversation_wakeup.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex, OnceLock};
-use std::time::{Duration, SystemTime};
 
 use anyhow::Context;
 use exoharness::Result;
@@ -9,7 +8,19 @@ use lingua::Message;
 use lingua::universal::UserContent;
 use tokio::sync::Mutex as AsyncMutex;
 
+use crate::inbox::{Inbox, InboxItem};
 use crate::{HarnessConversation, SendRequest, SendResult};
+
+/// Default on-disk location of the durable conversation inbox.
+///
+/// Overridable via `EXO_INBOX_DIR` so deployments can place it on a
+/// volume with the same durability guarantees as the event log.
+pub fn default_inbox() -> Inbox {
+    let root = std::env::var_os("EXO_INBOX_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| std::env::temp_dir().join("exo-inbox"));
+    Inbox::new(root)
+}
 
 pub async fn send_conversation_wakeup(
     conversation: &dyn HarnessConversation,
@@ -20,83 +31,60 @@ pub async fn send_conversation_wakeup(
 
 /// Wakeup variant for multimodal content, e.g. adapter messages that carry
 /// inbound images for the model to analyze.
+///
+/// The content is first appended to the conversation's durable inbox and
+/// only then injected. This gives producers FIFO delivery (items drain in
+/// UUIDv7 arrival order) and crash safety (an unacked item survives a
+/// restart and is redelivered), replacing the old race-prone lock-file
+/// handoff (issue #207).
 pub async fn send_conversation_wakeup_content(
     conversation: &dyn HarnessConversation,
     content: UserContent,
 ) -> Result<SendResult> {
-    let _file_guard = WakeupFileLock::acquire(&conversation.record().id.to_string()).await?;
+    let conversation_id = conversation.record().id.to_string();
+    let inbox = default_inbox();
+    let pending = inbox.enqueue(&conversation_id, content).await?;
+
+    // Serialize turn start across tasks in this process; items drain in
+    // arrival order under this per-conversation lock.
+    let send_lock = conversation_send_lock(&conversation_id);
+    let _send_guard = send_lock.lock().await;
+
+    let items = inbox.drain(&conversation_id).await?;
+    let mut result = None;
+    for item in items {
+        let sent = deliver_item(conversation, &item).await?;
+        if item.item_id == pending {
+            result = Some(sent);
+        }
+        inbox.ack(&conversation_id, item.item_id).await?;
+    }
+    match result {
+        Some(result) => Ok(result),
+        // The just-enqueued item was already drained+acked by another task
+        // between our enqueue and drain; treat it as delivered.
+        None => Err(anyhow::anyhow!(
+            "wakeup item {} was consumed by a concurrent sender",
+            pending
+        )
+        .into()),
+    }
+}
+
+async fn deliver_item(
+    conversation: &dyn HarnessConversation,
+    item: &InboxItem,
+) -> Result<SendResult> {
     let result = conversation
         .send(SendRequest {
-            input: vec![Message::User { content }],
+            input: vec![Message::User {
+                content: item.content.clone(),
+            }],
             session_id: None,
         })
         .await?;
     conversation.close_session(result.session_id).await?;
     Ok(result)
-}
-
-struct WakeupFileLock {
-    path: PathBuf,
-}
-
-impl WakeupFileLock {
-    async fn acquire(conversation_id: &str) -> Result<Self> {
-        let dir = std::env::temp_dir().join("exo-wakeup-locks");
-        tokio::fs::create_dir_all(&dir).await?;
-        let path = dir.join(format!("{conversation_id}.lock"));
-        loop {
-            match tokio::fs::OpenOptions::new()
-                .write(true)
-                .create_new(true)
-                .open(&path)
-                .await
-            {
-                Ok(_) => return Ok(Self { path }),
-                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-                    remove_stale_lock(&path).await?;
-                    tokio::time::sleep(Duration::from_millis(100)).await;
-                }
-                Err(error) => {
-                    return Err(error).with_context(|| {
-                        format!("failed to acquire wakeup lock {}", path.display())
-                    });
-                }
-            }
-        }
-    }
-}
-
-impl Drop for WakeupFileLock {
-    fn drop(&mut self) {
-        if let Err(error) = std::fs::remove_file(&self.path) {
-            tracing::error!(
-                path = %self.path.display(),
-                %error,
-                "failed to remove wakeup lock"
-            );
-        }
-    }
-}
-
-async fn remove_stale_lock(path: &PathBuf) -> Result<()> {
-    const STALE_AFTER: Duration = Duration::from_secs(30 * 60);
-    let Ok(metadata) = tokio::fs::metadata(path).await else {
-        return Ok(());
-    };
-    let Ok(modified) = metadata.modified() else {
-        return Ok(());
-    };
-    if SystemTime::now()
-        .duration_since(modified)
-        .is_ok_and(|age| age > STALE_AFTER)
-    {
-        match tokio::fs::remove_file(path).await {
-            Ok(()) => {}
-            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-            Err(error) => return Err(error.into()),
-        }
-    }
-    Ok(())
 }
 
 pub(crate) fn conversation_send_lock(conversation_id: &str) -> Arc<AsyncMutex<()>> {
@@ -114,30 +102,33 @@ pub(crate) fn conversation_send_lock(conversation_id: &str) -> Arc<AsyncMutex<()
 
 #[cfg(test)]
 mod tests {
-    use std::pin::pin;
-
-    use exoharness::Uuid7;
-
     use super::*;
 
     #[tokio::test]
-    async fn wakeup_file_lock_serializes_conversation_ids() {
-        let conversation_id = format!("test-{}", Uuid7::now());
-        let first = WakeupFileLock::acquire(&conversation_id).await.unwrap();
-        let mut second = pin!(WakeupFileLock::acquire(&conversation_id));
+    async fn send_lock_serializes_same_conversation_only() {
+        let id = "test-lock-conv";
+        let first_lock = conversation_send_lock(id);
+        let guard = first_lock.lock().await;
+        let second = conversation_send_lock(id);
 
-        tokio::select! {
-            _ = &mut second => {
-                panic!("second lock acquired while first lock was held");
-            }
-            _ = tokio::time::sleep(Duration::from_millis(20)) => {}
-        }
+        // A different conversation is never blocked by ours.
+        let other_conv = conversation_send_lock("other-conv");
+        let other =
+            tokio::time::timeout(std::time::Duration::from_millis(20), other_conv.lock()).await;
+        assert!(other.is_ok(), "unrelated conversation lock was blocked");
 
-        drop(first);
-        let second = tokio::time::timeout(Duration::from_secs(1), second)
-            .await
-            .unwrap()
-            .unwrap();
-        drop(second);
+        // The same conversation cannot re-enter while held.
+        let reentry =
+            tokio::time::timeout(std::time::Duration::from_millis(20), second.lock()).await;
+        assert!(
+            reentry.is_err(),
+            "same conversation acquired lock twice concurrently"
+        );
+
+        drop(guard);
+        let same_conv = conversation_send_lock(id);
+        let again =
+            tokio::time::timeout(std::time::Duration::from_secs(1), same_conv.lock()).await;
+        assert!(again.is_ok(), "lock was not released after guard drop");
     }
 }

--- a/crates/executor/src/inbox.rs
+++ b/crates/executor/src/inbox.rs
@@ -1,0 +1,244 @@
+use std::path::{Path, PathBuf};
+use std::str::FromStr;
+
+use anyhow::Context;
+use exoharness::Uuid7;
+use lingua::universal::UserContent;
+use serde::{Deserialize, Serialize};
+use tokio::fs;
+
+/// A durably enqueued message awaiting injection into a conversation.
+///
+/// Items are stored one JSON file per item under
+/// `<root>/<conversation_id>/<uuid7>.json`. Because [`Uuid7`] embeds a
+/// millisecond timestamp in its top bits, lexicographic file order equals
+/// arrival order, which restores FIFO delivery that the previous lock-file
+/// wakeup path could not guarantee (issue #207).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InboxItem {
+    pub item_id: Uuid7,
+    pub conversation_id: String,
+    pub content: UserContent,
+}
+
+#[derive(Debug, Clone)]
+pub struct Inbox {
+    root: PathBuf,
+}
+
+impl Inbox {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    /// Durably append an item for `conversation_id`.
+    ///
+    /// The file is written to a temp name and renamed into place so readers
+    /// never observe a partial write. Producers return as soon as this
+    /// resolves; delivery happens later during drain.
+    pub async fn enqueue(
+        &self,
+        conversation_id: &str,
+        content: UserContent,
+    ) -> anyhow::Result<Uuid7> {
+        let dir = self.conversation_dir(conversation_id);
+        fs::create_dir_all(&dir)
+            .await
+            .with_context(|| format!("failed to create inbox dir {}", dir.display()))?;
+
+        let item = InboxItem {
+            item_id: Uuid7::now(),
+            conversation_id: conversation_id.to_string(),
+            content,
+        };
+
+        let final_path = self.item_path(&dir, item.item_id, "");
+        let tmp_path = self.item_path(&dir, item.item_id, ".tmp");
+        let json = serde_json::to_vec_pretty(&item)?;
+
+        fs::write(&tmp_path, &json).await.with_context(|| {
+            format!("failed to write inbox item {}", tmp_path.display())
+        })?;
+        fs::rename(&tmp_path, &final_path).await.with_context(|| {
+            format!(
+                "failed to finalize inbox item {} -> {}",
+                tmp_path.display(),
+                final_path.display()
+            )
+        })?;
+        Ok(item.item_id)
+    }
+
+    /// Return pending items for `conversation_id` in arrival order.
+    ///
+    /// Items whose `.json.done` marker exists are considered delivered and
+    /// are skipped; leftover `.tmp` files from interrupted enqueues are
+    /// ignored until their rename completes.
+    pub async fn drain(&self, conversation_id: &str) -> anyhow::Result<Vec<InboxItem>> {
+        let dir = self.conversation_dir(conversation_id);
+        if fs::metadata(&dir).await.is_err() {
+            return Ok(Vec::new());
+        }
+
+        let mut ids: Vec<Uuid7> = Vec::new();
+        let mut entries = fs::read_dir(&dir)
+            .await
+            .with_context(|| format!("failed to read inbox dir {}", dir.display()))?;
+        while let Some(entry) = entries.next_entry().await? {
+            let name = entry.file_name();
+            if let Some(id) = parse_pending_item_name(&name.to_string_lossy()) {
+                ids.push(id);
+            }
+        }
+        // Uuid7 is time-ordered, so sorting by id sorts by arrival time.
+        ids.sort();
+
+        let mut items = Vec::with_capacity(ids.len());
+        for id in ids {
+            let path = self.item_path(&dir, id, "");
+            let bytes = match fs::read(&path).await {
+                Ok(bytes) => bytes,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(error) => {
+                    return Err(error).context(format!("failed to read {}", path.display()))
+                }
+            };
+            let item: InboxItem = serde_json::from_slice(&bytes)
+                .with_context(|| format!("failed to parse inbox item {}", path.display()))?;
+            items.push(item);
+        }
+        Ok(items)
+    }
+
+    /// Mark an item delivered after its content was successfully sent.
+    ///
+    /// Acknowledgement is a rename to `<id>.json.done`, so a crash between
+    /// send and ack simply redelivers the item on the next drain
+    /// (at-least-once semantics).
+    pub async fn ack(&self, conversation_id: &str, item_id: Uuid7) -> anyhow::Result<()> {
+        let dir = self.conversation_dir(conversation_id);
+        let from = self.item_path(&dir, item_id, "");
+        let to = self.item_path(&dir, item_id, ".done");
+        match fs::rename(&from, &to).await {
+            Ok(()) => Ok(()),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(error) => Err(error).context(format!("failed to ack {}", from.display())),
+        }
+    }
+
+    fn conversation_dir(&self, conversation_id: &str) -> PathBuf {
+        self.root.join(sanitize(conversation_id))
+    }
+
+    fn item_path(&self, dir: &Path, id: Uuid7, suffix: &str) -> PathBuf {
+        dir.join(format!("{id}.json{suffix}"))
+    }
+}
+
+/// Accept `<uuid>.json`; reject `.tmp`, `.done`, and unrelated files.
+fn parse_pending_item_name(name: &str) -> Option<Uuid7> {
+    let rest = name.strip_suffix(".json")?;
+    Uuid7::from_str(rest).ok()
+}
+
+/// Keep conversation ids from escaping the inbox root when used as a dirname.
+fn sanitize(conversation_id: &str) -> String {
+    conversation_id
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '-' || c == '_' { c } else { '_' })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_inbox() -> (tempfile::TempDir, Inbox) {
+        let dir = tempfile::tempdir().unwrap();
+        let inbox = Inbox::new(dir.path().join("inbox"));
+        (dir, inbox)
+    }
+
+    #[tokio::test]
+    async fn enqueue_then_drain_returns_items_in_arrival_order() {
+        let (_dir, inbox) = temp_inbox();
+        for text in ["first", "second", "third"] {
+            inbox.enqueue("conv-1", UserContent::String(text.into())).await.unwrap();
+            // Tiny sleep keeps millisecond uuid7 timestamps distinct.
+            tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+        }
+
+        let items = inbox.drain("conv-1").await.unwrap();
+        let texts: Vec<&str> = items
+            .iter()
+            .map(|i| match &i.content {
+                UserContent::String(s) => s.as_str(),
+                _ => panic!("unexpected content"),
+            })
+            .collect();
+        assert_eq!(texts, ["first", "second", "third"]);
+    }
+
+    #[tokio::test]
+    async fn acked_items_are_not_redelivered() {
+        let (_dir, inbox) = temp_inbox();
+        let id = inbox.enqueue("conv", UserContent::String("hello".into())).await.unwrap();
+        assert_eq!(inbox.drain("conv").await.unwrap().len(), 1);
+
+        inbox.ack("conv", id).await.unwrap();
+        assert!(inbox.drain("conv").await.unwrap().is_empty());
+        // Acking twice is idempotent.
+        inbox.ack("conv", id).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn unacked_items_survive_as_new_inbox_instance() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("inbox");
+        let inbox_a = Inbox::new(&root);
+        inbox_a.enqueue("conv", UserContent::String("durable".into())).await.unwrap();
+
+        // Simulate restart: fresh handle over the same root.
+        let inbox_b = Inbox::new(root);
+        let items = inbox_b.drain("conv").await.unwrap();
+        assert_eq!(items.len(), 1);
+        match &items[0].content {
+            UserContent::String(s) => assert_eq!(s, "durable"),
+            _ => panic!("unexpected content"),
+        }
+    }
+
+    #[tokio::test]
+    async fn tmp_files_are_ignored_by_drain() {
+        let (_dir, inbox) = temp_inbox();
+        inbox.enqueue("conv", UserContent::String("real".into())).await.unwrap();
+
+        let conv_dir = inbox.root.join("conv");
+        fs::write(conv_dir.join("00000000-0000-7000-8000-000000000000.json.tmp"), b"junk")
+            .await
+            .unwrap();
+
+        let items = inbox.drain("conv").await.unwrap();
+        assert_eq!(items.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn conversations_are_isolated_and_unknown_are_empty() {
+        let (_dir, inbox) = temp_inbox();
+        inbox.enqueue("a", UserContent::String("for-a".into())).await.unwrap();
+        assert_eq!(inbox.drain("b").await.unwrap().len(), 0);
+        assert_eq!(inbox.drain("a").await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn conversation_ids_with_unsafe_chars_are_sanitized() {
+        let (_dir, inbox) = temp_inbox();
+        inbox
+            .enqueue("../evil", UserContent::String("contained".into()))
+            .await
+            .unwrap();
+        // The escaped id must stay inside the root, not above it.
+        assert_eq!(inbox.drain("../evil").await.unwrap().len(), 1);
+        assert!(!inbox.root.parent().unwrap().join("evil").exists());
+    }
+}

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -22,6 +22,7 @@ mod harness_js_repl;
 mod harness_runtime;
 mod harness_tool;
 mod harness_types;
+mod inbox;
 mod local_sandbox;
 mod rlm;
 #[cfg(test)]

--- a/exo/tools/guardian-tools.ts
+++ b/exo/tools/guardian-tools.ts
@@ -22,7 +22,7 @@ const GUARDIAN_SCRIPT = new URL(
   import.meta.url,
 ).pathname;
 const DEFERRED_SCRIPT = new URL(
-  "./scripts/deferred-rebuild-and-restart",
+  "../scripts/deferred-rebuild-and-restart",
   import.meta.url,
 ).pathname;
 const ROOT_DIR = new URL("../..", import.meta.url).pathname;


### PR DESCRIPTION
Part of #207 — durable inbox primitive (first pass)

## Problem
`send_conversation_wakeup` used a lock file in `/tmp`: producers raced on `create_new`, arrival order was lost, and a 30-minute mtime heuristic let any waiting producer steal a lock from a legitimately slow turn — producing concurrent turns interleaving writes into one event log. Nothing was durable; a crash lost the prompt.

## This PR
Adds `crates/executor/src/inbox.rs`, a durable per-conversation inbox:

- **enqueue()** writes `<root>/<conversation_id>/<uuid7>.json` via temp-file + rename. Producers return once durable.
- **drain()** lists pending items and sorts by `Uuid7` — time-ordered IDs make FIFO delivery free, restoring arrival-order guarantees the lock race destroyed.
- **ack()** renames to `.json.done` after successful send → at-least-once semantics: crash between send and ack redelivers on next drain.

`send_conversation_wakeup_content` now enqueues first, then under the existing in-process per-conversation async mutex drains all pending items in order and injects each via `conversation.send`.

The racy `WakeupFileLock` + 30-minute stale-lock steal is deleted from the delivery path entirely.

## What this fixes (vs issue #207)
| Issue complaint | Status |
|---|---|
| Lost arrival ordering | ✅ fixed within/between processes sharing an inbox root (UUIDv7 sort) |
| No durability / producers block | ✅ enqueue returns after durable write |
| Ordering info discarded | ✅ preserved by UUIDv7 keys |
| 30-min lock steal → concurrent turns | ✅ removed from delivery path; turn mutual exclusion is now the in-process mutex |

## Deliberately out of scope (follow-up)
This PR is the **storage primitive half** of #207. Not included here:

- `producer` / `dedupe_key` / `attention` fields on `InboxItem` — the idempotent-append + attention-scheduler half
- Dispatcher `decide(state, pending, now_ms)` and the `Attention` classes (`Interrupt` / `Wake` / `Batch`)
- `retract()` / cancellation of undrained items
- ack at **turn commit** + `OfferDisposition` settlement
- Cross-process per-conversation dispatch lease (depends on #113)

See the scoping comment for the full gap table.

## Verification
`cargo test -p executor`: 120 passed (6 new inbox tests + reworked lock test), 0 failed.

Configurable root via `EXO_INBOX_DIR` so deployments can co-locate it with durable storage.
