### PR TITLE
exo.sh: fix startup prompt crash under bash 3.2

### DIFF
--- a/exo.sh
+++ b/exo.sh
@@ -1041,10 +1041,14 @@ send_startup_prompt() {
     return
   fi
 
+  # bash 3.2, which macOS ships as /bin/bash, rejects "${array[@]}" for an
+  # empty array under `set -u`, and --template minimal adds no adapter.
   local adapter
-  for adapter in "${SETUP_ADAPTERS[@]}"; do
-    send_adapter_setup_prompt "$adapter"
-  done
+  if [[ "${#SETUP_ADAPTERS[@]}" -gt 0 ]]; then
+    for adapter in "${SETUP_ADAPTERS[@]}"; do
+      send_adapter_setup_prompt "$adapter"
+    done
+  fi
 
   if [[ -n "$INITIAL_PROMPT_FILE" ]]; then
     send_prompt_from_files "$(startup_prompt_file "$INITIAL_PROMPT_FILE")"


### PR DESCRIPTION
## Problem

macOS ships bash 3.2 as `/bin/bash`. On a machine with no newer bash on `PATH`, the `#!/usr/bin/env bash` line in `exo.sh` resolves to it. Under `set -u`, bash 3.2 rejects `"${array[@]}"` when the array is empty:

```
$ /bin/bash --version
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin25)
$ /bin/bash -c 'set -euo pipefail; declare -a A=(); for x in "${A[@]}"; do :; done'
/bin/bash: A[@]: unbound variable
```

`send_startup_prompt` loops over `SETUP_ADAPTERS`. Its early return only fires when `SETUP_ADAPTERS` is empty *and* `INITIAL_PROMPT_FILE` is unset. So `--template minimal --initial-prompt-file <file>` reaches the loop with an empty array and the launch dies before the prompt is sent.

`--template minimal` is the only template that adds no adapter, which is why this stayed hidden.

## Reproduction

This runs `send_startup_prompt` exactly as extracted from `exo.sh`, with `SETUP_ADAPTERS` empty and a prompt file set, under `/bin/bash` 3.2:

```bash
start=$(awk '/^send_startup_prompt\(\) \{$/ { print NR; exit }' exo.sh)
end=$(awk -v s="$start" 'NR >= s && /^\}$/ { print NR; exit }' exo.sh)
body=$(sed -n "${start},${end}p" exo.sh)
prompt=$(mktemp) && echo hello >"$prompt"
/bin/bash -c '
set -euo pipefail
declare -a SETUP_ADAPTERS=()
INITIAL_PROMPT_FILE="'"$prompt"'"
send_adapter_setup_prompt() { echo "would send setup prompt for $1"; }
startup_prompt_file() { printf "%s\n" "$1"; }
send_prompt_from_files() { echo "would send initial prompt from $1"; }
'"$body"'
send_startup_prompt
echo "send_startup_prompt returned 0"
'
```

Before this change:

```
/bin/bash: line 7: SETUP_ADAPTERS[@]: unbound variable
exit status: 1
```

After:

```
would send initial prompt from /var/folders/.../tmp.jlsLJvpLhY
send_startup_prompt returned 0
exit status: 0
```

## Fix

Skip the loop when the array is empty. `${#array[@]}` is safe on an empty array in bash 3.2, and the file already uses that shape in `setup_requested`, whose own `SETUP_ADAPTERS` expansion sits behind a count check and was never affected.

## Test plan

- [x] `/bin/bash -n exo.sh`
- [x] Reproduction above fails on `main` and passes on this branch
- [x] Same harness with `SETUP_ADAPTERS=(exochat irc)` still sends both setup prompts, before and after
