### PR TITLE
add support for pi harness

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -326,6 +326,7 @@ enum TypeScriptHarnessPreset {
     Codex,
     ClaudeCode,
     Cursor,
+    Pi,
 }
 
 impl HarnessSelection {
@@ -370,6 +371,7 @@ impl FromStr for HarnessSelection {
             "typescript" => Ok(Self::Kind(HarnessKind::TypeScript)),
             "exo" => Ok(Self::Kind(HarnessKind::Exo)),
             "codex" => Ok(Self::TypeScriptPreset(TypeScriptHarnessPreset::Codex)),
+            "pi" => Ok(Self::TypeScriptPreset(TypeScriptHarnessPreset::Pi)),
             "claude-code" => Ok(Self::TypeScriptPreset(TypeScriptHarnessPreset::ClaudeCode)),
             "cursor" | "cursor-sdk" => Ok(Self::TypeScriptPreset(TypeScriptHarnessPreset::Cursor)),
             value if looks_like_typescript_module_path(value) => {
@@ -388,6 +390,7 @@ impl TypeScriptHarnessPreset {
             Self::Codex => "codex",
             Self::ClaudeCode => "claude-code",
             Self::Cursor => "cursor",
+            Self::Pi => "pi",
         }
     }
 
@@ -396,6 +399,7 @@ impl TypeScriptHarnessPreset {
             Self::Codex => Path::new("exoharness/examples/typescript/codex-harness.ts"),
             Self::ClaudeCode => Path::new("exoharness/examples/typescript/claude-code-harness.ts"),
             Self::Cursor => Path::new("exoharness/examples/typescript/cursor-sdk-harness.ts"),
+            Self::Pi => Path::new("exoharness/examples/typescript/pi-harness.ts"),
         }
     }
 
@@ -404,6 +408,7 @@ impl TypeScriptHarnessPreset {
             Self::Codex => Some("exo-codex-sandbox:latest"),
             Self::ClaudeCode => Some("exo-claude-code-sandbox:latest"),
             Self::Cursor => Some("exo-cursor-sdk-sandbox:latest"),
+            Self::Pi => Some("exo-pi-sandbox:latest"),
         }
     }
 }
@@ -3282,6 +3287,7 @@ fn format_harness_selection(selection: &HarnessSelection) -> String {
             HarnessKind::Exo => "exo".to_string(),
         },
         HarnessSelection::TypeScriptPreset(preset) => match preset {
+            TypeScriptHarnessPreset::Pi => "pi".to_string(),
             TypeScriptHarnessPreset::Codex => "codex".to_string(),
             TypeScriptHarnessPreset::ClaudeCode => "claude-code".to_string(),
             TypeScriptHarnessPreset::Cursor => "cursor".to_string(),

--- a/exoharness/containers/pi-sandbox/Dockerfile
+++ b/exoharness/containers/pi-sandbox/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:22-bookworm-slim
+
+ARG PI_PACKAGE=@earendil-works/pi-coding-agent
+
+ENV HOME=/home/exo
+ENV PATH=/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        ca-certificates \
+        curl \
+        git \
+        openssh-client \
+        ripgrep \
+    && rm -rf /var/lib/apt/lists/*
+
+# pi's bundle imports globSync from node:fs, so the base image must be node 22.
+RUN npm install -g --ignore-scripts "${PI_PACKAGE}"
+
+RUN mkdir -p /home/exo/.pi /home/exo/workspace
+
+WORKDIR /home/exo/workspace
+
+CMD ["bash"]

--- a/exoharness/docs/coding-agent-harnesses.md
+++ b/exoharness/docs/coding-agent-harnesses.md
@@ -126,6 +126,40 @@ Create the agent and start a conversation:
 ./target/debug/exo repl --agent ts-cursor --conversation <conversation>
 ```
 
+## Pi
+
+Register a model Pi supports. Pi reads the provider key from the sandbox
+environment, so the same variable has to be set where exo runs:
+
+```bash
+./target/debug/exo secret set openai --env OPENAI_API_KEY
+./target/debug/exo model register gpt-5.5 --secret openai
+```
+
+Build the sandbox image:
+
+```bash
+container build \
+  --platform linux/arm64 \
+  -t exo-pi-sandbox:latest \
+  exoharness/containers/pi-sandbox
+```
+
+Create the agent and start a conversation:
+
+```bash
+./target/debug/exo --harness pi agent create "TS Pi" \
+  --model gpt-5.5
+
+./target/debug/exo conversation create ts-pi
+./target/debug/exo conversation mount add ts-pi <conversation> "$PWD" /workspace --rw
+./target/debug/exo repl --agent ts-pi --conversation <conversation>
+```
+
+An agent model of `provider/model` selects a provider explicitly; a bare name
+is read as OpenAI. Pi otherwise picks its own default, which is an Anthropic
+model, and a run configured for another provider then produces nothing.
+
 ## Live E2E
 
 The live e2e script runs replay checks against the coding-agent harnesses:
@@ -134,6 +168,7 @@ The live e2e script runs replay checks against the coding-agent harnesses:
 pnpm e2e:agent-harnesses --only codex
 pnpm e2e:agent-harnesses --only claude
 pnpm e2e:agent-harnesses --only cursor
+pnpm e2e:agent-harnesses --only pi
 ```
 
 Use `--build-images` to build the required sandbox images before running.

--- a/exoharness/examples/typescript/pi-harness.ts
+++ b/exoharness/examples/typescript/pi-harness.ts
@@ -1,0 +1,253 @@
+// Pi harness: runs the Pi coding agent (https://pi.dev) inside an exo sandbox.
+//
+// Each turn spawns `pi --mode json`, seeded from exo's history, and every step
+// pi reports is appended back.
+
+import {
+  assistantTextMessage,
+  defineHarness,
+  materializeConversationMessages,
+  messageText,
+  messagesToTranscript,
+  toolRequestedEvent,
+  toolResultEvent,
+  messagesEvent,
+  type JsonValue,
+  type Message,
+  type TurnContext,
+} from "@exo/harness";
+
+import {
+  appendEvents,
+  pickEnv,
+  resolveLlmBinding,
+  type ResolvedLlmBinding,
+} from "@exo/model-runtime/shared";
+
+const PI_BIN = "pi";
+const DEFAULT_PROVIDER = "openai";
+const PROVIDER_KEY_VARIABLES: Record<string, string> = {
+  openai: "OPENAI_API_KEY",
+  anthropic: "ANTHROPIC_API_KEY",
+  google: "GEMINI_API_KEY",
+};
+
+// exo names a model on its own; `provider/model` selects one explicitly.
+function splitModelReference(reference: string): [string, string] {
+  const slash = reference.indexOf("/");
+  return slash === -1
+    ? [DEFAULT_PROVIDER, reference]
+    : [reference.slice(0, slash), reference.slice(slash + 1)];
+}
+
+function systemPrompt(context: TurnContext): string | null {
+  const instructions = context.agentConfig.instructions
+    .map(messageText)
+    .filter(Boolean)
+    .join("\n\n");
+  return instructions || null;
+}
+
+function piCommand(context: TurnContext): string[] {
+  const [provider, model] = splitModelReference(context.agentConfig.model);
+  const command = [
+    PI_BIN,
+    "--mode",
+    "json",
+    "--print",
+    "--no-session", // exo owns the convo, so no need to look for a session
+    "--model",
+    `${provider}/${model}`,
+  ];
+  const instructions = systemPrompt(context);
+  if (instructions) {
+    command.push("--system-prompt", instructions);
+  }
+  return command;
+}
+
+// The key comes from exo's binding rather than the env.
+function piEnv(
+  context: TurnContext,
+  binding: ResolvedLlmBinding,
+): Record<string, string> {
+  const [provider] = splitModelReference(context.agentConfig.model);
+  const env = pickEnv((key) => key.startsWith("PI_"));
+  const keyVariable = PROVIDER_KEY_VARIABLES[provider];
+  if (keyVariable && binding.apiKey) {
+    env[keyVariable] = binding.apiKey;
+  }
+  return env;
+}
+
+// pi emits one JSON object per line; a chunk can split a line anywhere.
+async function* jsonLines(
+  stream: ReadableStream<string>,
+): AsyncGenerator<Record<string, unknown>> {
+  const reader = stream.getReader();
+  let buffer = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    buffer += value;
+    let newline = buffer.indexOf("\n");
+    while (newline !== -1) {
+      const line = buffer.slice(0, newline).trim();
+      buffer = buffer.slice(newline + 1);
+      if (line) {
+        try {
+          yield JSON.parse(line) as Record<string, unknown>;
+        } catch {
+          // pi writes only JSON here; anything else is not ours to interpret.
+        }
+      }
+      newline = buffer.indexOf("\n");
+    }
+  }
+}
+
+function assistantText(message: Record<string, unknown>): string {
+  const content = message.content;
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .map((part) => {
+      const record = part as Record<string, unknown>;
+      return record.type === "text" && typeof record.text === "string"
+        ? record.text
+        : "";
+    })
+    .join("");
+}
+
+// Translate Pi's cost tracking into the local record.
+function usageRecord(
+  context: TurnContext,
+  message: Record<string, unknown>,
+): Record<string, JsonValue> | undefined {
+  const usage = message.usage as Record<string, unknown> | undefined;
+  if (!usage) {
+    return undefined;
+  }
+  const number = (value: unknown): number | undefined =>
+    typeof value === "number" ? value : undefined;
+  const cost = usage.cost as Record<string, unknown> | undefined;
+  const record: Record<string, JsonValue> = {
+    model: String(message.model ?? context.agentConfig.model),
+  };
+  const fields: Array<[string, number | undefined]> = [
+    ["prompt_tokens", number(usage.input)],
+    ["completion_tokens", number(usage.output)],
+    ["prompt_cached_tokens", number(usage.cacheRead)],
+    ["prompt_cache_creation_tokens", number(usage.cacheWrite)],
+    ["completion_reasoning_tokens", number(usage.reasoning)],
+    ["cost_usd", number(cost?.total)],
+  ];
+  for (const [key, value] of fields) {
+    if (value !== undefined) {
+      record[key] = value;
+    }
+  }
+  return record;
+}
+
+// map pi's steps to exo events: a tool call, its result, and assistant text.
+function eventsForPiEvent(
+  context: TurnContext,
+  event: Record<string, unknown>,
+) {
+  const type = event.type;
+
+  if (type === "tool_execution_start") {
+    return [
+      toolRequestedEvent({
+        toolCallId: String(event.toolCallId),
+        request: {
+          functionName: String(event.toolName),
+          arguments: (event.args ?? {}) as Record<string, JsonValue>,
+        },
+      }),
+    ];
+  }
+
+  if (type === "tool_execution_end") {
+    return [
+      toolResultEvent(String(event.toolCallId), {
+        result: (event.result ?? null) as JsonValue,
+        is_error: event.isError === true,
+      }),
+    ];
+  }
+
+  if (type === "message_end") {
+    const message = event.message as Record<string, unknown> | undefined;
+    if (message?.role === "assistant") {
+      const text = assistantText(message);
+      if (text) {
+        return [
+          messagesEvent(
+            [assistantTextMessage(text)],
+            undefined,
+            usageRecord(context, message),
+          ),
+        ];
+      }
+    }
+  }
+
+  return [];
+}
+
+const harness = defineHarness({
+  tools: [],
+
+  async runTurn(context) {
+    const history = await materializeConversationMessages(
+      context.exoharness.current.conversation,
+    );
+    const prompt = messagesToTranscript(
+      history.filter(
+        (message: Message) =>
+          message.role !== "system" && message.role !== "developer",
+      ),
+    );
+
+    const binding = await resolveLlmBinding(context);
+    const process = await context.startSandboxProcess({
+      command: piCommand(context),
+      env: piEnv(context, binding),
+    });
+
+    // The prompt goes over stdin (otherwise could be too long for argv).
+    await process.writeStdin(prompt);
+    await process.closeStdin();
+
+    let lastText = "";
+    for await (const event of jsonLines(process.stdout)) {
+      const events = eventsForPiEvent(context, event);
+      if (events.length > 0) {
+        await appendEvents(context, events);
+      }
+      if (event.type === "message_end") {
+        const message = event.message as Record<string, unknown> | undefined;
+        if (message?.role === "assistant") {
+          lastText = assistantText(message) || lastText;
+        }
+      }
+    }
+
+    if (lastText) {
+      await context.stream.text(lastText);
+    }
+
+    const exitCode = await process.wait();
+    if (exitCode !== 0) {
+      throw new Error(`pi exited with status ${exitCode}`);
+    }
+  },
+});
+
+export default harness;

--- a/exoharness/scripts/agent-harness-e2e.ts
+++ b/exoharness/scripts/agent-harness-e2e.ts
@@ -269,14 +269,7 @@ function runHistoryReplayCheck(
     "/workspace",
     "--rw",
   ]);
-  runExo([
-    "conversation",
-    "update",
-    agent.slug,
-    conversation,
-    "--networking",
-    "enabled",
-  ]);
+  runExo(["agent", "update", agent.slug, "--networking", "enabled"]);
 
   const codeWord = `${harness.key}-blue-lantern-${runId}`;
   runChat(
@@ -376,14 +369,7 @@ function runFilesystemSandboxCheck(
     "/workspace",
     "--rw",
   ]);
-  runExo([
-    "conversation",
-    "update",
-    agent.slug,
-    conversation,
-    "--networking",
-    "enabled",
-  ]);
+  runExo(["agent", "update", agent.slug, "--networking", "enabled"]);
 
   const outsideSecret = join(outside, "secret.txt");
   const outsideWrite = join(outside, "escape.txt");
@@ -469,14 +455,7 @@ function runNetworkDisabledCheck(
     "/workspace",
     "--rw",
   ]);
-  runExo([
-    "conversation",
-    "update",
-    agent.slug,
-    conversation,
-    "--networking",
-    "disabled",
-  ]);
+  runExo(["agent", "update", agent.slug, "--networking", "disabled"]);
 
   let failedText: string | null = null;
   try {

--- a/exoharness/scripts/agent-harness-e2e.ts
+++ b/exoharness/scripts/agent-harness-e2e.ts
@@ -13,7 +13,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-type HarnessKey = "codex" | "claude" | "cursor";
+type HarnessKey = "codex" | "claude" | "cursor" | "pi";
 
 interface HarnessDefinition {
   key: HarnessKey;
@@ -106,6 +106,15 @@ const harnesses: HarnessDefinition[] = [
     module: "exoharness/examples/typescript/claude-code-harness.ts",
     image: "exo-claude-code-sandbox:latest",
     imageBuildArgs: ["exoharness/containers/claude-code-sandbox"],
+  },
+  {
+    key: "pi",
+    envName: "OPENAI_API_KEY",
+    secret: "openai",
+    model: "gpt-5.5",
+    module: "exoharness/examples/typescript/pi-harness.ts",
+    image: "exo-pi-sandbox:latest",
+    imageBuildArgs: ["exoharness/containers/pi-sandbox"],
   },
   {
     key: "cursor",
@@ -689,7 +698,12 @@ function parseArgs(rawArgs: string[]): CliArgs {
 }
 
 function isHarnessKey(value: string): value is HarnessKey {
-  return value === "codex" || value === "claude" || value === "cursor";
+  return (
+    value === "codex" ||
+    value === "claude" ||
+    value === "cursor" ||
+    value === "pi"
+  );
 }
 
 function readArgValue(rawArgs: string[], index: number, flag: string): string {


### PR DESCRIPTION
Adding pi harness integration as an executor option. This will allow running benchmarks against Pi.

This integration runs Pi inside the sandbox – we use the dockerfile that already loads in the Pi process – and populates the API key from the secret store.

We keep the exoharness state as the source of truth, and also record cost figures coming from Pi.