### PR TITLE
model-runtime: send parallel tool calls as one assistant message

### DIFF
--- a/exoharness/typescript/model-runtime/responses.test.ts
+++ b/exoharness/typescript/model-runtime/responses.test.ts
@@ -6,6 +6,7 @@ import {
   ChatCompletionsRuntime,
   isAnthropicModel,
   isOpenRouterBinding,
+  messagesToChatMessages,
   modelRequiresResponsesApi,
   responseToLinguaEvents,
   responseToolCalls,
@@ -148,5 +149,97 @@ describe("response tool-call parsing", () => {
         error: expect.stringContaining("Invalid JSON arguments for shell"),
       },
     });
+  });
+});
+
+describe("chat-completions history replay", () => {
+  // A model that answers with text and two tool calls at once produces one
+  // reply, but the conversation stores it as three assistant messages. Sent
+  // through as three, the provider rejects the whole request because the
+  // result for the first call no longer follows that call.
+  it("replays parallel tool calls as the single reply the model made", () => {
+    const chatMessages = messagesToChatMessages([
+      { role: "assistant", content: [{ type: "text", text: "checking" }] },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_call",
+            tool_call_id: "call_a",
+            tool_name: "search_memory",
+            arguments: { query: "exo" },
+          },
+        ],
+      },
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "tool_call",
+            tool_call_id: "call_b",
+            tool_name: "shell",
+            arguments: { command: "ls" },
+          },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          { type: "tool_result", tool_call_id: "call_a", output: "ok" },
+        ],
+      },
+      {
+        role: "tool",
+        content: [
+          { type: "tool_result", tool_call_id: "call_b", output: "ok" },
+        ],
+      },
+    ]);
+
+    expect(chatMessages.map((message) => message.role)).toEqual([
+      "assistant",
+      "tool",
+      "tool",
+    ]);
+    const [assistant] = chatMessages;
+    expect(assistant.role === "assistant" && assistant.content).toBe(
+      "checking",
+    );
+    expect(
+      assistant.role === "assistant" &&
+        assistant.tool_calls?.map((call) => call.id),
+    ).toEqual(["call_a", "call_b"]);
+  });
+
+  it("keeps separate tool-calling rounds separate", () => {
+    const round = (id: string) => [
+      {
+        role: "assistant" as const,
+        content: [
+          {
+            type: "tool_call",
+            tool_call_id: id,
+            tool_name: "shell",
+            arguments: { command: "ls" },
+          },
+        ],
+      },
+      {
+        role: "tool" as const,
+        content: [{ type: "tool_result", tool_call_id: id, output: "ok" }],
+      },
+    ];
+
+    const chatMessages = messagesToChatMessages([
+      ...round("call_a"),
+      ...round("call_b"),
+    ]);
+
+    expect(chatMessages.map((message) => message.role)).toEqual([
+      "assistant",
+      "tool",
+      "assistant",
+      "tool",
+    ]);
   });
 });

--- a/exoharness/typescript/model-runtime/responses.ts
+++ b/exoharness/typescript/model-runtime/responses.ts
@@ -42,6 +42,7 @@ import type {
   ChatCompletionChunk,
   ChatCompletionCreateParamsNonStreaming,
   ChatCompletionCreateParamsStreaming,
+  ChatCompletionAssistantMessageParam,
   ChatCompletionMessageParam,
   ChatCompletionMessageToolCall,
   ChatCompletionTool,
@@ -853,10 +854,47 @@ function buildChatStreamingBody(
   };
 }
 
-function messagesToChatMessages(
+export function messagesToChatMessages(
   messages: Message[],
 ): ChatCompletionMessageParam[] {
-  return messages.map(messageToChatMessage);
+  return coalesceAssistantMessages(messages.map(messageToChatMessage));
+}
+
+// One model reply that calls several tools at once is stored as several
+// assistant messages — the text in one, each tool call in another. Mapped 1:1
+// that reaches the provider as assistant([A]), assistant([B]), tool(A),
+// tool(B), and the provider rejects the whole request: the result for A does
+// not follow the call to A. Consecutive assistant messages can only ever be
+// one reply that was split apart — nothing else may sit between an assistant
+// message and the next one — so put them back together.
+function coalesceAssistantMessages(
+  messages: ChatCompletionMessageParam[],
+): ChatCompletionMessageParam[] {
+  const coalesced: ChatCompletionMessageParam[] = [];
+  for (const message of messages) {
+    const previous = coalesced[coalesced.length - 1];
+    if (message.role !== "assistant" || previous?.role !== "assistant") {
+      coalesced.push(message);
+      continue;
+    }
+    coalesced[coalesced.length - 1] = mergeAssistantMessages(previous, message);
+  }
+  return coalesced;
+}
+
+function mergeAssistantMessages(
+  first: ChatCompletionAssistantMessageParam,
+  second: ChatCompletionAssistantMessageParam,
+): ChatCompletionAssistantMessageParam {
+  const toolCalls = [...(first.tool_calls ?? []), ...(second.tool_calls ?? [])];
+  const text = [first.content, second.content]
+    .filter((content): content is string => typeof content === "string")
+    .join("");
+  return {
+    role: "assistant",
+    content: text === "" ? null : text,
+    tool_calls: toolCalls.length === 0 ? undefined : toolCalls,
+  };
 }
 
 function messageToChatMessage(message: Message): ChatCompletionMessageParam {


### PR DESCRIPTION
## The problem

When a model answers with several tool calls at once, that single reply is stored as several assistant messages — the text in one, each tool call in another. `messagesToChatMessages` maps them 1:1, so the request goes out as:

```
assistant(text)
assistant(tool_calls=[A])
assistant(tool_calls=[B])
tool(A)
tool(B)
```

The call to B interrupts A before A's result arrives, which is not a valid chat-completions history. A provider that enforces the ordering rejects the whole request:

```
400 invalid params, tool call result does not follow tool call
```

The failure mode is worse than one bad turn. The malformed pair lands in the conversation history, so it is replayed on every subsequent request — once an agent makes one parallel tool call, every later turn in that conversation fails the same way, with no assistant output at all. It looks like the agent has gone silent rather than like a request error.

I hit this on a long-running agent: it stopped replying entirely, and the size-shaped symptoms sent me looking at the prompt budget first. The events showed both `tool_requested` records carrying the same turn id and the same millisecond timestamp — one reply, split in storage.

## The fix

Coalesce consecutive assistant messages just before they go on the wire, merging text and concatenating `tool_calls`. Nothing may legally sit between an assistant message and the next one, so consecutive assistant messages can only ever be one reply that was split apart — merging them is safe by construction, and separate tool-calling rounds (which always have a `tool` message between them) are untouched.

## Verification

- Replayed the fix over the rejected request bodies I had captured on disk: 8 bodies, 2–10 malformed positions each, all going to 0. Bodies rejected for other reasons (quota) had 0 before and after.
- Two tests: the parallel-call shape, and separate rounds staying separate. The first fails without the fix.
- `pnpm check` clean.

`messagesToChatMessages` is exported so the tests can drive it directly, matching the other internals this module already exports for its tests.
