### PR TITLE
scripts: read exo state from the checkout, not the cwd

### DIFF
--- a/exo.sh
+++ b/exo.sh
@@ -359,7 +359,10 @@ scheduler_source_newer_than() {
 }
 
 append_exo_global_args() {
-  EXO_GLOBAL_ARGS=(--env-file-if-exists "$ENV_FILE")
+  # --root defaults to the relative path .exo, so without this the state root
+  # follows the caller's working directory while every pid, lock, and log
+  # path below resolves under $ROOT_DIR.
+  EXO_GLOBAL_ARGS=(--root "$ROOT_DIR/.exo" --env-file-if-exists "$ENV_FILE")
 }
 
 exo() {
@@ -469,7 +472,7 @@ ensure_scheduler() {
   log_file="$(scheduler_log_file)"
   echo "Starting scheduler loop..."
   rm -f "$(scheduler_lock_file)"
-  local scheduler_args=(--env-file-if-exists "$ENV_FILE")
+  local scheduler_args=(--root "$ROOT_DIR/.exo" --env-file-if-exists "$ENV_FILE")
   nohup "$SCHEDULER_BIN" "${scheduler_args[@]}" run --watch \
     --interval-seconds "$SCHEDULER_INTERVAL_SECONDS" >>"$log_file" 2>&1 &
   echo "$!" >"$pid_file"

--- a/exo/scripts/exo-cli
+++ b/exo/scripts/exo-cli
@@ -33,7 +33,9 @@ die() {
 }
 
 exo() {
-  "$EXO_BIN" --env-file-if-exists "$ENV_FILE" "$@"
+  # The CLI resolves --root relative to the working directory, and exo-cli is
+  # meant to run from any repo, so point it at the checkout's state.
+  "$EXO_BIN" --root "$ROOT_DIR/.exo" --env-file-if-exists "$ENV_FILE" "$@"
 }
 
 adapter_runner_running() {

--- a/exo/scripts/exo-service-guardian
+++ b/exo/scripts/exo-service-guardian
@@ -209,7 +209,9 @@ pid_running() {
 }
 
 exo_global_args() {
-  printf '%s\0' --env-file-if-exists "$ENV_FILE"
+  # --root defaults to the relative path .exo, and the guardian is started
+  # from wherever the caller happens to be, so pin it to STATE_DIR.
+  printf '%s\0' --root "$STATE_DIR" --env-file-if-exists "$ENV_FILE"
 }
 
 read_exo_global_args() {
@@ -243,7 +245,7 @@ start_scheduler() {
   fi
   rm -f "$(scheduler_lock_file)" "$(scheduler_restart_file)"
   echo "Starting scheduler..."
-  local scheduler_args=(--env-file-if-exists "$ENV_FILE")
+  local scheduler_args=(--root "$STATE_DIR" --env-file-if-exists "$ENV_FILE")
   nohup "$SCHEDULER_BIN" "${scheduler_args[@]}" run --watch \
     --interval-seconds "$SCHEDULER_INTERVAL_SECONDS" >>"$log_file" 2>&1 &
   echo "$!" >"$pid_file"


### PR DESCRIPTION
## Problem

The exo CLI and the scheduler runner both default `--root` to the relative path `.exo`, so the state root follows the process working directory. None of `exo.sh`, `exo/scripts/exo-cli`, or `exo/scripts/exo-service-guardian` passes `--root`, while all three resolve every pid, lock, log, and env path under their own `$ROOT_DIR`. Started from any directory other than the checkout, the two disagree.

`exo-cli` is the clearest case, because its header says to symlink it onto your `PATH` and run it from any repository:

```
$ cd /private/var/tmp/exo-work/otherrepo
$ exo-cli "hi"
exo-cli: agent-cli adapter is not listening on /Users/me/.exo/agent-cli.sock
exo-cli: agent-cli adapter not running; bootstrapping it now...
exo-cli: mounting /private/var/tmp/exo-work/otherrepo at /agent-cli in the agent sandbox...
Error: agent not found: exo-agent
```

`exo.sh` has the same defect:

```
$ cd /private/var/tmp/exo-work/otherrepo && /path/to/exo/exo.sh list
Agents and conversations:
  none
$ cd /path/to/exo && ./exo.sh list
Agents and conversations:

exo-agent - Exo Agent
  dev - Dev
```

It then creates an empty `.exo` in the caller's directory, starts the scheduler and adapter runner against it, and opens a REPL on an agent that holds none of the user's conversation state. The guardian inherits whatever directory it was started from and restarts those same services later.

## Fix

Pass `--root` explicitly in all three scripts, for the CLI and for the scheduler runner. `exo.sh` and `exo-cli` use `$ROOT_DIR/.exo`; the guardian already computes `STATE_DIR` for exactly this purpose.

`exo-cli` pins only `--root`, not its working directory, so relative path arguments still resolve against the caller's cwd. The node client in `run_client` is untouched and still reports the caller's real cwd, which is what the adapter maps into the sandbox mount.

## Reproduction after the change

```
$ cd /private/var/tmp/exo-work/otherrepo && /path/to/exo/exo.sh list
Agents and conversations:

exo-agent - Exo Agent
  dev - Dev
$ exo-cli "hi"
exo-cli: agent-cli adapter not running; bootstrapping it now...
exo-cli: mounting /private/var/tmp/exo-work/otherrepo at /agent-cli in the agent sandbox...
exo-cli: asking the agent to create the agent-cli adapter...
```

The mount lands on the agent in the checkout's state, and the run continues to the setup send. In the scratch checkout used here it stops at an unregistered model, which is unrelated to the state root.

## Test plan

- [x] `/bin/bash -n exo.sh exo/scripts/exo-cli exo/scripts/exo-service-guardian`
- [x] `./exo.sh list` from outside the checkout, before and after
- [x] `exo-cli` bootstrap from outside the checkout, before and after
- [x] `./exo.sh list` and `exo-cli` from inside the checkout still behave the same
