### PR TITLE
Generalize snapshot formats

### DIFF
--- a/crates/cli/tests/daytona_backend.rs
+++ b/crates/cli/tests/daytona_backend.rs
@@ -10,7 +10,7 @@ use bytes::Bytes;
 use exoharness::{
     DaytonaConfig, DaytonaSandboxBackend, ManagedSandboxBackend, SandboxKey,
     SandboxLifecycleConfig, SandboxMount, SandboxMountAccess, SandboxNetworkPolicy, SandboxRequest,
-    SandboxSpec, SnapshotKind, SnapshotPayload,
+    SandboxSpec, SnapshotFormat, SnapshotPayload,
 };
 use futures::io::{AsyncReadExt, AsyncWriteExt};
 use serde_json::{Value, json};
@@ -434,11 +434,7 @@ async fn snapshot_returns_daytona_snapshot_payload_with_manifest() {
         .await
         .expect("snapshot should succeed against the mock");
 
-    assert!(
-        matches!(payload.kind, SnapshotKind::DaytonaSnapshot),
-        "kind should be DaytonaSnapshot, got {:?}",
-        payload.kind
-    );
+    assert_eq!(payload.format, SnapshotFormat::DaytonaRef);
 
     let manifest: Value =
         serde_json::from_slice(&payload.bytes).expect("payload should be a JSON manifest");
@@ -517,7 +513,7 @@ async fn acquire_from_snapshot_passes_snapshot_name_in_create_body() {
 
     let manifest = json!({ "snapshot_name": "exo-snap-canonical-fixture" });
     let payload = SnapshotPayload {
-        kind: SnapshotKind::DaytonaSnapshot,
+        format: SnapshotFormat::DaytonaRef,
         bytes: Bytes::from(serde_json::to_vec(&manifest).unwrap()),
     };
 
@@ -543,27 +539,27 @@ async fn acquire_from_snapshot_passes_snapshot_name_in_create_body() {
 }
 
 #[tokio::test]
-async fn acquire_from_snapshot_rejects_foreign_kinds() {
+async fn acquire_from_snapshot_rejects_foreign_formats() {
     let server = MockServer::start().await;
     let backend = backend_for_mock(&server);
 
     let payload = SnapshotPayload {
-        kind: SnapshotKind::E2bSnapshot,
+        format: SnapshotFormat::E2bRef,
         bytes: Bytes::from_static(b"{}"),
     };
     let request = make_request("conv-10", "sandbox-10");
     let error = match backend.acquire_from_snapshot(request, payload).await {
-        Ok(_) => panic!("Daytona backend must reject an E2bSnapshot payload"),
+        Ok(_) => panic!("Daytona backend must reject an e2b-ref payload"),
         Err(e) => e,
     };
     let msg = format!("{error:#}").to_lowercase();
     assert!(
-        msg.contains("daytona") && msg.contains("e2bsnapshot"),
-        "error should explain the kind mismatch: {msg}"
+        msg.contains("daytona") && msg.contains("e2b-ref"),
+        "error should explain the format mismatch: {msg}"
     );
 
     let requests = server.received_requests().await.unwrap_or_default();
-    assert_eq!(requests.len(), 0, "kind-mismatch must not reach the API");
+    assert_eq!(requests.len(), 0, "format mismatch must not reach the API");
 }
 
 #[tokio::test]
@@ -575,7 +571,7 @@ async fn acquire_from_snapshot_bridges_docker_tar_but_fails_on_garbage() {
     let backend = backend_for_mock(&server);
 
     let payload = SnapshotPayload {
-        kind: SnapshotKind::DockerImageTar,
+        format: SnapshotFormat::DockerImageTar,
         bytes: Bytes::from_static(b"\x00not-a-real-tar"),
     };
     let request = make_request("conv-11", "sandbox-11");

--- a/crates/cli/tests/e2b_backend.rs
+++ b/crates/cli/tests/e2b_backend.rs
@@ -8,7 +8,7 @@ use bytes::Bytes;
 use exoharness::{
     E2bConfig, E2bSandboxBackend, ManagedSandboxBackend, SandboxCommand, SandboxKey,
     SandboxLifecycleConfig, SandboxMount, SandboxMountAccess, SandboxNetworkPolicy, SandboxRequest,
-    SandboxSpec, SnapshotKind, SnapshotPayload,
+    SandboxSpec, SnapshotFormat, SnapshotPayload,
 };
 use serde_json::{Value, json};
 use wiremock::matchers::{method, path};
@@ -317,7 +317,7 @@ async fn snapshot_returns_e2b_snapshot_payload() {
         .unwrap();
     let payload = handle.snapshot().await.expect("snapshot ok");
 
-    assert!(matches!(payload.kind, SnapshotKind::E2bSnapshot));
+    assert_eq!(payload.format, SnapshotFormat::E2bRef);
     let manifest: Value = serde_json::from_slice(&payload.bytes).unwrap();
     assert_eq!(
         manifest.get("snapshot_id").and_then(Value::as_str),
@@ -342,7 +342,7 @@ async fn acquire_from_snapshot_uses_snapshot_template_id() {
         "base_template": "base",
     });
     let payload = SnapshotPayload {
-        kind: SnapshotKind::E2bSnapshot,
+        format: SnapshotFormat::E2bRef,
         bytes: Bytes::from(serde_json::to_vec(&manifest).unwrap()),
     };
 
@@ -364,23 +364,23 @@ async fn acquire_from_snapshot_uses_snapshot_template_id() {
 }
 
 #[tokio::test]
-async fn acquire_from_snapshot_rejects_wrong_kind() {
+async fn acquire_from_snapshot_rejects_wrong_format() {
     let server = MockServer::start().await;
     let backend = backend_for_mock(&server);
 
     let payload = SnapshotPayload {
-        kind: SnapshotKind::DockerImageTar,
+        format: SnapshotFormat::DockerImageTar,
         bytes: Bytes::from_static(b"\x00"),
     };
     let error = match backend
         .acquire_from_snapshot(make_request("conv-9", "sandbox-9"), payload)
         .await
     {
-        Ok(_) => panic!("expected kind mismatch error"),
+        Ok(_) => panic!("expected format mismatch error"),
         Err(error) => error,
     };
     let msg = format!("{error:#}").to_lowercase();
-    assert!(msg.contains("e2b") || msg.contains("kind"));
+    assert!(msg.contains("e2b") || msg.contains("format"));
 }
 
 #[tokio::test]

--- a/crates/cli/tests/smolvm_sandbox_live.rs
+++ b/crates/cli/tests/smolvm_sandbox_live.rs
@@ -402,8 +402,8 @@ async fn snapshot_round_trip_preserves_guest_state() {
 
     let payload = source.snapshot().await.expect("snapshot");
     println!(
-        "snapshot kind={:?} manifest={} bytes",
-        payload.kind,
+        "snapshot format={} manifest={} bytes",
+        payload.format,
         payload.bytes.len()
     );
 

--- a/crates/cli/tests/sprites_backend.rs
+++ b/crates/cli/tests/sprites_backend.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 use bytes::Bytes;
 use exoharness::{
     ManagedSandboxBackend, SandboxKey, SandboxLifecycleConfig, SandboxMount, SandboxMountAccess,
-    SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotKind, SnapshotPayload,
+    SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotFormat, SnapshotPayload,
     SpritesConfig, SpritesSandboxBackend,
 };
 use serde_json::{Value, json};
@@ -386,7 +386,7 @@ async fn snapshot_returns_sprites_snapshot_payload() {
     let handle = backend.acquire(request).await.unwrap();
     let payload = handle.snapshot().await.expect("snapshot");
 
-    assert!(matches!(payload.kind, SnapshotKind::SpritesSnapshot));
+    assert_eq!(payload.format, SnapshotFormat::SpritesRef);
     let manifest: Value = serde_json::from_slice(&payload.bytes).unwrap();
     assert_eq!(
         manifest.get("checkpoint_id").and_then(Value::as_str),
@@ -426,7 +426,7 @@ async fn acquire_from_snapshot_restores_checkpoint() {
         "sprite_name": name,
     });
     let payload = SnapshotPayload {
-        kind: SnapshotKind::SpritesSnapshot,
+        format: SnapshotFormat::SpritesRef,
         bytes: Bytes::from(serde_json::to_vec(&manifest).unwrap()),
     };
 
@@ -437,12 +437,12 @@ async fn acquire_from_snapshot_restores_checkpoint() {
 }
 
 #[tokio::test]
-async fn acquire_from_snapshot_rejects_wrong_kind() {
+async fn acquire_from_snapshot_rejects_wrong_format() {
     let server = MockServer::start().await;
     let backend = backend_for_mock(&server);
 
     let payload = SnapshotPayload {
-        kind: SnapshotKind::DockerImageTar,
+        format: SnapshotFormat::DockerImageTar,
         bytes: Bytes::from_static(b"not-a-tar"),
     };
 
@@ -450,12 +450,12 @@ async fn acquire_from_snapshot_rejects_wrong_kind() {
         .acquire_from_snapshot(make_request("conv-9", "sandbox-9"), payload)
         .await
     {
-        Ok(_) => panic!("wrong snapshot kind should fail"),
+        Ok(_) => panic!("wrong snapshot format should fail"),
         Err(error) => error,
     };
     let msg = format!("{error:#}").to_lowercase();
     assert!(
-        msg.contains("sprites") || msg.contains("kind"),
+        msg.contains("sprites") || msg.contains("format"),
         "unexpected: {msg}"
     );
 }

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -22,7 +22,7 @@ use crate::sandbox::{
     BoxSandboxTcpStream, CliContainerSandboxBackend, LocalProcessSandboxBackend,
     ManagedSandboxBackend, ManagedSandboxHandle, SANDBOX_MAIN_MOUNT_DIR, SandboxCommand,
     SandboxKey, SandboxLifecycleConfig, SandboxMount, SandboxMountAccess, SandboxNetworkPolicy,
-    SandboxRequest, SandboxSpec, SnapshotKind, SnapshotPayload, sandbox_spec_hash,
+    SandboxRequest, SandboxSpec, SnapshotFormat, SnapshotPayload, sandbox_spec_hash,
 };
 #[cfg(feature = "apple-keychain")]
 use crate::secrets::AppleKeychainSecretKeyProvider;
@@ -1944,6 +1944,7 @@ impl<'a> BasicScopedSandboxHandle<'a> {
             .inner
             .sandbox_backend_for_provider(sandbox.provider.clone())
             .await?;
+        ensure_snapshot_format_supported(backend.as_ref(), &sandbox.provider, &payload.format)?;
         let sandbox_handle = backend
             .acquire_from_snapshot(
                 sandbox_request(self.owner, &sandbox_id, &sandbox, None),
@@ -3244,7 +3245,7 @@ async fn snapshot_sandbox_side_effect(
     let manifest = StoredSnapshotManifest {
         snapshot_id,
         sandbox_id: id.clone(),
-        kind: payload.kind,
+        format: payload.format,
         created_at: Utc::now(),
         payload_size_bytes: payload.bytes.len() as u64,
     };
@@ -3298,12 +3299,17 @@ async fn start_sandbox_side_effect(
     // Optional provider override: restore under a different backend (e.g.
     // teleport a Docker snapshot up to Daytona). Set before routing so the
     // restore targets the new backend and the new provider is persisted;
-    // unsupported providers / snapshot kinds error in the calls below.
+    // unsupported providers / snapshot formats error before dispatch.
     let previous_provider = sandbox.provider.clone();
     if let Some(provider) = request.provider {
         sandbox.provider = provider;
     }
     let cross_provider = sandbox.provider != previous_provider;
+    let backend = harness
+        .inner
+        .sandbox_backend_for_provider(sandbox.provider.clone())
+        .await?;
+    ensure_snapshot_format_supported(backend.as_ref(), &sandbox.provider, &payload.format)?;
 
     // Two orders, chosen by whether the restore changes providers:
     //   - Cross-provider (teleport): make-before-break. Boot the new sandbox
@@ -3315,10 +3321,7 @@ async fn start_sandbox_side_effect(
     //     handle after the new one exists would tear down the new container's
     //     warm-cache entry (both handles share the same SandboxKey).
     let sandbox_handle = if cross_provider {
-        let sandbox_handle = harness
-            .inner
-            .sandbox_backend_for_provider(sandbox.provider.clone())
-            .await?
+        let sandbox_handle = backend
             .acquire_from_snapshot(sandbox_request(owner, &request.id, &sandbox, None), payload)
             .await?;
         let previous_handle = harness
@@ -3350,10 +3353,7 @@ async fn start_sandbox_side_effect(
         if let Some(previous_handle) = previous_handle {
             previous_handle.stop().await?;
         }
-        harness
-            .inner
-            .sandbox_backend_for_provider(sandbox.provider.clone())
-            .await?
+        backend
             .acquire_from_snapshot(sandbox_request(owner, &request.id, &sandbox, None), payload)
             .await?
     };
@@ -3417,9 +3417,33 @@ async fn load_snapshot_payload(
     let payload_bytes =
         payload_result.with_context(|| format!("loading snapshot payload for {snapshot_id}"))?;
     Ok(SnapshotPayload {
-        kind: manifest.kind,
+        format: manifest.format,
         bytes: Bytes::from(payload_bytes),
     })
+}
+
+fn ensure_snapshot_format_supported(
+    backend: &dyn ManagedSandboxBackend,
+    provider: &SandboxProvider,
+    format: &SnapshotFormat,
+) -> Result<()> {
+    let supported = backend.consumable_snapshot_formats();
+    if supported.contains(format) {
+        return Ok(());
+    }
+    let supported = supported
+        .iter()
+        .map(SnapshotFormat::as_str)
+        .collect::<Vec<_>>()
+        .join(", ");
+    let supported = if supported.is_empty() {
+        "none".to_string()
+    } else {
+        supported
+    };
+    bail!(
+        "sandbox provider {provider} cannot restore snapshot format {format}; supported formats: {supported}"
+    )
 }
 
 async fn load_stored_sandbox(
@@ -4346,14 +4370,15 @@ async fn wait_for_sandbox_process_terminal_status(
 /// Sidecar JSON describing a snapshot payload.
 ///
 /// Lives at `{conversation_dir}/snapshots/{snapshot_id}/manifest.json` alongside
-/// the payload blob at `payload.bin`. The `kind` controls how the payload is
-/// interpreted on restore — only a backend that recognises that kind can
+/// the payload blob at `payload.bin`. The `format` controls how the payload is
+/// interpreted on restore — only a backend that declares that format can
 /// reconstruct a sandbox from it.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct StoredSnapshotManifest {
     snapshot_id: SnapshotId,
     sandbox_id: SandboxId,
-    kind: SnapshotKind,
+    #[serde(alias = "kind")]
+    format: SnapshotFormat,
     created_at: DateTime<Utc>,
     payload_size_bytes: u64,
 }
@@ -4783,4 +4808,46 @@ fn build_secret_cipher(
         SecretBackendChoice::Static(key) => Arc::new(StaticSecretKeyProvider::new(key)),
     };
     Ok(SecretCipher::new(provider))
+}
+
+#[cfg(test)]
+mod snapshot_manifest_tests {
+    use super::*;
+
+    #[test]
+    fn snapshot_format_validation_uses_backend_capabilities() {
+        let docker = CliContainerSandboxBackend::docker();
+        ensure_snapshot_format_supported(
+            &docker,
+            &SandboxProvider::Docker,
+            &SnapshotFormat::DockerImageTar,
+        )
+        .expect("Docker should consume docker-image-tar");
+
+        let error = ensure_snapshot_format_supported(
+            &docker,
+            &SandboxProvider::Docker,
+            &SnapshotFormat::WorkspaceChunksV1,
+        )
+        .expect_err("Docker should reject undeclared formats");
+        assert!(error.to_string().contains("workspace-chunks-v1"));
+    }
+
+    #[test]
+    fn stored_snapshot_manifest_reads_legacy_kind_field_and_value() {
+        let snapshot_id = Uuid7::now();
+        let manifest: StoredSnapshotManifest = serde_json::from_value(serde_json::json!({
+            "snapshot_id": snapshot_id,
+            "sandbox_id": "sandbox-legacy",
+            "kind": "docker_image_tar",
+            "created_at": "2026-08-29T00:00:00Z",
+            "payload_size_bytes": 42,
+        }))
+        .expect("deserialize legacy snapshot manifest");
+        assert_eq!(manifest.format, SnapshotFormat::DockerImageTar);
+
+        let rewritten = serde_json::to_value(manifest).expect("serialize snapshot manifest");
+        assert_eq!(rewritten.get("format").unwrap(), "docker-image-tar");
+        assert!(rewritten.get("kind").is_none());
+    }
 }

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -29,7 +29,7 @@ use crate::{
     SandboxAttachment, SandboxBackendRegistration, SandboxCommand, SandboxCommandOutput,
     SandboxKey, SandboxLifecycleConfig, SandboxNetworkPolicy, SandboxProcessEvent,
     SandboxProcessEventQuery, SandboxProcessParts, SandboxProcessStatus, SandboxProcessStdin,
-    SandboxProvider, SandboxProviderConfig, SandboxRequest, SandboxSpec, Secret, SnapshotKind,
+    SandboxProvider, SandboxProviderConfig, SandboxRequest, SandboxSpec, Secret, SnapshotFormat,
     SnapshotPayload, StartSandboxProcessRequest, StartSandboxRequest, Uuid7,
     WaitSandboxProcessRequest, WriteArtifactRequest, WriteSandboxProcessInputRequest,
 };
@@ -2336,6 +2336,10 @@ impl ManagedSandboxBackend for TestProviderStateBackend {
         false
     }
 
+    fn consumable_snapshot_formats(&self) -> &[SnapshotFormat] {
+        &[]
+    }
+
     async fn acquire(
         &self,
         request: SandboxRequest,
@@ -2423,6 +2427,10 @@ impl TestSandboxBackend {
 impl ManagedSandboxBackend for TestSandboxBackend {
     fn is_local(&self) -> bool {
         false
+    }
+
+    fn consumable_snapshot_formats(&self) -> &[SnapshotFormat] {
+        &[]
     }
 
     async fn acquire(
@@ -2716,6 +2724,11 @@ impl ManagedSandboxBackend for RestoreImageTestBackend {
         false
     }
 
+    fn consumable_snapshot_formats(&self) -> &[SnapshotFormat] {
+        static FORMATS: [SnapshotFormat; 1] = [SnapshotFormat::DockerImageTar];
+        &FORMATS
+    }
+
     async fn acquire(
         &self,
         request: SandboxRequest,
@@ -2782,7 +2795,7 @@ impl ManagedSandboxHandle for RestoreImageTestHandle {
 
     async fn snapshot(&self) -> crate::Result<SnapshotPayload> {
         Ok(SnapshotPayload {
-            kind: SnapshotKind::DockerImageTar,
+            format: SnapshotFormat::DockerImageTar,
             bytes: bytes::Bytes::from_static(b"restore-image-test"),
         })
     }

--- a/crates/exoharness/src/http_tests.rs
+++ b/crates/exoharness/src/http_tests.rs
@@ -13,7 +13,7 @@ use crate::{
     EventQueryDirection, ExoHarness, HttpExoHarness, ManagedSandboxBackend, ManagedSandboxHandle,
     RestoreSandboxRequest, RunInSandboxRequest, SandboxAttachment, SandboxCommand,
     SandboxCommandOutput, SandboxProcessEvent, SandboxProcessEventQuery, SandboxProcessParts,
-    SandboxProcessStatus, SandboxProcessStdin, SandboxProvider, SandboxRequest, SnapshotKind,
+    SandboxProcessStatus, SandboxProcessStdin, SandboxProvider, SandboxRequest, SnapshotFormat,
     SnapshotPayload, StartSandboxProcessRequest, StartSandboxRequest, WaitSandboxProcessRequest,
     WriteSandboxProcessInputRequest, serve_exoharness_http_listener,
 };
@@ -507,6 +507,11 @@ impl ManagedSandboxBackend for SnapshotTestSandboxBackend {
         false
     }
 
+    fn consumable_snapshot_formats(&self) -> &[SnapshotFormat] {
+        static FORMATS: [SnapshotFormat; 1] = [SnapshotFormat::DaytonaRef];
+        &FORMATS
+    }
+
     async fn acquire(
         &self,
         _request: SandboxRequest,
@@ -558,7 +563,7 @@ impl ManagedSandboxHandle for SnapshotTestSandboxHandle {
 
     async fn snapshot(&self) -> crate::Result<SnapshotPayload> {
         Ok(SnapshotPayload {
-            kind: SnapshotKind::DaytonaSnapshot,
+            format: SnapshotFormat::DaytonaRef,
             bytes: Bytes::from_static(b"snapshot"),
         })
     }

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::{HashMap, hash_map::DefaultHasher};
 use std::ffi::OsString;
 use std::fmt;
@@ -112,41 +113,92 @@ pub struct SandboxCommandOutput {
 }
 
 /// Opaque blob produced by `ManagedSandboxHandle::snapshot` and consumed by
-/// `ManagedSandboxBackend::acquire_from_snapshot`. The `kind` tag is the
-/// contract: a snapshot produced by one backend can only be restored by a
-/// backend that knows how to interpret that kind.
+/// `ManagedSandboxBackend::acquire_from_snapshot`. The `format` identifier is
+/// the contract: a snapshot produced by one backend can only be restored by a
+/// backend that declares support for that format.
 #[derive(Debug, Clone)]
 pub struct SnapshotPayload {
-    pub kind: SnapshotKind,
+    pub format: SnapshotFormat,
     pub bytes: Bytes,
 }
 
-/// Tag identifying the on-disk format of a snapshot payload. Backends both
-/// produce and consume a specific kind; the conversation layer just hands the
-/// bytes back to the same backend type that produced them.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum SnapshotKind {
-    /// `docker save` output: a tar of OCI image layers + manifest, loadable
-    /// with `docker load`.
-    DockerImageTar,
-    /// JSON manifest pointing at a named snapshot in Daytona's registry; the
-    /// filesystem bytes live in Daytona, not in the payload.
-    DaytonaSnapshot,
-    /// Reference to an E2B snapshot template id. Payload bytes are a small JSON
-    /// manifest; restoring is `POST /sandboxes { templateID: <snapshot_id> }`.
-    E2bSnapshot,
-    /// Reference to a Sprites checkpoint id on a named sprite. Payload bytes are
-    /// a small JSON manifest; restoring is `POST .../checkpoints/{id}/restore`.
-    SpritesSnapshot,
-    /// Reference to a `.smolmachine` pack on the local disk. Payload bytes are a
-    /// small JSON manifest; restoring is `smolvm machine create --from <path>`.
-    /// A pack captures a whole stateful VM, so it is far too large to inline.
-    SmolMachinePack,
-    /// Reference to an immutable Firecracker state/RAM/disk bundle in the
-    /// backend's private state root. Payload bytes are a small JSON manifest;
-    /// the multi-gigabyte snapshot remains local to that Firecracker host.
-    FirecrackerSnapshot,
+/// Open identifier for the on-disk format of a snapshot payload.
+///
+/// Portable formats use shared names that any backend can declare support for.
+/// Backend-private references use namespaced names. Format evolution is
+/// represented by a new, versioned identifier rather than a core enum variant.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize)]
+#[serde(transparent)]
+pub struct SnapshotFormat(Cow<'static, str>);
+
+#[allow(non_upper_case_globals)]
+impl SnapshotFormat {
+    /// `docker save` output: a tar of OCI image layers + manifest.
+    pub const DockerImageTar: Self = Self::from_static("docker-image-tar");
+    /// Portable content-addressed workspace chunks plus a manifest.
+    pub const WorkspaceChunksV1: Self = Self::from_static("workspace-chunks-v1");
+    /// Reference to a named snapshot in Daytona's registry.
+    pub const DaytonaRef: Self = Self::from_static("daytona-ref");
+    /// Reference to an E2B snapshot template id.
+    pub const E2bRef: Self = Self::from_static("e2b-ref");
+    /// Reference to a Sprites checkpoint id.
+    pub const SpritesRef: Self = Self::from_static("sprites-ref");
+    /// Reference to a `.smolmachine` pack on the local disk.
+    pub const SmolvmMachinePack: Self = Self::from_static("smolvm-machine-pack");
+    /// Reference to an immutable bundle in a Firecracker host's private root.
+    pub const FirecrackerHostRef: Self = Self::from_static("firecracker-host-ref");
+
+    pub const fn from_static(format: &'static str) -> Self {
+        Self(Cow::Borrowed(format))
+    }
+
+    pub fn new(format: impl Into<Cow<'static, str>>) -> Self {
+        Self(format.into())
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.0.as_ref()
+    }
+
+    fn from_serialized(format: String) -> Self {
+        match format.as_str() {
+            "docker-image-tar" | "DockerImageTar" | "docker_image_tar" => Self::DockerImageTar,
+            "workspace-chunks-v1" => Self::WorkspaceChunksV1,
+            "daytona-ref" | "DaytonaSnapshot" | "daytona_snapshot" => Self::DaytonaRef,
+            "e2b-ref" | "E2bSnapshot" | "e2b_snapshot" => Self::E2bRef,
+            "sprites-ref" | "SpritesSnapshot" | "sprites_snapshot" => Self::SpritesRef,
+            "smolvm-machine-pack" | "SmolMachinePack" | "smol_machine_pack" => {
+                Self::SmolvmMachinePack
+            }
+            "firecracker-host-ref" | "FirecrackerSnapshot" | "firecracker_snapshot" => {
+                Self::FirecrackerHostRef
+            }
+            _ => Self(Cow::Owned(format)),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for SnapshotFormat {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        String::deserialize(deserializer).map(Self::from_serialized)
+    }
+}
+
+impl fmt::Display for SnapshotFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for SnapshotFormat {
+    type Err = std::convert::Infallible;
+
+    fn from_str(format: &str) -> std::result::Result<Self, Self::Err> {
+        Ok(Self(Cow::Owned(format.to_string())))
+    }
 }
 
 #[async_trait]
@@ -198,6 +250,9 @@ pub type BoxSandboxTcpStream = Pin<Box<dyn SandboxTcpStream>>;
 pub trait ManagedSandboxBackend: Send + Sync {
     fn is_local(&self) -> bool;
 
+    /// Formats this backend can consume in `acquire_from_snapshot`.
+    fn consumable_snapshot_formats(&self) -> &[SnapshotFormat];
+
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>>;
     async fn attach(
         &self,
@@ -209,7 +264,7 @@ pub trait ManagedSandboxBackend: Send + Sync {
     /// The request is honoured for mounts, network, lifecycle, etc., but the
     /// container's filesystem is sourced from the payload instead of
     /// `request.spec.image`. Returns an error if this backend can't restore
-    /// the supplied `payload.kind`.
+    /// the supplied `payload.format`.
     async fn acquire_from_snapshot(
         &self,
         request: SandboxRequest,
@@ -355,6 +410,8 @@ pub struct CliContainerSandboxBackend {
     network_created: Mutex<bool>,
     warm_sandboxes: Arc<Mutex<HashMap<SandboxKey, WarmSandboxEntry>>>,
 }
+
+static DOCKER_CONSUMABLE_SNAPSHOT_FORMATS: [SnapshotFormat; 1] = [SnapshotFormat::DockerImageTar];
 
 impl CliContainerSandboxBackend {
     pub fn apple_container() -> Self {
@@ -533,6 +590,13 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
         true
     }
 
+    fn consumable_snapshot_formats(&self) -> &[SnapshotFormat] {
+        match self.cli {
+            ContainerCliFlavor::Docker => &DOCKER_CONSUMABLE_SNAPSHOT_FORMATS,
+            ContainerCliFlavor::AppleContainer => &[],
+        }
+    }
+
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
         let request = self.prepare_request(request).await?;
 
@@ -626,30 +690,8 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
         if request.lifecycle.idle_ttl.is_none() {
             bail!("restore-from-snapshot requires a warm sandbox lifecycle (idle_ttl must be set)");
         }
-        match (self.cli, payload.kind) {
-            (ContainerCliFlavor::Docker, SnapshotKind::DockerImageTar) => {}
-            (ContainerCliFlavor::AppleContainer, _) => bail!(
-                "restore-from-snapshot is not yet implemented for the apple-container backend"
-            ),
-            (_, SnapshotKind::DaytonaSnapshot) => {
-                bail!("restoring a Daytona snapshot on a container backend is not implemented yet")
-            }
-            (_, SnapshotKind::E2bSnapshot) => bail!(
-                "E2bSnapshot payloads can only be restored by the E2B sandbox provider; \
-                 select provider e2b to rewind this snapshot"
-            ),
-            (_, SnapshotKind::SpritesSnapshot) => bail!(
-                "SpritesSnapshot payloads can only be restored by the Sprites sandbox provider; \
-                 select provider sprites to rewind this snapshot"
-            ),
-            (_, SnapshotKind::SmolMachinePack) => bail!(
-                "SmolMachinePack payloads can only be restored by the smolvm sandbox provider; \
-                 select provider smolvm to rewind this snapshot"
-            ),
-            (_, SnapshotKind::FirecrackerSnapshot) => bail!(
-                "FirecrackerSnapshot payloads can only be restored by the Firecracker sandbox provider; \
-                 select provider firecracker to rewind this snapshot"
-            ),
+        if self.cli == ContainerCliFlavor::AppleContainer {
+            bail!("restore-from-snapshot is not yet implemented for the apple-container backend");
         }
 
         let image_tag = docker_load_image(&self.container_bin, &payload.bytes).await?;
@@ -888,8 +930,7 @@ impl ManagedSandboxHandle for WarmSandboxHandle {
             // `container commit`-style flow on its roadmap but neither is in
             // the released versions we target today. When it lands, the path
             // will mirror docker_snapshot_container: produce a single tarball
-            // and tag it with a new SnapshotKind variant (e.g.
-            // AppleContainerImageTar). Until then, fail explicitly so callers
+            // and tag it with a new SnapshotFormat. Until then, fail explicitly so callers
             // know to choose Docker for snapshot-using flows.
             ContainerCliFlavor::AppleContainer => bail!(
                 "snapshot is not yet implemented for the apple-container backend; \
@@ -912,6 +953,10 @@ impl LocalProcessSandboxBackend {
 impl ManagedSandboxBackend for LocalProcessSandboxBackend {
     fn is_local(&self) -> bool {
         true
+    }
+
+    fn consumable_snapshot_formats(&self) -> &[SnapshotFormat] {
+        &[]
     }
 
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
@@ -2124,7 +2169,7 @@ async fn docker_snapshot_container(
     }
 
     Ok(SnapshotPayload {
-        kind: SnapshotKind::DockerImageTar,
+        format: SnapshotFormat::DockerImageTar,
         bytes,
     })
 }
@@ -2186,6 +2231,42 @@ async fn docker_load_image(container_bin: &Path, payload: &Bytes) -> Result<Stri
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn snapshot_format_reads_legacy_names_and_writes_canonical_names() {
+        let cases = [
+            ("DockerImageTar", SnapshotFormat::DockerImageTar),
+            ("docker_image_tar", SnapshotFormat::DockerImageTar),
+            ("DaytonaSnapshot", SnapshotFormat::DaytonaRef),
+            ("daytona_snapshot", SnapshotFormat::DaytonaRef),
+            ("E2bSnapshot", SnapshotFormat::E2bRef),
+            ("e2b_snapshot", SnapshotFormat::E2bRef),
+            ("SpritesSnapshot", SnapshotFormat::SpritesRef),
+            ("sprites_snapshot", SnapshotFormat::SpritesRef),
+            ("SmolMachinePack", SnapshotFormat::SmolvmMachinePack),
+            ("smol_machine_pack", SnapshotFormat::SmolvmMachinePack),
+            ("FirecrackerSnapshot", SnapshotFormat::FirecrackerHostRef),
+            ("firecracker_snapshot", SnapshotFormat::FirecrackerHostRef),
+        ];
+
+        for (legacy, expected) in cases {
+            let decoded: SnapshotFormat =
+                serde_json::from_value(serde_json::Value::String(legacy.to_string()))
+                    .expect("deserialize legacy snapshot format");
+            assert_eq!(decoded, expected);
+            assert_eq!(serde_json::to_value(&decoded).unwrap(), expected.as_str());
+        }
+    }
+
+    #[test]
+    fn snapshot_format_preserves_unknown_open_identifiers() {
+        let decoded: SnapshotFormat = serde_json::from_str(r#""vendor-format-v3""#).unwrap();
+        assert_eq!(decoded.as_str(), "vendor-format-v3");
+        assert_eq!(
+            serde_json::to_string(&decoded).unwrap(),
+            r#""vendor-format-v3""#
+        );
+    }
 
     #[cfg(unix)]
     #[tokio::test]

--- a/crates/exoharness/src/sandbox_provider/aws_agentcore.rs
+++ b/crates/exoharness/src/sandbox_provider/aws_agentcore.rs
@@ -11,8 +11,8 @@ use serde::{Deserialize, Serialize};
 use crate::SandboxAttachment;
 use crate::sandbox::{
     ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand, SandboxCommandOutput,
-    SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotPayload, sandbox_spec_hash,
-    validate_durable_file_systems,
+    SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotFormat, SnapshotPayload,
+    sandbox_spec_hash, validate_durable_file_systems,
 };
 use crate::sandbox_provider::process_bridge;
 
@@ -94,6 +94,10 @@ impl AwsAgentCoreSandboxBackend {
 impl ManagedSandboxBackend for AwsAgentCoreSandboxBackend {
     fn is_local(&self) -> bool {
         false
+    }
+
+    fn consumable_snapshot_formats(&self) -> &[SnapshotFormat] {
+        &[]
     }
 
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {

--- a/crates/exoharness/src/sandbox_provider/daytona.rs
+++ b/crates/exoharness/src/sandbox_provider/daytona.rs
@@ -3,9 +3,9 @@
 //!
 //! Daytona persists state itself: `stop` keeps the filesystem and the next
 //! `acquire` finds the sandbox by label and `start`s it. Snapshots use
-//! [`SnapshotKind::DaytonaSnapshot`] payloads — a JSON manifest naming a
+//! [`SnapshotFormat::DaytonaRef`] payload — a JSON manifest naming a
 //! snapshot in Daytona's registry, not the bytes themselves. A
-//! [`SnapshotKind::DockerImageTar`] payload (the Docker backend's snapshot
+//! [`SnapshotFormat::DockerImageTar`] payload (the Docker backend's snapshot
 //! format) can also be restored here, which is how a sandbox teleports from
 //! local Docker up to Daytona.
 
@@ -33,7 +33,7 @@ use uuid::Uuid;
 use crate::SandboxAttachment;
 use crate::sandbox::{
     ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand, SandboxCommandOutput,
-    SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotKind, SnapshotPayload,
+    SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotFormat, SnapshotPayload,
     WARM_SANDBOX_KEY_LABEL, WARM_SANDBOX_SPEC_HASH_LABEL, sandbox_spec_hash,
 };
 use crate::sandbox_provider::shell_quote;
@@ -48,6 +48,8 @@ const START_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const START_TIMEOUT: Duration = Duration::from_secs(120);
 const SNAPSHOT_POLL_INTERVAL: Duration = Duration::from_secs(2);
 const SNAPSHOT_WAIT_TIMEOUT: Duration = Duration::from_secs(180);
+static CONSUMABLE_SNAPSHOT_FORMATS: [SnapshotFormat; 2] =
+    [SnapshotFormat::DaytonaRef, SnapshotFormat::DockerImageTar];
 const PROCESS_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const PROCESS_PIPE_BUFFER_SIZE: usize = 64 * 1024;
 const PROCESS_ENV_END_MARKER: &str = "__EXO_ENV_END__";
@@ -249,6 +251,10 @@ impl ManagedSandboxBackend for DaytonaSandboxBackend {
         false
     }
 
+    fn consumable_snapshot_formats(&self) -> &[SnapshotFormat] {
+        &CONSUMABLE_SNAPSHOT_FORMATS
+    }
+
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
         reject_unsupported_mounts(&request)?;
         let spec_hash = sandbox_spec_hash(&request.spec);
@@ -293,23 +299,17 @@ impl ManagedSandboxBackend for DaytonaSandboxBackend {
         payload: SnapshotPayload,
     ) -> Result<Arc<dyn ManagedSandboxHandle>> {
         reject_unsupported_mounts(&request)?;
-        let snapshot_name = match payload.kind {
-            SnapshotKind::DaytonaSnapshot => {
-                let manifest: DaytonaSnapshotManifest = serde_json::from_slice(&payload.bytes)
-                    .context("decoding DaytonaSnapshot manifest")?;
-                manifest.snapshot_name
-            }
-            SnapshotKind::DockerImageTar => {
-                import_docker_image_tar(&self.handle_backend(), &payload.bytes).await?
-            }
-            SnapshotKind::E2bSnapshot
-            | SnapshotKind::SpritesSnapshot
-            | SnapshotKind::SmolMachinePack
-            | SnapshotKind::FirecrackerSnapshot => bail!(
-                "the Daytona backend cannot restore a {:?} payload; \
-                 select the provider that produced the snapshot",
-                payload.kind
-            ),
+        let snapshot_name = if payload.format == SnapshotFormat::DaytonaRef {
+            let manifest: DaytonaSnapshotManifest = serde_json::from_slice(&payload.bytes)
+                .context("decoding Daytona snapshot manifest")?;
+            manifest.snapshot_name
+        } else if payload.format == SnapshotFormat::DockerImageTar {
+            import_docker_image_tar(&self.handle_backend(), &payload.bytes).await?
+        } else {
+            bail!(
+                "the Daytona backend cannot restore a {} payload",
+                payload.format
+            )
         };
         let spec_hash = sandbox_spec_hash(&request.spec);
         let sandbox = self
@@ -1132,7 +1132,7 @@ async fn save_as_snapshot_via_backend(
     let manifest = DaytonaSnapshotManifest { snapshot_name };
     let bytes = serde_json::to_vec(&manifest).context("serializing Daytona snapshot manifest")?;
     Ok(SnapshotPayload {
-        kind: SnapshotKind::DaytonaSnapshot,
+        format: SnapshotFormat::DaytonaRef,
         bytes: Bytes::from(bytes),
     })
 }
@@ -1530,7 +1530,7 @@ struct DaytonaSessionCommandInputRequest {
     data: String,
 }
 
-/// Persisted alongside a `SnapshotKind::DaytonaSnapshot`: a Daytona snapshot is
+/// Persisted alongside a `SnapshotFormat::DaytonaRef`: a Daytona snapshot is
 /// self-contained, so the registered name is all we need to recreate it.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct DaytonaSnapshotManifest {

--- a/crates/exoharness/src/sandbox_provider/e2b.rs
+++ b/crates/exoharness/src/sandbox_provider/e2b.rs
@@ -3,7 +3,7 @@
 //! Uses E2B's platform REST API (`api.e2b.app`) for lifecycle and the per-sandbox
 //! envd Connect API for command execution. Cross-process resume uses sandbox
 //! `metadata` (same keys as Docker/Daytona labels). Snapshots are bytes-by-reference
-//! via [`SnapshotKind::E2bSnapshot`] manifests pointing at an E2B snapshot template id.
+//! via [`SnapshotFormat::E2bRef`] manifests pointing at an E2B snapshot template id.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -26,7 +26,7 @@ use uuid::Uuid;
 use crate::SandboxAttachment;
 use crate::sandbox::{
     DEFAULT_SANDBOX_IMAGE, ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand,
-    SandboxCommandOutput, SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotKind,
+    SandboxCommandOutput, SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotFormat,
     SnapshotPayload, WARM_SANDBOX_KEY_LABEL, WARM_SANDBOX_SPEC_HASH_LABEL, sandbox_spec_hash,
 };
 
@@ -40,6 +40,7 @@ const CONNECT_FLAG_COMPRESSED: u8 = 0x01;
 /// Connect envelope flag: final message carrying stream status / errors.
 const CONNECT_FLAG_END_STREAM: u8 = 0x02;
 const CONNECT_MAX_ENVELOPE_BYTES: usize = 16 * 1024 * 1024;
+static CONSUMABLE_SNAPSHOT_FORMATS: [SnapshotFormat; 1] = [SnapshotFormat::E2bRef];
 
 #[derive(Debug, Clone)]
 pub struct E2bConfig {
@@ -53,7 +54,7 @@ pub struct E2bConfig {
     pub secure: bool,
 }
 
-/// JSON persisted for [`SnapshotKind::E2bSnapshot`]. Filesystem state lives in E2B;
+/// JSON persisted for [`SnapshotFormat::E2bRef`]. Filesystem state lives in E2B;
 /// we only store the snapshot template id returned by `POST /sandboxes/{id}/snapshots`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct E2bSnapshotManifest {
@@ -222,6 +223,10 @@ impl ManagedSandboxBackend for E2bSandboxBackend {
         false
     }
 
+    fn consumable_snapshot_formats(&self) -> &[SnapshotFormat] {
+        &CONSUMABLE_SNAPSHOT_FORMATS
+    }
+
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
         reject_host_mounts(&request)?;
         let spec_hash = sandbox_spec_hash(&request.spec);
@@ -275,10 +280,11 @@ impl ManagedSandboxBackend for E2bSandboxBackend {
         payload: SnapshotPayload,
     ) -> Result<Arc<dyn ManagedSandboxHandle>> {
         reject_host_mounts(&request)?;
-        if !matches!(payload.kind, SnapshotKind::E2bSnapshot) {
+        if payload.format != SnapshotFormat::E2bRef {
             bail!(
-                "E2B sandbox backend can only restore from SnapshotKind::E2bSnapshot, got {:?}",
-                payload.kind
+                "E2B sandbox backend can only restore from {}, got {}",
+                SnapshotFormat::E2bRef,
+                payload.format
             );
         }
         let manifest: E2bSnapshotManifest =
@@ -1053,7 +1059,7 @@ async fn save_snapshot_via_backend(
     };
     let bytes = serde_json::to_vec(&manifest).context("serializing E2bSnapshot manifest")?;
     Ok(SnapshotPayload {
-        kind: SnapshotKind::E2bSnapshot,
+        format: SnapshotFormat::E2bRef,
         bytes: Bytes::from(bytes),
     })
 }

--- a/crates/exoharness/src/sandbox_provider/firecracker.rs
+++ b/crates/exoharness/src/sandbox_provider/firecracker.rs
@@ -45,7 +45,7 @@ use uuid::Uuid;
 use crate::sandbox::{
     BoxSandboxTcpStream, ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand,
     SandboxCommandOutput, SandboxKey, SandboxNetworkPolicy, SandboxRequest, SandboxSpec,
-    SnapshotKind, SnapshotPayload, sandbox_spec_hash,
+    SnapshotFormat, SnapshotPayload, sandbox_spec_hash,
 };
 use crate::sandbox_provider::process_bridge;
 use crate::{FileSystemMountMode, SandboxAttachment, SandboxProcessParts};
@@ -95,6 +95,7 @@ pub const DEFAULT_MEMORY_MIB: u32 = 4096;
 #[cfg(target_os = "macos")]
 pub const DEFAULT_MEMORY_MIB: u32 = 1024;
 const SNAPSHOT_FORMAT_VERSION: u32 = 2;
+static CONSUMABLE_SNAPSHOT_FORMATS: [SnapshotFormat; 1] = [SnapshotFormat::FirecrackerHostRef];
 // Upstream warns that a compromised guest kernel can reactivate the serial
 // device even with 8250.nr_uarts=0, and unbounded console output written to a
 // host file is their named disk-fill DoS. VMM output therefore goes to
@@ -228,10 +229,11 @@ struct FirecrackerSnapshotManifest {
 
 impl FirecrackerSnapshotManifest {
     fn from_payload(payload: SnapshotPayload) -> Result<Self> {
-        if payload.kind != SnapshotKind::FirecrackerSnapshot {
+        if payload.format != SnapshotFormat::FirecrackerHostRef {
             bail!(
-                "Firecracker sandbox backend can only restore a FirecrackerSnapshot payload, got {:?}",
-                payload.kind
+                "Firecracker sandbox backend can only restore a {} payload, got {}",
+                SnapshotFormat::FirecrackerHostRef,
+                payload.format
             );
         }
         let manifest: Self = serde_json::from_slice(&payload.bytes)
@@ -244,7 +246,7 @@ impl FirecrackerSnapshotManifest {
         let bytes =
             serde_json::to_vec(&self).context("serializing FirecrackerSnapshot manifest")?;
         Ok(SnapshotPayload {
-            kind: SnapshotKind::FirecrackerSnapshot,
+            format: SnapshotFormat::FirecrackerHostRef,
             bytes: Bytes::from(bytes),
         })
     }
@@ -1006,6 +1008,10 @@ impl FirecrackerSandboxBackend {
 impl ManagedSandboxBackend for FirecrackerSandboxBackend {
     fn is_local(&self) -> bool {
         true
+    }
+
+    fn consumable_snapshot_formats(&self) -> &[SnapshotFormat] {
+        &CONSUMABLE_SNAPSHOT_FORMATS
     }
 
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {

--- a/crates/exoharness/src/sandbox_provider/firecracker_bridge.rs
+++ b/crates/exoharness/src/sandbox_provider/firecracker_bridge.rs
@@ -14,7 +14,7 @@ use tokio_util::compat::{FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
 
 use crate::{
     FirecrackerConfig, FirecrackerSandboxBackend, ManagedSandboxBackend, ManagedSandboxHandle,
-    SandboxCommand, SandboxCommandOutput, SandboxProcessParts, SandboxRequest, SnapshotKind,
+    SandboxCommand, SandboxCommandOutput, SandboxProcessParts, SandboxRequest, SnapshotFormat,
     SnapshotPayload,
 };
 
@@ -57,7 +57,7 @@ pub enum FirecrackerBridgeRequest {
     AcquireFromSnapshot {
         config: FirecrackerConfig,
         request: SandboxRequest,
-        kind: SnapshotKind,
+        format: SnapshotFormat,
         payload: String,
     },
     Snapshot {
@@ -88,7 +88,7 @@ pub enum FirecrackerBridgeResponse {
         output: SandboxCommandOutput,
     },
     Snapshot {
-        kind: SnapshotKind,
+        format: SnapshotFormat,
         payload: String,
     },
     Unit,
@@ -336,7 +336,7 @@ async fn handle_request(
         FirecrackerBridgeRequest::AcquireFromSnapshot {
             config,
             request,
-            kind,
+            format,
             payload,
         } => {
             let payload = BASE64
@@ -348,7 +348,7 @@ async fn handle_request(
                 .acquire_from_snapshot(
                     request,
                     SnapshotPayload {
-                        kind,
+                        format,
                         bytes: payload.into(),
                     },
                 )
@@ -362,7 +362,7 @@ async fn handle_request(
         FirecrackerBridgeRequest::Snapshot { config, request } => {
             let snapshot = backends.acquire(config, request).await?.snapshot().await?;
             Ok(FirecrackerBridgeResponse::Snapshot {
-                kind: snapshot.kind,
+                format: snapshot.format,
                 payload: BASE64.encode(snapshot.bytes),
             })
         }

--- a/crates/exoharness/src/sandbox_provider/firecracker_lima.rs
+++ b/crates/exoharness/src/sandbox_provider/firecracker_lima.rs
@@ -31,7 +31,7 @@ use tokio_util::sync::PollSender;
 
 use crate::sandbox::{
     BoxSandboxTcpStream, ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand,
-    SandboxCommandOutput, SandboxRequest, SnapshotPayload,
+    SandboxCommandOutput, SandboxRequest, SnapshotFormat, SnapshotPayload,
 };
 use crate::{SandboxAttachment, SandboxProcessParts};
 
@@ -42,6 +42,8 @@ use super::firecracker_bridge::{
     FirecrackerBridgeServerFrame, FirecrackerBridgeStreamChannel, STREAM_CHUNK_BYTES, read_frame,
     write_frame,
 };
+
+static CONSUMABLE_SNAPSHOT_FORMATS: [SnapshotFormat; 1] = [SnapshotFormat::FirecrackerHostRef];
 
 const BRIDGE_FRAME_QUEUE_DEPTH: usize = 16;
 const BRIDGE_STREAM_QUEUE_DEPTH: usize = 16;
@@ -107,6 +109,10 @@ impl LimaFirecrackerSandboxBackend {
 impl ManagedSandboxBackend for LimaFirecrackerSandboxBackend {
     fn is_local(&self) -> bool {
         true
+    }
+
+    fn consumable_snapshot_formats(&self) -> &[SnapshotFormat] {
+        &CONSUMABLE_SNAPSHOT_FORMATS
     }
 
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
@@ -199,7 +205,7 @@ impl ManagedSandboxBackend for LimaFirecrackerSandboxBackend {
             .request(FirecrackerBridgeRequest::AcquireFromSnapshot {
                 config: self.config.clone(),
                 request: request.clone(),
-                kind: payload.kind,
+                format: payload.format,
                 payload: BASE64.encode(payload.bytes),
             })
             .await?;
@@ -315,14 +321,14 @@ impl ManagedSandboxHandle for LimaFirecrackerSandboxHandle {
                 request: self.request.clone(),
             })
             .await?;
-        let FirecrackerBridgeResponse::Snapshot { kind, payload } = response else {
+        let FirecrackerBridgeResponse::Snapshot { format, payload } = response else {
             bail!("Firecracker Lima bridge returned the wrong response to snapshot");
         };
         let bytes = BASE64
             .decode(payload)
             .context("decoding Firecracker snapshot bridge response")?;
         Ok(SnapshotPayload {
-            kind,
+            format,
             bytes: Bytes::from(bytes),
         })
     }

--- a/crates/exoharness/src/sandbox_provider/smolvm.rs
+++ b/crates/exoharness/src/sandbox_provider/smolvm.rs
@@ -29,7 +29,7 @@ use tokio::sync::OnceCell;
 use crate::SandboxAttachment;
 use crate::sandbox::{
     ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand, SandboxCommandOutput, SandboxKey,
-    SandboxMountAccess, SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotKind,
+    SandboxMountAccess, SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotFormat,
     SnapshotPayload, WARM_SANDBOX_KEY_LABEL, WARM_SANDBOX_OWNER_PID_LABEL, owner_pid_is_alive,
     run_command, spawn_sandbox_process,
 };
@@ -48,6 +48,7 @@ const MIN_WARM_VERSION: Version = Version::new(1, 7, 2);
 /// Probed from `--help`, not the version: a build carrying `--label` still
 /// reported 1.7.5, so a version gate would refuse a flag that is right there.
 const LABEL_FLAG: &str = "--label";
+static CONSUMABLE_SNAPSHOT_FORMATS: [SnapshotFormat; 1] = [SnapshotFormat::SmolvmMachinePack];
 
 /// What the installed smolvm supports. Probed once per backend.
 #[derive(Debug, Clone, Copy)]
@@ -415,6 +416,10 @@ impl ManagedSandboxBackend for SmolvmSandboxBackend {
         true
     }
 
+    fn consumable_snapshot_formats(&self) -> &[SnapshotFormat] {
+        &CONSUMABLE_SNAPSHOT_FORMATS
+    }
+
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
         reject_unsupported_spec(&request.spec)?;
         match self.resolve_mode(&request).await {
@@ -457,10 +462,10 @@ impl ManagedSandboxBackend for SmolvmSandboxBackend {
         request: SandboxRequest,
         payload: SnapshotPayload,
     ) -> Result<Arc<dyn ManagedSandboxHandle>> {
-        if payload.kind != SnapshotKind::SmolMachinePack {
+        if payload.format != SnapshotFormat::SmolvmMachinePack {
             bail!(
-                "smolvm backend cannot restore snapshot kind {:?}",
-                payload.kind
+                "smolvm backend cannot restore snapshot format {}",
+                payload.format
             );
         }
         reject_unsupported_spec(&request.spec)?;
@@ -704,7 +709,7 @@ impl ManagedSandboxHandle for SmolvmWarmHandle {
         run_checked(start, "smolvm machine start").await?;
 
         Ok(SnapshotPayload {
-            kind: SnapshotKind::SmolMachinePack,
+            format: SnapshotFormat::SmolvmMachinePack,
             bytes: Bytes::from(bytes),
         })
     }

--- a/crates/exoharness/src/sandbox_provider/sprites.rs
+++ b/crates/exoharness/src/sandbox_provider/sprites.rs
@@ -5,7 +5,7 @@
 //! checkpoint/restore snapshots. Cross-process resume uses a
 //! deterministic sprite name derived from [`SandboxKey`] + spec hash (same role
 //! as Docker labels / E2B metadata). Snapshots are bytes-by-reference via
-//! [`SnapshotKind::SpritesSnapshot`] manifests pointing at a checkpoint id.
+//! [`SnapshotFormat::SpritesRef`] manifests pointing at a checkpoint id.
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -29,7 +29,7 @@ use url::Url;
 use crate::SandboxAttachment;
 use crate::sandbox::{
     ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand, SandboxCommandOutput,
-    SandboxRequest, SandboxSpec, SnapshotKind, SnapshotPayload, WARM_SANDBOX_KEY_LABEL,
+    SandboxRequest, SandboxSpec, SnapshotFormat, SnapshotPayload, WARM_SANDBOX_KEY_LABEL,
     WARM_SANDBOX_SPEC_HASH_LABEL, sandbox_spec_hash,
 };
 
@@ -41,6 +41,7 @@ const SPRITES_STREAM_STDOUT: u8 = 1;
 const SPRITES_STREAM_STDERR: u8 = 2;
 const SPRITES_STREAM_EXIT: u8 = 3;
 const SPRITES_STREAM_STDIN_EOF: u8 = 4;
+static CONSUMABLE_SNAPSHOT_FORMATS: [SnapshotFormat; 1] = [SnapshotFormat::SpritesRef];
 
 #[derive(Debug, Clone)]
 pub struct SpritesConfig {
@@ -54,7 +55,7 @@ pub struct SpritesConfig {
     pub extra_labels: Vec<String>,
 }
 
-/// JSON persisted for [`SnapshotKind::SpritesSnapshot`]. Filesystem state lives on
+/// JSON persisted for [`SnapshotFormat::SpritesRef`]. Filesystem state lives on
 /// the sprite; we only store the checkpoint id and sprite name.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct SpritesSnapshotManifest {
@@ -172,6 +173,10 @@ impl ManagedSandboxBackend for SpritesSandboxBackend {
         false
     }
 
+    fn consumable_snapshot_formats(&self) -> &[SnapshotFormat] {
+        &CONSUMABLE_SNAPSHOT_FORMATS
+    }
+
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
         reject_host_mounts(&request)?;
         let sprite_name = sprite_name_for_request(&request);
@@ -198,11 +203,11 @@ impl ManagedSandboxBackend for SpritesSandboxBackend {
         payload: SnapshotPayload,
     ) -> Result<Arc<dyn ManagedSandboxHandle>> {
         reject_host_mounts(&request)?;
-        if !matches!(payload.kind, SnapshotKind::SpritesSnapshot) {
+        if payload.format != SnapshotFormat::SpritesRef {
             bail!(
-                "Sprites sandbox backend can only restore from SnapshotKind::SpritesSnapshot, \
-                 got {:?}",
-                payload.kind
+                "Sprites sandbox backend can only restore from {}, got {}",
+                SnapshotFormat::SpritesRef,
+                payload.format
             );
         }
         let manifest: SpritesSnapshotManifest =
@@ -660,7 +665,7 @@ async fn save_checkpoint_via_backend(
     };
     let bytes = serde_json::to_vec(&manifest).context("serializing Sprites snapshot manifest")?;
     Ok(SnapshotPayload {
-        kind: SnapshotKind::SpritesSnapshot,
+        format: SnapshotFormat::SpritesRef,
         bytes: Bytes::from(bytes),
     })
 }

--- a/crates/exoharness/src/sandbox_provider/vercel.rs
+++ b/crates/exoharness/src/sandbox_provider/vercel.rs
@@ -22,8 +22,8 @@ use serde::{Deserialize, Serialize};
 use crate::SandboxAttachment;
 use crate::sandbox::{
     ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand, SandboxCommandOutput,
-    SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotPayload, WARM_SANDBOX_KEY_LABEL,
-    WARM_SANDBOX_SPEC_HASH_LABEL, sandbox_spec_hash,
+    SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotFormat, SnapshotPayload,
+    WARM_SANDBOX_KEY_LABEL, WARM_SANDBOX_SPEC_HASH_LABEL, sandbox_spec_hash,
 };
 use crate::sandbox_provider::{process_bridge, shell_quote};
 
@@ -153,6 +153,10 @@ impl VercelSandboxBackend {
 impl ManagedSandboxBackend for VercelSandboxBackend {
     fn is_local(&self) -> bool {
         false
+    }
+
+    fn consumable_snapshot_formats(&self) -> &[SnapshotFormat] {
+        &[]
     }
 
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {

--- a/exoharness/docs/sandbox-snapshots.md
+++ b/exoharness/docs/sandbox-snapshots.md
@@ -1,13 +1,13 @@
 # Sandbox Snapshots
 
-Status: implemented for the Docker, E2B, Sprites, and Daytona sandbox
-backends; stubs in place for the others. Daytona can additionally restore a
-Docker snapshot (the cross-provider "teleport" bridge).
+Status: implemented for Docker, Daytona, E2B, Sprites, SmolVM, and
+Firecracker. Daytona can additionally restore a Docker snapshot (the
+cross-provider "teleport" bridge).
 
 ## Summary
 
-A snapshot captures the current filesystem state of a sandboxed container so
-that the sandbox can later be rewound to that state. Snapshots are taken,
+A snapshot captures backend-defined sandbox state so that the sandbox can
+later be rewound to that state. Snapshots are taken,
 listed, and replayed within an `exo` conversation. They give the user — or in
 a later iteration, an executor policy — the ability to time-travel a
 sandbox's state without forking the conversation itself.
@@ -33,9 +33,10 @@ it, and the restore path that actually consumes it.
 
 ## What this is not
 
-- **Not a process or memory checkpoint.** Only filesystem state is captured.
-  Running processes inside the container are not preserved; they are
-  re-launched fresh from the restored image.
+- **Not uniformly a process or memory checkpoint.** Image-based formats such
+  as `docker-image-tar` capture filesystem state only, while
+  `firecracker-host-ref` points to a host-local full-VM snapshot. Consumers
+  must use the semantics of the specific format.
 - **Not a conversation rewind.** The event log, message history, and prior
   tool calls are untouched. Use `conversation fork` to rewind the
   conversation itself.
@@ -52,7 +53,7 @@ ConversationHandle             ManagedSandboxHandle           ManagedSandboxBack
        │                              │                                │
   snapshot_sandbox(id) ──► running_sandboxes.get(id).snapshot() ──┐    │
        │                                                          │    │
-       ◄────────── SnapshotPayload { kind, bytes } ────────────────┘    │
+       ◄────────── SnapshotPayload { format, bytes } ──────────────┘    │
        │                                                                │
   put_bytes / put_json                                                  │
   (manifest.json + payload.bin)                                         │
@@ -66,25 +67,44 @@ payload, persists the bytes, updates sandbox metadata, and emits the
 `ManagedSandboxBackend::acquire_from_snapshot` are the backend-specific
 methods that produce and consume the bytes.
 
-### SnapshotPayload and SnapshotKind
+### SnapshotPayload and SnapshotFormat
 
 ```rust
 pub struct SnapshotPayload {
-    pub kind: SnapshotKind,
+    pub format: SnapshotFormat,
     pub bytes: Bytes,
 }
 
-pub enum SnapshotKind {
-    DockerImageTar,
-    // future: AppleContainerImageTar, etc.
+pub struct SnapshotFormat(Cow<'static, str>);
+
+impl SnapshotFormat {
+    pub const DockerImageTar: Self = Self::from_static("docker-image-tar");
+    pub const WorkspaceChunksV1: Self = Self::from_static("workspace-chunks-v1");
 }
 ```
 
-`SnapshotPayload` is opaque to the harness. The `kind` tag is the contract
+`SnapshotPayload` is opaque to the harness. The `format` identifier is the contract
 between producer and consumer: a payload produced by one backend can only be
-restored by a backend that knows how to interpret that kind. The harness
+restored by a backend that declares that format in
+`ManagedSandboxBackend::consumable_snapshot_formats`. The harness validates
+that capability before dispatch. It
 never inspects `bytes` — it just persists them and hands them back on
 restore.
+
+`SnapshotFormat` is an open string newtype, like `SandboxProvider`, so adding a
+backend or a private format does not require editing a core enum. Portable
+formats use shared names; opaque references use backend-namespaced names. A
+format name includes a version when its wire representation can evolve.
+
+| Format                 | Producer                          | Consumers                          |
+| ---------------------- | --------------------------------- | ---------------------------------- |
+| `docker-image-tar`     | Docker                            | Docker, Daytona                    |
+| `daytona-ref`          | Daytona                           | Daytona                            |
+| `e2b-ref`              | E2B                               | E2B                                |
+| `sprites-ref`          | Sprites                           | Sprites                            |
+| `smolvm-machine-pack`  | SmolVM                            | SmolVM                             |
+| `firecracker-host-ref` | Firecracker                       | Firecracker, Firecracker-over-Lima |
+| `workspace-chunks-v1`  | reserved for workspace durability | none yet                           |
 
 ## Docker pipeline
 
@@ -102,7 +122,8 @@ restore.
 
 `ManagedSandboxBackend::acquire_from_snapshot` (Docker):
 
-1. Validate that `payload.kind == DockerImageTar`.
+1. The harness validates that the selected backend declares
+   `docker-image-tar` as consumable.
 2. `docker load < payload.bytes` — load the image back into the local
    daemon; parse stdout to find the assigned image reference (the line
    `Loaded image: <ref>`).
@@ -123,7 +144,7 @@ conversation-scoped artifacts:
 ```
 agents/<agent_id>/conversations/<conversation_id>/snapshots/<snapshot_id>/
 ├── manifest.json   JSON sidecar (StoredSnapshotManifest)
-└── payload.bin     raw blob (docker save tarball for SnapshotKind::DockerImageTar)
+└── payload.bin     raw blob (docker save tarball for `docker-image-tar`)
 ```
 
 The manifest schema:
@@ -132,7 +153,7 @@ The manifest schema:
 {
   "snapshot_id": "019e5782-7c6b-72a2-b4fa-a81bf56eb37e",
   "sandbox_id": "sandbox-019e5782-2a46-7970-a5bf-62900a2233e8",
-  "kind": "docker_image_tar",
+  "format": "docker-image-tar",
   "created_at": "2026-05-24T01:03:49.867230008Z",
   "payload_size_bytes": 48498688
 }
@@ -141,6 +162,11 @@ The manifest schema:
 This mirrors the existing artifact layout (sidecar `.json` + `.bin` blob in
 a per-id directory). A future migration to chunked or streamed storage
 would touch a small surface.
+
+Existing manifests need no migration. Deserialization accepts the old `kind`
+field and both legacy enum spellings (`docker_image_tar` and
+`DockerImageTar`, with equivalent mappings for every former variant). New
+writes always use the `format` field and canonical hyphenated identifier.
 
 The snapshot's existence is also recorded in the conversation event log as
 `SandboxSnapshotted { sandbox_id, snapshot_id }`, which is what
@@ -199,17 +225,18 @@ cargo test -p exo --test teleport_docker_to_daytona -- --ignored --nocapture
 To add snapshot support for a new backend (say, Apple's `container` CLI
 when it grows a commit/save flow):
 
-1. Add a new variant to `SnapshotKind` — e.g. `AppleContainerImageTar`.
-   The tag is the contract; pick a name that names the on-disk format.
+1. Choose a stable format identifier. Reuse an existing portable format when
+   the bytes have the same contract; otherwise define a backend-local
+   `SnapshotFormat::from_static(...)` constant. No core change is required.
 2. Implement `ManagedSandboxHandle::snapshot` for that backend's handle
    type, producing the appropriate `SnapshotPayload`. The Docker version in
    `docker_snapshot_container` is the template — three CLI calls and a
    `Bytes` capture.
-3. Implement `ManagedSandboxBackend::acquire_from_snapshot` to consume the
-   same `kind`, including the safety check that the payload's `kind`
-   matches what the backend understands. The Docker version is the
-   template here too — load the bytes, get the loaded image reference,
-   swap `request.spec.image`, evict + recreate the warm container.
+3. Return every supported identifier from
+   `ManagedSandboxBackend::consumable_snapshot_formats`, then implement
+   `acquire_from_snapshot` for those formats. The Docker version is the
+   template here — load the bytes, get the loaded image reference, swap
+   `request.spec.image`, evict + recreate the warm container.
 4. Backends that genuinely can't snapshot (the local-process backend
    today, since there's no isolated filesystem) should return an explicit
    error from both methods rather than silently degrading.
@@ -253,9 +280,8 @@ recent N, or evict by total size.
 
 ### Restore semantics
 
-Restore is a fresh container booted from the restored image, not a
-checkpoint of running processes or in-memory state. Any long-running
-processes the agent had started inside the container are not preserved;
-they would need to be re-launched from the restored filesystem state.
-This is consistent with how a fresh container is brought up for any chat
-turn.
+Restore semantics belong to the format. Restoring `docker-image-tar` boots a
+fresh container from the restored image, so long-running processes are not
+preserved and must be relaunched. Opaque backend references may represent a
+different checkpoint boundary; callers can route them safely but must not
+infer their semantics from the payload bytes.


### PR DESCRIPTION
Instead of a fixed enum of snapshot formats, use a string, so that each provider can perform its own snapshot (including arbitrary trait implementations which are not in the main repo)