### PR TITLE
Add optional Parallel Search MCP provider

### DIFF
--- a/exo/tools/parallel-search.ts
+++ b/exo/tools/parallel-search.ts
@@ -1,0 +1,140 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { CallToolResultSchema } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+
+import type { WebSearchResult } from "./web-tools";
+
+const ENDPOINT = "https://search.parallel.ai/mcp";
+const MAX_RESPONSE_BYTES = 1_000_000;
+const MAX_SNIPPET_CHARS = 2_500;
+
+const searchPayload = z.object({
+  results: z.array(
+    z.object({
+      url: z.url(),
+      title: z.string().nullish(),
+      excerpts: z.array(z.string()),
+    }),
+  ),
+  warnings: z.array(z.string()).nullish(),
+});
+
+/** Anonymous, explicitly selected search. The SDK owns MCP framing and sessions. */
+export async function searchParallel(
+  query: string,
+  count: number,
+  conversationId: string,
+): Promise<{
+  results: WebSearchResult[];
+  warnings: string[];
+  truncated: boolean;
+}> {
+  // Reject rather than silently accept the service's query truncation.
+  if (query.length > 200) {
+    throw new Error("Parallel search queries must be at most 200 characters");
+  }
+  let deadline = AbortSignal.timeout(12_000);
+  const client = new Client({ name: "exo-parallel-search", version: "1.0.0" });
+  const transport = new StreamableHTTPClientTransport(new URL(ENDPOINT), {
+    // No auth provider, API key, fallback, or automatic stream reconnection.
+    reconnectionOptions: {
+      maxRetries: 0,
+      initialReconnectionDelay: 1_000,
+      maxReconnectionDelay: 1_000,
+      reconnectionDelayGrowFactor: 1,
+    },
+    fetch: async (url, init) => {
+      const response = await fetch(url, {
+        ...init,
+        redirect: "error",
+        signal: AbortSignal.any(
+          init?.signal ? [deadline, init.signal] : [deadline],
+        ),
+      });
+      if (response.body === null) return response;
+      let bytes = 0;
+      // Bound JSON and SSE before the SDK buffers/parses the response.
+      const body = response.body.pipeThrough(
+        new TransformStream<Uint8Array, Uint8Array>({
+          transform(chunk, controller) {
+            bytes += chunk.byteLength;
+            if (bytes > MAX_RESPONSE_BYTES) {
+              throw new Error("Parallel search response exceeded 1 MB");
+            }
+            controller.enqueue(chunk);
+          },
+        }),
+      );
+      return new Response(body, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
+    },
+  });
+
+  try {
+    await client.connect(transport, { signal: deadline });
+    let cursor: string | undefined;
+    do {
+      const page = await client.listTools({ cursor }, { signal: deadline });
+      if (page.tools.some(({ name }) => name === "web_search")) break;
+      cursor = page.nextCursor;
+      if (cursor === undefined) {
+        throw new Error("Parallel MCP did not advertise web_search");
+      }
+    } while (cursor !== undefined);
+
+    const result = CallToolResultSchema.parse(
+      await client.callTool(
+        {
+          name: "web_search",
+          arguments: {
+            objective: query,
+            search_queries: [query],
+            session_id: conversationId,
+          },
+        },
+        undefined,
+        { signal: deadline },
+      ),
+    );
+    if (result.isError) {
+      const detail = result.content
+        .filter((block) => block.type === "text")
+        .map((block) => block.text)
+        .join("\n")
+        .slice(0, 2_000);
+      throw new Error(`Parallel search failed: ${detail}`);
+    }
+    // Choose one representation, never duplicate structured and text content.
+    const payload = searchPayload.parse(
+      result.structuredContent ??
+        JSON.parse(
+          result.content
+            .filter((block) => block.type === "text")
+            .map((block) => block.text)
+            .join("\n"),
+        ),
+    );
+    let truncated = false;
+    const results = payload.results.slice(0, count).map((item) => {
+      const snippet = item.excerpts.join("\n");
+      if (snippet.length > MAX_SNIPPET_CHARS) truncated = true;
+      return {
+        title: item.title ?? "",
+        url: item.url,
+        snippet: snippet.slice(0, MAX_SNIPPET_CHARS),
+      };
+    });
+    return { results, warnings: payload.warnings ?? [], truncated };
+  } finally {
+    // A canceled search must not prevent cleanup or let cleanup hide its result.
+    deadline = AbortSignal.timeout(1_000);
+    if (transport.sessionId !== undefined) {
+      await transport.terminateSession().catch(() => {});
+    }
+    await client.close().catch(() => {});
+  }
+}

--- a/exo/tools/web-tools.test.ts
+++ b/exo/tools/web-tools.test.ts
@@ -1,4 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { randomUUID } from "node:crypto";
+import { createServer } from "node:http";
+
+import { HarnessToolRegistry, type TurnContext } from "@exo/harness";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { resolveExoProfile } from "../profiles";
 
 import {
   decodeEntities,
@@ -241,5 +247,412 @@ describe("decodeEntities", () => {
     expect(decodeEntities("&bogus; &#x110000; &#0;")).toBe(
       "&bogus; &#x110000; &#0;",
     );
+  });
+});
+
+describe("web search provider selection", () => {
+  const nativeFetch = globalThis.fetch;
+  const entries = [
+    {
+      url: "https://example.com/one",
+      title: "One",
+      excerpts: ["first", "second"],
+    },
+    { url: "https://example.com/two", title: null, excerpts: ["third"] },
+  ];
+
+  let now = Date.now();
+  beforeEach(() => {
+    // The existing Brave credential cache lasts one minute; isolate each case.
+    vi.spyOn(Date, "now").mockImplementation(() => now);
+    now += 61_000;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  function context(conversationId = randomUUID()) {
+    return {
+      agentConfig: { enableAgentToolCreation: false },
+      streaming: false,
+      exoharness: {
+        listSecrets: async () => [],
+        current: {
+          conversation: { record: { id: conversationId } },
+          turn: {
+            writeArtifactText: async ({
+              path,
+              text,
+            }: {
+              path: string;
+              text: string;
+            }) => ({
+              artifactId: "artifact",
+              path,
+              version: 1,
+              sizeBytes: text.length,
+            }),
+          },
+        },
+      },
+    } as unknown as TurnContext;
+  }
+
+  async function search(
+    query: string = randomUUID(),
+    count: number | null = null,
+    ctx = context(),
+  ) {
+    const registry = new HarnessToolRegistry(ctx);
+    resolveExoProfile("practical").registerTools(registry, ctx);
+    const [event] = await registry.executePending([
+      {
+        toolCallId: "test-search",
+        request: { functionName: "web_search", arguments: { query, count } },
+      },
+    ]);
+    const result = event.result as { value: Record<string, unknown> };
+    return result.value;
+  }
+
+  function mcp(
+    result: unknown = { content: [], structuredContent: { results: entries } },
+    options: {
+      rpcError?: boolean;
+      status?: number;
+      sse?: boolean;
+      missingTool?: boolean;
+      cleanupFails?: boolean;
+    } = {},
+  ) {
+    vi.stubEnv("EXO_WEB_SEARCH_PROVIDER", "parallel");
+    const requests: { method: string; params?: Record<string, unknown> }[] = [];
+    const mock = vi.fn(async (_url: unknown, init?: RequestInit) => {
+      expect(String(_url)).toBe("https://search.parallel.ai/mcp");
+      expect(init?.redirect).toBe("error");
+      const headers = new Headers(init?.headers);
+      expect(headers.has("authorization")).toBe(false);
+      expect(headers.has("x-api-key")).toBe(false);
+      if (init?.method === "GET") return new Response(null, { status: 405 });
+      if (init?.method === "DELETE") {
+        if (options.cleanupFails) throw new Error("cleanup failed");
+        return new Response(null, { status: 200 });
+      }
+      const request = JSON.parse(String(init?.body));
+      requests.push(request);
+      if (request.method === "notifications/initialized")
+        return new Response(null, { status: 202 });
+      let payload: unknown;
+      if (request.method === "initialize") {
+        payload = {
+          protocolVersion: request.params.protocolVersion,
+          capabilities: { tools: {} },
+          serverInfo: { name: "fixture", version: "1" },
+        };
+      } else if (request.method === "tools/list") {
+        payload = options.missingTool
+          ? { tools: [] }
+          : {
+              tools: [{ name: "web_search", inputSchema: { type: "object" } }],
+            };
+      } else {
+        if (options.status)
+          return new Response("service unavailable", {
+            status: options.status,
+          });
+        payload = result;
+      }
+      const envelope =
+        options.rpcError && request.method === "tools/call"
+          ? {
+              jsonrpc: "2.0",
+              id: request.id,
+              error: { code: -32000, message: "quota reached" },
+            }
+          : { jsonrpc: "2.0", id: request.id, result: payload };
+      const isSse = options.sse && request.method === "tools/call";
+      return new Response(
+        isSse
+          ? `event: message\ndata: ${JSON.stringify(envelope)}\n\n`
+          : JSON.stringify(envelope),
+        {
+          headers: {
+            "content-type": isSse ? "text/event-stream" : "application/json",
+            "mcp-session-id": "fixture-session",
+          },
+        },
+      );
+    });
+    vi.stubGlobal("fetch", mock);
+    return { mock, requests };
+  }
+
+  it("maps search through the practical profile and real MCP SDK without credentials", async () => {
+    vi.stubEnv("BRAVE_API_KEY", "unused-brave-key");
+    vi.stubEnv("PARALLEL_API_KEY", "must-not-be-sent");
+    const { requests } = mcp({
+      content: [{ type: "text", text: "not the structured representation" }],
+      structuredContent: { results: entries, warnings: ["service warning"] },
+    });
+    const ctx = context();
+    const value = await search("public documentation", 1, ctx);
+    expect(value).toMatchObject({
+      ok: true,
+      provider: "parallel",
+      results: [
+        { title: "One", url: entries[0].url, snippet: "first\nsecond" },
+      ],
+      warnings: ["service warning"],
+      truncated: false,
+    });
+    expect(
+      requests.find(({ method }) => method === "tools/call")?.params,
+    ).toEqual({
+      name: "web_search",
+      arguments: {
+        objective: "public documentation",
+        search_queries: ["public documentation"],
+        session_id: ctx.exoharness.current.conversation.record.id,
+      },
+    });
+    expect(requests.map(({ method }) => method)).toContain("tools/list");
+  });
+
+  it("accepts text-only payloads and SDK-parsed SSE", async () => {
+    mcp(
+      {
+        content: [{ type: "text", text: JSON.stringify({ results: entries }) }],
+      },
+      { sse: true },
+    );
+    expect(await search()).toMatchObject({
+      ok: true,
+      results: [{ snippet: "first\nsecond" }, { title: "" }],
+    });
+  });
+
+  it("preserves valid empty results", async () => {
+    mcp({ content: [], structuredContent: { results: [] } });
+    expect(await search()).toMatchObject({ ok: true, results: [] });
+  });
+
+  it.each([
+    [
+      { content: [{ type: "text", text: "rate limited" }], isError: true },
+      {},
+      "rate limited",
+    ],
+    [
+      {
+        content: [],
+        structuredContent: { results: [{ url: "bad", excerpts: [] }] },
+      },
+      {},
+      "Invalid",
+    ],
+    [{ content: [] }, { rpcError: true }, "quota reached"],
+    [{ content: [] }, { status: 503 }, "service unavailable"],
+    [{ content: [] }, { missingTool: true }, "did not advertise"],
+  ])(
+    "returns errors without falling back: %j",
+    async (result, options, error) => {
+      mcp(result, options);
+      expect(await search()).toMatchObject({
+        ok: false,
+        provider: "parallel",
+        error: expect.stringContaining(error),
+      });
+    },
+  );
+
+  it("caps snippets and preserves warnings", async () => {
+    mcp({
+      content: [],
+      structuredContent: {
+        results: [{ ...entries[0], excerpts: ["x".repeat(3_000)] }],
+        warnings: ["partial"],
+      },
+    });
+    expect(await search()).toMatchObject({
+      truncated: true,
+      warnings: ["partial"],
+      results: [{ snippet: "x".repeat(2_500) }],
+    });
+  });
+
+  it("rejects overlong queries before making a request", async () => {
+    const { mock } = mcp();
+    expect(await search("x".repeat(201))).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("200 characters"),
+    });
+    expect(mock).not.toHaveBeenCalled();
+  });
+
+  it("enforces the response byte limit before parsing", async () => {
+    mcp({ content: [{ type: "text", text: "x".repeat(1_000_001) }] });
+    expect(await search()).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("exceeded 1 MB"),
+    });
+  });
+
+  it("keeps conversation metadata stable across turns and distinct across conversations", async () => {
+    const { requests } = mcp();
+    const ctx = context();
+    await search(randomUUID(), 1, ctx);
+    await search(randomUUID(), 1, ctx);
+    await search();
+    const ids = requests
+      .filter(({ method }) => method === "tools/call")
+      .map(
+        ({ params }) =>
+          (params?.arguments as { session_id: string } | undefined)?.session_id,
+      );
+    expect(ids[0]).toBe(ids[1]);
+    expect(ids[2]).not.toBe(ids[0]);
+  });
+
+  it("retains provider-scoped caching and does not repeat an MCP call on a cache hit", async () => {
+    const { requests } = mcp();
+    const query = randomUUID();
+    await search(query);
+    expect(await search(query)).toMatchObject({
+      ok: true,
+      cached: true,
+      provider: "parallel",
+    });
+    expect(
+      requests.filter(({ method }) => method === "tools/call"),
+    ).toHaveLength(1);
+  });
+
+  it("does not let cleanup failure replace a successful result", async () => {
+    mcp(undefined, { cleanupFails: true });
+    expect(await search()).toMatchObject({ ok: true, provider: "parallel" });
+  });
+
+  it("aborts a stalled request at the host deadline", async () => {
+    vi.useFakeTimers();
+    vi.stubEnv("EXO_WEB_SEARCH_PROVIDER", "parallel");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        (_url, init) =>
+          new Promise((_resolve, reject) => {
+            init.signal.addEventListener(
+              "abort",
+              () => reject(init.signal.reason),
+              { once: true },
+            );
+          }),
+      ),
+    );
+    // Node's AbortSignal.timeout uses native timers, so stub only its clock.
+    vi.spyOn(AbortSignal, "timeout").mockImplementation((ms) => {
+      const controller = new AbortController();
+      setTimeout(() => controller.abort(new Error("request deadline")), ms);
+      return controller.signal;
+    });
+    try {
+      const pending = search();
+      await vi.advanceTimersByTimeAsync(12_000);
+      expect(await pending).toMatchObject({
+        ok: false,
+        error: expect.stringContaining("deadline"),
+      });
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+
+  it("rejects redirects without contacting their destination", async () => {
+    let destinationRequests = 0;
+    const destination = createServer((_req, res) => {
+      destinationRequests++;
+      res.end("unexpected");
+    });
+    const redirect = createServer((_req, res) => {
+      const address = destination.address();
+      if (!address || typeof address === "string")
+        throw new Error("missing address");
+      res.writeHead(307, { Location: `http://127.0.0.1:${address.port}` });
+      res.end();
+    });
+    await new Promise<void>((resolve) =>
+      destination.listen(0, "127.0.0.1", resolve),
+    );
+    await new Promise<void>((resolve) =>
+      redirect.listen(0, "127.0.0.1", resolve),
+    );
+    vi.stubEnv("EXO_WEB_SEARCH_PROVIDER", "parallel");
+    vi.stubGlobal("fetch", (_url: unknown, init?: RequestInit) => {
+      const address = redirect.address();
+      if (!address || typeof address === "string")
+        throw new Error("missing address");
+      return nativeFetch(`http://127.0.0.1:${address.port}`, init);
+    });
+    try {
+      expect(await search()).toMatchObject({ ok: false, provider: "parallel" });
+      expect(destinationRequests).toBe(0);
+    } finally {
+      redirect.closeAllConnections();
+      destination.closeAllConnections();
+      await Promise.all(
+        [redirect, destination].map(
+          (server) =>
+            new Promise<void>((resolve) => server.close(() => resolve())),
+        ),
+      );
+    }
+  });
+
+  it.each([
+    [undefined, undefined, "duckduckgo"],
+    [undefined, "brave-key", "brave"],
+    ["duckduckgo", "brave-key", "duckduckgo"],
+    ["brave", "brave-key", "brave"],
+  ])(
+    "preserves existing provider routing: %s / %s",
+    async (forced, key, provider) => {
+      vi.stubEnv("EXO_WEB_SEARCH_PROVIDER", forced ?? "");
+      vi.stubEnv("BRAVE_API_KEY", key ?? "");
+      const mock = vi.fn(async (url: unknown) => {
+        if (provider === "brave") {
+          expect(String(url)).toContain("api.search.brave.com");
+          return Response.json({
+            web: {
+              results: [
+                { title: "Brave", url: entries[0].url, description: "snippet" },
+              ],
+            },
+          });
+        }
+        expect(String(url)).toContain("html.duckduckgo.com");
+        return new Response(
+          `<a class="result__a" href="${entries[0].url}">DuckDuckGo</a>`,
+        );
+      });
+      vi.stubGlobal("fetch", mock);
+      expect(await search()).toMatchObject({ ok: true, provider });
+      expect(mock).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("keeps explicitly selected Brave credential failure without a fallback", async () => {
+    vi.stubEnv("EXO_WEB_SEARCH_PROVIDER", "brave");
+    vi.stubEnv("BRAVE_API_KEY", "");
+    const mock = vi.fn();
+    vi.stubGlobal("fetch", mock);
+    expect(await search()).toMatchObject({
+      ok: false,
+      provider: "brave",
+      error: expect.stringContaining("no Brave key"),
+    });
+    expect(mock).not.toHaveBeenCalled();
   });
 });

--- a/exo/tools/web-tools.ts
+++ b/exo/tools/web-tools.ts
@@ -7,6 +7,8 @@ import { parseHTML } from "linkedom";
 import TurndownService from "turndown";
 import { Agent, fetch as undiciFetch } from "undici";
 
+import { searchParallel } from "./parallel-search";
+
 import type {
   HarnessToolRegistry,
   JsonObject,
@@ -24,7 +26,8 @@ import type {
 // of a Brave key in the exo secret store (`exo secret set brave-api-key ...`)
 // or BRAVE_API_KEY env var.
 //
-// EXO_WEB_SEARCH_PROVIDER=brave|duckduckgo to force a provider.
+// EXO_WEB_SEARCH_PROVIDER=brave|duckduckgo|parallel to force a provider.
+// Parallel is anonymous Search MCP and is never selected automatically.
 
 const BRAVE_SECRET_ID = "brave-api-key";
 
@@ -47,7 +50,7 @@ export type WebSearchResult = {
   snippet: string;
 };
 
-type SearchProvider = "brave" | "duckduckgo";
+type SearchProvider = "brave" | "duckduckgo" | "parallel";
 
 const searchCache = new Map<
   string,
@@ -304,11 +307,11 @@ async function resolveSearchProvider(
 ): Promise<{ provider: SearchProvider; braveKey: string | null } | string> {
   const braveKey = await resolveBraveKey(context);
   const forced = process.env.EXO_WEB_SEARCH_PROVIDER?.trim().toLowerCase();
-  if (forced === "brave" || forced === "duckduckgo") {
+  if (forced === "brave" || forced === "duckduckgo" || forced === "parallel") {
     return { provider: forced, braveKey };
   }
   if (forced !== undefined && forced !== "") {
-    return `unknown EXO_WEB_SEARCH_PROVIDER: ${forced} (use brave or duckduckgo)`;
+    return `unknown EXO_WEB_SEARCH_PROVIDER: ${forced} (use brave, duckduckgo, or parallel)`;
   }
   return { provider: braveKey !== null ? "brave" : "duckduckgo", braveKey };
 }
@@ -596,7 +599,7 @@ function webSearchTool(): ToolInstance {
     definition: {
       name: "web_search",
       description:
-        "Search the web for current information. Uses the Brave Search API when a brave-api-key secret (or BRAVE_API_KEY env) is configured, otherwise key-free DuckDuckGo. Returns normalized results with title, url, and snippet. Results are cached for 15 minutes.",
+        "Search the web for current information. Uses the Brave Search API when a brave-api-key secret (or BRAVE_API_KEY env) is configured, otherwise key-free DuckDuckGo. EXO_WEB_SEARCH_PROVIDER can explicitly select Brave, DuckDuckGo, or anonymous Parallel Search MCP. Parallel queries are limited to 200 characters. Returns normalized results with title, url, and snippet. Results are cached for 15 minutes.",
       parameters: {
         type: "object",
         additionalProperties: false,
@@ -640,11 +643,25 @@ function webSearchTool(): ToolInstance {
           return { ...cached, cached: true };
         }
         let results: WebSearchResult[];
+        let parallelMetadata: JsonObject = {};
         try {
-          results =
-            provider === "brave"
-              ? await searchBrave(query, count, braveKey)
-              : await searchDuckDuckGo(query, count);
+          if (provider === "parallel") {
+            const search = await searchParallel(
+              query,
+              count,
+              execution.context.exoharness.current.conversation.record.id,
+            );
+            results = search.results;
+            parallelMetadata = {
+              warnings: search.warnings,
+              truncated: search.truncated,
+            };
+          } else {
+            results =
+              provider === "brave"
+                ? await searchBrave(query, count, braveKey)
+                : await searchDuckDuckGo(query, count);
+          }
         } catch (error) {
           const message =
             error instanceof Error ? error.message : String(error);
@@ -655,6 +672,7 @@ function webSearchTool(): ToolInstance {
           provider,
           query,
           results: results.map((result) => ({ ...result })),
+          ...parallelMetadata,
         };
         if (results.length === 0 && provider === "duckduckgo") {
           value.note = `No results parsed; DuckDuckGo may be rate limiting or its markup may have changed. Consider configuring a Brave key (exo secret set ${BRAVE_SECRET_ID}).`;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@braintrust/lingua-wasm": "^0.1.0",
     "@cursor/sdk": "^1.0.12",
     "@discordjs/voice": "^0.19.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@mozilla/readability": "^0.6.0",
     "@shadcn/react": "^0.1.0",
     "@whiskeysockets/baileys": "7.0.0-rc13",
@@ -49,7 +50,8 @@
     "sodium-native": "^5.1.0",
     "tailwind-merge": "^3.6.0",
     "turndown": "^7.2.4",
-    "undici": "^8.7.0"
+    "undici": "^8.7.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@discordjs/voice':
         specifier: ^0.19.0
         version: 0.19.2(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(opusscript@0.1.1)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
       '@mozilla/readability':
         specifier: ^0.6.0
         version: 0.6.0
@@ -86,6 +89,9 @@ importers:
       undici:
         specifier: ^8.7.0
         version: 8.7.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.3.1

--- a/website/docs-src/concepts/tools.md
+++ b/website/docs-src/concepts/tools.md
@@ -94,5 +94,39 @@ Code mode, generic adapter command generation, and treating the scheduler as an
 adapter are also deferred. Scheduling continues through the current scheduler
 service.
 
+## Web search providers
+
+The practical profile's `web_search` uses Brave when a `brave-api-key` secret
+or `BRAVE_API_KEY` environment variable is configured, otherwise DuckDuckGo.
+Set `EXO_WEB_SEARCH_PROVIDER` on the host to explicitly select `brave`,
+`duckduckgo`, or `parallel`. For example, start Exo with:
+
+```bash
+EXO_WEB_SEARCH_PROVIDER=parallel ./exo.sh
+```
+
+The `parallel` option uses [Parallel Search MCP](https://docs.parallel.ai/integrations/mcp/search-mcp)
+at `https://search.parallel.ai/mcp` over Streamable HTTP. It needs no Parallel
+account or API key. Free access is rate limited; errors are returned without
+switching providers. Unset the variable to restore automatic Brave/DuckDuckGo
+selection. Restart an already-running executor with the new environment.
+
+Once selected, the agent can call `web_search` during its turns. Each uncached
+call sends its query (also used as the search objective) and conversation ID
+to Parallel from the host, even if sandbox networking is disabled. Do not put
+private information in queries. See Parallel's [terms](https://parallel.ai/customer-terms)
+and [privacy policy](https://parallel.ai/privacy-policy).
+
+Queries can contain up to 200 characters. `count` caps returned results locally
+at 1-10, with a default of 5; it does not control how much Parallel retrieves.
+Results keep their source URLs, titles, and excerpt snippets. Snippets are
+limited to 2,500 characters each, with `truncated` indicating shortening;
+service warnings are preserved. Requests have a 12-second deadline and a 1 MB
+response limit. The existing 15-minute search cache still applies.
+
+This option changes only search. `web_fetch` still fetches pages directly from
+the host with Exo's existing private-address guards; it does not use Parallel.
+The bootstrap profile does not gain web tools.
+
 See [Adapters](./adapters) for the long-running integrations that can wake a
 conversation.


### PR DESCRIPTION
Exo already has web search through Brave and DuckDuckGo. This PR adds a free Parallel option users can try without creating another account or managing an API key. Set `EXO_WEB_SEARCH_PROVIDER=parallel` and keep using the same `web_search` tool.

There's a useful independent comparison behind the choice. In [Artificial Analysis's Search API benchmark](https://artificialanalysis.ai/agents/search-api), checked September 2, Parallel Search (basic) scores **79 vs 62 on DeepSearchQA** and **73 vs 65 on the overall Search Index** compared with Brave Search (web). That's Brave's regular web-search endpoint, which Exo uses, not its separate LLM Context API. AA [keeps the answering agent and settings the same](https://artificialanalysis.ai/methodology/search-api) and swaps the search provider. These are API benchmark results, not measurements of Exo or this free MCP integration. DuckDuckGo isn't in AA's benchmark, so I'm not claiming a measured improvement over it.

The integration uses the official MCP SDK for the connection and maps results into Exo's existing title, URL, and snippet format. The SDK and Zod are already in the lockfile; this makes them direct dependencies without changing their locked versions. Requests have a deadline and response-size limit, and redirects are rejected.

Nothing changes unless you select Parallel. Brave and DuckDuckGo remain available, the current default stays the same, and `web_fetch` still reads pages directly through Exo's existing private-address guards. There is no automatic fallback to Parallel.

Once selected, the agent can send search queries and the conversation ID to Parallel from the host, even when sandbox networking is disabled. Free access is rate limited. The Tools guide explains setup, how to switch back, and what gets sent.

Checked with all 167 tests, lint, typechecking, formatting, the docs build, and workspace Clippy. A live no-key search through Exo's practical profile and tool registry returned two TypeScript documentation results with source URLs. That used a minimal host context for artifact writes, not a full interactive session. No Rust files changed, and Rust tests weren't run locally.

I work at Parallel, which operates this service.
