### PR TITLE
exo.sh: skip the setup prompt for a configured adapter

### DIFF
--- a/exo.sh
+++ b/exo.sh
@@ -1051,8 +1051,20 @@ send_startup_prompt() {
   fi
 }
 
+adapter_configured() {
+  # `exo adapters list` prints one row per adapter with the name last. It
+  # covers every conversation in this checkout, which is fine because exo.sh
+  # drives one; a name it cannot match just falls through to the prompt.
+  exo adapters list 2>/dev/null |
+    awk -v name="$1" 'NR > 1 && $NF == name { found = 1 } END { exit !found }'
+}
+
 send_adapter_setup_prompt() {
   local adapter="$1"
+  if adapter_configured "$adapter"; then
+    echo "Adapter $adapter is already configured; skipping its setup prompt."
+    return
+  fi
   local file prompt
   file="$(adapter_setup_prompt_file "$adapter")"
   prompt="$(<"$file")"


### PR DESCRIPTION
## Problem

`send_startup_prompt` sends each `--setup` adapter's setup prompt on every launch. The prompts already tell the agent to create the adapter only if one does not exist, for example `exo/adapters/exochat/setup-prompt.md`:

> Create a library ExoChat adapter if one does not already exist for this conversation

So on every launch after the first, the turn confirms an existing adapter and reports its id. That is one model call per `--setup` adapter per launch, plus one more message in the conversation.

## Fix

Look in the adapter store first and skip the prompt when an adapter with that name is registered. The names the setup prompts assign are the same names `exo.sh` passes to `--setup`, so a lookup by name is enough.

`exo adapters list` prints the name last on each row, and the check is an exact match on that field. If the lookup finds nothing, for any reason, including the CLI failing, the prompt is sent exactly as before.

The lookup covers every conversation in the checkout, because `exo adapters list` has no conversation filter. `exo.sh` drives one agent and conversation per checkout, so this only matters if a second conversation registers an adapter under the same name.

## Reproduction

The checkout's `.exo` holds an exochat adapter and no irc adapter. `exo` is wrapped to log each call and forward to the real binary, because `conversation send` starts a model turn.

Before this change, both adapters get a send:

```
=== send_adapter_setup_prompt exochat ===
Sending startup prompt from: .../setup-prompt.md
EXO CALL: exo conversation send <prompt>

=== send_adapter_setup_prompt irc ===
Sending startup prompt from: .../setup-prompt.md
EXO CALL: exo conversation send <prompt>
```

After, the configured adapter is skipped and the missing one still gets its prompt:

```
=== send_adapter_setup_prompt exochat ===
Adapter exochat is already configured; skipping its setup prompt.

=== send_adapter_setup_prompt irc ===
Sending startup prompt from: .../setup-prompt.md
EXO CALL: exo conversation send <prompt>
```

## Notes

Related to #183, which asks for less launch noise.

If you would rather not parse `exo adapters list` from shell, the alternative is a filter flag or a JSON output mode on that command. That is a larger change and I did not want to add CLI surface for this.

## Test plan

- [x] `/bin/bash -n exo.sh`
- [x] Reproduction above, both adapters, before and after
