### PR TITLE
cli: let /teleport take the provider names --provider advertises

### DIFF
--- a/crates/cli/src/tui.rs
+++ b/crates/cli/src/tui.rs
@@ -24,11 +24,30 @@ use crate::render::{
     ASSISTANT_LABEL, Verbosity, compact_result_status, compact_timestamp, print_transcript,
     render_assistant_content, render_tool_call, render_tool_result,
 };
-use crate::run_sandbox_shell_command;
+use crate::{SandboxProviderArg, run_sandbox_shell_command};
+use clap::ValueEnum;
 
 const DEFAULT_SHELL_PROGRAM: &str = "/bin/bash";
+
 const REMOTE_HISTORY_BASE: usize = 1_000_000;
 const REMOTE_HISTORY_PAGE_SIZE: u32 = 32;
+
+/// Resolve the provider name a user typed at `/teleport`.
+///
+/// `--provider` advertises kebab-case names for the providers exo ships
+/// (`apple-container`, `local-process`, `aws-agentcore`), but those are
+/// registered under the snake_case constants, and since sandbox providers
+/// became an open set any string parses as-is. Routing the built-ins through
+/// the same mapping `--provider` uses keeps one spelling working everywhere;
+/// any other name belongs to a provider this build does not define, so it is
+/// taken verbatim and out-of-tree backends still reach their registration.
+fn resolve_sandbox_provider(provider_str: &str) -> Result<SandboxProvider> {
+    let provider_str = provider_str.trim();
+    match SandboxProviderArg::from_str(provider_str, true) {
+        Ok(builtin) => Ok(builtin.into()),
+        Err(_) => Ok(provider_str.parse::<SandboxProvider>()?),
+    }
+}
 
 pub async fn run_chat_repl(
     agent: Arc<dyn HarnessAgent>,
@@ -535,9 +554,7 @@ impl ChatRepl {
     /// provider. Prints progress between the slow steps, which is why the
     /// line-mode repl doesn't use the TUI's silent `teleport_lines`.
     async fn teleport_sandbox(&self, provider_str: &str) -> Result<(SandboxId, SandboxProvider)> {
-        let provider = provider_str
-            .parse::<SandboxProvider>()
-            .map_err(|error| anyhow::anyhow!("invalid provider `{provider_str}`: {error}"))?;
+        let provider = resolve_sandbox_provider(provider_str)?;
         let sandbox_id = latest_sandbox_id(self.conversation.as_ref())
             .await?
             .ok_or_else(|| {
@@ -1050,9 +1067,7 @@ async fn teleport_sandbox(
     conversation: &dyn HarnessConversation,
     provider_str: &str,
 ) -> Result<(SandboxId, SandboxProvider)> {
-    let provider = provider_str
-        .parse::<SandboxProvider>()
-        .map_err(|error| anyhow::anyhow!("invalid provider `{provider_str}`: {error}"))?;
+    let provider = resolve_sandbox_provider(provider_str)?;
     let sandbox_id = latest_sandbox_id(conversation)
         .await?
         .ok_or_else(|| anyhow::anyhow!("no sandbox has been created in this conversation yet"))?;
@@ -1195,10 +1210,45 @@ async fn sandbox_id_for_snapshot(
 
 #[cfg(test)]
 mod tests {
-    use super::{Verbosity, render_external_event, render_user_content_for_history};
+    use super::{
+        SandboxProvider, Verbosity, render_external_event, render_user_content_for_history,
+        resolve_sandbox_provider,
+    };
     use executor::EventData;
     use lingua::Message;
     use lingua::universal::UserContent;
+
+    #[test]
+    fn teleport_accepts_the_provider_spellings_the_cli_advertises() {
+        // `--provider apple-container` and `/teleport apple-container` have to
+        // reach the same backend; the constants are snake_case.
+        assert_eq!(
+            resolve_sandbox_provider("apple-container").unwrap(),
+            SandboxProvider::AppleContainer
+        );
+        assert_eq!(
+            resolve_sandbox_provider("local-process").unwrap(),
+            SandboxProvider::LocalProcess
+        );
+        assert_eq!(
+            resolve_sandbox_provider("aws-agentcore").unwrap(),
+            SandboxProvider::AwsAgentCore
+        );
+        assert_eq!(
+            resolve_sandbox_provider(" docker ").unwrap(),
+            SandboxProvider::Docker
+        );
+    }
+
+    #[test]
+    fn teleport_passes_through_providers_this_build_does_not_define() {
+        // Sandbox providers are an open set, so a name exo does not ship must
+        // reach the registry exactly as the operator registered it.
+        assert_eq!(
+            resolve_sandbox_provider("my-own-vm").unwrap().as_str(),
+            "my-own-vm"
+        );
+    }
 
     #[test]
     fn renders_scheduled_task_wakeup_user_messages() {


### PR DESCRIPTION
Follow-up to #195. Not a disagreement with the open provider set — this is about the one entry point that takes a provider name as free text.

## The problem

`--provider` and `--sandbox-backend` are clap value enums, so they advertise `apple-container`, `local-process`, `aws-agentcore` and map those onto the constants. `/teleport` takes a raw string instead. Since `FromStr` now accepts anything, the typed name is used verbatim, and the constants are snake_case:

```
/teleport apple-container   ->  SandboxProvider("apple-container")
registry has              ->  SandboxProvider("apple_container")
```

So the spelling the CLI itself publishes does not resolve, while `--provider apple-container` on the same build does. Same for `local-process` and `aws-agentcore`.

It also fails late. `FromStr` can no longer return `Err`, so the `invalid provider` guard at the top of `teleport_sandbox` is unreachable, and a name that does not resolve is not caught until `start_sandbox` — after the snapshot has already been taken. A typo costs a full snapshot before it reports anything.

## The fix

Resolve the built-ins through the same `SandboxProviderArg` mapping `--provider` uses, so there is still one table of spellings rather than a second alias list that can drift from it. Anything clap does not recognize is a provider this build does not define, so it passes through verbatim and out-of-tree registrations are unaffected. The unreachable guard goes with it.

I left `FromStr` alone — `preserves_sandbox_provider_names` pins the permissive behavior deliberately, and this belongs at the CLI boundary rather than in the type.

## Verification

Two tests in `tui.rs`: the advertised spellings resolve to the constants, and an unknown name (`my-own-vm`) still passes through untouched. The first fails without the change. `cargo test -p exo --bin exo` 65 passed, `cargo fmt --check` and `clippy` clean.
