### PR TITLE
Reconnect ExoChat after WebSocket drops

### DIFF
--- a/website/src/chat.jsx
+++ b/website/src/chat.jsx
@@ -38,6 +38,7 @@ import {
   MessageScrollerViewport,
 } from "@/components/ui/message-scroller";
 import { Textarea } from "@/components/ui/textarea";
+import { createReconnectingWebSocket } from "@/reconnecting-websocket";
 import "./chat.css";
 
 function ChatApp() {
@@ -73,7 +74,7 @@ function ChatApp() {
   const remoteSeenRef = React.useRef(false);
   const seqRef = React.useRef(0);
   const textareaRef = React.useRef(null);
-  const wsRef = React.useRef(null);
+  const connectionRef = React.useRef(null);
 
   const addEvent = React.useCallback((event) => {
     setEvents((current) => [
@@ -136,7 +137,8 @@ function ChatApp() {
 
     return () => {
       disposed = true;
-      wsRef.current?.close();
+      connectionRef.current?.stop();
+      connectionRef.current = null;
     };
 
     async function start() {
@@ -149,76 +151,106 @@ function ChatApp() {
       }
 
       setStatusPart("data", { tone: "success", value: "ready" });
-      wsRef.current = connectRelay();
+      const connection = connectRelay();
+      connectionRef.current = connection;
+      connection.start();
     }
 
     function connectRelay() {
-      const wsUrl = new URL(`/chat/ws/${session.channelId}`, location.href);
-      wsUrl.protocol = location.protocol === "https:" ? "wss:" : "ws:";
-      wsUrl.searchParams.set("role", session.role);
+      return createReconnectingWebSocket({
+        createSocket() {
+          const wsUrl = new URL(`/chat/ws/${session.channelId}`, location.href);
+          wsUrl.protocol = location.protocol === "https:" ? "wss:" : "ws:";
+          wsUrl.searchParams.set("role", session.role);
+          return new WebSocket(wsUrl);
+        },
+        onConnecting({ attempt }) {
+          if (attempt === 0) {
+            return;
+          }
+          setStatusPart("signal", {
+            tone: "warning",
+            value: "reconnecting",
+          });
+          setStatusPart("peer", { tone: "warning", value: "waiting" });
+          setComposer({ enabled: false, label: "Reconnecting" });
+        },
+        onOpen({ reconnected }) {
+          setStatusPart("signal", { tone: "success", value: "open" });
+          addNotice(
+            reconnected
+              ? "Connection restored. Waiting for the other peer..."
+              : session.role === "user"
+                ? "Waiting for the desktop peer..."
+                : "Waiting for the phone peer...",
+            reconnected ? "success" : "neutral",
+          );
+        },
+        onReconnectScheduled({ attempt, delayMs }) {
+          setStatusPart("signal", {
+            tone: "warning",
+            value: "reconnecting",
+          });
+          setStatusPart("peer", { tone: "warning", value: "waiting" });
+          setComposer({ enabled: false, label: "Reconnecting" });
+          if (attempt === 1) {
+            addNotice(
+              `Connection lost. Reconnecting in ${formatDelay(delayMs)}...`,
+            );
+          }
+        },
+        onTerminalClose() {
+          setStatusPart("signal", { tone: "danger", value: "replaced" });
+          setStatusPart("peer", { tone: "warning", value: "waiting" });
+          setComposer({ enabled: false, label: "Opened elsewhere" });
+          addNotice(
+            "This session was opened in a newer tab. Continue there instead.",
+            "danger",
+          );
+        },
+        onError() {
+          console.warn("ExoChat WebSocket error");
+        },
+        onMessage(event) {
+          void handleRelayMessage(event);
+        },
+      });
+    }
 
-      const ws = new WebSocket(wsUrl);
+    async function handleRelayMessage(event) {
+      let message;
+      try {
+        message = JSON.parse(event.data);
+      } catch (error) {
+        console.warn("Unable to parse relay message", error);
+        addNotice("Rejected a malformed relay message.", "danger");
+        return;
+      }
 
-      ws.addEventListener("open", () => {
-        setStatusPart("signal", { tone: "success", value: "open" });
+      if (!isRecord(message)) {
+        addNotice("Rejected a relay message that was not an object.", "danger");
+        return;
+      }
+
+      if (message.channel === "rendezvous" && message.type === "presence") {
+        handlePresence(Array.isArray(message.roles) ? message.roles : []);
+        return;
+      }
+
+      const frame = await decryptRelayFrame(
+        message,
+        relayKeyRef.current,
+        session.channelId,
+      );
+      if (!frame) {
         addNotice(
-          session.role === "user"
-            ? "Waiting for the desktop peer..."
-            : "Waiting for the phone peer...",
+          "Rejected a relay message that could not be decrypted.",
+          "danger",
         );
-      });
+        return;
+      }
 
-      ws.addEventListener("close", () => {
-        setStatusPart("signal", { tone: "danger", value: "closed" });
-        setStatusPart("peer", { tone: "warning", value: "waiting" });
-        setComposer({ enabled: false, label: "Closed" });
-      });
-
-      ws.addEventListener("error", () => {
-        setStatusPart("signal", { tone: "danger", value: "error" });
-        setComposer({ enabled: false, label: "Error" });
-      });
-
-      ws.addEventListener("message", async (event) => {
-        let message;
-        try {
-          message = JSON.parse(event.data);
-        } catch (error) {
-          console.warn("Unable to parse relay message", error);
-          addNotice("Rejected a malformed relay message.", "danger");
-          return;
-        }
-
-        if (!isRecord(message)) {
-          addNotice(
-            "Rejected a relay message that was not an object.",
-            "danger",
-          );
-          return;
-        }
-
-        if (message.channel === "rendezvous" && message.type === "presence") {
-          handlePresence(Array.isArray(message.roles) ? message.roles : []);
-          return;
-        }
-
-        const frame = await decryptRelayFrame(
-          message,
-          relayKeyRef.current,
-          session.channelId,
-        );
-        if (!frame) {
-          addNotice(
-            "Rejected a relay message that could not be decrypted.",
-            "danger",
-          );
-          return;
-        }
-
-        renderFrame(frame, false);
-      });
-
-      return ws;
+      renderFrame(frame, false);
     }
 
     function handlePresence(roles) {
@@ -314,8 +346,8 @@ function ChatApp() {
       return;
     }
 
-    const socket = wsRef.current;
-    if (!text || !socket || socket.readyState !== WebSocket.OPEN) {
+    const connection = connectionRef.current;
+    if (!text || !connection) {
       return;
     }
 
@@ -333,7 +365,13 @@ function ChatApp() {
         session,
         ++seqRef.current,
       );
-      socket.send(JSON.stringify(envelope));
+      if (!connection.send(JSON.stringify(envelope))) {
+        addNotice(
+          "The connection changed before this message could be sent. Please try again.",
+          "danger",
+        );
+        return;
+      }
     } catch (error) {
       console.warn("Unable to encrypt relay message", error);
       addNotice("Could not encrypt the message for the relay.", "danger");
@@ -777,6 +815,11 @@ function formatTime(value) {
     hour: "numeric",
     minute: "2-digit",
   }).format(value);
+}
+
+function formatDelay(delayMs) {
+  const seconds = delayMs / 1000;
+  return `${seconds} second${seconds === 1 ? "" : "s"}`;
 }
 
 function stripCodeLanguage(value) {

--- a/website/src/reconnecting-websocket.test.ts
+++ b/website/src/reconnecting-websocket.test.ts
@@ -1,0 +1,221 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createReconnectingWebSocket } from "./reconnecting-websocket";
+
+type SocketListener = (event: never) => void;
+
+class FakeWebSocket {
+  readonly listeners = new Map<string, SocketListener[]>();
+  readonly sent: string[] = [];
+  closeCalls = 0;
+  readyState = 0;
+
+  addEventListener(type: string, listener: SocketListener) {
+    const listeners = this.listeners.get(type) ?? [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  close() {
+    this.closeCalls += 1;
+    this.readyState = 3;
+    this.emit("close", { code: 1000, reason: "" });
+  }
+
+  emit(type: string, event: unknown) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event as never);
+    }
+  }
+
+  error() {
+    this.emit("error", {});
+  }
+
+  message(data: string) {
+    this.emit("message", { data });
+  }
+
+  open() {
+    this.readyState = 1;
+    this.emit("open", {});
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  serverClose(code: number, reason = "") {
+    this.readyState = 3;
+    this.emit("close", { code, reason });
+  }
+}
+
+function setup() {
+  const sockets: FakeWebSocket[] = [];
+  const callbacks = {
+    onConnecting: vi.fn(),
+    onError: vi.fn(),
+    onMessage: vi.fn(),
+    onOpen: vi.fn(),
+    onReconnectScheduled: vi.fn(),
+    onTerminalClose: vi.fn(),
+  };
+  const connection = createReconnectingWebSocket({
+    createSocket: () => {
+      const socket = new FakeWebSocket();
+      sockets.push(socket);
+      return socket as unknown as WebSocket;
+    },
+    ...callbacks,
+  });
+  return { callbacks, connection, sockets };
+}
+
+describe("reconnecting WebSocket", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts once and forwards events from the active socket", () => {
+    const { callbacks, connection, sockets } = setup();
+
+    connection.start();
+    connection.start();
+
+    expect(sockets).toHaveLength(1);
+    expect(callbacks.onConnecting).toHaveBeenCalledOnce();
+    expect(callbacks.onConnecting).toHaveBeenCalledWith({ attempt: 0 });
+    expect(connection.send("too early")).toBe(false);
+
+    sockets[0].open();
+    sockets[0].message("hello");
+    sockets[0].error();
+
+    expect(callbacks.onOpen).toHaveBeenCalledWith({ reconnected: false });
+    expect(callbacks.onMessage).toHaveBeenCalledWith({ data: "hello" });
+    expect(callbacks.onError).toHaveBeenCalledOnce();
+    expect(connection.send("ready")).toBe(true);
+    expect(sockets[0].sent).toEqual(["ready"]);
+  });
+
+  it("reconnects with exponential backoff and resets after opening", () => {
+    const { callbacks, connection, sockets } = setup();
+    connection.start();
+
+    sockets[0].serverClose(1006);
+    expect(callbacks.onReconnectScheduled).toHaveBeenLastCalledWith({
+      attempt: 1,
+      delayMs: 1_000,
+      event: { code: 1006, reason: "" },
+    });
+
+    vi.advanceTimersByTime(999);
+    expect(sockets).toHaveLength(1);
+    vi.advanceTimersByTime(1);
+    expect(sockets).toHaveLength(2);
+    expect(callbacks.onConnecting).toHaveBeenLastCalledWith({ attempt: 1 });
+
+    sockets[1].serverClose(1006);
+    vi.advanceTimersByTime(2_000);
+    expect(sockets).toHaveLength(3);
+    expect(callbacks.onConnecting).toHaveBeenLastCalledWith({ attempt: 2 });
+
+    sockets[2].open();
+    expect(callbacks.onOpen).toHaveBeenLastCalledWith({ reconnected: true });
+    sockets[2].serverClose(1006);
+    expect(callbacks.onReconnectScheduled).toHaveBeenLastCalledWith({
+      attempt: 1,
+      delayMs: 1_000,
+      event: { code: 1006, reason: "" },
+    });
+  });
+
+  it("caps the reconnect delay at thirty seconds", () => {
+    const { callbacks, connection, sockets } = setup();
+    connection.start();
+
+    for (let index = 0; index < 8; index += 1) {
+      sockets[index].serverClose(1006);
+      const { delayMs } = callbacks.onReconnectScheduled.mock.calls[index][0];
+      vi.advanceTimersByTime(delayMs);
+    }
+
+    expect(
+      callbacks.onReconnectScheduled.mock.calls.map(
+        ([reconnect]) => reconnect.delayMs,
+      ),
+    ).toEqual([1_000, 2_000, 4_000, 8_000, 16_000, 30_000, 30_000, 30_000]);
+  });
+
+  it("does not fight a newer connection for the same role", () => {
+    const { callbacks, connection, sockets } = setup();
+    connection.start();
+
+    sockets[0].serverClose(1000, "Replaced by a newer connection");
+    vi.advanceTimersByTime(60_000);
+
+    expect(sockets).toHaveLength(1);
+    expect(callbacks.onTerminalClose).toHaveBeenCalledWith({
+      code: 1000,
+      reason: "Replaced by a newer connection",
+    });
+    expect(callbacks.onReconnectScheduled).not.toHaveBeenCalled();
+  });
+
+  it("reconnects after a relay session expiry", () => {
+    const { callbacks, connection, sockets } = setup();
+    connection.start();
+
+    sockets[0].serverClose(1000, "Session expired");
+    vi.advanceTimersByTime(1_000);
+
+    expect(sockets).toHaveLength(2);
+    expect(callbacks.onTerminalClose).not.toHaveBeenCalled();
+  });
+
+  it("does not queue or replay messages sent while disconnected", () => {
+    const { connection, sockets } = setup();
+    connection.start();
+    sockets[0].open();
+    expect(connection.send("before disconnect")).toBe(true);
+
+    sockets[0].serverClose(1006);
+    expect(connection.send("during disconnect")).toBe(false);
+    vi.advanceTimersByTime(1_000);
+    sockets[1].open();
+
+    expect(sockets[0].sent).toEqual(["before disconnect"]);
+    expect(sockets[1].sent).toEqual([]);
+  });
+
+  it("clears retries and ignores stale socket events when stopped", () => {
+    const { callbacks, connection, sockets } = setup();
+    connection.start();
+    sockets[0].serverClose(1006);
+    sockets[0].message("late");
+
+    connection.stop();
+    vi.advanceTimersByTime(60_000);
+
+    expect(sockets).toHaveLength(1);
+    expect(callbacks.onMessage).not.toHaveBeenCalled();
+    expect(connection.send("after stop")).toBe(false);
+  });
+
+  it("closes an active socket when stopped", () => {
+    const { callbacks, connection, sockets } = setup();
+    connection.start();
+    sockets[0].open();
+
+    connection.stop();
+
+    expect(sockets[0].closeCalls).toBe(1);
+    expect(callbacks.onTerminalClose).not.toHaveBeenCalled();
+    expect(callbacks.onReconnectScheduled).not.toHaveBeenCalled();
+  });
+});

--- a/website/src/reconnecting-websocket.ts
+++ b/website/src/reconnecting-websocket.ts
@@ -1,0 +1,144 @@
+const OPEN_READY_STATE = 1;
+const INITIAL_RECONNECT_DELAY_MS = 1_000;
+const MAX_RECONNECT_DELAY_MS = 30_000;
+const REPLACED_CONNECTION_REASON = "Replaced by a newer connection";
+
+type ConnectionAttempt = {
+  attempt: number;
+};
+
+type OpenedConnection = {
+  reconnected: boolean;
+};
+
+type ScheduledReconnect = {
+  attempt: number;
+  delayMs: number;
+  event: CloseEvent;
+};
+
+type ReconnectingWebSocketOptions = {
+  createSocket: () => WebSocket;
+  onConnecting: (connection: ConnectionAttempt) => void;
+  onError: (event: Event) => void;
+  onMessage: (event: MessageEvent) => void;
+  onOpen: (connection: OpenedConnection) => void;
+  onReconnectScheduled: (reconnect: ScheduledReconnect) => void;
+  onTerminalClose: (event: CloseEvent) => void;
+};
+
+export type ReconnectingWebSocket = {
+  send: (data: string) => boolean;
+  start: () => void;
+  stop: () => void;
+};
+
+export function createReconnectingWebSocket({
+  createSocket,
+  onConnecting,
+  onError,
+  onMessage,
+  onOpen,
+  onReconnectScheduled,
+  onTerminalClose,
+}: ReconnectingWebSocketOptions): ReconnectingWebSocket {
+  let reconnectAttempt = 0;
+  let reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
+  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  let socket: WebSocket | null = null;
+  let stopped = true;
+
+  function connect() {
+    if (stopped || socket || reconnectTimer) {
+      return;
+    }
+
+    onConnecting({ attempt: reconnectAttempt });
+    const nextSocket = createSocket();
+    socket = nextSocket;
+
+    nextSocket.addEventListener("open", () => {
+      if (stopped || socket !== nextSocket) {
+        return;
+      }
+
+      const reconnected = reconnectAttempt > 0;
+      reconnectAttempt = 0;
+      reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
+      onOpen({ reconnected });
+    });
+
+    nextSocket.addEventListener("message", (event) => {
+      if (!stopped && socket === nextSocket) {
+        onMessage(event);
+      }
+    });
+
+    nextSocket.addEventListener("error", (event) => {
+      if (!stopped && socket === nextSocket) {
+        onError(event);
+      }
+    });
+
+    nextSocket.addEventListener("close", (event) => {
+      if (stopped || socket !== nextSocket) {
+        return;
+      }
+
+      socket = null;
+      if (!shouldReconnect(event)) {
+        onTerminalClose(event);
+        return;
+      }
+
+      const delayMs = reconnectDelayMs;
+      reconnectDelayMs = Math.min(reconnectDelayMs * 2, MAX_RECONNECT_DELAY_MS);
+      reconnectAttempt += 1;
+      onReconnectScheduled({
+        attempt: reconnectAttempt,
+        delayMs,
+        event,
+      });
+      reconnectTimer = setTimeout(() => {
+        reconnectTimer = null;
+        connect();
+      }, delayMs);
+    });
+  }
+
+  return {
+    send(data) {
+      if (!socket || socket.readyState !== OPEN_READY_STATE) {
+        return false;
+      }
+      socket.send(data);
+      return true;
+    },
+    start() {
+      if (!stopped) {
+        return;
+      }
+      stopped = false;
+      connect();
+    },
+    stop() {
+      if (stopped) {
+        return;
+      }
+      stopped = true;
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+      }
+      const activeSocket = socket;
+      socket = null;
+      activeSocket?.close();
+      reconnectAttempt = 0;
+      reconnectDelayMs = INITIAL_RECONNECT_DELAY_MS;
+    },
+  };
+}
+
+function shouldReconnect(event: CloseEvent) {
+  return !(event.code === 1000 && event.reason === REPLACED_CONNECTION_REASON);
+}


### PR DESCRIPTION
## Summary

- reconnect the ExoChat browser client after dropped relay WebSockets with exponential backoff from 1 to 30 seconds
- preserve unsent drafts while disconnected and never queue or automatically replay messages
- surface reconnecting, restored, and replaced states in the UI
- stop retrying when the relay replaces an older connection for the same role
- cover retry timing, reset behavior, terminal replacement, session expiry, stale events, shutdown, and send behavior with focused unit tests

[download.webm](https://github.com/user-attachments/assets/e4ed25bf-c3e9-4797-b0eb-13017ae58288)

## Testing

- `pnpm check` (15 files, 154 tests)
- `pnpm format:check`
- `pnpm website:build`
- `cargo test --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- manual local relay test: typed an unsent draft, stopped and restarted Wrangler, verified automatic recovery and draft preservation, sent the message once, then opened a newer same-role tab and verified the old tab entered the terminal replaced state