### PR TITLE
Rename sandbox conversation ID to thread ID

### DIFF
--- a/crates/cli/tests/daytona_backend.rs
+++ b/crates/cli/tests/daytona_backend.rs
@@ -23,10 +23,10 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 
 /// Standard sandbox request used across tests. Conversation-keyed so the label
 /// format matches what the find-by-label query expects to see.
-fn make_request(conversation_id: &str, sandbox_id: &str) -> SandboxRequest {
+fn make_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
         key: SandboxKey::ConversationSandbox {
-            conversation_id: conversation_id.into(),
+            thread_id: thread_id.into(),
             sandbox_id: sandbox_id.into(),
         },
         spec: SandboxSpec {

--- a/crates/cli/tests/e2b_backend.rs
+++ b/crates/cli/tests/e2b_backend.rs
@@ -14,10 +14,10 @@ use serde_json::{Value, json};
 use wiremock::matchers::{method, path};
 use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate};
 
-fn make_request(conversation_id: &str, sandbox_id: &str) -> SandboxRequest {
+fn make_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
         key: SandboxKey::ConversationSandbox {
-            conversation_id: conversation_id.into(),
+            thread_id: thread_id.into(),
             sandbox_id: sandbox_id.into(),
         },
         spec: SandboxSpec {

--- a/crates/cli/tests/e2b_backend.rs
+++ b/crates/cli/tests/e2b_backend.rs
@@ -160,7 +160,7 @@ async fn acquire_reuses_running_sandbox_without_connect() {
         .await
         .expect("acquire should reuse running sandbox");
 
-    assert_eq!(handle.id(), "e2b:conversation:conv-3:sandbox-3");
+    assert_eq!(handle.id(), "e2b:thread:conv-3:sandbox-3");
 
     let requests = server.received_requests().await.unwrap_or_default();
     assert!(
@@ -225,8 +225,8 @@ async fn acquire_list_metadata_query_is_not_double_url_encoded() {
         "metadata filter must not double-encode ':' in sandbox keys; got {query}"
     );
     assert!(
-        query.contains("conversation%3Aconv-colons%3Asandbox-colons")
-            || query.contains("conversation:conv-colons:sandbox-colons"),
+        query.contains("thread%3Aconv-colons%3Asandbox-colons")
+            || query.contains("thread:conv-colons:sandbox-colons"),
         "expected sandbox key in metadata query; got {query}"
     );
     assert!(

--- a/crates/cli/tests/sandbox_start_process_live.rs
+++ b/crates/cli/tests/sandbox_start_process_live.rs
@@ -33,10 +33,10 @@ fn live_provider_secret(provider: &str, secret_name: &str) -> Option<String> {
     }
 }
 
-fn make_e2b_request(conversation_id: &str, sandbox_id: &str) -> SandboxRequest {
+fn make_e2b_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
         key: SandboxKey::ConversationSandbox {
-            conversation_id: conversation_id.into(),
+            thread_id: thread_id.into(),
             sandbox_id: sandbox_id.into(),
         },
         spec: SandboxSpec {
@@ -83,10 +83,10 @@ fn sprites_config_from_env() -> Option<SpritesConfig> {
     })
 }
 
-fn make_sprites_request(conversation_id: &str, sandbox_id: &str) -> SandboxRequest {
+fn make_sprites_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
         key: SandboxKey::ConversationSandbox {
-            conversation_id: conversation_id.into(),
+            thread_id: thread_id.into(),
             sandbox_id: sandbox_id.into(),
         },
         spec: SandboxSpec {

--- a/crates/cli/tests/sprites_backend.rs
+++ b/crates/cli/tests/sprites_backend.rs
@@ -15,10 +15,10 @@ use serde_json::{Value, json};
 use wiremock::matchers::{method, path, path_regex};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-fn make_request(conversation_id: &str, sandbox_id: &str) -> SandboxRequest {
+fn make_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
         key: SandboxKey::ConversationSandbox {
-            conversation_id: conversation_id.into(),
+            thread_id: thread_id.into(),
             sandbox_id: sandbox_id.into(),
         },
         spec: SandboxSpec {

--- a/crates/cli/tests/sprites_backend.rs
+++ b/crates/cli/tests/sprites_backend.rs
@@ -99,7 +99,7 @@ async fn acquire_creates_sprite_when_missing() {
         .await;
 
     let handle = backend.acquire(request).await.expect("acquire");
-    assert_eq!(handle.id(), "sprites:conversation:conv-1:sandbox-1");
+    assert_eq!(handle.id(), "sprites:thread:conv-1:sandbox-1");
 }
 
 #[tokio::test]
@@ -135,7 +135,7 @@ async fn acquire_create_includes_exo_metadata_labels() {
         .and_then(Value::as_array)
         .expect("labels array");
     assert!(labels.iter().any(|label| {
-        label.as_str() == Some("exo.sandbox.key=conversation:conv-labels:sandbox-labels")
+        label.as_str() == Some("exo.sandbox.key=thread:conv-labels:sandbox-labels")
     }));
     assert!(
         labels
@@ -241,7 +241,7 @@ async fn acquire_reuses_existing_sprite_without_create() {
         .acquire(request)
         .await
         .expect("acquire should reuse existing sprite");
-    assert_eq!(handle.id(), "sprites:conversation:conv-3:sandbox-3");
+    assert_eq!(handle.id(), "sprites:thread:conv-3:sandbox-3");
 
     let requests = server.received_requests().await.unwrap_or_default();
     assert!(

--- a/crates/cli/tests/vercel_backend.rs
+++ b/crates/cli/tests/vercel_backend.rs
@@ -13,10 +13,10 @@ use serde_json::{Value, json};
 use wiremock::matchers::{method, path, path_regex, query_param};
 use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 
-fn make_request(conversation_id: &str, sandbox_id: &str) -> SandboxRequest {
+fn make_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
         key: SandboxKey::ConversationSandbox {
-            conversation_id: conversation_id.into(),
+            thread_id: thread_id.into(),
             sandbox_id: sandbox_id.into(),
         },
         spec: SandboxSpec {

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -4420,8 +4420,8 @@ fn sandbox_request(
                 agent_id: agent_id.to_string(),
                 sandbox_id: sandbox_id.to_string(),
             },
-            SandboxOwner::Conversation(conversation_id) => SandboxKey::ConversationSandbox {
-                conversation_id: conversation_id.to_string(),
+            SandboxOwner::Conversation(thread_id) => SandboxKey::ConversationSandbox {
+                thread_id: thread_id.to_string(),
                 sandbox_id: sandbox_id.to_string(),
             },
         },

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -670,7 +670,7 @@ async fn local_process_contract_handle(
     backend
         .acquire(SandboxRequest {
             key: SandboxKey::ConversationSandbox {
-                conversation_id: Uuid7::now().to_string(),
+                thread_id: Uuid7::now().to_string(),
                 sandbox_id: sandbox_id.to_string(),
             },
             spec: SandboxSpec {
@@ -871,7 +871,7 @@ fn provider_contract_request(
 ) -> SandboxRequest {
     SandboxRequest {
         key: SandboxKey::ConversationSandbox {
-            conversation_id: Uuid7::now().to_string(),
+            thread_id: Uuid7::now().to_string(),
             sandbox_id: format!("{provider}-{contract}-contract"),
         },
         spec: SandboxSpec {

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -31,7 +31,8 @@ pub enum SandboxKey {
         sandbox_id: String,
     },
     ConversationSandbox {
-        conversation_id: String,
+        #[serde(alias = "conversation_id")]
+        thread_id: String,
         sandbox_id: String,
     },
 }
@@ -44,9 +45,9 @@ impl fmt::Display for SandboxKey {
                 sandbox_id,
             } => write!(f, "agent:{agent_id}:{sandbox_id}"),
             Self::ConversationSandbox {
-                conversation_id,
+                thread_id,
                 sandbox_id,
-            } => write!(f, "conversation:{conversation_id}:{sandbox_id}"),
+            } => write!(f, "thread:{thread_id}:{sandbox_id}"),
         }
     }
 }
@@ -2280,6 +2281,35 @@ mod tests {
     use super::*;
 
     #[test]
+    fn conversation_sandbox_key_uses_thread_id_and_reads_conversation_id() {
+        let key = SandboxKey::ConversationSandbox {
+            thread_id: "thread-1".to_string(),
+            sandbox_id: "sandbox-1".to_string(),
+        };
+
+        assert_eq!(
+            serde_json::to_value(&key).unwrap(),
+            serde_json::json!({
+                "ConversationSandbox": {
+                    "thread_id": "thread-1",
+                    "sandbox_id": "sandbox-1"
+                }
+            })
+        );
+        assert_eq!(
+            serde_json::from_value::<SandboxKey>(serde_json::json!({
+                "ConversationSandbox": {
+                    "conversation_id": "thread-1",
+                    "sandbox_id": "sandbox-1"
+                }
+            }))
+            .unwrap(),
+            key
+        );
+        assert_eq!(key.to_string(), "thread:thread-1:sandbox-1");
+    }
+
+    #[test]
     fn apple_container_list_item_reads_current_status_shape() {
         let container: ContainerListItem = serde_json::from_value(serde_json::json!({
             "configuration": {
@@ -2391,7 +2421,7 @@ mod tests {
 
         let request = SandboxRequest {
             key: SandboxKey::ConversationSandbox {
-                conversation_id: "conversation".to_string(),
+                thread_id: "thread".to_string(),
                 sandbox_id: "sandbox".to_string(),
             },
             spec: SandboxSpec {
@@ -2468,7 +2498,7 @@ mod tests {
         };
         let request = SandboxRequest {
             key: SandboxKey::ConversationSandbox {
-                conversation_id: "conversation".to_string(),
+                thread_id: "thread".to_string(),
                 sandbox_id: "sandbox".to_string(),
             },
             spec: SandboxSpec {
@@ -2561,7 +2591,7 @@ esac
         };
         let request = SandboxRequest {
             key: SandboxKey::ConversationSandbox {
-                conversation_id: "conversation".to_string(),
+                thread_id: "thread".to_string(),
                 sandbox_id: "sandbox".to_string(),
             },
             spec: SandboxSpec {
@@ -2673,7 +2703,7 @@ esac
         };
         let request = SandboxRequest {
             key: SandboxKey::ConversationSandbox {
-                conversation_id: "conversation".to_string(),
+                thread_id: "thread".to_string(),
                 sandbox_id: "sandbox".to_string(),
             },
             spec: SandboxSpec {

--- a/crates/exoharness/src/sandbox_provider/aws_agentcore.rs
+++ b/crates/exoharness/src/sandbox_provider/aws_agentcore.rs
@@ -555,11 +555,12 @@ mod tests {
     fn durable_request(mount_path: &str, mode: FileSystemMountMode) -> SandboxRequest {
         SandboxRequest {
             key: SandboxKey::ConversationSandbox {
-                conversation_id: "conversation".to_string(),
+                thread_id: "thread".to_string(),
                 sandbox_id: "sandbox".to_string(),
             },
             spec: SandboxSpec {
                 image: "agentcore".to_string(),
+                resources: Default::default(),
                 mounts: Vec::new(),
                 durable_file_systems: vec![DurableFileSystem {
                     name: "workspace".to_string(),

--- a/crates/exoharness/src/sandbox_provider/smolvm.rs
+++ b/crates/exoharness/src/sandbox_provider/smolvm.rs
@@ -1142,7 +1142,7 @@ mod tests {
             sandbox_id: "sandbox-1".into(),
         };
         let b = SandboxKey::ConversationSandbox {
-            conversation_id: "agent-1".into(),
+            thread_id: "agent-1".into(),
             sandbox_id: "sandbox-1".into(),
         };
         assert_eq!(machine_name(&a), machine_name(&a));


### PR DESCRIPTION
## Summary
- rename the conversation-scoped SandboxKey field to thread_id
- serialize the canonical thread_id field while accepting legacy conversation_id payloads
- use the thread: prefix for newly derived sandbox keys
- update Exoharness and CLI test request construction

## Validation
- cargo fmt --all -- --check
- cargo test -p exoharness --features basic-backend --lib
- cargo check -p exoharness --all-features --all-targets
- cargo check -p exo --tests
- repository pre-commit and pre-push checks