### PR TITLE
feat: add JSON-RPC agent server over stdio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2544,6 +2544,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tracing",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ rustix = { version = "1.1.4", features = ["event", "process"] }
 crossterm = { version = "0.28", features = ["bracketed-paste", "event-stream"] }
 ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.145"
+serde_json = { version = "1.0.145", features = ["raw_value"] }
 sha2 = "0.10.9"
 shlex = "1.3.0"
 sqlx = { version = "0.8.6", default-features = false, features = [

--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ pnpm events:tail exo-agent dev --history 0  # new events only
 
 Press `Ctrl-C` to stop following events.
 
+For headless integrations, [`exo agent-server`](docs/agent-server.md) runs the
+executor harness as a long-lived JSON-RPC 2.0 server over newline-delimited
+stdin/stdout. It streams model and tool events while Exoharness remains the
+authority for durable history. This is separate from `exo serve`, which exposes
+the Exoharness substrate API over HTTP.
+
 The scheduler and adapter services have separate host-side logs:
 
 ```bash

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -29,22 +29,23 @@ use std::sync::Arc;
 use anyhow::{Context, Result, anyhow, bail};
 use clap::{ArgAction, Args, Parser, Subcommand, ValueEnum};
 use executor::{
-    AgentHandle, AgentHarnessKind, AttachSandboxRequest, BasicExoHarness, BasicExoHarnessConfig,
-    BasicHarness, BasicToolRuntime, Binding, BraintrustProject, BraintrustRuntimeConfig,
-    BraintrustTracingConfig, ConversationModelConfig, CreateAgentRequest,
-    CreateConversationRequest, CreateSandboxRequest, DEFAULT_SANDBOX_MEMORY_MIB,
-    DEFAULT_SANDBOX_VCPU_COUNT, DaytonaBackendSpec, DurableFileSystem, E2bBackendSpec, EventKind,
-    EventQuery, EventQueryDirection, ExoHarness, ExoHarnessHttpServeOptions, ExoToolRuntime,
-    FileSystemMount, FileSystemMountMode, FirecrackerBackendSpec, ForkConversationRequest,
-    HOST_EVENT_REBUILD_AND_RESTART, HTTP_EXOHARNESS_TRACING_TARGET, Harness, HarnessAgent,
-    HarnessConversation, HttpExoHarness, LocalSandboxExoHarness, NewAgentRequest, PutSecretRequest,
-    RlmHarness, RunInSandboxRequest, SANDBOX_MAIN_MOUNT_DIR, SandboxAttachment,
-    SandboxBackendRegistration, SandboxProcess, SandboxProvider, SandboxProviderConfig,
-    SandboxResourceShape, SandboxScope, Secret, SecretBackendChoice, SpritesBackendSpec,
-    ToolRequest, ToolRuntime, TypeScriptHarness, TypeScriptHarnessConfig, Uuid7, VercelBackendSpec,
-    default_aws_agentcore_image, default_daytona_image, default_docker_image, default_e2b_template,
-    default_firecracker_image, default_vercel_image, effective_sandbox_scope,
-    finalize_rebuild_update_file, load_agent_config, record_host_event, send_conversation_wakeup,
+    AGENT_SERVER_TRACING_TARGET, AgentHandle, AgentHarnessKind, AttachSandboxRequest,
+    BasicExoHarness, BasicExoHarnessConfig, BasicHarness, BasicToolRuntime, Binding,
+    BraintrustProject, BraintrustRuntimeConfig, BraintrustTracingConfig, ConversationModelConfig,
+    CreateAgentRequest, CreateConversationRequest, CreateSandboxRequest,
+    DEFAULT_SANDBOX_MEMORY_MIB, DEFAULT_SANDBOX_VCPU_COUNT, DaytonaBackendSpec, DurableFileSystem,
+    E2bBackendSpec, EventKind, EventQuery, EventQueryDirection, ExoHarness,
+    ExoHarnessHttpServeOptions, ExoToolRuntime, FileSystemMount, FileSystemMountMode,
+    FirecrackerBackendSpec, ForkConversationRequest, HOST_EVENT_REBUILD_AND_RESTART,
+    HTTP_EXOHARNESS_TRACING_TARGET, Harness, HarnessAgent, HarnessConversation, HttpExoHarness,
+    LocalSandboxExoHarness, NewAgentRequest, PutSecretRequest, RlmHarness, RunInSandboxRequest,
+    SANDBOX_MAIN_MOUNT_DIR, SandboxAttachment, SandboxBackendRegistration, SandboxProcess,
+    SandboxProvider, SandboxProviderConfig, SandboxResourceShape, SandboxScope, Secret,
+    SecretBackendChoice, SpritesBackendSpec, ToolRequest, ToolRuntime, TypeScriptHarness,
+    TypeScriptHarnessConfig, Uuid7, VercelBackendSpec, default_aws_agentcore_image,
+    default_daytona_image, default_docker_image, default_e2b_template, default_firecracker_image,
+    default_vercel_image, effective_sandbox_scope, finalize_rebuild_update_file, load_agent_config,
+    record_host_event, send_conversation_wakeup, serve_agent_server_stdio,
     serve_exoharness_http_listener_with_options,
 };
 use serde::Deserialize;
@@ -626,6 +627,11 @@ enum Commands {
         #[command(flatten, next_help_heading = "Firecracker backend options")]
         firecracker: FirecrackerArgs,
     },
+    /// Start the executor-facing JSON-RPC server on stdin/stdout.
+    AgentServer {
+        #[arg(short, long, action = ArgAction::Count)]
+        verbose: u8,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -1199,6 +1205,9 @@ async fn main() -> Result<()> {
         }
         #[cfg(not(feature = "firecracker"))]
         bail!("Firecracker bridge support requires building Exo with --features firecracker");
+    }
+    if let Commands::AgentServer { verbose } = &cli.command {
+        init_server_tracing(AGENT_SERVER_TRACING_TARGET, *verbose);
     }
     let exo_config = build_exo_config(&cli)?;
     let env = CliEnvironment::load(cli.env_file_if_exists.as_deref(), cli.env_file.as_deref())?;
@@ -2575,6 +2584,10 @@ async fn main() -> Result<()> {
                 println!("configured sandbox provider {binding_name} ({id})");
             }
         },
+        Commands::AgentServer { .. } => {
+            serve_agent_server_stdio(Arc::clone(&harness), to_agent_harness_kind(harness_kind))
+                .await?;
+        }
         Commands::Serve { .. } => {
             unreachable!("serve commands are handled before harness instantiation")
         }
@@ -2971,6 +2984,7 @@ fn command_agent_ref(command: &Commands) -> Option<&str> {
         | Commands::Provider { .. }
         | Commands::Adapters { .. }
         | Commands::Tools { .. }
+        | Commands::AgentServer { .. }
         | Commands::Serve { .. } => None,
     }
 }
@@ -3007,7 +3021,7 @@ async fn serve_exoharness_http(
     exo_config: &BasicExoHarnessConfig,
     config: ServeConfig,
 ) -> Result<()> {
-    init_serve_tracing(config.verbosity);
+    init_server_tracing(HTTP_EXOHARNESS_TRACING_TARGET, config.verbosity);
     if !config.bind.ip().is_loopback() {
         anyhow::bail!(
             "exo serve only binds loopback addresses; got {}",
@@ -3033,17 +3047,13 @@ async fn serve_exoharness_http(
     Ok(())
 }
 
-fn init_serve_tracing(verbosity: u8) {
-    if verbosity == 0 {
-        return;
-    }
-    let level = if verbosity > 1 {
-        tracing_subscriber::filter::LevelFilter::DEBUG
-    } else {
-        tracing_subscriber::filter::LevelFilter::INFO
+fn init_server_tracing(target: &'static str, verbosity: u8) {
+    let level = match verbosity {
+        0 => tracing_subscriber::filter::LevelFilter::ERROR,
+        1 => tracing_subscriber::filter::LevelFilter::INFO,
+        _ => tracing_subscriber::filter::LevelFilter::DEBUG,
     };
-    let filter = tracing_subscriber::filter::Targets::new()
-        .with_target(HTTP_EXOHARNESS_TRACING_TARGET, level);
+    let filter = tracing_subscriber::filter::Targets::new().with_target(target, level);
     let layer = tracing_subscriber::fmt::layer()
         .with_target(false)
         .without_time()

--- a/crates/cli/tests/agent_server_stdio.rs
+++ b/crates/cli/tests/agent_server_stdio.rs
@@ -1,0 +1,246 @@
+use std::io::{BufRead, BufReader, Read, Write};
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+
+use serde::Deserialize;
+use serde_json::value::RawValue;
+use tempfile::TempDir;
+
+fn exo_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_exo"))
+}
+
+fn exo_command(root: &TempDir, xdg: &TempDir, pricing_path: &std::path::Path) -> Command {
+    let mut command = Command::new(exo_bin());
+    command
+        .args(["--root", root.path().to_str().expect("utf-8 root")])
+        .args(["--secret-backend", "file"])
+        .args([
+            "--pricing-path",
+            pricing_path.to_str().expect("utf-8 pricing path"),
+        ])
+        .env("XDG_CONFIG_HOME", xdg.path());
+    command
+}
+
+#[test]
+fn agent_server_stdout_is_protocol_only_jsonl() {
+    let root = TempDir::new().expect("temporary exo root");
+    let xdg = TempDir::new().expect("temporary config root");
+    let pricing_path = root.path().join("pricing.json");
+    std::fs::write(&pricing_path, "{}").expect("write empty pricing table");
+
+    let create_agent = exo_command(&root, &xdg, &pricing_path)
+        .args([
+            "agent",
+            "create",
+            "Basic Agent",
+            "--slug",
+            "basic-agent",
+            "--provider",
+            "local-process",
+            "--model",
+            "missing-model",
+        ])
+        .output()
+        .expect("create basic agent");
+    assert!(
+        create_agent.status.success(),
+        "agent create failed: {}",
+        String::from_utf8_lossy(&create_agent.stderr)
+    );
+    let create_conversation = exo_command(&root, &xdg, &pricing_path)
+        .args([
+            "conversation",
+            "create",
+            "basic-agent",
+            "Development",
+            "--slug",
+            "dev",
+        ])
+        .output()
+        .expect("create basic conversation");
+    assert!(
+        create_conversation.status.success(),
+        "conversation create failed: {}",
+        String::from_utf8_lossy(&create_conversation.stderr)
+    );
+
+    let mut child = exo_command(&root, &xdg, &pricing_path)
+        .arg("agent-server")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn exo agent-server");
+
+    let mut stdin = child.stdin.take().expect("piped stdin");
+    writeln!(stdin, "{{").expect("write malformed request");
+    stdin
+        .write_all(&[0xff, b'\n'])
+        .expect("write invalid UTF-8 request");
+    writeln!(
+        stdin,
+        r#"{{"jsonrpc":"2.0","id":null,"method":"initialize","params":{{"protocol_version":1}}}}"#
+    )
+    .expect("write initialize request");
+    writeln!(
+        stdin,
+        r#"{{"jsonrpc":"2.0","id":2,"method":"agent/list","params":{{}}}}"#
+    )
+    .expect("write agent list request");
+    writeln!(
+        stdin,
+        r#"{{"jsonrpc":"2.0","id":3,"method":"turn/start","params":{{"agent_ref":"basic-agent","conversation_ref":"dev","input":[{{"role":"user","content":"hello"}}],"session_id":null}}}}"#
+    )
+    .expect("write failing turn request");
+    stdin.flush().expect("flush requests");
+
+    let stdout = child.stdout.take().expect("piped stdout");
+    let mut frames = Vec::new();
+    for line in BufReader::new(stdout).lines() {
+        let line = line.expect("read stdout line");
+        let frame = serde_json::from_str::<Frame>(&line).expect("stdout line must be JSON-RPC");
+        let terminal = frame.method.as_deref() == Some("turn/failed");
+        frames.push(frame);
+        if terminal {
+            break;
+        }
+    }
+    drop(stdin);
+
+    let status = child.wait().expect("wait for agent server");
+    assert!(status.success(), "agent server failed with status {status}");
+    let mut stderr = String::new();
+    child
+        .stderr
+        .take()
+        .expect("piped stderr")
+        .read_to_string(&mut stderr)
+        .expect("read stderr");
+    assert_eq!(frames.len(), 7);
+    assert!(frames.iter().all(|frame| frame.jsonrpc == "2.0"));
+    assert_eq!(
+        frames[0].error.as_ref().map(|error| error.code),
+        Some(-32700)
+    );
+    assert_eq!(
+        frames[1].error.as_ref().map(|error| error.code),
+        Some(-32700)
+    );
+    assert!(frames[2].result.is_some());
+    assert!(frames[3].result.is_some());
+    assert_eq!(frames[6].method.as_deref(), Some("turn/failed"));
+    assert!(
+        stderr.contains("agent server executor failure"),
+        "missing default error diagnostic: {stderr}"
+    );
+}
+
+#[test]
+fn basic_agent_server_rejects_a_persisted_rlm_agent_turn() {
+    let root = TempDir::new().expect("temporary exo root");
+    let xdg = TempDir::new().expect("temporary config root");
+    let pricing_path = root.path().join("pricing.json");
+    std::fs::write(&pricing_path, "{}").expect("write empty pricing table");
+
+    let create_agent = exo_command(&root, &xdg, &pricing_path)
+        .args([
+            "--harness",
+            "rlm",
+            "agent",
+            "create",
+            "RLM Agent",
+            "--slug",
+            "rlm-agent",
+            "--provider",
+            "local-process",
+            "--model",
+            "unused-model",
+        ])
+        .output()
+        .expect("create RLM agent");
+    assert!(
+        create_agent.status.success(),
+        "agent create failed: {}",
+        String::from_utf8_lossy(&create_agent.stderr)
+    );
+    let create_conversation = exo_command(&root, &xdg, &pricing_path)
+        .args([
+            "conversation",
+            "create",
+            "rlm-agent",
+            "Development",
+            "--slug",
+            "dev",
+        ])
+        .output()
+        .expect("create RLM conversation");
+    assert!(
+        create_conversation.status.success(),
+        "conversation create failed: {}",
+        String::from_utf8_lossy(&create_conversation.stderr)
+    );
+
+    let mut server = exo_command(&root, &xdg, &pricing_path)
+        .arg("agent-server")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn basic agent server");
+    let mut stdin = server.stdin.take().expect("piped stdin");
+    writeln!(
+        stdin,
+        r#"{{"jsonrpc":"2.0","id":1,"method":"initialize","params":{{"protocol_version":1}}}}"#
+    )
+    .expect("write initialize request");
+    writeln!(
+        stdin,
+        r#"{{"jsonrpc":"2.0","id":2,"method":"turn/start","params":{{"agent_ref":"rlm-agent","conversation_ref":"dev","input":[{{"role":"user","content":"hello"}}],"session_id":null}}}}"#
+    )
+    .expect("write turn request");
+    drop(stdin);
+
+    let output = server.wait_with_output().expect("wait for agent server");
+    assert!(
+        output.status.success(),
+        "agent server failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let frames = String::from_utf8(output.stdout)
+        .expect("utf-8 stdout")
+        .lines()
+        .map(|line| serde_json::from_str::<Frame>(line).expect("JSON-RPC frame"))
+        .collect::<Vec<_>>();
+    assert_eq!(frames.len(), 2);
+    let error = frames[1].error.as_ref().expect("turn should be rejected");
+    assert_eq!(error.code, -32006);
+    assert_eq!(
+        error.data.as_ref().map(|data| data.kind.as_str()),
+        Some("incompatible_harness")
+    );
+}
+
+#[derive(Deserialize)]
+struct Frame {
+    jsonrpc: String,
+    #[serde(default)]
+    method: Option<String>,
+    #[serde(default)]
+    result: Option<Box<RawValue>>,
+    #[serde(default)]
+    error: Option<ErrorFrame>,
+}
+
+#[derive(Deserialize)]
+struct ErrorFrame {
+    code: i32,
+    #[serde(default)]
+    data: Option<ErrorData>,
+}
+
+#[derive(Deserialize)]
+struct ErrorData {
+    kind: String,
+}

--- a/crates/executor/Cargo.toml
+++ b/crates/executor/Cargo.toml
@@ -31,6 +31,7 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tokio-stream.workspace = true
+tokio-util.workspace = true
 tracing.workspace = true
 url.workspace = true
 

--- a/crates/executor/src/agent_server/mod.rs
+++ b/crates/executor/src/agent_server/mod.rs
@@ -1,0 +1,22 @@
+mod protocol;
+mod server;
+
+use std::sync::Arc;
+
+use anyhow::Result;
+
+use crate::{AgentHarnessKind, Harness};
+
+pub const AGENT_SERVER_TRACING_TARGET: &str = "executor::agent_server";
+
+pub async fn serve_agent_server_stdio(
+    harness: Arc<dyn Harness>,
+    harness_kind: AgentHarnessKind,
+) -> Result<()> {
+    server::AgentServer::new(harness, harness_kind)
+        .serve(tokio::io::stdin(), tokio::io::stdout())
+        .await
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/executor/src/agent_server/protocol.rs
+++ b/crates/executor/src/agent_server/protocol.rs
@@ -1,0 +1,415 @@
+use exoharness::{
+    AgentId, AgentRecord, ConversationId, ConversationRecord, EventId, SandboxProvider, SessionId,
+    ToolArguments, ToolCallId, ToolResult, TurnId, Uuid7,
+};
+use lingua::{Message, UniversalStreamChunk};
+use serde::{Deserialize, Serialize};
+use serde_json::value::RawValue;
+
+pub(crate) const PROTOCOL_VERSION: u32 = 1;
+pub(crate) const RUNTIME_CONTRACT: &str = "exo-agent-server-v1";
+
+#[derive(Debug, Clone, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub(crate) enum RequestId {
+    Number(serde_json::Number),
+    String(String),
+    Null(()),
+    #[serde(skip)]
+    #[default]
+    Missing,
+}
+
+impl RequestId {
+    pub(crate) fn is_missing(&self) -> bool {
+        matches!(self, Self::Missing)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct RpcRequest {
+    pub(crate) jsonrpc: String,
+    #[serde(default)]
+    pub(crate) id: RequestId,
+    pub(crate) method: String,
+    #[serde(default)]
+    pub(crate) params: Option<Box<RawValue>>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct RpcSuccess {
+    jsonrpc: &'static str,
+    id: RequestId,
+    result: ResponseResult,
+}
+
+impl RpcSuccess {
+    pub(crate) fn new(id: RequestId, result: ResponseResult) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            id,
+            result,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct RpcFailure {
+    jsonrpc: &'static str,
+    id: RequestId,
+    error: RpcError,
+}
+
+impl RpcFailure {
+    pub(crate) fn new(id: RequestId, error: RpcError) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            id: match id {
+                RequestId::Missing => RequestId::Null(()),
+                id => id,
+            },
+            error,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub(crate) enum RpcResponse {
+    Success(RpcSuccess),
+    Failure(RpcFailure),
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct RpcError {
+    code: i32,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<ErrorData>,
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorData {
+    kind: &'static str,
+}
+
+impl RpcError {
+    pub(crate) fn parse() -> Self {
+        Self::standard(-32700, "parse error")
+    }
+
+    pub(crate) fn invalid_request() -> Self {
+        Self::standard(-32600, "invalid request")
+    }
+
+    pub(crate) fn method_not_found() -> Self {
+        Self::standard(-32601, "method not found")
+    }
+
+    pub(crate) fn invalid_params() -> Self {
+        Self::standard(-32602, "invalid params")
+    }
+
+    pub(crate) fn executor(error: impl std::fmt::Display) -> Self {
+        Self::domain(-32000, error.to_string(), "executor_error")
+    }
+
+    pub(crate) fn turn_already_active() -> Self {
+        Self::domain(
+            -32001,
+            "conversation already has an active turn",
+            "turn_already_active",
+        )
+    }
+
+    pub(crate) fn not_found(message: String, kind: &'static str) -> Self {
+        Self::domain(-32002, message, kind)
+    }
+
+    pub(crate) fn unsupported_protocol_version() -> Self {
+        Self::domain(
+            -32003,
+            format!("unsupported protocol version; expected {PROTOCOL_VERSION}"),
+            "unsupported_protocol_version",
+        )
+    }
+
+    pub(crate) fn not_initialized() -> Self {
+        Self::domain(-32004, "initialize must be called first", "not_initialized")
+    }
+
+    pub(crate) fn cancellation_unsupported() -> Self {
+        Self::domain(-32005, "turn cancellation is not supported", "unsupported")
+    }
+
+    pub(crate) fn incompatible_harness(message: String) -> Self {
+        Self::domain(-32006, message, "incompatible_harness")
+    }
+
+    fn standard(code: i32, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            data: None,
+        }
+    }
+
+    fn domain(code: i32, message: impl Into<String>, kind: &'static str) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            data: Some(ErrorData { kind }),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub(crate) enum ResponseResult {
+    Initialize(InitializeResult),
+    AgentList(AgentListResult),
+    AgentGet(AgentGetResult),
+    ConversationList(ConversationListResult),
+    ConversationGet(ConversationGetResult),
+    ConversationCreate(ConversationCreateResult),
+    TurnStart(TurnStartResult),
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct InitializeParams {
+    pub(crate) protocol_version: u32,
+    #[serde(default)]
+    pub(crate) client: Option<ClientInfo>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct ClientInfo {
+    pub(crate) name: String,
+    pub(crate) version: String,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct InitializeResult {
+    pub(crate) protocol_version: u32,
+    pub(crate) runtime_contract: &'static str,
+    pub(crate) server: ServerInfo,
+    pub(crate) transport: TransportInfo,
+    pub(crate) capabilities: Capabilities,
+}
+
+impl Default for InitializeResult {
+    fn default() -> Self {
+        Self {
+            protocol_version: PROTOCOL_VERSION,
+            runtime_contract: RUNTIME_CONTRACT,
+            server: ServerInfo {
+                name: "exo",
+                version: env!("CARGO_PKG_VERSION"),
+            },
+            transport: TransportInfo {
+                kind: "stdio",
+                framing: "jsonl",
+                bidirectional: true,
+            },
+            capabilities: Capabilities {
+                agent_list: true,
+                agent_get: true,
+                conversation_list: true,
+                conversation_get: true,
+                conversation_create: true,
+                turn_start: true,
+                turn_stream: true,
+                turn_cancel: false,
+            },
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ServerInfo {
+    name: &'static str,
+    version: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct TransportInfo {
+    kind: &'static str,
+    framing: &'static str,
+    bidirectional: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct Capabilities {
+    agent_list: bool,
+    agent_get: bool,
+    conversation_list: bool,
+    conversation_get: bool,
+    conversation_create: bool,
+    turn_start: bool,
+    turn_stream: bool,
+    turn_cancel: bool,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub(crate) struct EmptyParams {}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct AgentGetParams {
+    pub(crate) agent_ref: String,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct AgentListResult {
+    pub(crate) agents: Vec<AgentRecord>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct AgentGetResult {
+    pub(crate) agent: AgentRecord,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct ConversationListParams {
+    pub(crate) agent_ref: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct ConversationGetParams {
+    pub(crate) agent_ref: String,
+    pub(crate) conversation_ref: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct ConversationCreateParams {
+    pub(crate) agent_ref: String,
+    #[serde(default)]
+    pub(crate) slug: Option<String>,
+    #[serde(default)]
+    pub(crate) name: Option<String>,
+    #[serde(default)]
+    pub(crate) sandbox_image: Option<String>,
+    #[serde(default)]
+    pub(crate) sandbox_provider: Option<SandboxProvider>,
+    #[serde(default)]
+    pub(crate) shell_program: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ConversationListResult {
+    pub(crate) conversations: Vec<ConversationRecord>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ConversationGetResult {
+    pub(crate) conversation: ConversationRecord,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ConversationCreateResult {
+    pub(crate) conversation: ConversationRecord,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct TurnStartParams {
+    pub(crate) agent_ref: String,
+    pub(crate) conversation_ref: String,
+    pub(crate) input: Vec<Message>,
+    #[serde(default)]
+    pub(crate) session_id: Option<SessionId>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub(crate) struct TurnCancelParams {
+    pub(crate) operation_id: Uuid7,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct TurnStartResult {
+    pub(crate) operation_id: Uuid7,
+    pub(crate) state: &'static str,
+    pub(crate) agent_id: AgentId,
+    pub(crate) conversation_id: ConversationId,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct RpcNotification<P> {
+    jsonrpc: &'static str,
+    method: &'static str,
+    params: P,
+}
+
+impl<P> RpcNotification<P> {
+    pub(crate) fn new(method: &'static str, params: P) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            method,
+            params,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct TurnStartedParams {
+    pub(crate) operation_id: Uuid7,
+    pub(crate) sequence: u64,
+    pub(crate) agent_id: AgentId,
+    pub(crate) conversation_id: ConversationId,
+    pub(crate) session_id: Option<SessionId>,
+    pub(crate) turn_id: Option<TurnId>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct TurnEventParams {
+    pub(crate) operation_id: Uuid7,
+    pub(crate) sequence: u64,
+    pub(crate) event: TurnEvent,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum TurnEvent {
+    FirstChunk {
+        ttft_ms: u64,
+    },
+    Chunk {
+        chunk: UniversalStreamChunk,
+    },
+    ToolCall {
+        tool_call_id: ToolCallId,
+        tool_name: String,
+        arguments: ToolArguments,
+    },
+    ToolResult {
+        tool_call_id: ToolCallId,
+        result: ToolResult,
+    },
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct TurnCompletedParams {
+    pub(crate) operation_id: Uuid7,
+    pub(crate) sequence: u64,
+    pub(crate) agent_id: AgentId,
+    pub(crate) conversation_id: ConversationId,
+    pub(crate) session_id: SessionId,
+    pub(crate) turn_id: TurnId,
+    pub(crate) latest_event_id: EventId,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct TurnFailedParams {
+    pub(crate) operation_id: Uuid7,
+    pub(crate) sequence: u64,
+    pub(crate) agent_id: AgentId,
+    pub(crate) conversation_id: ConversationId,
+    pub(crate) session_id: Option<SessionId>,
+    pub(crate) turn_id: Option<TurnId>,
+    pub(crate) latest_event_id: Option<EventId>,
+    pub(crate) error: OperationError,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct OperationError {
+    pub(crate) kind: &'static str,
+    pub(crate) message: String,
+}

--- a/crates/executor/src/agent_server/server.rs
+++ b/crates/executor/src/agent_server/server.rs
@@ -1,0 +1,816 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use anyhow::{Context, Result, anyhow};
+use exoharness::{AgentId, ConversationId, Uuid7};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use serde_json::value::RawValue;
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader, BufWriter};
+use tokio::sync::Mutex;
+use tokio::task::{JoinError, JoinSet};
+use tokio_stream::StreamExt;
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    AgentHarnessKind, CreateConversationRequest, ExecutionStreamEvent, ExecutionStreamHandle,
+    Harness, HarnessConversation, SendRequest,
+};
+
+use super::AGENT_SERVER_TRACING_TARGET;
+use super::protocol::{
+    AgentGetParams, AgentGetResult, AgentListResult, ConversationCreateParams,
+    ConversationCreateResult, ConversationGetParams, ConversationGetResult, ConversationListParams,
+    ConversationListResult, EmptyParams, InitializeParams, InitializeResult, OperationError,
+    PROTOCOL_VERSION, RequestId, ResponseResult, RpcError, RpcFailure, RpcNotification, RpcRequest,
+    RpcResponse, RpcSuccess, TurnCancelParams, TurnCompletedParams, TurnEvent, TurnEventParams,
+    TurnFailedParams, TurnStartParams, TurnStartResult, TurnStartedParams,
+};
+
+type SharedWriter<W> = Arc<Mutex<BufWriter<W>>>;
+type ActiveConversations = Arc<Mutex<HashSet<ConversationId>>>;
+pub(super) const MAX_FRAME_BYTES: usize = 8 * 1024 * 1024;
+const CLIENT_EXECUTOR_FAILURE_MESSAGE: &str = "executor turn failed; see server logs";
+
+pub(crate) struct AgentServer {
+    harness: Arc<dyn Harness>,
+    harness_kind: AgentHarnessKind,
+    initialized: bool,
+    active_conversations: ActiveConversations,
+}
+
+impl AgentServer {
+    pub(crate) fn new(harness: Arc<dyn Harness>, harness_kind: AgentHarnessKind) -> Self {
+        Self {
+            harness,
+            harness_kind,
+            initialized: false,
+            active_conversations: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+
+    pub(crate) async fn serve<R, W>(mut self, reader: R, writer: W) -> Result<()>
+    where
+        R: AsyncRead + Unpin,
+        W: AsyncWrite + Unpin + Send + 'static,
+    {
+        tracing::info!(target: AGENT_SERVER_TRACING_TARGET, "agent server started");
+        let mut frames = FrameReader::new(reader);
+        let writer = Arc::new(Mutex::new(BufWriter::new(writer)));
+        let mut operations = JoinSet::new();
+        let shutdown = CancellationToken::new();
+        let mut server_error = None;
+
+        loop {
+            match next_event(&mut frames, &mut operations).await {
+                ServeEvent::Input(Ok(Some(frame))) => {
+                    let dispatch = match frame {
+                        InputFrame::Bytes(frame) => self.dispatch_frame(&frame).await,
+                        InputFrame::TooLarge => {
+                            Dispatch::failure(RequestId::Null(()), RpcError::parse())
+                        }
+                    };
+                    if let Some(response) = dispatch.response
+                        && let Err(error) = write_frame(&writer, &response).await
+                    {
+                        if let Some(operation) = dispatch.operation {
+                            operation.release().await;
+                        }
+                        server_error = Some(error);
+                        break;
+                    }
+                    if let Some(operation) = dispatch.operation {
+                        operations
+                            .spawn(operation.run(Arc::clone(&writer), shutdown.child_token()));
+                    }
+                }
+                ServeEvent::Input(Ok(None)) => break,
+                ServeEvent::Input(Err(error)) => {
+                    server_error = Some(error.into());
+                    break;
+                }
+                ServeEvent::Operation(result) => {
+                    if let Err(error) = operation_result(result) {
+                        server_error = Some(error);
+                        break;
+                    }
+                }
+            }
+        }
+
+        shutdown.cancel();
+        while let Some(result) = operations.join_next().await {
+            if let Err(error) = operation_result(result)
+                && server_error.is_none()
+            {
+                server_error = Some(error);
+            }
+        }
+        writer.lock().await.flush().await?;
+        tracing::info!(target: AGENT_SERVER_TRACING_TARGET, "agent server stopped");
+
+        match server_error {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
+    }
+
+    async fn dispatch_frame(&mut self, frame: &[u8]) -> Dispatch {
+        let raw = match serde_json::from_slice::<Box<RawValue>>(frame) {
+            Ok(raw) => raw,
+            Err(_) => return Dispatch::failure(RequestId::Null(()), RpcError::parse()),
+        };
+        let request = match serde_json::from_str::<RpcRequest>(raw.get()) {
+            Ok(request) => request,
+            Err(_) => {
+                return Dispatch::failure(RequestId::Null(()), RpcError::invalid_request());
+            }
+        };
+        if request.jsonrpc != "2.0" {
+            return Dispatch::failure(request.id, RpcError::invalid_request());
+        }
+
+        tracing::debug!(
+            target: AGENT_SERVER_TRACING_TARGET,
+            method = %request.method,
+            "agent server request"
+        );
+        let id = request.id.clone();
+        match self.dispatch_request(request).await {
+            Ok((result, operation)) => Dispatch {
+                response: (!id.is_missing())
+                    .then(|| RpcResponse::Success(RpcSuccess::new(id, result))),
+                operation,
+            },
+            Err(_) if id.is_missing() => Dispatch::empty(),
+            Err(error) => Dispatch::failure(id, error),
+        }
+    }
+
+    async fn dispatch_request(
+        &mut self,
+        request: RpcRequest,
+    ) -> std::result::Result<(ResponseResult, Option<TurnOperation>), RpcError> {
+        let params = request.params.as_deref();
+        match request.method.as_str() {
+            "initialize" => self.initialize(params),
+            "agent/list" => {
+                self.require_initialized()?;
+                let _: EmptyParams = parse_params(params)?;
+                let agents = self
+                    .harness
+                    .list_agents()
+                    .await
+                    .map_err(RpcError::executor)?;
+                Ok((ResponseResult::AgentList(AgentListResult { agents }), None))
+            }
+            "agent/get" => {
+                self.require_initialized()?;
+                let params: AgentGetParams = parse_params(params)?;
+                let agent = self
+                    .harness
+                    .get_agent(&params.agent_ref)
+                    .await
+                    .map_err(RpcError::executor)?
+                    .ok_or_else(|| agent_not_found(&params.agent_ref))?;
+                Ok((
+                    ResponseResult::AgentGet(AgentGetResult {
+                        agent: agent.record().clone(),
+                    }),
+                    None,
+                ))
+            }
+            "conversation/list" => {
+                self.require_initialized()?;
+                let params: ConversationListParams = parse_params(params)?;
+                let agent = self.resolve_agent(&params.agent_ref).await?;
+                let conversations = agent
+                    .list_conversations()
+                    .await
+                    .map_err(RpcError::executor)?;
+                Ok((
+                    ResponseResult::ConversationList(ConversationListResult { conversations }),
+                    None,
+                ))
+            }
+            "conversation/get" => {
+                self.require_initialized()?;
+                let params: ConversationGetParams = parse_params(params)?;
+                let agent = self.resolve_agent(&params.agent_ref).await?;
+                let conversation = agent
+                    .get_conversation(&params.conversation_ref)
+                    .await
+                    .map_err(RpcError::executor)?
+                    .ok_or_else(|| conversation_not_found(&params.conversation_ref))?;
+                Ok((
+                    ResponseResult::ConversationGet(ConversationGetResult {
+                        conversation: conversation.record().clone(),
+                    }),
+                    None,
+                ))
+            }
+            "conversation/create" => {
+                self.require_initialized()?;
+                let params: ConversationCreateParams = parse_params(params)?;
+                let agent = self.resolve_agent(&params.agent_ref).await?;
+                let conversation = agent
+                    .create_conversation(CreateConversationRequest {
+                        slug: params.slug,
+                        name: params.name,
+                        sandbox_image: params.sandbox_image,
+                        sandbox_provider: params.sandbox_provider,
+                        shell_program: params.shell_program,
+                    })
+                    .await
+                    .map_err(RpcError::executor)?;
+                Ok((
+                    ResponseResult::ConversationCreate(ConversationCreateResult {
+                        conversation: conversation.record().clone(),
+                    }),
+                    None,
+                ))
+            }
+            "turn/start" => {
+                self.require_initialized()?;
+                let params: TurnStartParams = parse_params(params)?;
+                self.start_turn(params).await
+            }
+            "turn/cancel" => {
+                self.require_initialized()?;
+                let params: TurnCancelParams = parse_params(params)?;
+                tracing::debug!(
+                    target: AGENT_SERVER_TRACING_TARGET,
+                    operation_id = %params.operation_id,
+                    "unsupported turn cancellation requested"
+                );
+                Err(RpcError::cancellation_unsupported())
+            }
+            _ => Err(RpcError::method_not_found()),
+        }
+    }
+
+    fn initialize(
+        &mut self,
+        params: Option<&RawValue>,
+    ) -> std::result::Result<(ResponseResult, Option<TurnOperation>), RpcError> {
+        let params: InitializeParams = parse_params(params)?;
+        if params.protocol_version != PROTOCOL_VERSION {
+            return Err(RpcError::unsupported_protocol_version());
+        }
+        if let Some(client) = params.client {
+            tracing::info!(
+                target: AGENT_SERVER_TRACING_TARGET,
+                client_name = %client.name,
+                client_version = %client.version,
+                "agent server initialized"
+            );
+        } else {
+            tracing::info!(target: AGENT_SERVER_TRACING_TARGET, "agent server initialized");
+        }
+        self.initialized = true;
+        Ok((
+            ResponseResult::Initialize(InitializeResult::default()),
+            None,
+        ))
+    }
+
+    fn require_initialized(&self) -> std::result::Result<(), RpcError> {
+        if self.initialized {
+            Ok(())
+        } else {
+            Err(RpcError::not_initialized())
+        }
+    }
+
+    async fn resolve_agent(
+        &self,
+        agent_ref: &str,
+    ) -> std::result::Result<Arc<dyn crate::HarnessAgent>, RpcError> {
+        self.harness
+            .get_agent(agent_ref)
+            .await
+            .map_err(RpcError::executor)?
+            .ok_or_else(|| agent_not_found(agent_ref))
+    }
+
+    async fn start_turn(
+        &self,
+        params: TurnStartParams,
+    ) -> std::result::Result<(ResponseResult, Option<TurnOperation>), RpcError> {
+        let agent = self.resolve_agent(&params.agent_ref).await?;
+        let agent_harness = agent.config().await.map_err(RpcError::executor)?.harness;
+        if agent_harness != self.harness_kind {
+            return Err(RpcError::incompatible_harness(format!(
+                "agent uses the {} harness but the agent server uses {}; restart with --harness {}",
+                harness_kind_name(agent_harness),
+                harness_kind_name(self.harness_kind),
+                harness_kind_name(agent_harness),
+            )));
+        }
+        let conversation = agent
+            .get_conversation(&params.conversation_ref)
+            .await
+            .map_err(RpcError::executor)?
+            .ok_or_else(|| conversation_not_found(&params.conversation_ref))?;
+        let agent_id = agent.record().id;
+        let conversation_id = conversation.record().id;
+        let operation_id = Uuid7::now();
+
+        let mut active = self.active_conversations.lock().await;
+        if !active.insert(conversation_id) {
+            return Err(RpcError::turn_already_active());
+        }
+        drop(active);
+
+        tracing::info!(
+            target: AGENT_SERVER_TRACING_TARGET,
+            %operation_id,
+            %agent_id,
+            %conversation_id,
+            "agent server turn accepted"
+        );
+        Ok((
+            ResponseResult::TurnStart(TurnStartResult {
+                operation_id,
+                state: "accepted",
+                agent_id,
+                conversation_id,
+            }),
+            Some(TurnOperation {
+                operation_id,
+                agent_id,
+                conversation_id,
+                conversation,
+                request: SendRequest {
+                    input: params.input,
+                    session_id: params.session_id,
+                },
+                active_conversations: Arc::clone(&self.active_conversations),
+            }),
+        ))
+    }
+}
+
+struct Dispatch {
+    response: Option<RpcResponse>,
+    operation: Option<TurnOperation>,
+}
+
+impl Dispatch {
+    fn failure(id: RequestId, error: RpcError) -> Self {
+        Self {
+            response: Some(RpcResponse::Failure(RpcFailure::new(id, error))),
+            operation: None,
+        }
+    }
+
+    fn empty() -> Self {
+        Self {
+            response: None,
+            operation: None,
+        }
+    }
+}
+
+struct TurnOperation {
+    operation_id: Uuid7,
+    agent_id: AgentId,
+    conversation_id: ConversationId,
+    conversation: Arc<dyn HarnessConversation>,
+    request: SendRequest,
+    active_conversations: ActiveConversations,
+}
+
+impl TurnOperation {
+    async fn run<W>(self, writer: SharedWriter<W>, shutdown: CancellationToken) -> Result<()>
+    where
+        W: AsyncWrite + Unpin,
+    {
+        let result = self.run_stream(&writer, &shutdown).await;
+        self.remove_active().await;
+        result
+    }
+
+    async fn run_stream<W>(
+        &self,
+        writer: &SharedWriter<W>,
+        shutdown: &CancellationToken,
+    ) -> Result<()>
+    where
+        W: AsyncWrite + Unpin,
+    {
+        let mut stream = match tokio::select! {
+            biased;
+            result = self.conversation.send_stream(self.request.clone()) => result,
+            () = shutdown.cancelled() => {
+                self.emit_failed(writer, 0, "cancelled", "agent server input closed").await?;
+                return Ok(());
+            },
+        } {
+            Ok(stream) => stream,
+            Err(error) => {
+                self.emit_executor_failed(writer, 0, error).await?;
+                return Ok(());
+            }
+        };
+        write_stream_frame(
+            writer,
+            &RpcNotification::new(
+                "turn/started",
+                TurnStartedParams {
+                    operation_id: self.operation_id,
+                    sequence: 0,
+                    agent_id: self.agent_id,
+                    conversation_id: self.conversation_id,
+                    session_id: None,
+                    turn_id: None,
+                },
+            ),
+            &mut stream,
+        )
+        .await?;
+
+        let mut sequence = 0;
+        loop {
+            let event = tokio::select! {
+                biased;
+                () = shutdown.cancelled() => {
+                    let (cancellation, completed) = cancel_for_shutdown(&mut stream).await;
+                    if let Some(result) = completed {
+                        self.emit_completed(writer, sequence + 1, result).await?;
+                        return Ok(());
+                    }
+                    if let Err(error) = cancellation {
+                        self.emit_executor_failed(writer, sequence + 1, error).await?;
+                        return Ok(());
+                    }
+                    self.emit_failed(
+                        writer,
+                        sequence + 1,
+                        "cancelled",
+                        "agent server input closed",
+                    )
+                    .await?;
+                    tracing::info!(
+                        target: AGENT_SERVER_TRACING_TARGET,
+                        operation_id = %self.operation_id,
+                        "agent server turn cancelled during shutdown"
+                    );
+                    return Ok(());
+                },
+                event = stream.next() => event,
+            };
+            let Some(event) = event else {
+                let message = match stream.join().await {
+                    Ok(()) => anyhow!("executor stream ended without a terminal event"),
+                    Err(error) => error,
+                };
+                self.emit_executor_failed(writer, sequence + 1, message)
+                    .await?;
+                return Ok(());
+            };
+            sequence += 1;
+            match event {
+                Ok(ExecutionStreamEvent::Completed(result)) => {
+                    if let Err(error) = stream.join().await {
+                        tracing::warn!(
+                            target: AGENT_SERVER_TRACING_TARGET,
+                            operation_id = %self.operation_id,
+                            %error,
+                            "executor task failed after reporting completion"
+                        );
+                    }
+                    self.emit_completed(writer, sequence, result).await?;
+                    tracing::info!(
+                        target: AGENT_SERVER_TRACING_TARGET,
+                        operation_id = %self.operation_id,
+                        "agent server turn completed"
+                    );
+                    return Ok(());
+                }
+                Ok(event) => {
+                    let event = wire_event(event)?;
+                    write_stream_frame(
+                        writer,
+                        &RpcNotification::new(
+                            "turn/event",
+                            TurnEventParams {
+                                operation_id: self.operation_id,
+                                sequence,
+                                event,
+                            },
+                        ),
+                        &mut stream,
+                    )
+                    .await?;
+                }
+                Err(error) => {
+                    let message = match stream.join().await {
+                        Ok(()) => error,
+                        Err(join_error) => error
+                            .context(format!("also failed to join executor task: {join_error}")),
+                    };
+                    self.emit_executor_failed(writer, sequence, message).await?;
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    async fn emit_completed<W>(
+        &self,
+        writer: &SharedWriter<W>,
+        sequence: u64,
+        result: crate::SendResult,
+    ) -> Result<()>
+    where
+        W: AsyncWrite + Unpin,
+    {
+        self.remove_active().await;
+        write_frame(
+            writer,
+            &RpcNotification::new(
+                "turn/completed",
+                TurnCompletedParams {
+                    operation_id: self.operation_id,
+                    sequence,
+                    agent_id: self.agent_id,
+                    conversation_id: self.conversation_id,
+                    session_id: result.session_id,
+                    turn_id: result.turn_id,
+                    latest_event_id: result.latest_event_id,
+                },
+            ),
+        )
+        .await
+    }
+
+    async fn emit_executor_failed<W>(
+        &self,
+        writer: &SharedWriter<W>,
+        sequence: u64,
+        error: anyhow::Error,
+    ) -> Result<()>
+    where
+        W: AsyncWrite + Unpin,
+    {
+        tracing::error!(
+            target: AGENT_SERVER_TRACING_TARGET,
+            operation_id = %self.operation_id,
+            error = ?error,
+            "agent server executor failure"
+        );
+        self.emit_failed(
+            writer,
+            sequence,
+            "executor_error",
+            CLIENT_EXECUTOR_FAILURE_MESSAGE,
+        )
+        .await
+    }
+
+    async fn emit_failed<W>(
+        &self,
+        writer: &SharedWriter<W>,
+        sequence: u64,
+        kind: &'static str,
+        message: impl Into<String>,
+    ) -> Result<()>
+    where
+        W: AsyncWrite + Unpin,
+    {
+        self.remove_active().await;
+        write_frame(
+            writer,
+            &RpcNotification::new(
+                "turn/failed",
+                TurnFailedParams {
+                    operation_id: self.operation_id,
+                    sequence,
+                    agent_id: self.agent_id,
+                    conversation_id: self.conversation_id,
+                    session_id: None,
+                    turn_id: None,
+                    latest_event_id: None,
+                    error: OperationError {
+                        kind,
+                        message: message.into(),
+                    },
+                },
+            ),
+        )
+        .await?;
+        tracing::info!(
+            target: AGENT_SERVER_TRACING_TARGET,
+            operation_id = %self.operation_id,
+            "agent server turn failed"
+        );
+        Ok(())
+    }
+
+    async fn release(self) {
+        self.remove_active().await;
+    }
+
+    async fn remove_active(&self) {
+        self.active_conversations
+            .lock()
+            .await
+            .remove(&self.conversation_id);
+    }
+}
+
+pub(super) async fn cancel_for_shutdown(
+    stream: &mut ExecutionStreamHandle,
+) -> (Result<()>, Option<crate::SendResult>) {
+    let finite = stream.supports_cancellation();
+    let cancellation = stream.cancel().await;
+    if !finite {
+        return (cancellation, None);
+    }
+    while let Some(event) = stream.next().await {
+        if let Ok(ExecutionStreamEvent::Completed(result)) = event {
+            return (cancellation, Some(result));
+        }
+    }
+    (cancellation, None)
+}
+
+fn wire_event(event: ExecutionStreamEvent) -> Result<TurnEvent> {
+    match event {
+        ExecutionStreamEvent::FirstChunk { ttft } => Ok(TurnEvent::FirstChunk {
+            ttft_ms: u64::try_from(ttft.as_millis()).unwrap_or(u64::MAX),
+        }),
+        ExecutionStreamEvent::Chunk(chunk) => Ok(TurnEvent::Chunk { chunk }),
+        ExecutionStreamEvent::ToolCall {
+            tool_call_id,
+            tool_name,
+            arguments,
+        } => Ok(TurnEvent::ToolCall {
+            tool_call_id,
+            tool_name,
+            arguments,
+        }),
+        ExecutionStreamEvent::ToolResult {
+            tool_call_id,
+            result,
+        } => Ok(TurnEvent::ToolResult {
+            tool_call_id,
+            result,
+        }),
+        ExecutionStreamEvent::Completed(_) => {
+            Err(anyhow!("completed event mapped as non-terminal"))
+        }
+    }
+}
+
+fn parse_params<T: DeserializeOwned>(
+    params: Option<&RawValue>,
+) -> std::result::Result<T, RpcError> {
+    serde_json::from_str(params.map_or("{}", RawValue::get)).map_err(|_| RpcError::invalid_params())
+}
+
+fn agent_not_found(agent_ref: &str) -> RpcError {
+    RpcError::not_found(format!("agent not found: {agent_ref}"), "agent_not_found")
+}
+
+fn conversation_not_found(conversation_ref: &str) -> RpcError {
+    RpcError::not_found(
+        format!("conversation not found: {conversation_ref}"),
+        "conversation_not_found",
+    )
+}
+
+fn harness_kind_name(kind: AgentHarnessKind) -> &'static str {
+    match kind {
+        AgentHarnessKind::Basic => "basic",
+        AgentHarnessKind::Rlm => "rlm",
+        AgentHarnessKind::TypeScript => "typescript",
+        AgentHarnessKind::Exo => "exo",
+    }
+}
+
+async fn write_frame<W, T>(writer: &SharedWriter<W>, frame: &T) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+    T: Serialize,
+{
+    let encoded = serde_json::to_vec(frame).context("serialize agent server frame")?;
+    let mut writer = writer.lock().await;
+    writer
+        .write_all(&encoded)
+        .await
+        .context("write agent server frame")?;
+    writer
+        .write_all(b"\n")
+        .await
+        .context("write agent server frame delimiter")?;
+    writer.flush().await.context("flush agent server frame")
+}
+
+async fn write_stream_frame<W, T>(
+    writer: &SharedWriter<W>,
+    frame: &T,
+    stream: &mut ExecutionStreamHandle,
+) -> Result<()>
+where
+    W: AsyncWrite + Unpin,
+    T: Serialize,
+{
+    if let Err(error) = write_frame(writer, frame).await {
+        return match stream.cancel().await {
+            Ok(()) => Err(error),
+            Err(cancel_error) => Err(error.context(format!(
+                "also failed to cancel executor stream: {cancel_error}"
+            ))),
+        };
+    }
+    Ok(())
+}
+
+enum ServeEvent {
+    Input(std::io::Result<Option<InputFrame>>),
+    Operation(std::result::Result<Result<()>, JoinError>),
+}
+
+async fn next_event<R>(
+    frames: &mut FrameReader<R>,
+    operations: &mut JoinSet<Result<()>>,
+) -> ServeEvent
+where
+    R: AsyncRead + Unpin,
+{
+    if operations.is_empty() {
+        return ServeEvent::Input(frames.next_frame().await);
+    }
+    tokio::select! {
+        frame = frames.next_frame() => ServeEvent::Input(frame),
+        Some(result) = operations.join_next() => ServeEvent::Operation(result),
+    }
+}
+
+fn operation_result(result: std::result::Result<Result<()>, JoinError>) -> Result<()> {
+    result.context("agent server turn task failed")?
+}
+
+enum InputFrame {
+    Bytes(Vec<u8>),
+    TooLarge,
+}
+
+struct FrameReader<R> {
+    reader: BufReader<R>,
+}
+
+impl<R> FrameReader<R>
+where
+    R: AsyncRead + Unpin,
+{
+    fn new(reader: R) -> Self {
+        Self {
+            reader: BufReader::new(reader),
+        }
+    }
+
+    async fn next_frame(&mut self) -> std::io::Result<Option<InputFrame>> {
+        let mut frame = Vec::new();
+        let mut too_large = false;
+
+        loop {
+            let available = self.reader.fill_buf().await?;
+            if available.is_empty() {
+                return Ok(if too_large {
+                    Some(InputFrame::TooLarge)
+                } else if frame.is_empty() {
+                    None
+                } else {
+                    Some(InputFrame::Bytes(frame))
+                });
+            }
+
+            let newline = available.iter().position(|byte| *byte == b'\n');
+            let consumed = newline.map_or(available.len(), |index| index + 1);
+            let payload_len = newline.unwrap_or(consumed);
+            if !too_large {
+                if frame.len() + payload_len > MAX_FRAME_BYTES {
+                    frame.clear();
+                    too_large = true;
+                } else {
+                    frame.extend_from_slice(&available[..payload_len]);
+                }
+            }
+            self.reader.consume(consumed);
+
+            if newline.is_some() {
+                if frame.last() == Some(&b'\r') {
+                    frame.pop();
+                }
+                return Ok(Some(if too_large {
+                    InputFrame::TooLarge
+                } else {
+                    InputFrame::Bytes(frame)
+                }));
+            }
+        }
+    }
+}

--- a/crates/executor/src/agent_server/tests.rs
+++ b/crates/executor/src/agent_server/tests.rs
@@ -1,0 +1,1137 @@
+use std::collections::VecDeque;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use anyhow::{Result, anyhow};
+use async_trait::async_trait;
+use exoharness::{
+    AgentHandle, AgentRecord, ConversationHandle, ConversationRecord, ExoHarness, SandboxProvider,
+    SessionId, Uuid7,
+};
+use lingua::Message;
+use lingua::universal::{UniversalStreamChunk, UserContent};
+use serde::{Deserialize, Serialize};
+use serde_json::value::RawValue;
+use tokio::io::{
+    AsyncBufReadExt, AsyncWrite, AsyncWriteExt, BufReader, DuplexStream, ReadHalf, WriteHalf,
+};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_util::sync::CancellationToken;
+
+use crate::{
+    AgentConfig, AgentHarnessKind, AgentSandboxConfig, ConversationConfig, ConversationModelConfig,
+    CreateAgentRequest, CreateConversationRequest, ExecutionStreamEvent, ExecutionStreamHandle,
+    Harness, HarnessAgent, HarnessConversation, SandboxScope, SendRequest, SendResult,
+};
+
+use super::protocol::{
+    AgentGetParams, ClientInfo, ConversationCreateParams, ConversationGetParams,
+    ConversationListParams, EmptyParams, InitializeParams, PROTOCOL_VERSION, RequestId,
+    TurnCancelParams, TurnStartParams,
+};
+use super::server::{AgentServer, MAX_FRAME_BYTES, cancel_for_shutdown};
+
+#[tokio::test]
+async fn protocol_discovery_and_conversation_methods() {
+    let conversation = immediate_conversation("dev", Vec::new());
+    let harness = test_harness(vec![conversation]);
+    let (mut client, server) = TestClient::start(harness);
+
+    client.send_raw("{").await;
+    assert_error(client.read().await, -32700, None);
+
+    client.send_raw("[]").await;
+    assert_error(client.read().await, -32600, None);
+
+    client.request(1, "agent/list", &EmptyParams {}).await;
+    assert_error(client.read().await, -32004, Some("not_initialized"));
+
+    client
+        .request(
+            2,
+            "initialize",
+            &InitializeParams {
+                protocol_version: 2,
+                client: None,
+            },
+        )
+        .await;
+    assert_error(
+        client.read().await,
+        -32003,
+        Some("unsupported_protocol_version"),
+    );
+
+    initialize(&mut client, 3).await;
+
+    client.request(4, "missing/method", &EmptyParams {}).await;
+    assert_error(client.read().await, -32601, None);
+
+    client.request(5, "agent/list", &EmptyParams {}).await;
+    let frame = client.read().await;
+    let result: AgentListView = parse_raw(frame.result.as_deref());
+    assert_eq!(result.agents.len(), 1);
+    assert_eq!(result.agents[0].slug, "agent");
+
+    client
+        .request(
+            6,
+            "agent/get",
+            &AgentGetParams {
+                agent_ref: "agent".to_string(),
+            },
+        )
+        .await;
+    let result: AgentGetView = parse_raw(client.read().await.result.as_deref());
+    assert_eq!(result.agent.slug, "agent");
+
+    client
+        .request(
+            61,
+            "agent/get",
+            &AgentGetParams {
+                agent_ref: "missing".to_string(),
+            },
+        )
+        .await;
+    assert_error(client.read().await, -32002, Some("agent_not_found"));
+
+    client
+        .request(
+            7,
+            "conversation/list",
+            &ConversationListParams {
+                agent_ref: "agent".to_string(),
+            },
+        )
+        .await;
+    let result: ConversationListView = parse_raw(client.read().await.result.as_deref());
+    assert_eq!(result.conversations.len(), 1);
+    assert_eq!(result.conversations[0].slug, "dev");
+
+    client
+        .request(
+            8,
+            "conversation/get",
+            &ConversationGetParams {
+                agent_ref: "agent".to_string(),
+                conversation_ref: "dev".to_string(),
+            },
+        )
+        .await;
+    let result: ConversationGetView = parse_raw(client.read().await.result.as_deref());
+    assert_eq!(result.conversation.slug, "dev");
+
+    client
+        .request(
+            9,
+            "conversation/create",
+            &ConversationCreateParams {
+                agent_ref: "agent".to_string(),
+                slug: Some("new".to_string()),
+                name: Some("New conversation".to_string()),
+                sandbox_image: None,
+                sandbox_provider: Some(SandboxProvider::LocalProcess),
+                shell_program: Some("/bin/sh".to_string()),
+            },
+        )
+        .await;
+    let result: ConversationGetView = parse_raw(client.read().await.result.as_deref());
+    assert_eq!(result.conversation.slug, "new");
+
+    client
+        .send_raw(r#"{"jsonrpc":"2.0","id":10,"method":"agent/get","params":{}}"#)
+        .await;
+    assert_error(client.read().await, -32602, None);
+
+    client
+        .request(
+            11,
+            "turn/cancel",
+            &TurnCancelParams {
+                operation_id: Uuid7::now(),
+            },
+        )
+        .await;
+    assert_error(client.read().await, -32005, Some("unsupported"));
+
+    client.close().await;
+    server
+        .await
+        .expect("server task should join")
+        .expect("server");
+}
+
+#[tokio::test]
+async fn null_ids_invalid_utf8_and_oversized_frames_receive_errors_without_stopping_server() {
+    let harness = test_harness(vec![immediate_conversation("dev", Vec::new())]);
+    let (mut client, server) = TestClient::start(harness);
+
+    client
+        .send_raw(
+            r#"{"jsonrpc":"2.0","id":null,"method":"initialize","params":{"protocol_version":1}}"#,
+        )
+        .await;
+    assert!(client.read().await.result.is_some());
+
+    client
+        .send_raw(r#"{"jsonrpc":"1.0","method":"initialize","params":{"protocol_version":1}}"#)
+        .await;
+    let invalid_version = client.read().await;
+    assert_eq!(invalid_version.id, RequestId::Null(()));
+    assert_error(invalid_version, -32600, None);
+
+    client.send_bytes(&[0xff]).await;
+    assert_error(client.read().await, -32700, None);
+
+    client.send_bytes(&vec![b' '; MAX_FRAME_BYTES + 1]).await;
+    assert_error(client.read().await, -32700, None);
+
+    client.request(1, "agent/list", &EmptyParams {}).await;
+    assert!(client.read().await.result.is_some());
+
+    client.close().await;
+    server
+        .await
+        .expect("server task should join")
+        .expect("server");
+}
+
+#[tokio::test]
+async fn turn_stream_preserves_order_and_terminal_ids() {
+    let send_result = SendResult {
+        session_id: Uuid7::now(),
+        turn_id: Uuid7::now(),
+        latest_event_id: Uuid7::now(),
+    };
+    let events = vec![
+        Ok(ExecutionStreamEvent::FirstChunk {
+            ttft: Duration::from_millis(12),
+        }),
+        Ok(ExecutionStreamEvent::Chunk(
+            UniversalStreamChunk::text_delta(0, "hello"),
+        )),
+        Ok(ExecutionStreamEvent::ToolCall {
+            tool_call_id: "call-1".to_string(),
+            tool_name: "shell".to_string(),
+            arguments: serde_json::Map::new(),
+        }),
+        Ok(ExecutionStreamEvent::ToolResult {
+            tool_call_id: "call-1".to_string(),
+            result: serde_json::json!({"ok": true}),
+        }),
+        Ok(ExecutionStreamEvent::Completed(send_result.clone())),
+    ];
+    let conversation = immediate_conversation("dev", events);
+    let harness = test_harness(vec![conversation]);
+    let (mut client, server) = TestClient::start(harness);
+    initialize(&mut client, 1).await;
+
+    start_turn(&mut client, 2, "dev").await;
+    let accepted = client.read().await;
+    let accepted: AcceptedView = parse_raw(accepted.result.as_deref());
+    assert_eq!(accepted.state, "accepted");
+
+    let expected_methods = [
+        "turn/started",
+        "turn/event",
+        "turn/event",
+        "turn/event",
+        "turn/event",
+        "turn/completed",
+    ];
+    let expected_event_types = ["first_chunk", "chunk", "tool_call", "tool_result"];
+    for (sequence, expected_method) in expected_methods.into_iter().enumerate() {
+        let frame = client.read().await;
+        assert_eq!(frame.method.as_deref(), Some(expected_method));
+        let params: SequencedView = parse_raw(frame.params.as_deref());
+        assert_eq!(params.operation_id, accepted.operation_id);
+        assert_eq!(params.sequence, sequence as u64);
+        if let Some(expected_event_type) = sequence
+            .checked_sub(1)
+            .and_then(|index| expected_event_types.get(index).copied())
+        {
+            let event: EventView = parse_raw(params.event.as_deref());
+            assert_eq!(event.event_type, expected_event_type);
+            if expected_event_type == "first_chunk" {
+                assert_eq!(event.ttft_ms, Some(12));
+            }
+            if expected_event_type == "tool_result" {
+                let result: ToolResultView = parse_raw(event.result.as_deref());
+                assert!(result.ok);
+            }
+        }
+    }
+
+    let terminal: CompletedView = parse_raw(client.last_params());
+    assert_eq!(terminal.session_id, send_result.session_id);
+    assert_eq!(terminal.turn_id, send_result.turn_id);
+    assert_eq!(terminal.latest_event_id, send_result.latest_event_id);
+
+    client.close().await;
+    server
+        .await
+        .expect("server task should join")
+        .expect("server");
+    assert!(client.read_optional().await.is_none());
+}
+
+#[tokio::test]
+async fn executor_diagnostics_are_not_sent_to_clients() {
+    let streamed = immediate_conversation(
+        "streamed",
+        vec![Err(anyhow!(
+            "secret=do-not-leak at /private/runner.ts\nstack trace"
+        ))],
+    );
+    let pre_stream = Arc::new(TestConversation::with_streams("pre-stream", Vec::new()));
+    let harness = test_harness(vec![streamed, pre_stream]);
+    let (mut client, server) = TestClient::start(harness);
+    initialize(&mut client, 1).await;
+    start_turn(&mut client, 2, "streamed").await;
+
+    let accepted = client.read().await;
+    assert!(accepted.result.is_some());
+    assert_eq!(client.read().await.method.as_deref(), Some("turn/started"));
+    let failed = client.read().await;
+    assert_eq!(failed.method.as_deref(), Some("turn/failed"));
+    let failed: FailedView = parse_raw(failed.params.as_deref());
+    assert_eq!(failed.error.kind, "executor_error");
+    assert_eq!(
+        failed.error.message,
+        "executor turn failed; see server logs"
+    );
+
+    start_turn(&mut client, 3, "pre-stream").await;
+    assert!(client.read().await.result.is_some());
+    let failed = client.read().await;
+    assert_eq!(failed.method.as_deref(), Some("turn/failed"));
+    let failed: FailedView = parse_raw(failed.params.as_deref());
+    assert_eq!(
+        failed.error.message,
+        "executor turn failed; see server logs"
+    );
+
+    client.close().await;
+    server
+        .await
+        .expect("server task should join")
+        .expect("server");
+    assert!(client.read_optional().await.is_none());
+}
+
+#[tokio::test]
+async fn terminal_notification_releases_conversation_for_the_next_turn() {
+    let conversation = Arc::new(TestConversation::with_streams(
+        "dev",
+        vec![
+            immediate_stream(vec![Ok(completed_event())]),
+            immediate_stream(vec![Ok(completed_event())]),
+        ],
+    ));
+    let harness = test_harness(vec![conversation]);
+    let (mut client, server) = TestClient::start(harness);
+    initialize(&mut client, 1).await;
+
+    for id in [2, 3] {
+        start_turn(&mut client, id, "dev").await;
+        assert!(client.read().await.result.is_some());
+        assert_eq!(client.read().await.method.as_deref(), Some("turn/started"));
+        assert_eq!(
+            client.read().await.method.as_deref(),
+            Some("turn/completed")
+        );
+    }
+
+    client.close().await;
+    server
+        .await
+        .expect("server task should join")
+        .expect("server");
+}
+
+#[tokio::test]
+async fn same_conversation_is_rejected_while_different_conversations_run() {
+    let (first, first_tx) = pending_conversation("first");
+    let (second, second_tx) = pending_conversation("second");
+    let harness = test_harness(vec![first, second]);
+    let (mut client, server) = TestClient::start(harness);
+    initialize(&mut client, 1).await;
+
+    start_turn(&mut client, 2, "first").await;
+    let first_accepted: AcceptedView = parse_raw(client.read().await.result.as_deref());
+    assert_eq!(client.read().await.method.as_deref(), Some("turn/started"));
+
+    start_turn(&mut client, 3, "first").await;
+    assert_error(client.read().await, -32001, Some("turn_already_active"));
+
+    start_turn(&mut client, 4, "second").await;
+    let second_accepted: AcceptedView = parse_raw(client.read().await.result.as_deref());
+    assert_ne!(first_accepted.operation_id, second_accepted.operation_id);
+    assert_eq!(client.read().await.method.as_deref(), Some("turn/started"));
+
+    first_tx
+        .send(Ok(completed_event()))
+        .expect("first stream should be open");
+    second_tx
+        .send(Ok(completed_event()))
+        .expect("second stream should be open");
+    drop(first_tx);
+    drop(second_tx);
+
+    let mut completed = 0;
+    while completed < 2 {
+        if client.read().await.method.as_deref() == Some("turn/completed") {
+            completed += 1;
+        }
+    }
+    client.close_input().await;
+    server
+        .await
+        .expect("server task should join")
+        .expect("server");
+    assert!(client.read_optional().await.is_none());
+}
+
+#[tokio::test]
+async fn eof_cancels_a_permanently_pending_stream() {
+    let (conversation, sender) = pending_conversation("pending");
+    let harness = test_harness(vec![conversation]);
+    let (mut client, server) = TestClient::start(harness);
+    initialize(&mut client, 1).await;
+    start_turn(&mut client, 2, "pending").await;
+    assert!(client.read().await.result.is_some());
+    assert_eq!(client.read().await.method.as_deref(), Some("turn/started"));
+
+    client.close_input().await;
+    let failed = client.read().await;
+    assert_eq!(failed.method.as_deref(), Some("turn/failed"));
+    let failed: FailedView = parse_raw(failed.params.as_deref());
+    assert_eq!(failed.error.kind, "cancelled");
+    assert_eq!(failed.error.message, "agent server input closed");
+    tokio::time::timeout(Duration::from_secs(1), server)
+        .await
+        .expect("server should not wait for a pending stream")
+        .expect("server task should join")
+        .expect("server");
+    assert!(sender.send(Ok(completed_event())).is_err());
+    assert!(client.read_optional().await.is_none());
+}
+
+#[tokio::test]
+async fn shutdown_preserves_a_buffered_completion() {
+    let send_result = SendResult {
+        session_id: Uuid7::now(),
+        turn_id: Uuid7::now(),
+        latest_event_id: Uuid7::now(),
+    };
+    let expected = send_result.clone();
+    let (event_tx, event_rx) = mpsc::unbounded_channel();
+    let cancellation = CancellationToken::new();
+    let task = tokio::spawn(async move {
+        event_tx
+            .send(Ok(ExecutionStreamEvent::Completed(send_result)))
+            .expect("completion receiver should be open");
+    });
+    let mut stream = ExecutionStreamHandle::with_task(
+        UnboundedReceiverStream::new(event_rx),
+        cancellation,
+        task,
+    );
+
+    let (cancellation, completed) = cancel_for_shutdown(&mut stream).await;
+    cancellation.expect("completed task should join");
+    let completed = completed.expect("buffered completion should win");
+    assert_eq!(completed.session_id, expected.session_id);
+    assert_eq!(completed.turn_id, expected.turn_id);
+    assert_eq!(completed.latest_event_id, expected.latest_event_id);
+}
+
+#[tokio::test]
+async fn eof_cancels_a_stream_with_buffered_events() {
+    let harness = test_harness(vec![backlogged_conversation("backlogged")]);
+    let (mut client, server) = TestClient::start(harness);
+    initialize(&mut client, 1).await;
+    start_turn(&mut client, 2, "backlogged").await;
+    assert!(client.read().await.result.is_some());
+    assert_eq!(client.read().await.method.as_deref(), Some("turn/started"));
+
+    client.close_input().await;
+    let failed = tokio::time::timeout(Duration::from_secs(1), async {
+        loop {
+            let frame = client.read().await;
+            if frame.method.as_deref() == Some("turn/failed") {
+                return frame;
+            }
+        }
+    })
+    .await
+    .expect("buffered events must not starve shutdown");
+    let failed: FailedView = parse_raw(failed.params.as_deref());
+    assert_eq!(failed.error.kind, "cancelled");
+    tokio::time::timeout(Duration::from_secs(1), server)
+        .await
+        .expect("server should cancel a backlogged stream")
+        .expect("server task should join")
+        .expect("server");
+    assert!(client.read_optional().await.is_none());
+}
+
+#[tokio::test]
+async fn executor_task_panic_fails_only_its_turn() {
+    let harness = test_harness(vec![panicking_conversation("panics")]);
+    let (mut client, server) = TestClient::start(harness);
+    initialize(&mut client, 1).await;
+    start_turn(&mut client, 2, "panics").await;
+    assert!(client.read().await.result.is_some());
+    assert_eq!(client.read().await.method.as_deref(), Some("turn/started"));
+
+    let failed = client.read().await;
+    assert_eq!(failed.method.as_deref(), Some("turn/failed"));
+    let failed: FailedView = parse_raw(failed.params.as_deref());
+    assert_eq!(failed.error.kind, "executor_error");
+    assert_eq!(
+        failed.error.message,
+        "executor turn failed; see server logs"
+    );
+
+    client.request(3, "agent/list", &EmptyParams {}).await;
+    assert!(client.read().await.result.is_some());
+    client.close().await;
+    server
+        .await
+        .expect("server task should join")
+        .expect("server");
+}
+
+#[tokio::test]
+async fn output_failure_cancels_a_permanently_pending_stream() {
+    let (conversation, sender) = pending_conversation("pending");
+    let harness = test_harness(vec![conversation]);
+    let (mut input, server_input) = tokio::io::duplex(64 * 1024);
+    let server = tokio::spawn(
+        AgentServer::new(harness, AgentHarnessKind::Basic)
+            .serve(server_input, FailOnThirdFlush::default()),
+    );
+    input
+        .write_all(
+            br#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocol_version":1}}
+{"jsonrpc":"2.0","id":2,"method":"turn/start","params":{"agent_ref":"agent","conversation_ref":"pending","input":[{"role":"user","content":"hello"}]}}
+"#,
+        )
+        .await
+        .expect("write requests");
+    input.flush().await.expect("flush requests");
+
+    tokio::time::timeout(Duration::from_secs(1), server)
+        .await
+        .expect("server should not wait after protocol output fails")
+        .expect("server task should join")
+        .expect_err("protocol output failure should stop the server");
+    assert!(sender.send(Ok(completed_event())).is_err());
+}
+
+fn completed_event() -> ExecutionStreamEvent {
+    ExecutionStreamEvent::Completed(SendResult {
+        session_id: Uuid7::now(),
+        turn_id: Uuid7::now(),
+        latest_event_id: Uuid7::now(),
+    })
+}
+
+fn immediate_conversation(
+    slug: &str,
+    events: Vec<Result<ExecutionStreamEvent>>,
+) -> Arc<TestConversation> {
+    Arc::new(TestConversation::new(slug, immediate_stream(events)))
+}
+
+fn immediate_stream(events: Vec<Result<ExecutionStreamEvent>>) -> ExecutionStreamHandle {
+    let (tx, rx) = mpsc::unbounded_channel();
+    for event in events {
+        tx.send(event).expect("test stream should be open");
+    }
+    drop(tx);
+    ExecutionStreamHandle::new(UnboundedReceiverStream::new(rx))
+}
+
+fn pending_conversation(
+    slug: &str,
+) -> (
+    Arc<TestConversation>,
+    mpsc::UnboundedSender<Result<ExecutionStreamEvent>>,
+) {
+    let (tx, mut rx) = mpsc::unbounded_channel();
+    let (event_tx, event_rx) = mpsc::unbounded_channel();
+    let cancellation = CancellationToken::new();
+    let task_cancellation = cancellation.clone();
+    let task = tokio::spawn(async move {
+        loop {
+            let event = tokio::select! {
+                event = rx.recv() => event,
+                () = task_cancellation.cancelled() => return,
+            };
+            let Some(event) = event else {
+                return;
+            };
+            let terminal = matches!(event, Err(_) | Ok(ExecutionStreamEvent::Completed(_)));
+            if event_tx.send(event).is_err() || terminal {
+                return;
+            }
+        }
+    });
+    (
+        Arc::new(TestConversation::new(
+            slug,
+            ExecutionStreamHandle::with_task(
+                UnboundedReceiverStream::new(event_rx),
+                cancellation,
+                task,
+            ),
+        )),
+        tx,
+    )
+}
+
+fn backlogged_conversation(slug: &str) -> Arc<TestConversation> {
+    let (event_tx, event_rx) = mpsc::unbounded_channel();
+    let cancellation = CancellationToken::new();
+    let task_cancellation = cancellation.clone();
+    let task = tokio::spawn(async move {
+        loop {
+            for _ in 0..64 {
+                if event_tx
+                    .send(Ok(ExecutionStreamEvent::Chunk(
+                        UniversalStreamChunk::text_delta(0, "event"),
+                    )))
+                    .is_err()
+                {
+                    return;
+                }
+            }
+            tokio::task::yield_now().await;
+            if task_cancellation.is_cancelled() {
+                return;
+            }
+        }
+    });
+    Arc::new(TestConversation::new(
+        slug,
+        ExecutionStreamHandle::with_task(
+            UnboundedReceiverStream::new(event_rx),
+            cancellation,
+            task,
+        ),
+    ))
+}
+
+fn panicking_conversation(slug: &str) -> Arc<TestConversation> {
+    let (event_tx, event_rx) = mpsc::unbounded_channel();
+    let cancellation = CancellationToken::new();
+    let task = tokio::spawn(async move {
+        drop(event_tx);
+        panic!("test executor panic");
+    });
+    Arc::new(TestConversation::new(
+        slug,
+        ExecutionStreamHandle::with_task(
+            UnboundedReceiverStream::new(event_rx),
+            cancellation,
+            task,
+        ),
+    ))
+}
+
+fn test_harness(conversations: Vec<Arc<TestConversation>>) -> Arc<dyn Harness> {
+    Arc::new(TestHarness {
+        agent: Arc::new(TestAgent {
+            record: AgentRecord {
+                id: Uuid7::now(),
+                slug: "agent".to_string(),
+                name: "Agent".to_string(),
+            },
+            conversations: Mutex::new(conversations),
+        }),
+    })
+}
+
+struct TestHarness {
+    agent: Arc<TestAgent>,
+}
+
+#[async_trait]
+impl Harness for TestHarness {
+    fn exoharness_handle(&self) -> Arc<dyn ExoHarness> {
+        panic!("not used by agent server")
+    }
+
+    async fn list_agents(&self) -> Result<Vec<AgentRecord>> {
+        Ok(vec![self.agent.record.clone()])
+    }
+
+    async fn get_agent(&self, agent_ref: &str) -> Result<Option<Arc<dyn HarnessAgent>>> {
+        if matches_ref(&self.agent.record.id, &self.agent.record.slug, agent_ref) {
+            Ok(Some(Arc::clone(&self.agent) as Arc<dyn HarnessAgent>))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn create_agent(&self, _request: CreateAgentRequest) -> Result<Arc<dyn HarnessAgent>> {
+        Err(anyhow!("not implemented"))
+    }
+
+    async fn delete_agent(&self, _agent_ref: &str) -> Result<bool> {
+        Err(anyhow!("not implemented"))
+    }
+
+    async fn flush_tracing(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+struct TestAgent {
+    record: AgentRecord,
+    conversations: Mutex<Vec<Arc<TestConversation>>>,
+}
+
+#[async_trait]
+impl HarnessAgent for TestAgent {
+    fn record(&self) -> &AgentRecord {
+        &self.record
+    }
+
+    fn exoharness_handle(&self) -> Arc<dyn AgentHandle> {
+        panic!("not used by agent server")
+    }
+
+    async fn config(&self) -> Result<AgentConfig> {
+        Ok(AgentConfig {
+            instructions: Vec::new(),
+            harness: AgentHarnessKind::Basic,
+            typescript: None,
+            enable_agent_tool_creation: false,
+            sandbox: AgentSandboxConfig {
+                scope: SandboxScope::Conversation,
+                image: None,
+                provider: SandboxProvider::LocalProcess,
+                mounts: Vec::new(),
+                enable_networking: false,
+            },
+            model: "test".to_string(),
+            max_output_tokens: None,
+            max_tool_round_trips: None,
+            braintrust: None,
+        })
+    }
+
+    async fn put_config(&self, _config: AgentConfig) -> Result<()> {
+        Err(anyhow!("not implemented"))
+    }
+
+    async fn list_conversations(&self) -> Result<Vec<ConversationRecord>> {
+        Ok(self
+            .conversations
+            .lock()
+            .expect("conversations poisoned")
+            .iter()
+            .map(|conversation| conversation.record.clone())
+            .collect())
+    }
+
+    async fn get_conversation(
+        &self,
+        conversation_ref: &str,
+    ) -> Result<Option<Arc<dyn HarnessConversation>>> {
+        Ok(self
+            .conversations
+            .lock()
+            .expect("conversations poisoned")
+            .iter()
+            .find(|conversation| {
+                matches_ref(
+                    &conversation.record.id,
+                    &conversation.record.slug,
+                    conversation_ref,
+                )
+            })
+            .cloned()
+            .map(|conversation| conversation as Arc<dyn HarnessConversation>))
+    }
+
+    async fn create_conversation(
+        &self,
+        request: CreateConversationRequest,
+    ) -> Result<Arc<dyn HarnessConversation>> {
+        let id = Uuid7::now();
+        let slug = request.slug.unwrap_or_else(|| id.to_string());
+        let mut conversation = immediate_conversation(&slug, Vec::new());
+        Arc::get_mut(&mut conversation)
+            .expect("new conversation should be unique")
+            .record
+            .name = request.name.unwrap_or_else(|| slug.clone());
+        self.conversations
+            .lock()
+            .expect("conversations poisoned")
+            .push(Arc::clone(&conversation));
+        Ok(conversation)
+    }
+
+    async fn delete_conversation(&self, _conversation_ref: &str) -> Result<bool> {
+        Err(anyhow!("not implemented"))
+    }
+}
+
+struct TestConversation {
+    record: ConversationRecord,
+    streams: Mutex<VecDeque<ExecutionStreamHandle>>,
+}
+
+impl TestConversation {
+    fn new(slug: &str, stream: ExecutionStreamHandle) -> Self {
+        Self::with_streams(slug, vec![stream])
+    }
+
+    fn with_streams(slug: &str, streams: Vec<ExecutionStreamHandle>) -> Self {
+        Self {
+            record: ConversationRecord {
+                id: Uuid7::now(),
+                slug: slug.to_string(),
+                name: slug.to_string(),
+                latest_event_id: None,
+            },
+            streams: Mutex::new(streams.into()),
+        }
+    }
+}
+
+#[async_trait]
+impl HarnessConversation for TestConversation {
+    fn record(&self) -> &ConversationRecord {
+        &self.record
+    }
+
+    fn exoharness_handle(&self) -> Arc<dyn ConversationHandle> {
+        panic!("not used by agent server")
+    }
+
+    async fn config(&self) -> Result<ConversationConfig> {
+        Ok(ConversationConfig::default())
+    }
+
+    async fn put_config(&self, _config: ConversationConfig) -> Result<()> {
+        Err(anyhow!("not implemented"))
+    }
+
+    async fn model_override(&self) -> Result<Option<ConversationModelConfig>> {
+        Ok(None)
+    }
+
+    async fn put_model_override(&self, _config: Option<ConversationModelConfig>) -> Result<()> {
+        Err(anyhow!("not implemented"))
+    }
+
+    async fn messages(&self) -> Result<Vec<Message>> {
+        Ok(Vec::new())
+    }
+
+    async fn close_session(&self, _session_id: SessionId) -> Result<()> {
+        Ok(())
+    }
+
+    async fn send(&self, _request: SendRequest) -> Result<SendResult> {
+        Err(anyhow!("not implemented"))
+    }
+
+    async fn send_stream(&self, _request: SendRequest) -> Result<ExecutionStreamHandle> {
+        let stream = self
+            .streams
+            .lock()
+            .expect("streams poisoned")
+            .pop_front()
+            .ok_or_else(|| anyhow!("no executor stream available; secret=do-not-leak"))?;
+        Ok(stream)
+    }
+}
+
+fn matches_ref(id: &Uuid7, slug: &str, reference: &str) -> bool {
+    id.to_string() == reference || slug == reference
+}
+
+struct TestClient {
+    lines: tokio::io::Lines<BufReader<ReadHalf<DuplexStream>>>,
+    writer: Option<WriteHalf<DuplexStream>>,
+    last_params: Option<Box<RawValue>>,
+}
+
+impl TestClient {
+    fn start(harness: Arc<dyn Harness>) -> (Self, JoinHandle<Result<()>>) {
+        let (client, server) = tokio::io::duplex(64 * 1024);
+        let (client_reader, client_writer) = tokio::io::split(client);
+        let (server_reader, server_writer) = tokio::io::split(server);
+        let task = tokio::spawn(
+            AgentServer::new(harness, AgentHarnessKind::Basic).serve(server_reader, server_writer),
+        );
+        (
+            Self {
+                lines: BufReader::new(client_reader).lines(),
+                writer: Some(client_writer),
+                last_params: None,
+            },
+            task,
+        )
+    }
+
+    async fn request<P: Serialize>(&mut self, id: i64, method: &str, params: &P) {
+        let request = TestRequest {
+            jsonrpc: "2.0",
+            id,
+            method,
+            params,
+        };
+        self.send_raw(&serde_json::to_string(&request).expect("serialize request"))
+            .await;
+    }
+
+    async fn send_raw(&mut self, line: &str) {
+        self.send_bytes(line.as_bytes()).await;
+    }
+
+    async fn send_bytes(&mut self, bytes: &[u8]) {
+        let writer = self.writer.as_mut().expect("client input is open");
+        writer.write_all(bytes).await.expect("write request");
+        writer.write_all(b"\n").await.expect("write delimiter");
+        writer.flush().await.expect("flush request");
+    }
+
+    async fn read(&mut self) -> TestFrame {
+        self.read_optional().await.expect("expected server frame")
+    }
+
+    async fn read_optional(&mut self) -> Option<TestFrame> {
+        let line = self.lines.next_line().await.expect("read server frame")?;
+        let frame: TestFrame = serde_json::from_str(&line).expect("valid JSON-RPC frame");
+        assert_eq!(frame.jsonrpc, "2.0");
+        self.last_params = frame.params.clone();
+        Some(frame)
+    }
+
+    fn last_params(&self) -> Option<&RawValue> {
+        self.last_params.as_deref()
+    }
+
+    async fn close_input(&mut self) {
+        if let Some(mut writer) = self.writer.take() {
+            writer.shutdown().await.expect("close client input");
+        }
+    }
+
+    async fn close(&mut self) {
+        self.close_input().await;
+    }
+}
+
+#[derive(Default)]
+struct FailOnThirdFlush {
+    flushes: usize,
+}
+
+impl AsyncWrite for FailOnThirdFlush {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buffer: &[u8],
+    ) -> Poll<std::io::Result<usize>> {
+        Poll::Ready(Ok(buffer.len()))
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        if self.flushes == 2 {
+            Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "test output closed",
+            )))
+        } else {
+            self.flushes += 1;
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[derive(Serialize)]
+struct TestRequest<'a, P> {
+    jsonrpc: &'static str,
+    id: i64,
+    method: &'a str,
+    params: &'a P,
+}
+
+#[derive(Deserialize)]
+struct TestFrame {
+    jsonrpc: String,
+    #[serde(default)]
+    id: RequestId,
+    #[serde(default)]
+    method: Option<String>,
+    #[serde(default)]
+    result: Option<Box<RawValue>>,
+    #[serde(default)]
+    error: Option<TestError>,
+    #[serde(default)]
+    params: Option<Box<RawValue>>,
+}
+
+#[derive(Deserialize)]
+struct TestError {
+    code: i32,
+    #[serde(default)]
+    data: Option<TestErrorData>,
+}
+
+#[derive(Deserialize)]
+struct TestErrorData {
+    kind: String,
+}
+
+#[derive(Deserialize)]
+struct InitializeView {
+    protocol_version: u32,
+    runtime_contract: String,
+    transport: TransportView,
+    capabilities: CapabilitiesView,
+}
+
+#[derive(Deserialize)]
+struct TransportView {
+    kind: String,
+    framing: String,
+}
+
+#[derive(Deserialize)]
+struct CapabilitiesView {
+    turn_cancel: bool,
+}
+
+#[derive(Deserialize)]
+struct AgentListView {
+    agents: Vec<AgentRecord>,
+}
+
+#[derive(Deserialize)]
+struct AgentGetView {
+    agent: AgentRecord,
+}
+
+#[derive(Deserialize)]
+struct ConversationListView {
+    conversations: Vec<ConversationRecord>,
+}
+
+#[derive(Deserialize)]
+struct ConversationGetView {
+    conversation: ConversationRecord,
+}
+
+#[derive(Deserialize)]
+struct AcceptedView {
+    operation_id: Uuid7,
+    state: String,
+}
+
+#[derive(Deserialize)]
+struct SequencedView {
+    operation_id: Uuid7,
+    sequence: u64,
+    #[serde(default)]
+    event: Option<Box<RawValue>>,
+}
+
+#[derive(Deserialize)]
+struct EventView {
+    #[serde(rename = "type")]
+    event_type: String,
+    #[serde(default)]
+    ttft_ms: Option<u64>,
+    #[serde(default)]
+    result: Option<Box<RawValue>>,
+}
+
+#[derive(Deserialize)]
+struct ToolResultView {
+    ok: bool,
+}
+
+#[derive(Deserialize)]
+struct CompletedView {
+    session_id: Uuid7,
+    turn_id: Uuid7,
+    latest_event_id: Uuid7,
+}
+
+#[derive(Deserialize)]
+struct FailedView {
+    error: FailedErrorView,
+}
+
+#[derive(Deserialize)]
+struct FailedErrorView {
+    kind: String,
+    message: String,
+}
+
+async fn initialize(client: &mut TestClient, id: i64) {
+    client
+        .request(
+            id,
+            "initialize",
+            &InitializeParams {
+                protocol_version: PROTOCOL_VERSION,
+                client: Some(ClientInfo {
+                    name: "test".to_string(),
+                    version: "1".to_string(),
+                }),
+            },
+        )
+        .await;
+    let result: InitializeView = parse_raw(client.read().await.result.as_deref());
+    assert_eq!(result.protocol_version, PROTOCOL_VERSION);
+    assert_eq!(result.runtime_contract, "exo-agent-server-v1");
+    assert_eq!(result.transport.kind, "stdio");
+    assert_eq!(result.transport.framing, "jsonl");
+    assert!(!result.capabilities.turn_cancel);
+}
+
+async fn start_turn(client: &mut TestClient, id: i64, conversation_ref: &str) {
+    client
+        .request(
+            id,
+            "turn/start",
+            &TurnStartParams {
+                agent_ref: "agent".to_string(),
+                conversation_ref: conversation_ref.to_string(),
+                input: vec![Message::User {
+                    content: UserContent::String("hello".to_string()),
+                }],
+                session_id: None,
+            },
+        )
+        .await;
+}
+
+fn parse_raw<T: for<'de> Deserialize<'de>>(raw: Option<&RawValue>) -> T {
+    serde_json::from_str(raw.expect("frame payload").get()).expect("deserialize frame payload")
+}
+
+fn assert_error(frame: TestFrame, code: i32, kind: Option<&str>) {
+    let error = frame.error.expect("error response");
+    assert_eq!(error.code, code);
+    assert_eq!(error.data.as_ref().map(|data| data.kind.as_str()), kind);
+}

--- a/crates/executor/src/basic_tests.rs
+++ b/crates/executor/src/basic_tests.rs
@@ -480,6 +480,100 @@ async fn send_stream_emits_chunks_and_persists_final_response() {
     }));
 }
 
+#[tokio::test]
+async fn cancelling_owned_stream_finishes_the_turn() {
+    let agent_id = Uuid7::now();
+    let conversation_id = Uuid7::now();
+    let exoharness = Arc::new(FakeExoHarness::new(agent_id, conversation_id));
+    let agent = exoharness
+        .get_agent(&agent_id)
+        .await
+        .expect("get agent should succeed")
+        .expect("agent should exist");
+    let conversation = agent
+        .get_conversation(&conversation_id)
+        .await
+        .expect("get conversation should succeed")
+        .expect("conversation should exist");
+    let turn = conversation
+        .begin_turn(BeginTurnRequest {
+            session_id: None,
+            input: vec![user_message("pending")],
+        })
+        .await
+        .expect("begin turn should succeed");
+    let mut stream = crate::shared::spawn_prepared_turn_stream(
+        Arc::new(NoopExecutionTracer),
+        agent,
+        Arc::clone(&conversation),
+        turn,
+        default_agent_config(),
+        |_turn_trace, _event_tx| Box::pin(std::future::pending()),
+    );
+
+    stream.cancel().await.expect("stream should cancel");
+    let error = stream
+        .next()
+        .await
+        .expect("cancel should emit a terminal error")
+        .expect_err("cancel should fail the stream");
+    assert_eq!(error.to_string(), "execution cancelled");
+
+    let events = conversation
+        .get_events(Some(EventQuery {
+            cursor: None,
+            direction: Some(EventQueryDirection::Asc),
+            limit: None,
+            session_id: None,
+            turn_id: None,
+            types: None,
+        }))
+        .await
+        .expect("get events should succeed")
+        .events;
+    assert!(matches!(
+        events.last().expect("turn ended event").data,
+        EventData::TurnEnded
+    ));
+}
+
+#[tokio::test]
+async fn cancelling_unowned_stream_is_explicitly_unsupported() {
+    let (_event_tx, event_rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut stream = ExecutionStreamHandle::new(UnboundedReceiverStream::new(event_rx));
+
+    let error = stream
+        .cancel()
+        .await
+        .expect_err("unowned stream cancellation should be unsupported");
+    assert_eq!(
+        error.to_string(),
+        "execution stream does not support cancellation"
+    );
+}
+
+struct NoopExecutionTracer;
+
+#[async_trait]
+impl crate::execution_tracing::ExecutionTracer for NoopExecutionTracer {
+    async fn flush(&self) -> Result<()> {
+        Ok(())
+    }
+
+    async fn start_turn(
+        &self,
+        _config: Option<&BraintrustTracingConfig>,
+        _agent: &AgentRecord,
+        _conversation: &ConversationRecord,
+        _agent_config: &AgentConfig,
+        _session_id: SessionId,
+        _turn_id: TurnId,
+        _streamed: bool,
+    ) -> Option<Box<dyn crate::execution_tracing::TurnExecutionTrace>> {
+        None
+    }
+}
+
 struct FakeModelClient {
     responses: Mutex<VecDeque<ModelResponse>>,
     streams: Mutex<VecDeque<FakeStreamResponse>>,

--- a/crates/executor/src/executor_types.rs
+++ b/crates/executor/src/executor_types.rs
@@ -13,7 +13,9 @@ use lingua::{Message, UniversalStreamChunk, UniversalUsage};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::sync::OwnedMutexGuard;
+use tokio::task::JoinHandle;
 use tokio_stream::{Stream, wrappers::UnboundedReceiverStream};
+use tokio_util::sync::CancellationToken;
 
 use crate::braintrust::BraintrustTracingConfig;
 
@@ -244,6 +246,8 @@ pub struct SendResult {
 
 pub struct ExecutionStreamHandle {
     event_stream: UnboundedReceiverStream<Result<ExecutionStreamEvent>>,
+    cancellation: Option<CancellationToken>,
+    task: Option<JoinHandle<()>>,
     _send_guard: Option<OwnedMutexGuard<()>>,
 }
 
@@ -251,8 +255,47 @@ impl ExecutionStreamHandle {
     pub fn new(event_stream: UnboundedReceiverStream<Result<ExecutionStreamEvent>>) -> Self {
         Self {
             event_stream,
+            cancellation: None,
+            task: None,
             _send_guard: None,
         }
+    }
+
+    pub(crate) fn with_task(
+        event_stream: UnboundedReceiverStream<Result<ExecutionStreamEvent>>,
+        cancellation: CancellationToken,
+        task: JoinHandle<()>,
+    ) -> Self {
+        Self {
+            event_stream,
+            cancellation: Some(cancellation),
+            task: Some(task),
+            _send_guard: None,
+        }
+    }
+
+    pub async fn cancel(&mut self) -> Result<()> {
+        let cancellation = self
+            .cancellation
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("execution stream does not support cancellation"))?;
+        cancellation.cancel();
+        self.join().await
+    }
+
+    pub(crate) fn supports_cancellation(&self) -> bool {
+        self.cancellation.is_some()
+    }
+
+    pub(crate) async fn join(&mut self) -> Result<()> {
+        let result = if let Some(task) = self.task.take() {
+            task.await
+                .map_err(|error| anyhow::anyhow!("execution stream task failed: {error}"))
+        } else {
+            Ok(())
+        };
+        self._send_guard.take();
+        result
     }
 
     pub(crate) fn with_send_guard(mut self, send_guard: OwnedMutexGuard<()>) -> Self {

--- a/crates/executor/src/lib.rs
+++ b/crates/executor/src/lib.rs
@@ -1,5 +1,6 @@
 mod adapter;
 mod agent_sandbox;
+mod agent_server;
 mod basic;
 #[cfg(test)]
 mod basic_tests;
@@ -40,6 +41,7 @@ pub use adapter::{
     AdapterRecord, AdapterSource, NewAdapter, WorkerSecretEnvVar,
 };
 pub use adapter::{AdapterRunOptions, run_adapters_watch};
+pub use agent_server::{AGENT_SERVER_TRACING_TARGET, serve_agent_server_stdio};
 pub use braintrust::{BraintrustProject, BraintrustRuntimeConfig, BraintrustTracingConfig};
 pub use conversation_events::{
     HOST_EVENT_ADAPTER_RUNNER_DRAINING, HOST_EVENT_ADAPTER_RUNNER_STARTED, HOST_EVENT_REBOOT,

--- a/crates/executor/src/shared.rs
+++ b/crates/executor/src/shared.rs
@@ -10,6 +10,7 @@ use exoharness::{
 };
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
+use tokio_util::sync::CancellationToken;
 
 use crate::execution_tracing::{ExecutionTracer, TurnExecutionTrace};
 use crate::{AgentConfig, ExecutionStreamEvent, ExecutionStreamHandle, SendResult};
@@ -99,12 +100,14 @@ where
         + 'static,
 {
     let (event_tx, event_rx) = mpsc::unbounded_channel();
+    let cancellation = CancellationToken::new();
+    let task_cancellation = cancellation.clone();
 
-    tokio::spawn(async move {
+    let task = tokio::spawn(async move {
         let session_id = turn.record().session_id;
         let turn_id = turn.record().id;
-        let turn_trace = tracer
-            .start_turn(
+        let turn_trace = tokio::select! {
+            turn_trace = tracer.start_turn(
                 agent_config.braintrust.as_ref(),
                 agent.record(),
                 conversation.record(),
@@ -112,35 +115,69 @@ where
                 session_id,
                 turn_id,
                 true,
-            )
-            .await;
-        let send_result = finalize_turn(turn.as_ref(), run(turn_trace.as_deref(), &event_tx).await)
-            .await
-            .map(|latest_event_id| SendResult {
-                session_id,
-                turn_id,
-                latest_event_id,
-            });
-
-        if let Some(turn_trace) = turn_trace {
-            match &send_result {
-                Ok(result) => {
-                    turn_trace
-                        .finish_success(Some(result.latest_event_id))
-                        .await
-                }
-                Err(error) => turn_trace.finish_error(error).await,
+            ) => turn_trace,
+            () = task_cancellation.cancelled() => {
+                complete_stream_turn(
+                    turn.as_ref(),
+                    session_id,
+                    turn_id,
+                    None,
+                    Err(Error::msg("execution cancelled")),
+                    &event_tx,
+                ).await;
+                return;
             }
-        }
-
-        if let Err(error) = &send_result {
-            try_send_stream_error(&event_tx, error);
-        } else if let Ok(result) = &send_result {
-            try_send_stream_event(&event_tx, ExecutionStreamEvent::Completed(result.clone()));
-        }
+        };
+        let run_result = tokio::select! {
+            result = run(turn_trace.as_deref(), &event_tx) => result,
+            () = task_cancellation.cancelled() => Err(Error::msg("execution cancelled")),
+        };
+        complete_stream_turn(
+            turn.as_ref(),
+            session_id,
+            turn_id,
+            turn_trace,
+            run_result,
+            &event_tx,
+        )
+        .await;
     });
 
-    ExecutionStreamHandle::new(UnboundedReceiverStream::new(event_rx))
+    ExecutionStreamHandle::with_task(UnboundedReceiverStream::new(event_rx), cancellation, task)
+}
+
+async fn complete_stream_turn(
+    turn: &dyn TurnHandle,
+    session_id: exoharness::SessionId,
+    turn_id: exoharness::TurnId,
+    turn_trace: Option<Box<dyn TurnExecutionTrace>>,
+    run_result: Result<()>,
+    event_tx: &mpsc::UnboundedSender<Result<ExecutionStreamEvent>>,
+) {
+    let send_result = finalize_turn(turn, run_result)
+        .await
+        .map(|latest_event_id| SendResult {
+            session_id,
+            turn_id,
+            latest_event_id,
+        });
+
+    if let Some(turn_trace) = turn_trace {
+        match &send_result {
+            Ok(result) => {
+                turn_trace
+                    .finish_success(Some(result.latest_event_id))
+                    .await
+            }
+            Err(error) => turn_trace.finish_error(error).await,
+        }
+    }
+
+    if let Err(error) = &send_result {
+        try_send_stream_error(event_tx, error);
+    } else if let Ok(result) = &send_result {
+        try_send_stream_event(event_tx, ExecutionStreamEvent::Completed(result.clone()));
+    }
 }
 
 async fn finish_turn_trace(

--- a/crates/executor/src/typescript.rs
+++ b/crates/executor/src/typescript.rs
@@ -2,7 +2,8 @@ use std::collections::HashMap;
 use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::process::{ExitStatus, Stdio};
-use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
 
 use anyhow::{Context as AnyhowContext, anyhow, bail};
@@ -24,7 +25,7 @@ use lingua::UniversalStreamChunk;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, BufWriter, Lines};
 use tokio::process::{Child, ChildStdout, Command};
-use tokio::sync::{Mutex, mpsc};
+use tokio::sync::{Mutex, MutexGuard, mpsc};
 use tokio::task::JoinHandle;
 
 use crate::execution_tracing::TurnExecutionTrace;
@@ -42,7 +43,7 @@ pub struct TypeScriptExecutor<T> {
     workspace_root: PathBuf,
     env: Arc<HashMap<String, String>>,
     tools: Arc<T>,
-    runners: Arc<Mutex<HashMap<String, Arc<Mutex<TypeScriptRunnerProcess>>>>>,
+    runners: Arc<StdMutex<HashMap<String, Arc<TypeScriptRunner>>>>,
 }
 
 impl<T> TypeScriptExecutor<T> {
@@ -57,7 +58,7 @@ impl<T> TypeScriptExecutor<T> {
             workspace_root,
             env: Arc::new(env),
             tools,
-            runners: Arc::new(Mutex::new(HashMap::new())),
+            runners: Arc::new(StdMutex::new(HashMap::new())),
         }
     }
 }
@@ -117,10 +118,20 @@ where
             bail!("typescript harness module does not exist: {module_path}");
         }
 
-        let runner = self.runner(&module_path).await?;
-        let result = {
-            let mut runner = runner.lock().await;
-            runner
+        loop {
+            let runner = self.runner(&module_path)?;
+            let process = runner.process.lock().await;
+            if !runner.valid.load(Ordering::Acquire) {
+                drop(process);
+                continue;
+            }
+            let mut run = TypeScriptRunnerRun::new(
+                process,
+                runner.as_ref(),
+                self.runners.as_ref(),
+                &module_path,
+            );
+            let result = run
                 .execute_turn(
                     self,
                     TypeScriptTurn {
@@ -134,14 +145,12 @@ where
                         turn_trace,
                     },
                 )
-                .await
-        };
+                .await;
+            run.reusable = result.is_ok();
+            drop(run);
 
-        if result.is_err() {
-            self.remove_runner(&module_path, &runner).await;
+            return result;
         }
-
-        result
     }
 }
 
@@ -149,28 +158,28 @@ impl<T> TypeScriptExecutor<T>
 where
     T: ToolRuntime + 'static,
 {
-    async fn runner(&self, module_path: &str) -> Result<Arc<Mutex<TypeScriptRunnerProcess>>> {
-        let mut runners = self.runners.lock().await;
-        if let Some(runner) = runners.get(module_path) {
+    fn runner(&self, module_path: &str) -> Result<Arc<TypeScriptRunner>> {
+        let mut runners = self
+            .runners
+            .lock()
+            .expect("typescript runner cache poisoned");
+        if let Some(runner) = runners
+            .get(module_path)
+            .filter(|runner| runner.valid.load(Ordering::Acquire))
+        {
             return Ok(Arc::clone(runner));
         }
 
-        let runner = Arc::new(Mutex::new(TypeScriptRunnerProcess::start(
-            &self.workspace_root,
-            self.env.as_ref(),
-            module_path,
-        )?));
+        let runner = Arc::new(TypeScriptRunner {
+            process: Mutex::new(TypeScriptRunnerProcess::start(
+                &self.workspace_root,
+                self.env.as_ref(),
+                module_path,
+            )?),
+            valid: AtomicBool::new(true),
+        });
         runners.insert(module_path.to_string(), Arc::clone(&runner));
         Ok(runner)
-    }
-
-    async fn remove_runner(&self, module_path: &str, runner: &Arc<Mutex<TypeScriptRunnerProcess>>) {
-        let mut runners = self.runners.lock().await;
-        if let Some(current) = runners.get(module_path)
-            && Arc::ptr_eq(current, runner)
-        {
-            runners.remove(module_path);
-        }
     }
 
     async fn execute_runtime_request(
@@ -207,6 +216,73 @@ where
 }
 
 const RUNNER_EXIT_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+struct TypeScriptRunner {
+    process: Mutex<TypeScriptRunnerProcess>,
+    valid: AtomicBool,
+}
+
+struct TypeScriptRunnerRun<'a> {
+    process: MutexGuard<'a, TypeScriptRunnerProcess>,
+    runner: &'a TypeScriptRunner,
+    runners: &'a StdMutex<HashMap<String, Arc<TypeScriptRunner>>>,
+    module_path: &'a str,
+    reusable: bool,
+}
+
+impl<'a> TypeScriptRunnerRun<'a> {
+    fn new(
+        process: MutexGuard<'a, TypeScriptRunnerProcess>,
+        runner: &'a TypeScriptRunner,
+        runners: &'a StdMutex<HashMap<String, Arc<TypeScriptRunner>>>,
+        module_path: &'a str,
+    ) -> Self {
+        Self {
+            process,
+            runner,
+            runners,
+            module_path,
+            reusable: false,
+        }
+    }
+}
+
+impl std::ops::Deref for TypeScriptRunnerRun<'_> {
+    type Target = TypeScriptRunnerProcess;
+
+    fn deref(&self) -> &Self::Target {
+        &self.process
+    }
+}
+
+impl std::ops::DerefMut for TypeScriptRunnerRun<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.process
+    }
+}
+
+impl Drop for TypeScriptRunnerRun<'_> {
+    fn drop(&mut self) {
+        if !self.reusable {
+            self.runner.valid.store(false, Ordering::Release);
+            if let Err(error) = self.process.child.start_kill() {
+                tracing::warn!(%error, "failed to terminate unusable TypeScript harness runner");
+            }
+            match self.runners.lock() {
+                Ok(mut runners) => {
+                    if let Some(current) = runners.get(self.module_path)
+                        && std::ptr::eq(current.as_ref(), self.runner)
+                    {
+                        runners.remove(self.module_path);
+                    }
+                }
+                Err(error) => {
+                    tracing::error!(%error, "failed to remove unusable TypeScript harness runner");
+                }
+            }
+        }
+    }
+}
 
 struct TypeScriptRunnerProcess {
     child: Child,
@@ -1299,9 +1375,255 @@ fn format_error_chain(error: &anyhow::Error, context: std::fmt::Arguments<'_>) -
 #[cfg(test)]
 mod tests {
     use std::collections::VecDeque;
+    #[cfg(unix)]
+    use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
     use std::sync::Mutex as StdMutex;
 
+    #[cfg(unix)]
+    use lingua::Message;
+    #[cfg(unix)]
+    use lingua::universal::UserContent;
+    #[cfg(unix)]
+    use tempfile::TempDir;
+    #[cfg(unix)]
+    use tokio_stream::StreamExt;
+
     use super::*;
+    #[cfg(unix)]
+    use crate::test_support::local_test_config;
+    #[cfg(unix)]
+    use crate::{
+        AgentHarnessKind, CreateAgentRequest, CreateConversationRequest, ExecutionStreamHandle,
+        Harness, SandboxProvider, SandboxScope, SendRequest, TypeScriptHarnessConfig,
+    };
+
+    #[cfg(unix)]
+    #[tokio::test(flavor = "current_thread")]
+    async fn queued_turns_replace_cancelled_and_failed_runners() {
+        let tempdir = TempDir::new().expect("tempdir should exist");
+        let bin_dir = tempdir.path().join("bin");
+        fs::create_dir(&bin_dir).expect("fake node bin should exist");
+        let node_path = bin_dir.join("node");
+        fs::write(
+            &node_path,
+            r#"#!/bin/sh
+pending=0
+while IFS= read -r line; do
+  if [ "$pending" -eq 1 ]; then
+    printf '%s\n' '{"kind":"done"}'
+    pending=0
+  fi
+  case "$line" in
+    *pending*)
+      printf '%s\n' '{"kind":"stream_event","event":{"type":"first_chunk","ttft_ms":1}}'
+      pending=1
+      ;;
+    *fail*)
+      printf '%s\n' '{"kind":"stream_event","event":{"type":"first_chunk","ttft_ms":1}}'
+      while [ ! -f "$FAIL_SIGNAL" ]; do sleep 0.01; done
+      printf '%s\n' '{"kind":"error","message":"expected failure","stack":"private stack"}'
+      exit 1
+      ;;
+    *fresh*)
+      printf '%s\n' '{"kind":"stream_event","event":{"type":"text_delta","text":"fresh"}}'
+      printf '%s\n' '{"kind":"done"}'
+      ;;
+  esac
+done
+"#,
+        )
+        .expect("fake node should be written");
+        let mut permissions = fs::metadata(&node_path)
+            .expect("fake node metadata")
+            .permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&node_path, permissions).expect("fake node should be executable");
+        let module_path = tempdir.path().join("harness.ts");
+        fs::write(&module_path, "export default {};").expect("module should be written");
+        let module_path = module_path.to_string_lossy().into_owned();
+        let fail_signal = tempdir.path().join("fail");
+
+        let exoharness = Arc::new(
+            BasicExoHarness::new(local_test_config(tempdir.path().join("exoharness")))
+                .await
+                .expect("basic exoharness should initialize"),
+        ) as Arc<dyn ExoHarness>;
+        let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+        let path = std::env::var("PATH").unwrap_or_default();
+        let executor = TypeScriptExecutor::new(
+            Arc::clone(&exoharness),
+            workspace_root,
+            HashMap::from([
+                ("PATH".to_string(), format!("{}:{path}", bin_dir.display())),
+                (
+                    "FAIL_SIGNAL".to_string(),
+                    fail_signal.to_string_lossy().into_owned(),
+                ),
+            ]),
+            Arc::new(BasicToolRuntime),
+        );
+        let executor_state = executor.clone();
+        let harness = TypeScriptHarness {
+            inner: SharedHarness::new(exoharness, ExecutorHarnessRuntime::new(executor, None)),
+        };
+        let agent = harness
+            .create_agent(CreateAgentRequest {
+                slug: "typescript".to_string(),
+                name: None,
+                harness: AgentHarnessKind::TypeScript,
+                typescript: Some(TypeScriptHarnessConfig {
+                    module_path: module_path.clone(),
+                    tool_module_paths: Vec::new(),
+                }),
+                enable_agent_tool_creation: false,
+                sandbox_image: None,
+                sandbox_provider: SandboxProvider::LocalProcess,
+                sandbox_scope: Some(SandboxScope::Conversation),
+                enable_networking: false,
+                model: "test".to_string(),
+                max_output_tokens: None,
+                max_tool_round_trips: None,
+                braintrust: None,
+            })
+            .await
+            .expect("agent should be created");
+        let first_conversation = agent
+            .create_conversation(CreateConversationRequest::default())
+            .await
+            .expect("first conversation should be created");
+        let second_conversation = agent
+            .create_conversation(CreateConversationRequest::default())
+            .await
+            .expect("second conversation should be created");
+        let third_conversation = agent
+            .create_conversation(CreateConversationRequest::default())
+            .await
+            .expect("third conversation should be created");
+        let fourth_conversation = agent
+            .create_conversation(CreateConversationRequest::default())
+            .await
+            .expect("fourth conversation should be created");
+
+        let mut first = first_conversation
+            .send_stream(SendRequest {
+                input: vec![Message::User {
+                    content: UserContent::String("pending".to_string()),
+                }],
+                session_id: None,
+            })
+            .await
+            .expect("first stream should start");
+        tokio::time::timeout(Duration::from_secs(1), first.next())
+            .await
+            .expect("first runner should start")
+            .expect("first runner should emit an event")
+            .expect("first runner event should succeed");
+        let mut second = second_conversation
+            .send_stream(SendRequest {
+                input: vec![Message::User {
+                    content: UserContent::String("fresh".to_string()),
+                }],
+                session_id: None,
+            })
+            .await
+            .expect("second stream should start");
+        wait_for_queued_turn(&executor_state, &module_path).await;
+        tokio::time::timeout(Duration::from_secs(1), first.cancel())
+            .await
+            .expect("first stream should cancel promptly")
+            .expect("first stream should support cancellation");
+
+        assert_eq!(stream_text(&mut second).await, "fresh");
+        second.join().await.expect("second stream task should join");
+
+        let mut failed = third_conversation
+            .send_stream(SendRequest {
+                input: vec![Message::User {
+                    content: UserContent::String("fail".to_string()),
+                }],
+                session_id: None,
+            })
+            .await
+            .expect("failing stream should start");
+        tokio::time::timeout(Duration::from_secs(1), failed.next())
+            .await
+            .expect("failing runner should start")
+            .expect("failing runner should emit an event")
+            .expect("failing runner event should succeed");
+        let mut after_failure = fourth_conversation
+            .send_stream(SendRequest {
+                input: vec![Message::User {
+                    content: UserContent::String("fresh".to_string()),
+                }],
+                session_id: None,
+            })
+            .await
+            .expect("queued stream should start");
+        wait_for_queued_turn(&executor_state, &module_path).await;
+        fs::write(&fail_signal, "").expect("failure signal should be written");
+        tokio::time::timeout(Duration::from_secs(1), failed.next())
+            .await
+            .expect("first queued turn should fail promptly")
+            .expect("first queued turn should emit its failure")
+            .expect_err("first queued turn should fail");
+        failed.join().await.expect("failed stream task should join");
+
+        assert_eq!(stream_text(&mut after_failure).await, "fresh");
+        after_failure
+            .join()
+            .await
+            .expect("replacement stream task should join");
+    }
+
+    #[cfg(unix)]
+    async fn wait_for_queued_turn(
+        executor: &TypeScriptExecutor<BasicToolRuntime>,
+        module_path: &str,
+    ) {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let queued = executor
+                    .runners
+                    .lock()
+                    .expect("typescript runner cache poisoned")
+                    .get(module_path)
+                    .is_some_and(|runner| Arc::strong_count(runner) >= 3);
+                if queued {
+                    return;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("turn should queue on the active runner");
+    }
+
+    #[cfg(unix)]
+    async fn stream_text(stream: &mut ExecutionStreamHandle) -> String {
+        tokio::time::timeout(Duration::from_secs(1), async {
+            let mut text = String::new();
+            while let Some(event) = stream.next().await {
+                match event.expect("stream event should succeed") {
+                    ExecutionStreamEvent::Chunk(chunk) => {
+                        for choice in chunk.choices {
+                            if let Some(delta) = choice.delta_view()
+                                && let Some(content) = delta.content
+                            {
+                                text.push_str(&content);
+                            }
+                        }
+                    }
+                    ExecutionStreamEvent::Completed(_) => break,
+                    _ => {}
+                }
+            }
+            text
+        })
+        .await
+        .expect("stream should complete promptly")
+    }
 
     #[tokio::test(flavor = "current_thread")]
     async fn latest_sandbox_process_event_cursor_pages_to_latest_cursor() {

--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -1,0 +1,72 @@
+# Agent Server
+
+`exo agent-server` exposes Exo's executor harness to a parent process over
+JSON-RPC 2.0. It is a long-lived, headless alternative to the interactive CLI:
+requests are newline-delimited JSON on stdin, responses and live turn
+notifications are newline-delimited JSON on stdout, and logs are written to
+stderr. Frames larger than 8 MiB are rejected as parse errors.
+
+```bash
+exo agent-server
+```
+
+The protocol contract is `exo-agent-server-v1`. Clients must initialize with
+protocol version 1 before calling other methods:
+
+```jsonl
+{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocol_version":1,"client":{"name":"demo","version":"0.1.0"}}}
+{"jsonrpc":"2.0","id":2,"method":"agent/list","params":{}}
+```
+
+The v1 request methods are:
+
+- `initialize`
+- `agent/list` and `agent/get`
+- `conversation/list`, `conversation/get`, and `conversation/create`
+- `turn/start`
+- `turn/cancel`, reserved but reported as unsupported in v1
+
+Agent and conversation references use the same ID-or-slug resolution as the
+Rust `Harness` facade. Conversation creation accepts `agent_ref` and the
+optional native fields `slug`, `name`, `sandbox_image`, `sandbox_provider`, and
+`shell_program`.
+
+The server uses one executor runtime, selected by the existing global
+`--harness` option (default: `basic`). A turn is rejected when the persisted
+agent configuration names a different runtime; restart the server with the
+matching `--harness` value.
+
+## Starting a turn
+
+`turn/start` accepts the native serialized Lingua message list and an optional
+Exoharness session ID:
+
+```text
+{"jsonrpc":"2.0","id":3,"method":"turn/start","params":{"agent_ref":"exo-agent","conversation_ref":"dev","input":[{"role":"user","content":"Summarize the repository."}],"session_id":null}}
+```
+
+The response acknowledges a process-local `operation_id`. The server then
+emits `turn/started`, ordered `turn/event` notifications for executor stream
+events, and exactly one `turn/completed` or `turn/failed` notification.
+`turn/completed` includes the native `session_id`, `turn_id`, and
+`latest_event_id` needed to correlate the live stream with durable Exoharness
+history.
+Executor failures use a bounded client message; detailed diagnostics remain on
+stderr.
+
+Only one Agent Server operation may run on a conversation at a time. Different
+conversations may run concurrently. `turn/cancel` remains unadvertised in v1.
+The process does own its executor tasks and cancels and joins in-flight turns
+when stdin closes or protocol output fails. A stdin closure emits `turn/failed`
+with `error.kind: "cancelled"` when stdout is still writable.
+
+## Agent Server versus `exo serve`
+
+`exo serve` is the Exoharness substrate API: it exposes durable agents, events,
+artifacts, sandboxes, and related primitives over unary HTTP. `exo agent-server`
+is the executor control API: it starts model/tool turns through
+`HarnessConversation::send_stream()` and delivers the live executor stream over
+stdio.
+
+Agent Server notifications are transient delivery, not a durable replay log.
+Exoharness remains the canonical recovery and evidence source.


### PR DESCRIPTION
## Summary

Adds `exo agent-server`, a long-lived JSON-RPC 2.0 server that exposes Exo’s executor harness over newline-delimited stdin/stdout.

This allows external processes to resolve persisted agents and conversations, start model/tool turns, consume typed streaming events, and correlate results with durable Exoharness identities without embedding the executor.

## What changed

- Add the `exo agent-server` CLI command.
- Add protocol initialization and capability discovery.
- Support:
  - `agent/list`
  - `agent/get`
  - `conversation/list`
  - `conversation/get`
  - `conversation/create`
  - `turn/start`
- Stream typed `turn/started`, `turn/event`, `turn/completed`, and `turn/failed` notifications.
- Return process-local operation IDs and native session, turn, and event IDs.
- Enforce one active turn per conversation while allowing different conversations to run concurrently.
- Reject agents whose persisted harness does not match the server runtime.
- Keep stdout protocol-only and send diagnostics to stderr.

## Protocol and lifecycle behavior

- Uses JSON-RPC 2.0 with JSONL framing.
- Requires initialization with protocol version 1.
- Preserves `null` request IDs and returns parse or invalid-request errors without terminating the server.
- Rejects frames larger than 8 MiB and recovers from malformed UTF-8 or JSON.
- Owns executor stream tasks and cancels/joins them on stdin EOF or output failure.
- Preserves an already-finalized completion during shutdown.
- Contains executor-task panics to the affected operation.
- Releases the active-conversation guard before terminal notifications become observable.
- Invalidates and terminates failed or cancelled TypeScript runners before queued turns may reuse them.
- Returns bounded client-safe executor errors while retaining full diagnostics in default stderr logging.

`turn/cancel` remains intentionally unsupported and is advertised as unavailable. The server can cancel owned turns during shutdown, but client-requested cancellation will wait until operation lookup, race handling, and terminal notification semantics are fully defined.

## Documentation

Adds `docs/agent-server.md` and README discovery for the new command and protocol.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets` — 346 passed, 0 failed
- `pnpm format:check`
- `pnpm check` — lint and typecheck passed; 146 tests passed

Credential-dependent and live integration tests remain ignored as before.