### PR TITLE
exo.sh: reuse the logged ExoChat URL when the runner is up

### DIFF
--- a/exo.sh
+++ b/exo.sh
@@ -39,6 +39,8 @@ USE_SANDBOX=true
 PULL_SANDBOX=false
 START_SCHEDULER="${EXO_START_SCHEDULER:-true}"
 START_ADAPTERS="${EXO_START_ADAPTERS:-true}"
+# Set by ensure_adapters when it reuses an adapter runner started earlier.
+ADAPTERS_ALREADY_RUNNING=false
 ADAPTER_LIMIT="${EXO_ADAPTER_LIMIT:-50}"
 CONTROL=false
 SETUP_PROFILE=false
@@ -481,6 +483,7 @@ ensure_adapters() {
     return
   fi
   if adapters_process_running; then
+    ADAPTERS_ALREADY_RUNNING=true
     return
   fi
 
@@ -1147,6 +1150,12 @@ show_exochat_url_if_needed() {
   fi
 
   local start_line="${1:-0}"
+  # A runner we did not start printed its URL during an earlier launch and
+  # will not print it again, so take the last URL already in the log instead
+  # of waiting 30 seconds for a line that never comes.
+  if [[ "$ADAPTERS_ALREADY_RUNNING" == true ]]; then
+    start_line=0
+  fi
   local log_file
   log_file="$(adapters_log_file)"
   echo "Waiting for ExoChat URL in $log_file..."
@@ -1161,8 +1170,13 @@ show_exochat_url_if_needed() {
           next
         }
         capture && /^https?:\/\// {
-          print
-          exit
+          url = $0
+          capture = 0
+        }
+        END {
+          if (url != "") {
+            print url
+          }
         }
       ' "$log_file")"
       if [[ -n "$url" ]]; then


### PR DESCRIPTION
## Problem

`show_exochat_url_if_needed` only looks at adapter log lines written after the current launch started, then polls once a second for 30 seconds. That is right when `exo.sh` starts the adapter runner, because the exochat worker prints its URL on startup.

It is wrong when `ensure_adapters` finds the runner from an earlier launch still alive and returns without restarting it. No worker starts, so no new URL is printed. Every relaunch of the canonical template waits the full 30 seconds and then prints:

```
Waiting for ExoChat URL in /path/to/exo/.exo/exo-adapters.log...
No ExoChat URL found yet. Watch the adapter log with: tail -f /path/to/exo/.exo/exo-adapters.log
```

The URL was in that log the whole time. The exochat worker persists its channel and secret in `session.json` under the adapter state dir, so the URL it printed on an earlier launch is still the current one.

## Fix

Record in `ensure_adapters` when it reused a live runner. In that case read the last ExoChat URL already in the log instead of waiting for a new one.

The awk block now keeps the last match rather than the first, so a fresh runner that appends a new URL below an older adapter's URL still shows the new one.

## Reproduction

Runs `show_exochat_url_if_needed` as extracted from `exo.sh` against a log that already holds a URL, with `start_line` set to the current line count the way `run_repl` passes it. Case A is a relaunch with a reused runner. Case B is a fresh runner that appends a new URL after 2 seconds, below an older adapter's URL.

Before this change:

```
=== A relaunch, runner reused (ADAPTERS_ALREADY_RUNNING=true, start_line=4) ===
Waiting for ExoChat URL in .../exo-adapters.log...
No ExoChat URL found yet. Watch the adapter log with: tail -f .../exo-adapters.log
--- elapsed: 30s

=== B fresh runner, new URL appended after 2s (start_line=4) ===
Open this ExoChat URL in a browser or on your phone:
https://exochat.example/c/new-adapter-url
--- elapsed: 2s
```

After:

```
=== A relaunch, runner reused (ADAPTERS_ALREADY_RUNNING=true, start_line=4) ===
Open this ExoChat URL in a browser or on your phone:
https://exochat.example/c/old-adapter-url
--- elapsed: 0s

=== B fresh runner, new URL appended after 2s (start_line=4) ===
Open this ExoChat URL in a browser or on your phone:
https://exochat.example/c/new-adapter-url
--- elapsed: 2s
```

The full harness is 60 lines of bash and I can attach it if that is useful.

## Notes

`show_signal_qr_if_needed` keeps its `start_line` window. A Signal linking QR is single use, so reusing an old one from the log would be wrong.

This touches `show_exochat_url_if_needed`, which #182 also edits. The hunks are different, mine changes `start_line` and the awk block while #182 changes the printed copy, so either order should merge with at most a trivial conflict.

## Test plan

- [x] `/bin/bash -n exo.sh`
- [x] Reproduction above, both cases, before and after
