### PR TITLE
More explicit copy semantics

### DIFF
--- a/crates/exoharness/src/sandbox_provider/firecracker.rs
+++ b/crates/exoharness/src/sandbox_provider/firecracker.rs
@@ -1988,17 +1988,33 @@ pub(super) fn trusted_host_command(program: &str) -> Result<PathBuf> {
     Ok(executable)
 }
 
-pub(super) fn copy_sparse_reflink(source: &Path, destination: &Path) -> Result<()> {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SparseCopyMode {
+    Full,
+    ReflinkRequired,
+}
+
+impl SparseCopyMode {
+    fn cp_arg(self) -> &'static str {
+        match self {
+            Self::Full => "--reflink=never",
+            Self::ReflinkRequired => "--reflink=always",
+        }
+    }
+}
+
+fn copy_sparse_with_mode(source: &Path, destination: &Path, mode: SparseCopyMode) -> Result<()> {
+    let reflink_mode = mode.cp_arg();
     let executable = trusted_host_command("cp")?;
     let output = Command::new(executable)
-        .args(["--sparse=always", "--reflink=auto", "--"])
+        .args(["--sparse=always", reflink_mode, "--"])
         .arg(source)
         .arg(destination)
         .output()
         .with_context(|| format!("copying {} to {}", source.display(), destination.display()))?;
     if !output.status.success() {
         bail!(
-            "copying {} to {} failed with {}: {}",
+            "copying {} to {} with {reflink_mode} failed with {}: {}",
             source.display(),
             destination.display(),
             output.status,
@@ -2006,6 +2022,14 @@ pub(super) fn copy_sparse_reflink(source: &Path, destination: &Path) -> Result<(
         );
     }
     Ok(())
+}
+
+pub(super) fn copy_sparse_full(source: &Path, destination: &Path) -> Result<()> {
+    copy_sparse_with_mode(source, destination, SparseCopyMode::Full)
+}
+
+fn copy_sparse_reflink(source: &Path, destination: &Path) -> Result<()> {
+    copy_sparse_with_mode(source, destination, SparseCopyMode::ReflinkRequired)
 }
 
 fn binary_version(path: &Path) -> Result<String> {

--- a/crates/exoharness/src/sandbox_provider/firecracker_image.rs
+++ b/crates/exoharness/src/sandbox_provider/firecracker_image.rs
@@ -322,7 +322,10 @@ fn cache_local_image(
     // The shared helper captures both output streams instead of inheriting
     // them. On macOS this code runs inside the Lima bridge process, whose
     // stdout is the length-prefixed protocol.
-    super::firecracker::copy_sparse_reflink(&source, &staged).with_context(|| {
+    // The allow-listed source can live on a different filesystem from the
+    // state root. This is an intentional one-time full copy into the cache,
+    // not a latency-sensitive snapshot/template clone.
+    super::firecracker::copy_sparse_full(&source, &staged).with_context(|| {
         format!(
             "staging local Firecracker image {} into its immutable cache",
             source.display()

--- a/crates/exoharness/src/sandbox_provider/firecracker_tests.rs
+++ b/crates/exoharness/src/sandbox_provider/firecracker_tests.rs
@@ -16,6 +16,12 @@ fn test_runtime() -> FirecrackerRuntimeFingerprint {
 }
 
 #[test]
+fn sparse_copy_modes_never_allow_automatic_reflink_fallback() {
+    assert_eq!(SparseCopyMode::Full.cp_arg(), "--reflink=never");
+    assert_eq!(SparseCopyMode::ReflinkRequired.cp_arg(), "--reflink=always");
+}
+
+#[test]
 fn resource_names_and_addresses_are_distinct() {
     let first = network_config(1);
     let second = network_config(2);

--- a/support/firecracker/README.md
+++ b/support/firecracker/README.md
@@ -235,11 +235,13 @@ interface at all — the control channel is vsock, so exec still works.
 Forking pauses the source VM, snapshots memory and disk, and boots clones with
 their own copy-on-write disk, network namespace, and IP; snapshot templates
 are copied out of the source VM's jail (never shared by hard link) and
-published root-owned and immutable. Every fork snapshots the source at the
-time of that call. The source resumes alongside its clones, which briefly
-share identical userspace state (PRNG pools, session tokens, boot_id), and only
-a VMGenID-capable guest kernel (5.18+) reseeds the kernel CSPRNG on restore.
-Forks are an explicit API call, never guest-triggerable.
+published root-owned and immutable. Snapshot capture and clone creation require
+reflink support in the state-root filesystem and fail rather than silently
+performing a full copy. Every fork snapshots the source at the time of that
+call. The source resumes alongside its clones, which briefly share identical
+userspace state (PRNG pools, session tokens, boot_id), and only a VMGenID-capable
+guest kernel (5.18+) reseeds the kernel CSPRNG on restore. Forks are an explicit
+API call, never guest-triggerable.
 
 ## Limitations and operator responsibilities
 


### PR DESCRIPTION
`cp --refilnk` can silently do a full copy eg if you go from XFS to EXT4