### PR TITLE
Reduce Firecracker network setup and termination latency

### DIFF
--- a/crates/exoharness/src/sandbox_provider/firecracker.rs
+++ b/crates/exoharness/src/sandbox_provider/firecracker.rs
@@ -2700,14 +2700,6 @@ fn prepare_network(
             "peer",
             "name",
             &network.namespace_veth,
-        ],
-    )?;
-    run_checked(
-        "ip",
-        &[
-            "link",
-            "set",
-            &network.namespace_veth,
             "netns",
             &network.namespace,
         ],
@@ -2975,7 +2967,7 @@ fn cleanup_network_blocking(network: &NetworkConfig) {
             "ACCEPT",
         ],
     );
-    run_ignoring_status("nft", &["delete", "table", "inet", &network.nft_table]);
+    run_ignoring_status("nft", &["destroy", "table", "inet", &network.nft_table]);
     run_ignoring_status("ip", &["route", "del", &network.guest_cidr]);
     run_ignoring_status("ip", &["link", "del", &network.host_veth]);
     run_ignoring_status("ip", &["netns", "del", &network.namespace]);

--- a/crates/exoharness/src/sandbox_provider/firecracker.rs
+++ b/crates/exoharness/src/sandbox_provider/firecracker.rs
@@ -57,34 +57,6 @@ use super::firecracker_image::resolve_image;
 #[cfg(test)]
 use super::firecracker_image::validate_ext4_image;
 
-pub(super) struct PhaseTimer {
-    phase: &'static str,
-    started: Instant,
-    span: tracing::Span,
-}
-
-impl PhaseTimer {
-    pub(super) fn new(phase: &'static str) -> Self {
-        Self {
-            phase,
-            started: Instant::now(),
-            span: tracing::Span::current(),
-        }
-    }
-}
-
-impl Drop for PhaseTimer {
-    fn drop(&mut self) {
-        tracing::info!(
-            parent: &self.span,
-            event = "firecracker.phase",
-            phase = self.phase,
-            duration_ms = self.started.elapsed().as_secs_f64() * 1000.0,
-            "Firecracker phase completed"
-        );
-    }
-}
-
 const GUEST_READY_TIMEOUT: Duration = Duration::from_secs(30);
 const PID_FILE_STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
 const PROCESS_STOP_TIMEOUT: Duration = Duration::from_secs(5);
@@ -744,7 +716,6 @@ impl FirecrackerSandboxBackend {
     }
 
     async fn reap_stale_machines(&self) -> Result<()> {
-        let _phase = PhaseTimer::new("reap_stale_machines");
         if self.shared.config.max_machines.is_none() {
             return Ok(());
         }
@@ -764,7 +735,6 @@ impl FirecrackerSandboxBackend {
     }
 
     async fn reap_expired_machines(&self) -> Result<()> {
-        let _phase = PhaseTimer::new("reap_expired_machines");
         let now = Instant::now();
         let mut expired = {
             let machines = self.shared.warm_machines.lock().await;
@@ -810,7 +780,6 @@ impl FirecrackerSandboxBackend {
     }
 
     async fn resolve_request(&self, request: SandboxRequest) -> Result<SandboxRequest> {
-        let _phase = PhaseTimer::new("resolve_request");
         let mut request = prepare_request(request)?;
         validate_resource_shape(request.spec.resources)?;
         let image = resolve_image(
@@ -1028,7 +997,6 @@ impl FirecrackerSandboxBackend {
         &self,
         request: SandboxRequest,
     ) -> Result<Arc<dyn ManagedSandboxHandle>> {
-        let _phase = PhaseTimer::new("acquire_resolved");
         let spec_hash = sandbox_spec_hash(&request.spec);
         let one_shot = request.lifecycle.idle_ttl.is_none();
         let machine_id = if one_shot {
@@ -1037,10 +1005,7 @@ impl FirecrackerSandboxBackend {
         } else {
             machine_id(&request.key, &spec_hash)
         };
-        let _lifecycle_guard = {
-            let _phase = PhaseTimer::new("lifecycle_lock");
-            self.shared.lifecycle_locks.lock_sandbox(&request.key).await
-        };
+        let _lifecycle_guard = self.shared.lifecycle_locks.lock_sandbox(&request.key).await;
         self.acquire_resolved_locked(request, spec_hash, machine_id, one_shot, None)
             .await
     }
@@ -1140,7 +1105,6 @@ impl ManagedSandboxBackend for FirecrackerSandboxBackend {
     }
 
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
-        let _phase = PhaseTimer::new("acquire");
         self.reap_stale_machines().await?;
         self.reap_expired_machines().await?;
         self.shared.reap_orphaned_fork_snapshot_templates().await;
@@ -1473,7 +1437,6 @@ impl Shared {
     }
 
     async fn reap_orphaned_fork_snapshot_templates(&self) {
-        let _phase = PhaseTimer::new("reap_orphaned_fork_snapshot_templates");
         let config = self.config.clone();
         match tokio::task::spawn_blocking(move || {
             reap_orphaned_fork_snapshot_templates_blocking(&config)
@@ -1507,7 +1470,6 @@ impl Shared {
         &self,
         machine_id: &str,
     ) -> Result<MachineCapacityReservation> {
-        let _phase = PhaseTimer::new("reserve_machine_capacity");
         let Some(max_machines) = self.config.max_machines else {
             return Ok(MachineCapacityReservation::inactive(Arc::clone(
                 &self.starting_machines,
@@ -1567,7 +1529,6 @@ impl Shared {
         machine_id: &str,
         spec_hash: &str,
     ) -> Result<Machine> {
-        let _phase = PhaseTimer::new("ensure_machine");
         let runtime = self.host_fingerprint.for_resources(request.spec.resources);
         let existing = self.load_machine_record(machine_id).await?;
         let reusing_existing_machine = existing
@@ -1656,7 +1617,6 @@ impl Shared {
     }
 
     async fn load_machine_record(&self, machine_id: &str) -> Result<Option<MachineRecord>> {
-        let _phase = PhaseTimer::new("load_machine_record");
         let path = self.manifest_path(machine_id);
         tokio::task::spawn_blocking(move || {
             if !path.try_exists()? {
@@ -1673,7 +1633,6 @@ impl Shared {
     }
 
     async fn touch_machine_lease(&self, machine_id: &str) -> Result<()> {
-        let _phase = PhaseTimer::new("touch_machine_lease");
         let state_root = self.config.state_root.clone();
         let machine_id = machine_id.to_string();
         tokio::task::spawn_blocking(move || touch_machine_lease(&state_root, &machine_id))
@@ -1688,7 +1647,6 @@ impl Shared {
         spec_hash: &str,
         snapshot: Option<SnapshotMachineRecord>,
     ) -> Result<MachineRecord> {
-        let _phase = PhaseTimer::new("new_machine_record");
         let state_root = self.config.state_root.clone();
         let machine_id = machine_id.to_string();
         let spec_hash = spec_hash.to_string();
@@ -1754,13 +1712,10 @@ impl Shared {
         request: &SandboxRequest,
         record: &MachineRecord,
     ) -> Result<GuestReadiness> {
-        let _phase = PhaseTimer::new("prepare_and_launch");
         let config = self.config.clone();
         let request = request.clone();
         let record = record.clone();
-        let span = tracing::Span::current();
         tokio::task::spawn_blocking(move || {
-            let _entered = span.enter();
             let network = record.network();
             let result = (|| {
                 if record.network_enabled {
@@ -2675,7 +2630,6 @@ fn prepare_network(
     policy: SandboxNetworkPolicy,
     jailer_uid: u32,
 ) -> Result<()> {
-    let _phase = PhaseTimer::new("prepare_network");
     // Firecracker intentionally delegates TAP routing and firewalling to the host.
     // nftables is the upstream-recommended production firewall, and a namespace per
     // VM keeps identical guest interface names and routes from colliding.
@@ -2938,7 +2892,6 @@ fn network_firewall_rules(
 }
 
 fn cleanup_network_blocking(network: &NetworkConfig) {
-    let _phase = PhaseTimer::new("cleanup_network_blocking");
     remove_all_matching_rules(
         "iptables",
         &[
@@ -2974,8 +2927,6 @@ fn cleanup_network_blocking(network: &NetworkConfig) {
 }
 
 fn run_checked(program: &str, arguments: &[&str]) -> Result<()> {
-    let _command = tracing::info_span!("firecracker.command", program = program).entered();
-    let _phase = PhaseTimer::new("host_command");
     let executable = trusted_host_command(program)?;
     let output = Command::new(&executable)
         .args(arguments)
@@ -2993,8 +2944,6 @@ fn run_checked(program: &str, arguments: &[&str]) -> Result<()> {
 }
 
 fn run_checked_input(program: &str, arguments: &[&str], input: &[u8]) -> Result<()> {
-    let _command = tracing::info_span!("firecracker.command", program = program).entered();
-    let _phase = PhaseTimer::new("host_command");
     let executable = trusted_host_command(program)?;
     let mut child = Command::new(&executable)
         .args(arguments)
@@ -3022,8 +2971,6 @@ fn run_checked_input(program: &str, arguments: &[&str], input: &[u8]) -> Result<
 }
 
 fn run_ignoring_status(program: &str, arguments: &[&str]) {
-    let _command = tracing::info_span!("firecracker.command", program = program).entered();
-    let _phase = PhaseTimer::new("host_command");
     let executable = match trusted_host_command(program) {
         Ok(executable) => executable,
         Err(error) => {
@@ -3037,8 +2984,6 @@ fn run_ignoring_status(program: &str, arguments: &[&str]) {
 }
 
 fn remove_all_matching_rules(program: &str, arguments: &[&str]) {
-    let _command = tracing::info_span!("firecracker.command", program = program).entered();
-    let _phase = PhaseTimer::new("host_command");
     let executable = match trusted_host_command(program) {
         Ok(executable) => executable,
         Err(error) => {
@@ -3109,7 +3054,6 @@ fn prepare_and_launch_blocking(
     request: &SandboxRequest,
     record: &MachineRecord,
 ) -> Result<GuestReadiness> {
-    let _phase = PhaseTimer::new("prepare_and_launch_blocking");
     if let Some(template) = record.snapshot_template.as_ref()
         && prepare_snapshot_overlay(config, record, &template.key)?
     {
@@ -3149,7 +3093,6 @@ fn prepare_and_launch_blocking(
     let overlay = root.join("overlay.ext4");
     let created_overlay = !overlay.try_exists()?;
     if created_overlay {
-        let _phase = PhaseTimer::new("create_overlay");
         let file = OpenOptions::new()
             .create_new(true)
             .write(true)
@@ -3228,7 +3171,6 @@ fn spawn_jailed_firecracker(
     jail_root: &Path,
     firecracker_arguments: &[&str],
 ) -> Result<()> {
-    let _phase = PhaseTimer::new("spawn_jailed_firecracker");
     let host_uid = jailer_uid(config, record)?;
     let memory_max = u64::from(
         record
@@ -4586,7 +4528,6 @@ async fn wait_for_guest(
     machine_id: &str,
     listener: StdUnixListener,
 ) -> Result<()> {
-    let _phase = PhaseTimer::new("wait_for_guest");
     let pid_path = shared.pid_path(machine_id);
     let stderr_path = jail_root(&shared.config, machine_id).join("firecracker.stderr");
     tokio::task::spawn_blocking(move || wait_for_guest_blocking(&pid_path, &stderr_path, listener))
@@ -4595,7 +4536,6 @@ async fn wait_for_guest(
 }
 
 async fn wait_for_restored_guest(shared: &Arc<Shared>, machine: &Machine) -> Result<()> {
-    let _phase = PhaseTimer::new("wait_for_restored_guest");
     let started = Instant::now();
     let pid_path = shared.pid_path(&machine.record.machine_id);
     let stderr_path =

--- a/crates/exoharness/src/sandbox_provider/firecracker.rs
+++ b/crates/exoharness/src/sandbox_provider/firecracker.rs
@@ -4067,12 +4067,6 @@ fn stop_machine_process_blocking(machine_id: &str, pid_path: &Path) -> Result<()
     if !is_firecracker || !has_machine_id || !in_machine_cgroup {
         bail!("refusing to stop pid {pid}: it does not match Firecracker machine {machine_id}");
     }
-    if !signal_pidfd(&pidfd, Signal::TERM)? {
-        return Ok(());
-    }
-    if wait_for_pidfd(&pidfd, PROCESS_STOP_TIMEOUT)? {
-        return Ok(());
-    }
     if !signal_pidfd(&pidfd, Signal::KILL)? {
         return Ok(());
     }

--- a/crates/exoharness/src/sandbox_provider/firecracker.rs
+++ b/crates/exoharness/src/sandbox_provider/firecracker.rs
@@ -57,6 +57,34 @@ use super::firecracker_image::resolve_image;
 #[cfg(test)]
 use super::firecracker_image::validate_ext4_image;
 
+pub(super) struct PhaseTimer {
+    phase: &'static str,
+    started: Instant,
+    span: tracing::Span,
+}
+
+impl PhaseTimer {
+    pub(super) fn new(phase: &'static str) -> Self {
+        Self {
+            phase,
+            started: Instant::now(),
+            span: tracing::Span::current(),
+        }
+    }
+}
+
+impl Drop for PhaseTimer {
+    fn drop(&mut self) {
+        tracing::info!(
+            parent: &self.span,
+            event = "firecracker.phase",
+            phase = self.phase,
+            duration_ms = self.started.elapsed().as_secs_f64() * 1000.0,
+            "Firecracker phase completed"
+        );
+    }
+}
+
 const GUEST_READY_TIMEOUT: Duration = Duration::from_secs(30);
 const PID_FILE_STARTUP_TIMEOUT: Duration = Duration::from_secs(5);
 const PROCESS_STOP_TIMEOUT: Duration = Duration::from_secs(5);
@@ -716,6 +744,7 @@ impl FirecrackerSandboxBackend {
     }
 
     async fn reap_stale_machines(&self) -> Result<()> {
+        let _phase = PhaseTimer::new("reap_stale_machines");
         if self.shared.config.max_machines.is_none() {
             return Ok(());
         }
@@ -735,6 +764,7 @@ impl FirecrackerSandboxBackend {
     }
 
     async fn reap_expired_machines(&self) -> Result<()> {
+        let _phase = PhaseTimer::new("reap_expired_machines");
         let now = Instant::now();
         let mut expired = {
             let machines = self.shared.warm_machines.lock().await;
@@ -780,6 +810,7 @@ impl FirecrackerSandboxBackend {
     }
 
     async fn resolve_request(&self, request: SandboxRequest) -> Result<SandboxRequest> {
+        let _phase = PhaseTimer::new("resolve_request");
         let mut request = prepare_request(request)?;
         validate_resource_shape(request.spec.resources)?;
         let image = resolve_image(
@@ -997,6 +1028,7 @@ impl FirecrackerSandboxBackend {
         &self,
         request: SandboxRequest,
     ) -> Result<Arc<dyn ManagedSandboxHandle>> {
+        let _phase = PhaseTimer::new("acquire_resolved");
         let spec_hash = sandbox_spec_hash(&request.spec);
         let one_shot = request.lifecycle.idle_ttl.is_none();
         let machine_id = if one_shot {
@@ -1005,7 +1037,10 @@ impl FirecrackerSandboxBackend {
         } else {
             machine_id(&request.key, &spec_hash)
         };
-        let _lifecycle_guard = self.shared.lifecycle_locks.lock_sandbox(&request.key).await;
+        let _lifecycle_guard = {
+            let _phase = PhaseTimer::new("lifecycle_lock");
+            self.shared.lifecycle_locks.lock_sandbox(&request.key).await
+        };
         self.acquire_resolved_locked(request, spec_hash, machine_id, one_shot, None)
             .await
     }
@@ -1105,6 +1140,7 @@ impl ManagedSandboxBackend for FirecrackerSandboxBackend {
     }
 
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
+        let _phase = PhaseTimer::new("acquire");
         self.reap_stale_machines().await?;
         self.reap_expired_machines().await?;
         self.shared.reap_orphaned_fork_snapshot_templates().await;
@@ -1437,6 +1473,7 @@ impl Shared {
     }
 
     async fn reap_orphaned_fork_snapshot_templates(&self) {
+        let _phase = PhaseTimer::new("reap_orphaned_fork_snapshot_templates");
         let config = self.config.clone();
         match tokio::task::spawn_blocking(move || {
             reap_orphaned_fork_snapshot_templates_blocking(&config)
@@ -1470,6 +1507,7 @@ impl Shared {
         &self,
         machine_id: &str,
     ) -> Result<MachineCapacityReservation> {
+        let _phase = PhaseTimer::new("reserve_machine_capacity");
         let Some(max_machines) = self.config.max_machines else {
             return Ok(MachineCapacityReservation::inactive(Arc::clone(
                 &self.starting_machines,
@@ -1529,6 +1567,7 @@ impl Shared {
         machine_id: &str,
         spec_hash: &str,
     ) -> Result<Machine> {
+        let _phase = PhaseTimer::new("ensure_machine");
         let runtime = self.host_fingerprint.for_resources(request.spec.resources);
         let existing = self.load_machine_record(machine_id).await?;
         let reusing_existing_machine = existing
@@ -1617,6 +1656,7 @@ impl Shared {
     }
 
     async fn load_machine_record(&self, machine_id: &str) -> Result<Option<MachineRecord>> {
+        let _phase = PhaseTimer::new("load_machine_record");
         let path = self.manifest_path(machine_id);
         tokio::task::spawn_blocking(move || {
             if !path.try_exists()? {
@@ -1633,6 +1673,7 @@ impl Shared {
     }
 
     async fn touch_machine_lease(&self, machine_id: &str) -> Result<()> {
+        let _phase = PhaseTimer::new("touch_machine_lease");
         let state_root = self.config.state_root.clone();
         let machine_id = machine_id.to_string();
         tokio::task::spawn_blocking(move || touch_machine_lease(&state_root, &machine_id))
@@ -1647,6 +1688,7 @@ impl Shared {
         spec_hash: &str,
         snapshot: Option<SnapshotMachineRecord>,
     ) -> Result<MachineRecord> {
+        let _phase = PhaseTimer::new("new_machine_record");
         let state_root = self.config.state_root.clone();
         let machine_id = machine_id.to_string();
         let spec_hash = spec_hash.to_string();
@@ -1712,10 +1754,13 @@ impl Shared {
         request: &SandboxRequest,
         record: &MachineRecord,
     ) -> Result<GuestReadiness> {
+        let _phase = PhaseTimer::new("prepare_and_launch");
         let config = self.config.clone();
         let request = request.clone();
         let record = record.clone();
+        let span = tracing::Span::current();
         tokio::task::spawn_blocking(move || {
+            let _entered = span.enter();
             let network = record.network();
             let result = (|| {
                 if record.network_enabled {
@@ -2630,6 +2675,7 @@ fn prepare_network(
     policy: SandboxNetworkPolicy,
     jailer_uid: u32,
 ) -> Result<()> {
+    let _phase = PhaseTimer::new("prepare_network");
     // Firecracker intentionally delegates TAP routing and firewalling to the host.
     // nftables is the upstream-recommended production firewall, and a namespace per
     // VM keeps identical guest interface names and routes from colliding.
@@ -2900,6 +2946,7 @@ fn network_firewall_rules(
 }
 
 fn cleanup_network_blocking(network: &NetworkConfig) {
+    let _phase = PhaseTimer::new("cleanup_network_blocking");
     remove_all_matching_rules(
         "iptables",
         &[
@@ -2935,6 +2982,8 @@ fn cleanup_network_blocking(network: &NetworkConfig) {
 }
 
 fn run_checked(program: &str, arguments: &[&str]) -> Result<()> {
+    let _command = tracing::info_span!("firecracker.command", program = program).entered();
+    let _phase = PhaseTimer::new("host_command");
     let executable = trusted_host_command(program)?;
     let output = Command::new(&executable)
         .args(arguments)
@@ -2952,6 +3001,8 @@ fn run_checked(program: &str, arguments: &[&str]) -> Result<()> {
 }
 
 fn run_checked_input(program: &str, arguments: &[&str], input: &[u8]) -> Result<()> {
+    let _command = tracing::info_span!("firecracker.command", program = program).entered();
+    let _phase = PhaseTimer::new("host_command");
     let executable = trusted_host_command(program)?;
     let mut child = Command::new(&executable)
         .args(arguments)
@@ -2979,6 +3030,8 @@ fn run_checked_input(program: &str, arguments: &[&str], input: &[u8]) -> Result<
 }
 
 fn run_ignoring_status(program: &str, arguments: &[&str]) {
+    let _command = tracing::info_span!("firecracker.command", program = program).entered();
+    let _phase = PhaseTimer::new("host_command");
     let executable = match trusted_host_command(program) {
         Ok(executable) => executable,
         Err(error) => {
@@ -2992,6 +3045,8 @@ fn run_ignoring_status(program: &str, arguments: &[&str]) {
 }
 
 fn remove_all_matching_rules(program: &str, arguments: &[&str]) {
+    let _command = tracing::info_span!("firecracker.command", program = program).entered();
+    let _phase = PhaseTimer::new("host_command");
     let executable = match trusted_host_command(program) {
         Ok(executable) => executable,
         Err(error) => {
@@ -3062,6 +3117,7 @@ fn prepare_and_launch_blocking(
     request: &SandboxRequest,
     record: &MachineRecord,
 ) -> Result<GuestReadiness> {
+    let _phase = PhaseTimer::new("prepare_and_launch_blocking");
     if let Some(template) = record.snapshot_template.as_ref()
         && prepare_snapshot_overlay(config, record, &template.key)?
     {
@@ -3101,6 +3157,7 @@ fn prepare_and_launch_blocking(
     let overlay = root.join("overlay.ext4");
     let created_overlay = !overlay.try_exists()?;
     if created_overlay {
+        let _phase = PhaseTimer::new("create_overlay");
         let file = OpenOptions::new()
             .create_new(true)
             .write(true)
@@ -3179,6 +3236,7 @@ fn spawn_jailed_firecracker(
     jail_root: &Path,
     firecracker_arguments: &[&str],
 ) -> Result<()> {
+    let _phase = PhaseTimer::new("spawn_jailed_firecracker");
     let host_uid = jailer_uid(config, record)?;
     let memory_max = u64::from(
         record
@@ -4536,6 +4594,7 @@ async fn wait_for_guest(
     machine_id: &str,
     listener: StdUnixListener,
 ) -> Result<()> {
+    let _phase = PhaseTimer::new("wait_for_guest");
     let pid_path = shared.pid_path(machine_id);
     let stderr_path = jail_root(&shared.config, machine_id).join("firecracker.stderr");
     tokio::task::spawn_blocking(move || wait_for_guest_blocking(&pid_path, &stderr_path, listener))
@@ -4544,6 +4603,7 @@ async fn wait_for_guest(
 }
 
 async fn wait_for_restored_guest(shared: &Arc<Shared>, machine: &Machine) -> Result<()> {
+    let _phase = PhaseTimer::new("wait_for_restored_guest");
     let started = Instant::now();
     let pid_path = shared.pid_path(&machine.record.machine_id);
     let stderr_path =

--- a/crates/exoharness/src/sandbox_provider/firecracker_image.rs
+++ b/crates/exoharness/src/sandbox_provider/firecracker_image.rs
@@ -29,8 +29,6 @@ use sha2::{Digest, Sha256};
 use tempfile::{Builder as TempBuilder, NamedTempFile};
 use tokio::io::AsyncWriteExt;
 
-use super::firecracker::PhaseTimer;
-
 const MATERIALIZER_VERSION: u32 = 4;
 const EXT4_MAGIC_OFFSET: u64 = 1024 + 0x38;
 const EXT4_MAGIC: [u8; 2] = [0x53, 0xef];
@@ -93,7 +91,6 @@ pub(super) async fn resolve_image(
     allowed_local_images: &[PathBuf],
     allowed_registries: &[String],
 ) -> Result<PathBuf> {
-    let _phase = PhaseTimer::new("resolve_image");
     if looks_like_local_image(source) {
         let state_root = state_root.to_path_buf();
         let source_path = source.to_string();
@@ -152,13 +149,10 @@ pub(super) async fn resolve_image(
     // response size limit in oci-client or a hand-rolled bounded fetch. Layer
     // blobs are NOT affected: pull_blob streams them to disk through
     // LimitedAsyncWriter under declared-size and cumulative budgets.
-    let (manifest, manifest_digest, config_json, list_digest) = {
-        let _phase = PhaseTimer::new("registry_manifest");
-        client
-            .pull_manifest_and_config_and_list_digest(&reference, &auth)
-            .await
-            .with_context(|| format!("resolving OCI image manifest for {source}"))?
-    };
+    let (manifest, manifest_digest, config_json, list_digest) = client
+        .pull_manifest_and_config_and_list_digest(&reference, &auth)
+        .await
+        .with_context(|| format!("resolving OCI image manifest for {source}"))?;
     let source_digest = list_digest.unwrap_or_else(|| manifest_digest.clone());
 
     let image_config: OciImageConfiguration = serde_json::from_str(&config_json)
@@ -385,7 +379,6 @@ fn is_cached_local_image(state_root: &Path, source: &Path) -> bool {
 }
 
 fn registry_auth(reference: &Reference) -> Result<RegistryAuth> {
-    let _phase = PhaseTimer::new("registry_auth");
     let Some(config_path) = docker_config_path() else {
         return Ok(RegistryAuth::Anonymous);
     };
@@ -1211,7 +1204,6 @@ fn validate_cache_entry(
     manifest_digest: Option<&str>,
     platform: &str,
 ) -> Result<PathBuf> {
-    let _phase = PhaseTimer::new("validate_cache_entry");
     let metadata_path = cache_dir.join("metadata.json");
     let metadata: CachedImageMetadata =
         serde_json::from_slice(&fs::read(&metadata_path).with_context(|| {

--- a/crates/exoharness/src/sandbox_provider/firecracker_image.rs
+++ b/crates/exoharness/src/sandbox_provider/firecracker_image.rs
@@ -29,6 +29,8 @@ use sha2::{Digest, Sha256};
 use tempfile::{Builder as TempBuilder, NamedTempFile};
 use tokio::io::AsyncWriteExt;
 
+use super::firecracker::PhaseTimer;
+
 const MATERIALIZER_VERSION: u32 = 4;
 const EXT4_MAGIC_OFFSET: u64 = 1024 + 0x38;
 const EXT4_MAGIC: [u8; 2] = [0x53, 0xef];
@@ -91,6 +93,7 @@ pub(super) async fn resolve_image(
     allowed_local_images: &[PathBuf],
     allowed_registries: &[String],
 ) -> Result<PathBuf> {
+    let _phase = PhaseTimer::new("resolve_image");
     if looks_like_local_image(source) {
         let state_root = state_root.to_path_buf();
         let source_path = source.to_string();
@@ -149,10 +152,13 @@ pub(super) async fn resolve_image(
     // response size limit in oci-client or a hand-rolled bounded fetch. Layer
     // blobs are NOT affected: pull_blob streams them to disk through
     // LimitedAsyncWriter under declared-size and cumulative budgets.
-    let (manifest, manifest_digest, config_json, list_digest) = client
-        .pull_manifest_and_config_and_list_digest(&reference, &auth)
-        .await
-        .with_context(|| format!("resolving OCI image manifest for {source}"))?;
+    let (manifest, manifest_digest, config_json, list_digest) = {
+        let _phase = PhaseTimer::new("registry_manifest");
+        client
+            .pull_manifest_and_config_and_list_digest(&reference, &auth)
+            .await
+            .with_context(|| format!("resolving OCI image manifest for {source}"))?
+    };
     let source_digest = list_digest.unwrap_or_else(|| manifest_digest.clone());
 
     let image_config: OciImageConfiguration = serde_json::from_str(&config_json)
@@ -379,6 +385,7 @@ fn is_cached_local_image(state_root: &Path, source: &Path) -> bool {
 }
 
 fn registry_auth(reference: &Reference) -> Result<RegistryAuth> {
+    let _phase = PhaseTimer::new("registry_auth");
     let Some(config_path) = docker_config_path() else {
         return Ok(RegistryAuth::Anonymous);
     };
@@ -1204,6 +1211,7 @@ fn validate_cache_entry(
     manifest_digest: Option<&str>,
     platform: &str,
 ) -> Result<PathBuf> {
+    let _phase = PhaseTimer::new("validate_cache_entry");
     let metadata_path = cache_dir.join("metadata.json");
     let metadata: CachedImageMetadata =
         serde_json::from_slice(&fs::read(&metadata_path).with_context(|| {


### PR DESCRIPTION
Firecracker network setup spent about 200–250 ms in avoidable host-kernel synchronization waits, and termination always waited five seconds for SIGTERM before killing the VMM.

Create the veth peer directly in its destination namespace and use `nft destroy table` for absent-table cleanup. For termination, send SIGKILL directly through the verified pidfd and confirm exit before cleanup. PID, machine ID, and cgroup checks remain intact. Firecracker runs as namespace PID 1 without a SIGTERM handler, so the old grace period did not provide graceful guest shutdown. Graceful shutdown requires a separate guest shutdown operation.

Validation:

- Linux x86_64 host, kernel 6.12 and nftables 1.1.3: network setup fell to 27–29 ms.
- Local ARM64 KVM host, Firecracker 1.16.1, debug build, 1 vCPU / 512 MiB guests: three fresh-guest termination measurements fell from 5,048–5,056 ms to 41–49 ms, including cleanup. Three restored-guest terminations took 38–48 ms.
- The local build compiled successfully, and guest creation, snapshot capture, restore, command execution, and termination completed successfully.

No automated tests were run. Temporary phase-timer instrumentation is excluded from this PR.
