### PR TITLE
Unwrap lingua typed-value envelope in replayed tool-call arguments

### DIFF
--- a/exoharness/typescript/model-runtime/envelope-unwrap.test.ts
+++ b/exoharness/typescript/model-runtime/envelope-unwrap.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { messagesToChatMessages } from "./responses";
+
+// History as materialized from the event log: tool-call arguments arrive in
+// lingua's typed-value envelope {"type":"valid","value":{...}} (see
+// responses-input.test.ts for the same shape on the Responses path).
+const HISTORY = [
+  { role: "user", content: "run it" },
+  {
+    role: "assistant",
+    content: [
+      {
+        type: "tool_call",
+        tool_call_id: "call_1",
+        tool_name: "shell",
+        arguments: { type: "valid", value: { command: "ls" } },
+      },
+    ],
+  },
+  {
+    role: "assistant",
+    content: [
+      {
+        type: "tool_call",
+        tool_call_id: "call_2",
+        tool_name: "shell",
+        // A model echoing its own wrapped arguments from history can nest
+        // envelopes; the harness must strip every layer.
+        arguments: {
+          type: "valid",
+          value: { type: "valid", value: { command: "pwd" } },
+        },
+      },
+    ],
+  },
+] as never;
+
+describe("chat history tool-call arguments", () => {
+  it("replays typed-value envelopes unwrapped so models do not imitate them", () => {
+    const messages = messagesToChatMessages(HISTORY);
+    const toolCalls = messages.flatMap(
+      (message) =>
+        (message as { tool_calls?: { function: { arguments: string } }[] })
+          .tool_calls ?? [],
+    );
+    expect(toolCalls).toHaveLength(2);
+    expect(JSON.parse(toolCalls[0].function.arguments)).toEqual({
+      command: "ls",
+    });
+    expect(JSON.parse(toolCalls[1].function.arguments)).toEqual({
+      command: "pwd",
+    });
+  });
+});

--- a/exoharness/typescript/model-runtime/responses.ts
+++ b/exoharness/typescript/model-runtime/responses.ts
@@ -853,7 +853,7 @@ function buildChatStreamingBody(
   };
 }
 
-function messagesToChatMessages(
+export function messagesToChatMessages(
   messages: Message[],
 ): ChatCompletionMessageParam[] {
   return messages.map(messageToChatMessage);
@@ -1065,13 +1065,30 @@ function assistantToolCalls(content: unknown): ChatCompletionMessageToolCall[] {
         type: "function",
         function: {
           name: part.tool_name,
+          // Unwrap the lingua typed-value envelope {"type":"valid","value":{...}}
+          // before replaying history to the model — otherwise the model imitates
+          // the wrapped shape in its own new tool calls (compounding when it
+          // copies itself from history). Strip every layer, defensively.
           arguments: JSON.stringify(
-            isRecord(part.arguments) ? part.arguments : {},
+            unwrapTypedValue(isRecord(part.arguments) ? part.arguments : {}),
           ),
         },
       },
     ];
   });
+}
+
+function unwrapTypedValue(value: unknown): unknown {
+  for (let depth = 0; depth < 8; depth += 1) {
+    if (!isRecord(value)) break;
+    const keys = Object.keys(value);
+    if (keys.length === 2 && value.type === "valid" && isRecord(value.value)) {
+      value = value.value;
+      continue;
+    }
+    break;
+  }
+  return value;
 }
 
 function assistantTextContent(content: unknown): string | null {
@@ -1332,13 +1349,14 @@ type JsonObjectParseResult =
 function parseJsonObject(json: string): JsonObjectParseResult {
   try {
     const value = JSON.parse(json) as unknown;
-    if (!isRecord(value)) {
+    const unwrapped = unwrapTypedValue(value);
+    if (!isRecord(unwrapped)) {
       return {
         ok: false,
         error: "function call arguments must be a JSON object",
       };
     }
-    return { ok: true, value: value as JsonObject };
+    return { ok: true, value: unwrapped as JsonObject };
   } catch (error) {
     return {
       ok: false,


### PR DESCRIPTION
## Problem

When a chat-completions conversation replays history, tool-call arguments materialized from the event log arrive in lingua's typed-value envelope `{"type":"valid","value":{...}}` (the same shape asserted in `responses-input.test.ts`). `assistantToolCalls` passed them through verbatim, so the model saw its own prior calls wrapped — and models imitate the shape of their own history. New tool calls started arriving as `{"type":"valid","value":{"command":"ls"}}`, every harness tool then failed with `missing field` errors, and the model copied its own wrapped retries, compounding the nesting (observed live with Claude Fable 5.1 through an OpenAI-compatible provider; the agent ended up triple-wrapping and dead-looping on `send_adapter_message`).

## Fix

- Strip the envelope recursively when replaying history (`assistantToolCalls` via `unwrapTypedValue`), so the model only ever sees clean argument shapes.
- Defensively, also unwrap when parsing incoming function-call arguments (`parseJsonObject`), covering providers that leak the envelope directly.

`unwrapTypedValue` strips up to 8 nested layers and no-ops on anything that isn't exactly `{type:"valid", value:{...}}`, so plain arguments pass through untouched.

## Testing

- New regression test (`envelope-unwrap.test.ts`) covers singly- and doubly-wrapped arguments replaying clean.
- Full suite passes locally: `pnpm check` → oxlint 0 warnings, tsgo typecheck clean, **147/147 vitest tests**.