### PR TITLE
Add persistent Firecracker terminals

### DIFF
--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -224,6 +224,14 @@ pub trait ManagedSandboxHandle: Send + Sync {
 
     async fn start_process(&self, command: &SandboxCommand) -> Result<crate::SandboxProcessParts>;
 
+    async fn start_terminal(
+        &self,
+        _command: &SandboxCommand,
+        _size: crate::SandboxTerminalSize,
+    ) -> Result<crate::SandboxTerminalParts> {
+        bail!("sandbox backend does not support terminal sessions")
+    }
+
     fn supports_tcp(&self) -> bool {
         false
     }

--- a/crates/exoharness/src/sandbox_provider/firecracker.rs
+++ b/crates/exoharness/src/sandbox_provider/firecracker.rs
@@ -587,6 +587,32 @@ impl FirecrackerSandboxBackend {
             .context("joining Firecracker backend construction")?
     }
 
+    pub async fn terminate_all(&self) -> Result<usize> {
+        let config = self.shared.config.clone();
+        let capacity = tokio::task::spawn_blocking(move || {
+            machine_capacity_state(&config.state_root, |candidate| {
+                process_running(&jail_root(&config, candidate).join("firecracker.pid"))
+            })
+        })
+        .await
+        .context("joining Firecracker machine scan")??;
+        let machine_ids = capacity
+            .live_machine_ids
+            .into_iter()
+            .chain(capacity.dead_machine_ids)
+            .collect::<Vec<_>>();
+        for machine_id in &machine_ids {
+            let _lifecycle_guard = self.shared.lifecycle_locks.lock_machine(machine_id).await;
+            self.shared
+                .warm_machines
+                .lock()
+                .await
+                .retain(|_, entry| entry.machine_id != *machine_id);
+            self.shared.cleanup_machine(machine_id, true).await?;
+        }
+        Ok(machine_ids.len())
+    }
+
     fn new_blocking(mut config: FirecrackerConfig) -> Result<Self> {
         let firecracker_version = validate_host_blocking(&config)?;
         fs::create_dir_all(&config.state_root).with_context(|| {

--- a/crates/exoharness/src/sandbox_provider/firecracker.rs
+++ b/crates/exoharness/src/sandbox_provider/firecracker.rs
@@ -26,7 +26,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use exo_firecracker_protocol::{
     GuestRequest as ProtocolGuestRequest, GuestResponse, MAX_REQUEST_BYTES, MAX_RESPONSE_BYTES,
-    Message, PROTOCOL_VERSION, decode_frame_length,
+    Message, PROTOCOL_VERSION, TerminalSize as GuestTerminalSize, decode_frame_length,
 };
 use ipnet::Ipv4Net;
 #[cfg(target_os = "linux")]
@@ -48,7 +48,10 @@ use crate::sandbox::{
     SnapshotFormat, SnapshotPayload, sandbox_spec_hash,
 };
 use crate::sandbox_provider::process_bridge;
-use crate::{FileSystemMountMode, SandboxAttachment, SandboxProcessParts, SandboxResourceShape};
+use crate::{
+    FileSystemMountMode, SandboxAttachment, SandboxProcessParts, SandboxResourceShape,
+    SandboxTerminalParts, SandboxTerminalSize,
+};
 
 use super::firecracker_image::resolve_image;
 #[cfg(test)]
@@ -1305,6 +1308,34 @@ impl ManagedSandboxHandle for FirecrackerSandboxHandle {
             .await?;
         }
         Ok(process)
+    }
+
+    async fn start_terminal(
+        &self,
+        command: &SandboxCommand,
+        size: SandboxTerminalSize,
+    ) -> Result<SandboxTerminalParts> {
+        let cleanup_machine_id = self
+            .one_shot
+            .then(|| self.machine.record.machine_id.clone());
+        let terminal = GuestClient::new(Arc::clone(&self.shared), self.machine.vsock_path.clone())
+            .start_terminal(&self.request.spec, command, size, cleanup_machine_id)
+            .await?;
+        if !self.one_shot {
+            let _lifecycle_guard = self
+                .shared
+                .lifecycle_locks
+                .lock_machine(&self.machine.record.machine_id)
+                .await;
+            touch_machine(
+                &self.shared,
+                &self.shared.warm_machines,
+                &self.request.key,
+                &self.machine.record.machine_id,
+            )
+            .await?;
+        }
+        Ok(terminal)
     }
 
     fn supports_tcp(&self) -> bool {
@@ -4176,6 +4207,63 @@ impl GuestClient {
                 wait,
                 cleanup: Some(cleanup),
             }),
+        })
+    }
+
+    async fn start_terminal(
+        &self,
+        spec: &SandboxSpec,
+        command: &SandboxCommand,
+        size: SandboxTerminalSize,
+        cleanup_machine_id: Option<String>,
+    ) -> Result<SandboxTerminalParts> {
+        if command.argv.is_empty() {
+            bail!("sandbox terminal command requires at least one argv entry");
+        }
+        let cwd = command
+            .cwd
+            .clone()
+            .unwrap_or_else(|| spec.default_workdir.clone());
+        let response: GuestResponse = self
+            .invoke(&GuestRequest::StartTerminal {
+                argv: command.argv.clone(),
+                env: command.env.clone(),
+                cwd,
+                size: GuestTerminalSize {
+                    rows: size.rows,
+                    cols: size.cols,
+                },
+            })
+            .await?;
+        if let Some(error) = response.error {
+            bail!("Firecracker start_terminal failed: {error}");
+        }
+        let process_id = response
+            .process_id
+            .context("Firecracker start_terminal response did not include process_id")?;
+        let bridge = Arc::new(FirecrackerProcessBridgeClient {
+            guest: self.clone(),
+            process_id: process_id.clone(),
+        });
+        let SandboxTerminalParts {
+            output,
+            input,
+            wait,
+            control,
+        } = process_bridge::terminal_parts(bridge);
+        let cleanup = ProcessCleanup {
+            guest: self.clone(),
+            process_id,
+            machine_id: cleanup_machine_id,
+        };
+        Ok(SandboxTerminalParts {
+            output,
+            input,
+            wait: Box::pin(ProcessWait {
+                wait,
+                cleanup: Some(cleanup),
+            }),
+            control,
         })
     }
 

--- a/crates/exoharness/src/sandbox_provider/process_bridge.rs
+++ b/crates/exoharness/src/sandbox_provider/process_bridge.rs
@@ -230,6 +230,8 @@ pub struct Request {
     data: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     timeout_seconds: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    size: Option<crate::SandboxTerminalSize>,
 }
 
 impl Request {
@@ -238,6 +240,7 @@ impl Request {
             kind: "ping",
             data: None,
             timeout_seconds: None,
+            size: None,
         }
     }
 
@@ -246,6 +249,7 @@ impl Request {
             kind: "recv",
             data: None,
             timeout_seconds: Some(RECV_TIMEOUT.as_secs_f64()),
+            size: None,
         }
     }
 
@@ -254,6 +258,7 @@ impl Request {
             kind: "write",
             data: Some(STANDARD.encode(data)),
             timeout_seconds: None,
+            size: None,
         }
     }
 
@@ -262,6 +267,16 @@ impl Request {
             kind: "close_stdin",
             data: None,
             timeout_seconds: None,
+            size: None,
+        }
+    }
+
+    fn resize(size: crate::SandboxTerminalSize) -> Self {
+        Self {
+            kind: "resize",
+            data: None,
+            timeout_seconds: None,
+            size: Some(size),
         }
     }
 }
@@ -363,6 +378,40 @@ pub fn process_parts(client: Arc<dyn Client>) -> crate::SandboxProcessParts {
         stderr: Box::pin(stderr_reader.compat()),
         stdin: Box::pin(stdin_writer.compat_write()),
         wait,
+    }
+}
+
+pub fn terminal_parts(client: Arc<dyn Client>) -> crate::SandboxTerminalParts {
+    let crate::SandboxProcessParts {
+        stdout,
+        stderr,
+        stdin,
+        wait,
+    } = process_parts(Arc::clone(&client));
+    drop(stderr);
+    crate::SandboxTerminalParts {
+        output: stdout,
+        input: stdin,
+        wait,
+        control: Arc::new(ProcessBridgeTerminalControl { client }),
+    }
+}
+
+struct ProcessBridgeTerminalControl {
+    client: Arc<dyn Client>,
+}
+
+#[async_trait]
+impl crate::SandboxTerminalControl for ProcessBridgeTerminalControl {
+    async fn resize(&self, size: crate::SandboxTerminalSize) -> crate::Result<()> {
+        let response = self.client.request(Request::resize(size)).await?;
+        if response.ok {
+            return Ok(());
+        }
+        anyhow::bail!(
+            "resizing sandbox terminal failed: {}",
+            response.error.as_deref().unwrap_or("unknown error")
+        )
     }
 }
 
@@ -538,6 +587,15 @@ mod tests {
     struct BridgeFixture {
         _temp: TempDir,
         script_path: PathBuf,
+    }
+
+    #[test]
+    fn resize_request_matches_guest_protocol() {
+        let request = Request::resize(crate::SandboxTerminalSize { rows: 24, cols: 80 });
+        assert_eq!(
+            serde_json::to_value(request).expect("serialize resize request"),
+            json!({"type": "resize", "size": {"rows": 24, "cols": 80}})
+        );
     }
 
     #[tokio::test]

--- a/crates/exoharness/src/types.rs
+++ b/crates/exoharness/src/types.rs
@@ -933,6 +933,24 @@ pub struct SandboxProcessParts {
     pub wait: BoxFuture<'static, Result<i32>>,
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SandboxTerminalSize {
+    pub rows: u16,
+    pub cols: u16,
+}
+
+#[async_trait]
+pub trait SandboxTerminalControl: Send + Sync {
+    async fn resize(&self, size: SandboxTerminalSize) -> Result<()>;
+}
+
+pub struct SandboxTerminalParts {
+    pub output: BoxAsyncRead,
+    pub input: BoxAsyncWrite,
+    pub wait: BoxFuture<'static, Result<i32>>,
+    pub control: Arc<dyn SandboxTerminalControl>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct BindingRecord {
     pub id: BindingId,

--- a/crates/firecracker-guest/src/linux.rs
+++ b/crates/firecracker-guest/src/linux.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, VecDeque};
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::net::Ipv4Addr;
@@ -7,7 +7,7 @@ use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
 use std::os::unix::fs::chown;
 use std::os::unix::process::{CommandExt, ExitStatusExt};
 use std::path::Path;
-use std::process::{Child, ChildStdin, Command, Stdio};
+use std::process::{Child, Command, Stdio};
 use std::ptr;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
@@ -19,7 +19,7 @@ use base64::engine::general_purpose::STANDARD;
 use exo_firecracker_protocol::{
     GuestIdentity, GuestProcessEvent as ProcessEvent, GuestProcessRequest as BridgeRequest,
     GuestRequest, GuestResponse as Response, MAX_REQUEST_BYTES, MAX_RESPONSE_BYTES, Message,
-    PROTOCOL_VERSION, decode_frame_length,
+    PROTOCOL_VERSION, TerminalSize, decode_frame_length,
 };
 
 const AGENT_PORT: u32 = 10_052;
@@ -231,7 +231,8 @@ fn reap_orphans() {
 
 struct ManagedProcess {
     process_group: i32,
-    stdin: Mutex<Option<ChildStdin>>,
+    stdin: Mutex<Option<Box<dyn Write + Send>>>,
+    terminal: Option<File>,
     events: Arc<EventQueue>,
     exited: AtomicBool,
 }
@@ -254,7 +255,8 @@ impl ManagedProcess {
         let stderr = child.stderr.take().ok_or("missing child stderr")?;
         let process = Arc::new(Self {
             process_group,
-            stdin: Mutex::new(Some(stdin)),
+            stdin: Mutex::new(Some(Box::new(stdin))),
+            terminal: None,
             events: Arc::new(EventQueue::default()),
             exited: AtomicBool::new(false),
         });
@@ -284,6 +286,58 @@ impl ManagedProcess {
         Ok(process)
     }
 
+    fn spawn_terminal(
+        argv: &[String],
+        cwd: &str,
+        env: &HashMap<String, String>,
+        size: TerminalSize,
+    ) -> Result<Arc<Self>, String> {
+        validate_command(argv, cwd)?;
+        validate_terminal_size(size)?;
+        let (master, slave) = open_terminal(size)?;
+        let mut command = terminal_command(argv, cwd, env);
+        command
+            .stdin(Stdio::from(
+                slave.try_clone().map_err(|error| error.to_string())?,
+            ))
+            .stdout(Stdio::from(
+                slave.try_clone().map_err(|error| error.to_string())?,
+            ))
+            .stderr(Stdio::from(slave));
+        let (mut child, process_group, registration) = spawn_direct_child(&mut command)?;
+        let output = master.try_clone().map_err(|error| error.to_string())?;
+        let terminal = master.try_clone().map_err(|error| error.to_string())?;
+        let process = Arc::new(Self {
+            process_group,
+            stdin: Mutex::new(Some(Box::new(master))),
+            terminal: Some(terminal),
+            events: Arc::new(EventQueue::default()),
+            exited: AtomicBool::new(false),
+        });
+        let output_thread = terminal_stream_thread(output, Arc::clone(&process.events));
+        let wait_process = Arc::clone(&process);
+        thread::spawn(move || {
+            let result = child.wait();
+            drop(registration);
+            let output_result = output_thread.join();
+            wait_process.exited.store(true, Ordering::Release);
+            match result {
+                Ok(status) if output_result.is_ok() => {
+                    wait_process.events.push(ProcessEvent::Exit {
+                        exit_code: exit_code(status),
+                    });
+                }
+                Ok(_) => wait_process.events.push(ProcessEvent::Error {
+                    message: "terminal output thread panicked".to_string(),
+                }),
+                Err(error) => wait_process.events.push(ProcessEvent::Error {
+                    message: format!("waiting for terminal process failed: {error}"),
+                }),
+            }
+        });
+        Ok(process)
+    }
+
     fn write(&self, encoded: &str) -> Result<(), String> {
         if self.exited.load(Ordering::Acquire) {
             return Err("process is not running".to_string());
@@ -299,6 +353,25 @@ impl ManagedProcess {
 
     fn close_stdin(&self) -> Result<(), String> {
         self.stdin.lock().map_err(|_| "stdin lock poisoned")?.take();
+        Ok(())
+    }
+
+    fn resize(&self, size: TerminalSize) -> Result<(), String> {
+        validate_terminal_size(size)?;
+        let terminal = self
+            .terminal
+            .as_ref()
+            .ok_or("process does not have a terminal")?;
+        set_terminal_size(terminal.as_raw_fd(), size)?;
+        if !self.exited.load(Ordering::Acquire) {
+            let result = unsafe { libc::kill(-self.process_group, libc::SIGWINCH) };
+            if result != 0 {
+                let error = std::io::Error::last_os_error();
+                if error.raw_os_error() != Some(libc::ESRCH) {
+                    return Err(error.to_string());
+                }
+            }
+        }
         Ok(())
     }
 
@@ -352,6 +425,12 @@ impl AgentState {
                 timeout_ms,
             } => exec(&argv, &cwd, &env, timeout_ms),
             Request::StartProcess { argv, env, cwd } => self.start_process(&argv, &cwd, &env),
+            Request::StartTerminal {
+                argv,
+                env,
+                cwd,
+                size,
+            } => self.start_terminal(&argv, &cwd, &env, size),
             Request::ProcessBridge {
                 process_id,
                 request,
@@ -367,6 +446,23 @@ impl AgentState {
     }
 
     fn start_process(&self, argv: &[String], cwd: &str, env: &HashMap<String, String>) -> Response {
+        self.insert_process(|| ManagedProcess::spawn(argv, cwd, env))
+    }
+
+    fn start_terminal(
+        &self,
+        argv: &[String],
+        cwd: &str,
+        env: &HashMap<String, String>,
+        size: TerminalSize,
+    ) -> Response {
+        self.insert_process(|| ManagedProcess::spawn_terminal(argv, cwd, env, size))
+    }
+
+    fn insert_process(
+        &self,
+        spawn: impl FnOnce() -> Result<Arc<ManagedProcess>, String>,
+    ) -> Response {
         let mut processes = match self.processes.lock() {
             Ok(processes) => processes,
             Err(_) => return Response::error("process map lock poisoned"),
@@ -374,7 +470,7 @@ impl AgentState {
         if processes.len() >= MAX_PROCESSES {
             return Response::error("too many managed processes");
         }
-        let process = match ManagedProcess::spawn(argv, cwd, env) {
+        let process = match spawn() {
             Ok(process) => process,
             Err(error) => return Response::error(error),
         };
@@ -431,6 +527,10 @@ impl AgentState {
                     Err(error) => Response::error(error),
                 }
             }
+            BridgeRequest::Resize { size } => match process.resize(size) {
+                Ok(()) => Response::ok(),
+                Err(error) => Response::error(error),
+            },
         }
     }
 
@@ -537,6 +637,31 @@ fn exec(
 }
 
 fn command(argv: &[String], cwd: &str, env: &HashMap<String, String>) -> Command {
+    let mut command = base_command(argv, cwd, env);
+    command.process_group(0);
+    unsafe {
+        command.pre_exec(drop_command_privileges);
+    }
+    command
+}
+
+fn terminal_command(argv: &[String], cwd: &str, env: &HashMap<String, String>) -> Command {
+    let mut command = base_command(argv, cwd, env);
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() < 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if libc::ioctl(libc::STDIN_FILENO, libc::TIOCSCTTY, 0) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            drop_command_privileges()
+        });
+    }
+    command
+}
+
+fn base_command(argv: &[String], cwd: &str, env: &HashMap<String, String>) -> Command {
     let mut command = Command::new(&argv[0]);
     command
         .args(&argv[1..])
@@ -546,26 +671,79 @@ fn command(argv: &[String], cwd: &str, env: &HashMap<String, String>) -> Command
             "PATH",
             "/usr/local/bin:/usr/local/sbin:/usr/sbin:/usr/bin:/sbin:/bin",
         )
-        .envs(env)
-        .process_group(0);
-    unsafe {
-        command.pre_exec(|| {
-            if libc::setgroups(0, ptr::null()) != 0 {
-                return Err(std::io::Error::last_os_error());
-            }
-            if libc::setresgid(GUEST_GID, GUEST_GID, GUEST_GID) != 0 {
-                return Err(std::io::Error::last_os_error());
-            }
-            if libc::setresuid(GUEST_UID, GUEST_UID, GUEST_UID) != 0 {
-                return Err(std::io::Error::last_os_error());
-            }
-            if libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) != 0 {
-                return Err(std::io::Error::last_os_error());
-            }
-            Ok(())
-        });
-    }
+        .envs(env);
     command
+}
+
+fn drop_command_privileges() -> std::io::Result<()> {
+    if unsafe { libc::setgroups(0, ptr::null()) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if unsafe { libc::setresgid(GUEST_GID, GUEST_GID, GUEST_GID) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if unsafe { libc::setresuid(GUEST_UID, GUEST_UID, GUEST_UID) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn open_terminal(size: TerminalSize) -> Result<(File, File), String> {
+    let descriptor = unsafe { libc::posix_openpt(libc::O_RDWR | libc::O_NOCTTY | libc::O_CLOEXEC) };
+    if descriptor < 0 {
+        return Err(std::io::Error::last_os_error().to_string());
+    }
+    let master = unsafe { OwnedFd::from_raw_fd(descriptor) };
+    if unsafe { libc::grantpt(master.as_raw_fd()) } != 0 {
+        return Err(std::io::Error::last_os_error().to_string());
+    }
+    if unsafe { libc::unlockpt(master.as_raw_fd()) } != 0 {
+        return Err(std::io::Error::last_os_error().to_string());
+    }
+    let mut path = [0_i8; 128];
+    let result = unsafe { libc::ptsname_r(master.as_raw_fd(), path.as_mut_ptr(), path.len()) };
+    if result != 0 {
+        return Err(std::io::Error::from_raw_os_error(result).to_string());
+    }
+    let path = unsafe { CStr::from_ptr(path.as_ptr()) };
+    let slave_descriptor = unsafe {
+        libc::open(
+            path.as_ptr(),
+            libc::O_RDWR | libc::O_NOCTTY | libc::O_CLOEXEC,
+        )
+    };
+    if slave_descriptor < 0 {
+        return Err(std::io::Error::last_os_error().to_string());
+    }
+    set_terminal_size(master.as_raw_fd(), size)?;
+    let master = File::from(master);
+    let slave = File::from(unsafe { OwnedFd::from_raw_fd(slave_descriptor) });
+    Ok((master, slave))
+}
+
+fn validate_terminal_size(size: TerminalSize) -> Result<(), String> {
+    if size.rows == 0 || size.cols == 0 {
+        return Err("terminal rows and columns must be positive".to_string());
+    }
+    Ok(())
+}
+
+fn set_terminal_size(descriptor: i32, size: TerminalSize) -> Result<(), String> {
+    let dimensions = libc::winsize {
+        ws_row: size.rows,
+        ws_col: size.cols,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
+    let result = unsafe { libc::ioctl(descriptor, libc::TIOCSWINSZ, &dimensions) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error().to_string())
+    }
 }
 
 fn validate_command(argv: &[String], cwd: &str) -> Result<(), String> {
@@ -631,6 +809,31 @@ where
             } else {
                 events.push(ProcessEvent::Stderr { data });
             }
+        }
+    })
+}
+
+fn terminal_stream_thread<R>(mut stream: R, events: Arc<EventQueue>) -> thread::JoinHandle<()>
+where
+    R: Read + Send + 'static,
+{
+    thread::spawn(move || {
+        let mut buffer = [0_u8; 64 * 1024];
+        loop {
+            let count = match stream.read(&mut buffer) {
+                Ok(0) => return,
+                Ok(count) => count,
+                Err(error) if error.raw_os_error() == Some(libc::EIO) => return,
+                Err(error) => {
+                    events.push(ProcessEvent::Error {
+                        message: format!("reading terminal output failed: {error}"),
+                    });
+                    return;
+                }
+            };
+            events.push(ProcessEvent::Stdout {
+                data: STANDARD.encode(&buffer[..count]),
+            });
         }
     })
 }
@@ -1230,7 +1433,7 @@ mod tests {
     #[test]
     fn parses_typed_requests() {
         let request = serde_json::from_str::<Message<Request>>(
-            r#"{"protocol_version":1,"payload":{"type":"exec","argv":["/bin/echo","hi"],"env":{},"cwd":"/","timeout_ms":1000}}"#,
+            r#"{"protocol_version":2,"payload":{"type":"exec","argv":["/bin/echo","hi"],"env":{},"cwd":"/","timeout_ms":1000}}"#,
         )
         .unwrap();
         assert!(matches!(request.payload, Request::Exec { .. }));
@@ -1255,5 +1458,28 @@ mod tests {
             queue.recv(Duration::ZERO).unwrap_err(),
             "process output exceeded the guest queue limit"
         );
+    }
+
+    #[test]
+    fn terminal_size_can_be_read_and_changed() {
+        let (master, slave) = open_terminal(TerminalSize { rows: 24, cols: 80 }).unwrap();
+        assert_eq!(terminal_size(slave.as_raw_fd()), (24, 80));
+
+        set_terminal_size(
+            master.as_raw_fd(),
+            TerminalSize {
+                rows: 50,
+                cols: 120,
+            },
+        )
+        .unwrap();
+        assert_eq!(terminal_size(slave.as_raw_fd()), (50, 120));
+    }
+
+    fn terminal_size(descriptor: i32) -> (u16, u16) {
+        let mut dimensions = unsafe { std::mem::zeroed::<libc::winsize>() };
+        let result = unsafe { libc::ioctl(descriptor, libc::TIOCGWINSZ, &mut dimensions) };
+        assert_eq!(result, 0);
+        (dimensions.ws_row, dimensions.ws_col)
     }
 }

--- a/crates/firecracker-guest/src/linux.rs
+++ b/crates/firecracker-guest/src/linux.rs
@@ -694,14 +694,23 @@ fn drop_command_privileges() -> std::io::Result<()> {
 fn open_terminal(size: TerminalSize) -> Result<(File, File), String> {
     let descriptor = unsafe { libc::posix_openpt(libc::O_RDWR | libc::O_NOCTTY | libc::O_CLOEXEC) };
     if descriptor < 0 {
-        return Err(std::io::Error::last_os_error().to_string());
+        return Err(format!(
+            "opening PTY master: {}",
+            std::io::Error::last_os_error()
+        ));
     }
     let master = unsafe { OwnedFd::from_raw_fd(descriptor) };
     if unsafe { libc::grantpt(master.as_raw_fd()) } != 0 {
-        return Err(std::io::Error::last_os_error().to_string());
+        return Err(format!(
+            "granting PTY slave access: {}",
+            std::io::Error::last_os_error()
+        ));
     }
     if unsafe { libc::unlockpt(master.as_raw_fd()) } != 0 {
-        return Err(std::io::Error::last_os_error().to_string());
+        return Err(format!(
+            "unlocking PTY slave: {}",
+            std::io::Error::last_os_error()
+        ));
     }
     let mut path: [libc::c_char; 128] = [0; 128];
     let result = unsafe { libc::ptsname_r(master.as_raw_fd(), path.as_mut_ptr(), path.len()) };
@@ -716,7 +725,11 @@ fn open_terminal(size: TerminalSize) -> Result<(File, File), String> {
         )
     };
     if slave_descriptor < 0 {
-        return Err(std::io::Error::last_os_error().to_string());
+        return Err(format!(
+            "opening PTY slave {}: {}",
+            path.to_string_lossy(),
+            std::io::Error::last_os_error()
+        ));
     }
     set_terminal_size(master.as_raw_fd(), size)?;
     let master = File::from(master);
@@ -1089,6 +1102,14 @@ fn mount_pseudo_filesystems() -> Result<(), String> {
         Some("devtmpfs"),
         libc::MS_NOSUID | libc::MS_NOEXEC,
         Some("mode=0755"),
+    )?;
+    fs::create_dir_all("/dev/pts").map_err(|error| error.to_string())?;
+    mount_filesystem(
+        Some("devpts"),
+        "/dev/pts",
+        Some("devpts"),
+        libc::MS_NOSUID | libc::MS_NOEXEC,
+        Some("mode=0620,ptmxmode=0666"),
     )?;
     Ok(())
 }

--- a/crates/firecracker-guest/src/linux.rs
+++ b/crates/firecracker-guest/src/linux.rs
@@ -703,7 +703,7 @@ fn open_terminal(size: TerminalSize) -> Result<(File, File), String> {
     if unsafe { libc::unlockpt(master.as_raw_fd()) } != 0 {
         return Err(std::io::Error::last_os_error().to_string());
     }
-    let mut path = [0_i8; 128];
+    let mut path: [libc::c_char; 128] = [0; 128];
     let result = unsafe { libc::ptsname_r(master.as_raw_fd(), path.as_mut_ptr(), path.len()) };
     if result != 0 {
         return Err(std::io::Error::from_raw_os_error(result).to_string());

--- a/crates/firecracker-protocol/src/lib.rs
+++ b/crates/firecracker-protocol/src/lib.rs
@@ -3,7 +3,7 @@ use std::net::Ipv4Addr;
 
 use serde::{Deserialize, Serialize};
 
-pub const PROTOCOL_VERSION: u32 = 1;
+pub const PROTOCOL_VERSION: u32 = 2;
 pub const MAX_REQUEST_BYTES: usize = 1024 * 1024;
 pub const MAX_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
 
@@ -37,6 +37,12 @@ pub enum GuestRequest<B> {
         env: HashMap<String, String>,
         cwd: String,
     },
+    StartTerminal {
+        argv: Vec<String>,
+        env: HashMap<String, String>,
+        cwd: String,
+        size: TerminalSize,
+    },
     ProcessBridge {
         process_id: String,
         request: B,
@@ -61,6 +67,13 @@ pub enum GuestProcessRequest {
     Write { data: String },
     CloseStdin,
     Recv { timeout_seconds: Option<f64> },
+    Resize { size: TerminalSize },
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct TerminalSize {
+    pub rows: u16,
+    pub cols: u16,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]


### PR DESCRIPTION
Adds an optional managed-sandbox terminal API backed by a real PTY in the Firecracker guest, including terminal resize propagation and cleanup. Existing backends remain unsupported by default.