### PR TITLE
Separate sandbox identity from owner scope and trace Firecracker lifecycle

### DIFF
--- a/crates/cli/tests/daytona_backend.rs
+++ b/crates/cli/tests/daytona_backend.rs
@@ -25,10 +25,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 /// format matches what the find-by-label query expects to see.
 fn make_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
-        key: SandboxKey::ConversationSandbox {
-            thread_id: thread_id.into(),
-            sandbox_id: sandbox_id.into(),
-        },
+        key: sandbox_id.into(),
         spec: SandboxSpec {
             image: "docker.io/library/ubuntu:24.04".into(),
             resources: Default::default(),

--- a/crates/cli/tests/daytona_backend.rs
+++ b/crates/cli/tests/daytona_backend.rs
@@ -8,8 +8,8 @@ use std::collections::HashMap;
 
 use bytes::Bytes;
 use exoharness::{
-    DaytonaConfig, DaytonaSandboxBackend, ManagedSandboxBackend, SandboxKey,
-    SandboxLifecycleConfig, SandboxMount, SandboxMountAccess, SandboxNetworkPolicy, SandboxRequest,
+    DaytonaConfig, DaytonaSandboxBackend, ManagedSandboxBackend, SandboxLifecycleConfig,
+    SandboxMount, SandboxMountAccess, SandboxNetworkPolicy, SandboxRequest, SandboxScope,
     SandboxSpec, SnapshotFormat, SnapshotPayload,
 };
 use futures::io::{AsyncReadExt, AsyncWriteExt};
@@ -25,10 +25,10 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 /// format matches what the find-by-label query expects to see.
 fn make_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
-        key: SandboxKey::ConversationSandbox {
+        sandbox_id: sandbox_id.into(),
+        scope: Some(SandboxScope::Conversation {
             thread_id: thread_id.into(),
-            sandbox_id: sandbox_id.into(),
-        },
+        }),
         spec: SandboxSpec {
             image: "docker.io/library/ubuntu:24.04".into(),
             resources: Default::default(),
@@ -120,7 +120,7 @@ async fn acquire_creates_when_no_warm_match() {
         .expect("POST /sandbox (create) should have been called");
     let body: Value = serde_json::from_slice(&create.body).expect("body is JSON");
 
-    // Labels carry the SandboxKey + spec hash; their absence would break
+    // Labels carry the sandbox ID + spec hash; their absence would break
     // cross-process recovery by label.
     let labels = body
         .get("labels")

--- a/crates/cli/tests/daytona_backend.rs
+++ b/crates/cli/tests/daytona_backend.rs
@@ -26,7 +26,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 fn make_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
         sandbox_id: sandbox_id.into(),
-        scope: Some(SandboxScope::Conversation {
+        scope: Some(SandboxScope::Thread {
             thread_id: thread_id.into(),
         }),
         spec: SandboxSpec {

--- a/crates/cli/tests/daytona_backend.rs
+++ b/crates/cli/tests/daytona_backend.rs
@@ -25,7 +25,10 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 /// format matches what the find-by-label query expects to see.
 fn make_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
-        key: sandbox_id.into(),
+        key: SandboxKey::ConversationSandbox {
+            thread_id: thread_id.into(),
+            sandbox_id: sandbox_id.into(),
+        },
         spec: SandboxSpec {
             image: "docker.io/library/ubuntu:24.04".into(),
             resources: Default::default(),

--- a/crates/cli/tests/e2b_backend.rs
+++ b/crates/cli/tests/e2b_backend.rs
@@ -16,10 +16,7 @@ use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate};
 
 fn make_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
-        key: SandboxKey::ConversationSandbox {
-            thread_id: thread_id.into(),
-            sandbox_id: sandbox_id.into(),
-        },
+        key: sandbox_id.into(),
         spec: SandboxSpec {
             image: "base".into(),
             resources: Default::default(),

--- a/crates/cli/tests/e2b_backend.rs
+++ b/crates/cli/tests/e2b_backend.rs
@@ -17,7 +17,7 @@ use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate};
 fn make_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
         sandbox_id: sandbox_id.into(),
-        scope: Some(SandboxScope::Conversation {
+        scope: Some(SandboxScope::Thread {
             thread_id: thread_id.into(),
         }),
         spec: SandboxSpec {

--- a/crates/cli/tests/e2b_backend.rs
+++ b/crates/cli/tests/e2b_backend.rs
@@ -6,8 +6,8 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use exoharness::{
-    E2bConfig, E2bSandboxBackend, ManagedSandboxBackend, SandboxCommand, SandboxKey,
-    SandboxLifecycleConfig, SandboxMount, SandboxMountAccess, SandboxNetworkPolicy, SandboxRequest,
+    E2bConfig, E2bSandboxBackend, ManagedSandboxBackend, SandboxCommand, SandboxLifecycleConfig,
+    SandboxMount, SandboxMountAccess, SandboxNetworkPolicy, SandboxRequest, SandboxScope,
     SandboxSpec, SnapshotFormat, SnapshotPayload,
 };
 use serde_json::{Value, json};
@@ -16,10 +16,10 @@ use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate};
 
 fn make_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
-        key: SandboxKey::ConversationSandbox {
+        sandbox_id: sandbox_id.into(),
+        scope: Some(SandboxScope::Conversation {
             thread_id: thread_id.into(),
-            sandbox_id: sandbox_id.into(),
-        },
+        }),
         spec: SandboxSpec {
             image: "base".into(),
             resources: Default::default(),

--- a/crates/cli/tests/e2b_backend.rs
+++ b/crates/cli/tests/e2b_backend.rs
@@ -16,7 +16,10 @@ use wiremock::{Match, Mock, MockServer, Request, ResponseTemplate};
 
 fn make_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
-        key: sandbox_id.into(),
+        key: SandboxKey::ConversationSandbox {
+            thread_id: thread_id.into(),
+            sandbox_id: sandbox_id.into(),
+        },
         spec: SandboxSpec {
             image: "base".into(),
             resources: Default::default(),
@@ -157,7 +160,7 @@ async fn acquire_reuses_running_sandbox_without_connect() {
         .await
         .expect("acquire should reuse running sandbox");
 
-    assert_eq!(handle.id(), "e2b:thread:conv-3:sandbox-3");
+    assert_eq!(handle.id(), "e2b:sandbox-3");
 
     let requests = server.received_requests().await.unwrap_or_default();
     assert!(
@@ -208,7 +211,7 @@ async fn acquire_list_metadata_query_is_not_double_url_encoded() {
         .await;
 
     backend
-        .acquire(make_request("conv-colons", "sandbox-colons"))
+        .acquire(make_request("conv-colons", "sandbox:colons"))
         .await
         .expect("acquire should find sandbox by metadata");
 
@@ -222,8 +225,7 @@ async fn acquire_list_metadata_query_is_not_double_url_encoded() {
         "metadata filter must not double-encode ':' in sandbox keys; got {query}"
     );
     assert!(
-        query.contains("thread%3Aconv-colons%3Asandbox-colons")
-            || query.contains("thread:conv-colons:sandbox-colons"),
+        query.contains("sandbox%3Acolons") || query.contains("sandbox:colons"),
         "expected sandbox key in metadata query; got {query}"
     );
     assert!(

--- a/crates/cli/tests/sandbox_start_process_live.rs
+++ b/crates/cli/tests/sandbox_start_process_live.rs
@@ -13,8 +13,8 @@ use std::time::{Duration, Instant};
 
 use exoharness::{
     E2bConfig, E2bSandboxBackend, ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand,
-    SandboxKey, SandboxLifecycleConfig, SandboxNetworkPolicy, SandboxRequest, SandboxSpec,
-    SpritesConfig, SpritesSandboxBackend,
+    SandboxLifecycleConfig, SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SpritesConfig,
+    SpritesSandboxBackend,
 };
 use futures::io::AsyncReadExt;
 use tokio::time::timeout;
@@ -35,10 +35,7 @@ fn live_provider_secret(provider: &str, secret_name: &str) -> Option<String> {
 
 fn make_e2b_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
-        key: SandboxKey::ConversationSandbox {
-            thread_id: thread_id.into(),
-            sandbox_id: sandbox_id.into(),
-        },
+        key: sandbox_id.into(),
         spec: SandboxSpec {
             image: e2b_template_id(),
             resources: Default::default(),
@@ -85,10 +82,7 @@ fn sprites_config_from_env() -> Option<SpritesConfig> {
 
 fn make_sprites_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
-        key: SandboxKey::ConversationSandbox {
-            thread_id: thread_id.into(),
-            sandbox_id: sandbox_id.into(),
-        },
+        key: sandbox_id.into(),
         spec: SandboxSpec {
             image: "default".into(),
             resources: Default::default(),

--- a/crates/cli/tests/sandbox_start_process_live.rs
+++ b/crates/cli/tests/sandbox_start_process_live.rs
@@ -13,7 +13,7 @@ use std::time::{Duration, Instant};
 
 use exoharness::{
     E2bConfig, E2bSandboxBackend, ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand,
-    SandboxKey, SandboxLifecycleConfig, SandboxNetworkPolicy, SandboxRequest, SandboxSpec,
+    SandboxLifecycleConfig, SandboxNetworkPolicy, SandboxRequest, SandboxScope, SandboxSpec,
     SpritesConfig, SpritesSandboxBackend,
 };
 use futures::io::AsyncReadExt;
@@ -35,10 +35,10 @@ fn live_provider_secret(provider: &str, secret_name: &str) -> Option<String> {
 
 fn make_e2b_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
-        key: SandboxKey::ConversationSandbox {
+        sandbox_id: sandbox_id.into(),
+        scope: Some(SandboxScope::Conversation {
             thread_id: thread_id.into(),
-            sandbox_id: sandbox_id.into(),
-        },
+        }),
         spec: SandboxSpec {
             image: e2b_template_id(),
             resources: Default::default(),
@@ -85,10 +85,10 @@ fn sprites_config_from_env() -> Option<SpritesConfig> {
 
 fn make_sprites_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
-        key: SandboxKey::ConversationSandbox {
+        sandbox_id: sandbox_id.into(),
+        scope: Some(SandboxScope::Conversation {
             thread_id: thread_id.into(),
-            sandbox_id: sandbox_id.into(),
-        },
+        }),
         spec: SandboxSpec {
             image: "default".into(),
             resources: Default::default(),

--- a/crates/cli/tests/sandbox_start_process_live.rs
+++ b/crates/cli/tests/sandbox_start_process_live.rs
@@ -36,7 +36,7 @@ fn live_provider_secret(provider: &str, secret_name: &str) -> Option<String> {
 fn make_e2b_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
         sandbox_id: sandbox_id.into(),
-        scope: Some(SandboxScope::Conversation {
+        scope: Some(SandboxScope::Thread {
             thread_id: thread_id.into(),
         }),
         spec: SandboxSpec {
@@ -86,7 +86,7 @@ fn sprites_config_from_env() -> Option<SpritesConfig> {
 fn make_sprites_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
         sandbox_id: sandbox_id.into(),
-        scope: Some(SandboxScope::Conversation {
+        scope: Some(SandboxScope::Thread {
             thread_id: thread_id.into(),
         }),
         spec: SandboxSpec {

--- a/crates/cli/tests/sandbox_start_process_live.rs
+++ b/crates/cli/tests/sandbox_start_process_live.rs
@@ -13,8 +13,8 @@ use std::time::{Duration, Instant};
 
 use exoharness::{
     E2bConfig, E2bSandboxBackend, ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand,
-    SandboxLifecycleConfig, SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SpritesConfig,
-    SpritesSandboxBackend,
+    SandboxKey, SandboxLifecycleConfig, SandboxNetworkPolicy, SandboxRequest, SandboxSpec,
+    SpritesConfig, SpritesSandboxBackend,
 };
 use futures::io::AsyncReadExt;
 use tokio::time::timeout;
@@ -35,7 +35,10 @@ fn live_provider_secret(provider: &str, secret_name: &str) -> Option<String> {
 
 fn make_e2b_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
-        key: sandbox_id.into(),
+        key: SandboxKey::ConversationSandbox {
+            thread_id: thread_id.into(),
+            sandbox_id: sandbox_id.into(),
+        },
         spec: SandboxSpec {
             image: e2b_template_id(),
             resources: Default::default(),
@@ -82,7 +85,10 @@ fn sprites_config_from_env() -> Option<SpritesConfig> {
 
 fn make_sprites_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
-        key: sandbox_id.into(),
+        key: SandboxKey::ConversationSandbox {
+            thread_id: thread_id.into(),
+            sandbox_id: sandbox_id.into(),
+        },
         spec: SandboxSpec {
             image: "default".into(),
             resources: Default::default(),

--- a/crates/cli/tests/smolvm_sandbox_live.rs
+++ b/crates/cli/tests/smolvm_sandbox_live.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 
 use exoharness::{
     ManagedSandboxBackend, ManagedSandboxHandle, SandboxBackendRegistration, SandboxCommand,
-    SandboxKey, SandboxLifecycleConfig, SandboxMount, SandboxMountAccess, SandboxNetworkPolicy,
+    SandboxLifecycleConfig, SandboxMount, SandboxMountAccess, SandboxNetworkPolicy,
     SandboxProvider, SandboxRequest, SandboxSpec, SmolvmExecutionMode, SmolvmSandboxBackend,
 };
 use futures::io::AsyncReadExt;
@@ -85,10 +85,7 @@ fn request(
     idle_ttl: Option<Duration>,
 ) -> SandboxRequest {
     SandboxRequest {
-        key: SandboxKey::AgentSandbox {
-            agent_id: "smolvm-live".into(),
-            sandbox_id: tag.into(),
-        },
+        key: tag.into(),
         spec: SandboxSpec {
             image,
             resources: Default::default(),

--- a/crates/cli/tests/smolvm_sandbox_live.rs
+++ b/crates/cli/tests/smolvm_sandbox_live.rs
@@ -17,8 +17,9 @@ use std::time::Duration;
 
 use exoharness::{
     ManagedSandboxBackend, ManagedSandboxHandle, SandboxBackendRegistration, SandboxCommand,
-    SandboxKey, SandboxLifecycleConfig, SandboxMount, SandboxMountAccess, SandboxNetworkPolicy,
-    SandboxProvider, SandboxRequest, SandboxSpec, SmolvmExecutionMode, SmolvmSandboxBackend,
+    SandboxLifecycleConfig, SandboxMount, SandboxMountAccess, SandboxNetworkPolicy,
+    SandboxProvider, SandboxRequest, SandboxScope, SandboxSpec, SmolvmExecutionMode,
+    SmolvmSandboxBackend,
 };
 use futures::io::AsyncReadExt;
 use tokio::sync::{OnceCell, RwLock};
@@ -85,10 +86,10 @@ fn request(
     idle_ttl: Option<Duration>,
 ) -> SandboxRequest {
     SandboxRequest {
-        key: SandboxKey::AgentSandbox {
+        sandbox_id: tag.into(),
+        scope: Some(SandboxScope::Agent {
             agent_id: "smolvm-live".into(),
-            sandbox_id: tag.into(),
-        },
+        }),
         spec: SandboxSpec {
             image,
             resources: Default::default(),

--- a/crates/cli/tests/smolvm_sandbox_live.rs
+++ b/crates/cli/tests/smolvm_sandbox_live.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 
 use exoharness::{
     ManagedSandboxBackend, ManagedSandboxHandle, SandboxBackendRegistration, SandboxCommand,
-    SandboxLifecycleConfig, SandboxMount, SandboxMountAccess, SandboxNetworkPolicy,
+    SandboxKey, SandboxLifecycleConfig, SandboxMount, SandboxMountAccess, SandboxNetworkPolicy,
     SandboxProvider, SandboxRequest, SandboxSpec, SmolvmExecutionMode, SmolvmSandboxBackend,
 };
 use futures::io::AsyncReadExt;
@@ -85,7 +85,10 @@ fn request(
     idle_ttl: Option<Duration>,
 ) -> SandboxRequest {
     SandboxRequest {
-        key: tag.into(),
+        key: SandboxKey::AgentSandbox {
+            agent_id: "smolvm-live".into(),
+            sandbox_id: tag.into(),
+        },
         spec: SandboxSpec {
             image,
             resources: Default::default(),

--- a/crates/cli/tests/sprites_backend.rs
+++ b/crates/cli/tests/sprites_backend.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use exoharness::{
-    ManagedSandboxBackend, SandboxKey, SandboxLifecycleConfig, SandboxMount, SandboxMountAccess,
+    ManagedSandboxBackend, SandboxLifecycleConfig, SandboxMount, SandboxMountAccess,
     SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotFormat, SnapshotPayload,
     SpritesConfig, SpritesSandboxBackend,
 };
@@ -17,10 +17,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn make_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
-        key: SandboxKey::ConversationSandbox {
-            thread_id: thread_id.into(),
-            sandbox_id: sandbox_id.into(),
-        },
+        key: sandbox_id.into(),
         spec: SandboxSpec {
             image: "default".into(),
             resources: Default::default(),

--- a/crates/cli/tests/sprites_backend.rs
+++ b/crates/cli/tests/sprites_backend.rs
@@ -7,9 +7,9 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use exoharness::{
-    ManagedSandboxBackend, SandboxKey, SandboxLifecycleConfig, SandboxMount, SandboxMountAccess,
-    SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotFormat, SnapshotPayload,
-    SpritesConfig, SpritesSandboxBackend,
+    ManagedSandboxBackend, SandboxLifecycleConfig, SandboxMount, SandboxMountAccess,
+    SandboxNetworkPolicy, SandboxRequest, SandboxScope, SandboxSpec, SnapshotFormat,
+    SnapshotPayload, SpritesConfig, SpritesSandboxBackend,
 };
 use serde_json::{Value, json};
 use wiremock::matchers::{method, path, path_regex};
@@ -17,10 +17,10 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn make_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
-        key: SandboxKey::ConversationSandbox {
+        sandbox_id: sandbox_id.into(),
+        scope: Some(SandboxScope::Conversation {
             thread_id: thread_id.into(),
-            sandbox_id: sandbox_id.into(),
-        },
+        }),
         spec: SandboxSpec {
             image: "default".into(),
             resources: Default::default(),
@@ -44,7 +44,7 @@ fn sandbox_spec_hash(spec: &SandboxSpec) -> String {
 
 fn expected_sprite_name(request: &SandboxRequest) -> String {
     let mut hasher = DefaultHasher::new();
-    request.key.sandbox_id().hash(&mut hasher);
+    request.sandbox_id.as_str().hash(&mut hasher);
     sandbox_spec_hash(&request.spec).hash(&mut hasher);
     format!("exo-{:016x}", hasher.finish())
 }

--- a/crates/cli/tests/sprites_backend.rs
+++ b/crates/cli/tests/sprites_backend.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use exoharness::{
-    ManagedSandboxBackend, SandboxLifecycleConfig, SandboxMount, SandboxMountAccess,
+    ManagedSandboxBackend, SandboxKey, SandboxLifecycleConfig, SandboxMount, SandboxMountAccess,
     SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotFormat, SnapshotPayload,
     SpritesConfig, SpritesSandboxBackend,
 };
@@ -17,7 +17,10 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn make_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
-        key: sandbox_id.into(),
+        key: SandboxKey::ConversationSandbox {
+            thread_id: thread_id.into(),
+            sandbox_id: sandbox_id.into(),
+        },
         spec: SandboxSpec {
             image: "default".into(),
             resources: Default::default(),
@@ -41,7 +44,7 @@ fn sandbox_spec_hash(spec: &SandboxSpec) -> String {
 
 fn expected_sprite_name(request: &SandboxRequest) -> String {
     let mut hasher = DefaultHasher::new();
-    request.key.hash(&mut hasher);
+    request.key.sandbox_id().hash(&mut hasher);
     sandbox_spec_hash(&request.spec).hash(&mut hasher);
     format!("exo-{:016x}", hasher.finish())
 }
@@ -96,7 +99,7 @@ async fn acquire_creates_sprite_when_missing() {
         .await;
 
     let handle = backend.acquire(request).await.expect("acquire");
-    assert_eq!(handle.id(), "sprites:thread:conv-1:sandbox-1");
+    assert_eq!(handle.id(), "sprites:sandbox-1");
 }
 
 #[tokio::test]
@@ -131,9 +134,11 @@ async fn acquire_create_includes_exo_metadata_labels() {
         .get("labels")
         .and_then(Value::as_array)
         .expect("labels array");
-    assert!(labels.iter().any(|label| {
-        label.as_str() == Some("exo.sandbox.key=thread:conv-labels:sandbox-labels")
-    }));
+    assert!(
+        labels
+            .iter()
+            .any(|label| { label.as_str() == Some("exo.sandbox.key=sandbox-labels") })
+    );
     assert!(
         labels
             .iter()
@@ -238,7 +243,7 @@ async fn acquire_reuses_existing_sprite_without_create() {
         .acquire(request)
         .await
         .expect("acquire should reuse existing sprite");
-    assert_eq!(handle.id(), "sprites:thread:conv-3:sandbox-3");
+    assert_eq!(handle.id(), "sprites:sandbox-3");
 
     let requests = server.received_requests().await.unwrap_or_default();
     assert!(

--- a/crates/cli/tests/sprites_backend.rs
+++ b/crates/cli/tests/sprites_backend.rs
@@ -18,7 +18,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 fn make_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
         sandbox_id: sandbox_id.into(),
-        scope: Some(SandboxScope::Conversation {
+        scope: Some(SandboxScope::Thread {
             thread_id: thread_id.into(),
         }),
         spec: SandboxSpec {

--- a/crates/cli/tests/vercel_backend.rs
+++ b/crates/cli/tests/vercel_backend.rs
@@ -5,8 +5,8 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use exoharness::{
-    ManagedSandboxBackend, SandboxCommand, SandboxKey, SandboxLifecycleConfig,
-    SandboxNetworkPolicy, SandboxRequest, SandboxSpec, VercelConfig, VercelSandboxBackend,
+    ManagedSandboxBackend, SandboxCommand, SandboxLifecycleConfig, SandboxNetworkPolicy,
+    SandboxRequest, SandboxSpec, VercelConfig, VercelSandboxBackend,
 };
 use serde::Deserialize;
 use serde_json::{Value, json};
@@ -15,10 +15,7 @@ use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 
 fn make_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
-        key: SandboxKey::ConversationSandbox {
-            thread_id: thread_id.into(),
-            sandbox_id: sandbox_id.into(),
-        },
+        key: sandbox_id.into(),
         spec: SandboxSpec {
             image: "node24".into(),
             resources: Default::default(),

--- a/crates/cli/tests/vercel_backend.rs
+++ b/crates/cli/tests/vercel_backend.rs
@@ -5,8 +5,8 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use exoharness::{
-    ManagedSandboxBackend, SandboxCommand, SandboxLifecycleConfig, SandboxNetworkPolicy,
-    SandboxRequest, SandboxSpec, VercelConfig, VercelSandboxBackend,
+    ManagedSandboxBackend, SandboxCommand, SandboxKey, SandboxLifecycleConfig,
+    SandboxNetworkPolicy, SandboxRequest, SandboxSpec, VercelConfig, VercelSandboxBackend,
 };
 use serde::Deserialize;
 use serde_json::{Value, json};
@@ -15,7 +15,10 @@ use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 
 fn make_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
-        key: sandbox_id.into(),
+        key: SandboxKey::ConversationSandbox {
+            thread_id: thread_id.into(),
+            sandbox_id: sandbox_id.into(),
+        },
         spec: SandboxSpec {
             image: "node24".into(),
             resources: Default::default(),

--- a/crates/cli/tests/vercel_backend.rs
+++ b/crates/cli/tests/vercel_backend.rs
@@ -16,7 +16,7 @@ use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 fn make_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
         sandbox_id: sandbox_id.into(),
-        scope: Some(SandboxScope::Conversation {
+        scope: Some(SandboxScope::Thread {
             thread_id: thread_id.into(),
         }),
         spec: SandboxSpec {

--- a/crates/cli/tests/vercel_backend.rs
+++ b/crates/cli/tests/vercel_backend.rs
@@ -5,8 +5,8 @@ use std::collections::HashMap;
 use std::time::Duration;
 
 use exoharness::{
-    ManagedSandboxBackend, SandboxCommand, SandboxKey, SandboxLifecycleConfig,
-    SandboxNetworkPolicy, SandboxRequest, SandboxSpec, VercelConfig, VercelSandboxBackend,
+    ManagedSandboxBackend, SandboxCommand, SandboxLifecycleConfig, SandboxNetworkPolicy,
+    SandboxRequest, SandboxScope, SandboxSpec, VercelConfig, VercelSandboxBackend,
 };
 use serde::Deserialize;
 use serde_json::{Value, json};
@@ -15,10 +15,10 @@ use wiremock::{Mock, MockServer, Request, ResponseTemplate};
 
 fn make_request(thread_id: &str, sandbox_id: &str) -> SandboxRequest {
     SandboxRequest {
-        key: SandboxKey::ConversationSandbox {
+        sandbox_id: sandbox_id.into(),
+        scope: Some(SandboxScope::Conversation {
             thread_id: thread_id.into(),
-            sandbox_id: sandbox_id.into(),
-        },
+        }),
         spec: SandboxSpec {
             image: "node24".into(),
             resources: Default::default(),

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -21,8 +21,8 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use crate::sandbox::{
     BoxSandboxTcpStream, CliContainerSandboxBackend, LocalProcessSandboxBackend,
     ManagedSandboxBackend, ManagedSandboxHandle, SANDBOX_MAIN_MOUNT_DIR, SandboxCommand,
-    SandboxKey, SandboxLifecycleConfig, SandboxMount, SandboxMountAccess, SandboxNetworkPolicy,
-    SandboxRequest, SandboxSpec, SnapshotFormat, SnapshotPayload, sandbox_spec_hash,
+    SandboxLifecycleConfig, SandboxMount, SandboxMountAccess, SandboxNetworkPolicy, SandboxRequest,
+    SandboxSpec, SnapshotFormat, SnapshotPayload, sandbox_spec_hash,
 };
 #[cfg(feature = "apple-keychain")]
 use crate::secrets::AppleKeychainSecretKeyProvider;
@@ -1916,8 +1916,8 @@ impl<'a> BasicScopedSandboxHandle<'a> {
             .inner
             .sandbox_backend_for_provider(sandbox.provider.clone())
             .await?;
-        let source_request = sandbox_request(self.owner, &request.source_id, &source, None);
-        let target_request = sandbox_request(self.owner, &sandbox_id, &sandbox, None);
+        let source_request = sandbox_request(&request.source_id, &source, None);
+        let target_request = sandbox_request(&sandbox_id, &sandbox, None);
         let sandbox_handle = backend.fork_sandbox(source_request, target_request).await?;
         let provider_state_event = sandbox_provider_state_event(
             &sandbox_id,
@@ -1946,10 +1946,7 @@ impl<'a> BasicScopedSandboxHandle<'a> {
             .await?;
         ensure_snapshot_format_supported(backend.as_ref(), &sandbox.provider, &payload.format)?;
         let sandbox_handle = backend
-            .acquire_from_snapshot(
-                sandbox_request(self.owner, &sandbox_id, &sandbox, None),
-                payload,
-            )
+            .acquire_from_snapshot(sandbox_request(&sandbox_id, &sandbox, None), payload)
             .await?;
         if let Some(effective_image) = sandbox_handle.effective_image()
             && effective_image != sandbox.image
@@ -1993,7 +1990,7 @@ impl<'a> BasicScopedSandboxHandle<'a> {
             )
             .await?;
             backend
-                .terminate(sandbox_request(self.owner, &id, &sandbox, provider_state))
+                .terminate(sandbox_request(&id, &sandbox, provider_state))
                 .await?;
             self.harness
                 .inner
@@ -3323,7 +3320,7 @@ async fn start_sandbox_side_effect(
     //     warm-cache entry (both handles share the same SandboxKey).
     let sandbox_handle = if cross_provider {
         let sandbox_handle = backend
-            .acquire_from_snapshot(sandbox_request(owner, &request.id, &sandbox, None), payload)
+            .acquire_from_snapshot(sandbox_request(&request.id, &sandbox, None), payload)
             .await?;
         let previous_handle = harness
             .inner
@@ -3355,7 +3352,7 @@ async fn start_sandbox_side_effect(
             previous_handle.stop().await?;
         }
         backend
-            .acquire_from_snapshot(sandbox_request(owner, &request.id, &sandbox, None), payload)
+            .acquire_from_snapshot(sandbox_request(&request.id, &sandbox, None), payload)
             .await?
     };
 
@@ -3624,7 +3621,7 @@ async fn create_sandbox_handle(
         .inner
         .sandbox_backend_for_provider(sandbox.provider.clone())
         .await?;
-    let request = sandbox_request(owner, sandbox_id, sandbox, previous_state.clone());
+    let request = sandbox_request(sandbox_id, sandbox, previous_state.clone());
     let handle = match &sandbox.attachment {
         Some(attachment) => backend.attach(request, attachment.clone()).await?,
         None => backend.acquire(request).await?,
@@ -3644,7 +3641,7 @@ fn sandbox_provider_state_key(
     sandbox_id: &SandboxId,
     sandbox: &StoredSandbox,
 ) -> String {
-    let request = sandbox_request(owner, sandbox_id, sandbox, None);
+    let request = sandbox_request(sandbox_id, sandbox, None);
     format!("{}\n{}", request.key, sandbox_spec_hash(&request.spec))
 }
 
@@ -4409,22 +4406,12 @@ impl SandboxProcess for LiveSandboxProcess {
 }
 
 fn sandbox_request(
-    owner: SandboxOwner,
     sandbox_id: &str,
     sandbox: &StoredSandbox,
     provider_state: Option<Value>,
 ) -> SandboxRequest {
     SandboxRequest {
-        key: match owner {
-            SandboxOwner::Agent(agent_id) => SandboxKey::AgentSandbox {
-                agent_id: agent_id.to_string(),
-                sandbox_id: sandbox_id.to_string(),
-            },
-            SandboxOwner::Conversation(thread_id) => SandboxKey::ConversationSandbox {
-                thread_id: thread_id.to_string(),
-                sandbox_id: sandbox_id.to_string(),
-            },
-        },
+        key: sandbox_id.to_string(),
         spec: SandboxSpec {
             image: sandbox.image.clone(),
             resources: sandbox.resources,

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -21,8 +21,8 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use crate::sandbox::{
     BoxSandboxTcpStream, CliContainerSandboxBackend, LocalProcessSandboxBackend,
     ManagedSandboxBackend, ManagedSandboxHandle, SANDBOX_MAIN_MOUNT_DIR, SandboxCommand,
-    SandboxLifecycleConfig, SandboxMount, SandboxMountAccess, SandboxNetworkPolicy, SandboxRequest,
-    SandboxSpec, SnapshotFormat, SnapshotPayload, sandbox_spec_hash,
+    SandboxKey, SandboxLifecycleConfig, SandboxMount, SandboxMountAccess, SandboxNetworkPolicy,
+    SandboxRequest, SandboxSpec, SnapshotFormat, SnapshotPayload, sandbox_spec_hash,
 };
 #[cfg(feature = "apple-keychain")]
 use crate::secrets::AppleKeychainSecretKeyProvider;
@@ -1916,8 +1916,8 @@ impl<'a> BasicScopedSandboxHandle<'a> {
             .inner
             .sandbox_backend_for_provider(sandbox.provider.clone())
             .await?;
-        let source_request = sandbox_request(&request.source_id, &source, None);
-        let target_request = sandbox_request(&sandbox_id, &sandbox, None);
+        let source_request = sandbox_request(self.owner, &request.source_id, &source, None);
+        let target_request = sandbox_request(self.owner, &sandbox_id, &sandbox, None);
         let sandbox_handle = backend.fork_sandbox(source_request, target_request).await?;
         let provider_state_event = sandbox_provider_state_event(
             &sandbox_id,
@@ -1946,7 +1946,10 @@ impl<'a> BasicScopedSandboxHandle<'a> {
             .await?;
         ensure_snapshot_format_supported(backend.as_ref(), &sandbox.provider, &payload.format)?;
         let sandbox_handle = backend
-            .acquire_from_snapshot(sandbox_request(&sandbox_id, &sandbox, None), payload)
+            .acquire_from_snapshot(
+                sandbox_request(self.owner, &sandbox_id, &sandbox, None),
+                payload,
+            )
             .await?;
         if let Some(effective_image) = sandbox_handle.effective_image()
             && effective_image != sandbox.image
@@ -1990,7 +1993,7 @@ impl<'a> BasicScopedSandboxHandle<'a> {
             )
             .await?;
             backend
-                .terminate(sandbox_request(&id, &sandbox, provider_state))
+                .terminate(sandbox_request(self.owner, &id, &sandbox, provider_state))
                 .await?;
             self.harness
                 .inner
@@ -3320,7 +3323,7 @@ async fn start_sandbox_side_effect(
     //     warm-cache entry (both handles share the same SandboxKey).
     let sandbox_handle = if cross_provider {
         let sandbox_handle = backend
-            .acquire_from_snapshot(sandbox_request(&request.id, &sandbox, None), payload)
+            .acquire_from_snapshot(sandbox_request(owner, &request.id, &sandbox, None), payload)
             .await?;
         let previous_handle = harness
             .inner
@@ -3352,7 +3355,7 @@ async fn start_sandbox_side_effect(
             previous_handle.stop().await?;
         }
         backend
-            .acquire_from_snapshot(sandbox_request(&request.id, &sandbox, None), payload)
+            .acquire_from_snapshot(sandbox_request(owner, &request.id, &sandbox, None), payload)
             .await?
     };
 
@@ -3621,7 +3624,7 @@ async fn create_sandbox_handle(
         .inner
         .sandbox_backend_for_provider(sandbox.provider.clone())
         .await?;
-    let request = sandbox_request(sandbox_id, sandbox, previous_state.clone());
+    let request = sandbox_request(owner, sandbox_id, sandbox, previous_state.clone());
     let handle = match &sandbox.attachment {
         Some(attachment) => backend.attach(request, attachment.clone()).await?,
         None => backend.acquire(request).await?,
@@ -3641,7 +3644,7 @@ fn sandbox_provider_state_key(
     sandbox_id: &SandboxId,
     sandbox: &StoredSandbox,
 ) -> String {
-    let request = sandbox_request(sandbox_id, sandbox, None);
+    let request = sandbox_request(owner, sandbox_id, sandbox, None);
     format!("{}\n{}", request.key, sandbox_spec_hash(&request.spec))
 }
 
@@ -4406,12 +4409,22 @@ impl SandboxProcess for LiveSandboxProcess {
 }
 
 fn sandbox_request(
+    owner: SandboxOwner,
     sandbox_id: &str,
     sandbox: &StoredSandbox,
     provider_state: Option<Value>,
 ) -> SandboxRequest {
     SandboxRequest {
-        key: sandbox_id.to_string(),
+        key: match owner {
+            SandboxOwner::Agent(agent_id) => SandboxKey::AgentSandbox {
+                agent_id: agent_id.to_string(),
+                sandbox_id: sandbox_id.to_string(),
+            },
+            SandboxOwner::Conversation(thread_id) => SandboxKey::ConversationSandbox {
+                thread_id: thread_id.to_string(),
+                sandbox_id: sandbox_id.to_string(),
+            },
+        },
         spec: SandboxSpec {
             image: sandbox.image.clone(),
             resources: sandbox.resources,

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -21,8 +21,8 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use crate::sandbox::{
     BoxSandboxTcpStream, CliContainerSandboxBackend, LocalProcessSandboxBackend,
     ManagedSandboxBackend, ManagedSandboxHandle, SANDBOX_MAIN_MOUNT_DIR, SandboxCommand,
-    SandboxKey, SandboxLifecycleConfig, SandboxMount, SandboxMountAccess, SandboxNetworkPolicy,
-    SandboxRequest, SandboxSpec, SnapshotFormat, SnapshotPayload, sandbox_spec_hash,
+    SandboxLifecycleConfig, SandboxMount, SandboxMountAccess, SandboxNetworkPolicy, SandboxRequest,
+    SandboxScope, SandboxSpec, SnapshotFormat, SnapshotPayload, sandbox_spec_hash,
 };
 #[cfg(feature = "apple-keychain")]
 use crate::secrets::AppleKeychainSecretKeyProvider;
@@ -3320,7 +3320,7 @@ async fn start_sandbox_side_effect(
     //   - Same provider: stop-then-boot. The backend replaces the warm
     //     container for this key itself during restore, and stopping the old
     //     handle after the new one exists would tear down the new container's
-    //     warm-cache entry (both handles share the same SandboxKey).
+    //     warm-cache entry (both handles share the same sandbox ID).
     let sandbox_handle = if cross_provider {
         let sandbox_handle = backend
             .acquire_from_snapshot(sandbox_request(owner, &request.id, &sandbox, None), payload)
@@ -3645,7 +3645,14 @@ fn sandbox_provider_state_key(
     sandbox: &StoredSandbox,
 ) -> String {
     let request = sandbox_request(owner, sandbox_id, sandbox, None);
-    format!("{}\n{}", request.key, sandbox_spec_hash(&request.spec))
+    let owner_key = match owner {
+        SandboxOwner::Agent(agent_id) => format!("agent:{agent_id}"),
+        SandboxOwner::Conversation(thread_id) => format!("thread:{thread_id}"),
+    };
+    format!(
+        "{owner_key}:{sandbox_id}\n{}",
+        sandbox_spec_hash(&request.spec)
+    )
 }
 
 async fn load_sandbox_provider_state(
@@ -4415,16 +4422,15 @@ fn sandbox_request(
     provider_state: Option<Value>,
 ) -> SandboxRequest {
     SandboxRequest {
-        key: match owner {
-            SandboxOwner::Agent(agent_id) => SandboxKey::AgentSandbox {
+        sandbox_id: sandbox_id.to_string(),
+        scope: Some(match owner {
+            SandboxOwner::Agent(agent_id) => SandboxScope::Agent {
                 agent_id: agent_id.to_string(),
-                sandbox_id: sandbox_id.to_string(),
             },
-            SandboxOwner::Conversation(thread_id) => SandboxKey::ConversationSandbox {
+            SandboxOwner::Conversation(thread_id) => SandboxScope::Conversation {
                 thread_id: thread_id.to_string(),
-                sandbox_id: sandbox_id.to_string(),
             },
-        },
+        }),
         spec: SandboxSpec {
             image: sandbox.image.clone(),
             resources: sandbox.resources,

--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -4427,7 +4427,7 @@ fn sandbox_request(
             SandboxOwner::Agent(agent_id) => SandboxScope::Agent {
                 agent_id: agent_id.to_string(),
             },
-            SandboxOwner::Conversation(thread_id) => SandboxScope::Conversation {
+            SandboxOwner::Conversation(thread_id) => SandboxScope::Thread {
                 thread_id: thread_id.to_string(),
             },
         }),

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -27,11 +27,11 @@ use crate::{
     ForkConversationRequest, ManagedSandboxBackend, ManagedSandboxHandle, NewAgentRequest,
     NewConversationRequest, PutSecretRequest, RestoreSandboxRequest, RunInSandboxRequest,
     SandboxAttachment, SandboxBackendRegistration, SandboxCommand, SandboxCommandOutput,
-    SandboxKey, SandboxLifecycleConfig, SandboxNetworkPolicy, SandboxProcessEvent,
-    SandboxProcessEventQuery, SandboxProcessParts, SandboxProcessStatus, SandboxProcessStdin,
-    SandboxProvider, SandboxProviderConfig, SandboxRequest, SandboxSpec, Secret, SnapshotFormat,
-    SnapshotPayload, StartSandboxProcessRequest, StartSandboxRequest, Uuid7,
-    WaitSandboxProcessRequest, WriteArtifactRequest, WriteSandboxProcessInputRequest,
+    SandboxLifecycleConfig, SandboxNetworkPolicy, SandboxProcessEvent, SandboxProcessEventQuery,
+    SandboxProcessParts, SandboxProcessStatus, SandboxProcessStdin, SandboxProvider,
+    SandboxProviderConfig, SandboxRequest, SandboxSpec, Secret, SnapshotFormat, SnapshotPayload,
+    StartSandboxProcessRequest, StartSandboxRequest, Uuid7, WaitSandboxProcessRequest,
+    WriteArtifactRequest, WriteSandboxProcessInputRequest,
 };
 
 const DEFAULT_DURABLE_CONTRACT_MOUNT_PATH: &str = "/home/exo/workspace";
@@ -669,10 +669,7 @@ async fn local_process_contract_handle(
         Arc::new(crate::LocalProcessSandboxBackend::new());
     backend
         .acquire(SandboxRequest {
-            key: SandboxKey::ConversationSandbox {
-                thread_id: Uuid7::now().to_string(),
-                sandbox_id: sandbox_id.to_string(),
-            },
+            key: sandbox_id.to_string(),
             spec: SandboxSpec {
                 image: "local-process".to_string(),
                 resources: Default::default(),
@@ -870,10 +867,7 @@ fn provider_contract_request(
     default_workdir: &str,
 ) -> SandboxRequest {
     SandboxRequest {
-        key: SandboxKey::ConversationSandbox {
-            thread_id: Uuid7::now().to_string(),
-            sandbox_id: format!("{provider}-{contract}-contract"),
-        },
+        key: format!("{provider}-{contract}-contract"),
         spec: SandboxSpec {
             image,
             resources: Default::default(),

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -27,11 +27,11 @@ use crate::{
     ForkConversationRequest, ManagedSandboxBackend, ManagedSandboxHandle, NewAgentRequest,
     NewConversationRequest, PutSecretRequest, RestoreSandboxRequest, RunInSandboxRequest,
     SandboxAttachment, SandboxBackendRegistration, SandboxCommand, SandboxCommandOutput,
-    SandboxLifecycleConfig, SandboxNetworkPolicy, SandboxProcessEvent, SandboxProcessEventQuery,
-    SandboxProcessParts, SandboxProcessStatus, SandboxProcessStdin, SandboxProvider,
-    SandboxProviderConfig, SandboxRequest, SandboxSpec, Secret, SnapshotFormat, SnapshotPayload,
-    StartSandboxProcessRequest, StartSandboxRequest, Uuid7, WaitSandboxProcessRequest,
-    WriteArtifactRequest, WriteSandboxProcessInputRequest,
+    SandboxKey, SandboxLifecycleConfig, SandboxNetworkPolicy, SandboxProcessEvent,
+    SandboxProcessEventQuery, SandboxProcessParts, SandboxProcessStatus, SandboxProcessStdin,
+    SandboxProvider, SandboxProviderConfig, SandboxRequest, SandboxSpec, Secret, SnapshotFormat,
+    SnapshotPayload, StartSandboxProcessRequest, StartSandboxRequest, Uuid7,
+    WaitSandboxProcessRequest, WriteArtifactRequest, WriteSandboxProcessInputRequest,
 };
 
 const DEFAULT_DURABLE_CONTRACT_MOUNT_PATH: &str = "/home/exo/workspace";
@@ -669,7 +669,10 @@ async fn local_process_contract_handle(
         Arc::new(crate::LocalProcessSandboxBackend::new());
     backend
         .acquire(SandboxRequest {
-            key: sandbox_id.to_string(),
+            key: SandboxKey::ConversationSandbox {
+                thread_id: Uuid7::now().to_string(),
+                sandbox_id: sandbox_id.to_string(),
+            },
             spec: SandboxSpec {
                 image: "local-process".to_string(),
                 resources: Default::default(),
@@ -867,7 +870,10 @@ fn provider_contract_request(
     default_workdir: &str,
 ) -> SandboxRequest {
     SandboxRequest {
-        key: format!("{provider}-{contract}-contract"),
+        key: SandboxKey::ConversationSandbox {
+            thread_id: Uuid7::now().to_string(),
+            sandbox_id: format!("{provider}-{contract}-contract"),
+        },
         spec: SandboxSpec {
             image,
             resources: Default::default(),

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -670,7 +670,7 @@ async fn local_process_contract_handle(
     backend
         .acquire(SandboxRequest {
             sandbox_id: sandbox_id.to_string(),
-            scope: Some(SandboxScope::Conversation {
+            scope: Some(SandboxScope::Thread {
                 thread_id: Uuid7::now().to_string(),
             }),
             spec: SandboxSpec {
@@ -871,7 +871,7 @@ fn provider_contract_request(
 ) -> SandboxRequest {
     SandboxRequest {
         sandbox_id: format!("{provider}-{contract}-contract"),
-        scope: Some(SandboxScope::Conversation {
+        scope: Some(SandboxScope::Thread {
             thread_id: Uuid7::now().to_string(),
         }),
         spec: SandboxSpec {

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -27,9 +27,9 @@ use crate::{
     ForkConversationRequest, ManagedSandboxBackend, ManagedSandboxHandle, NewAgentRequest,
     NewConversationRequest, PutSecretRequest, RestoreSandboxRequest, RunInSandboxRequest,
     SandboxAttachment, SandboxBackendRegistration, SandboxCommand, SandboxCommandOutput,
-    SandboxKey, SandboxLifecycleConfig, SandboxNetworkPolicy, SandboxProcessEvent,
-    SandboxProcessEventQuery, SandboxProcessParts, SandboxProcessStatus, SandboxProcessStdin,
-    SandboxProvider, SandboxProviderConfig, SandboxRequest, SandboxSpec, Secret, SnapshotFormat,
+    SandboxLifecycleConfig, SandboxNetworkPolicy, SandboxProcessEvent, SandboxProcessEventQuery,
+    SandboxProcessParts, SandboxProcessStatus, SandboxProcessStdin, SandboxProvider,
+    SandboxProviderConfig, SandboxRequest, SandboxScope, SandboxSpec, Secret, SnapshotFormat,
     SnapshotPayload, StartSandboxProcessRequest, StartSandboxRequest, Uuid7,
     WaitSandboxProcessRequest, WriteArtifactRequest, WriteSandboxProcessInputRequest,
 };
@@ -669,10 +669,10 @@ async fn local_process_contract_handle(
         Arc::new(crate::LocalProcessSandboxBackend::new());
     backend
         .acquire(SandboxRequest {
-            key: SandboxKey::ConversationSandbox {
+            sandbox_id: sandbox_id.to_string(),
+            scope: Some(SandboxScope::Conversation {
                 thread_id: Uuid7::now().to_string(),
-                sandbox_id: sandbox_id.to_string(),
-            },
+            }),
             spec: SandboxSpec {
                 image: "local-process".to_string(),
                 resources: Default::default(),
@@ -870,10 +870,10 @@ fn provider_contract_request(
     default_workdir: &str,
 ) -> SandboxRequest {
     SandboxRequest {
-        key: SandboxKey::ConversationSandbox {
+        sandbox_id: format!("{provider}-{contract}-contract"),
+        scope: Some(SandboxScope::Conversation {
             thread_id: Uuid7::now().to_string(),
-            sandbox_id: format!("{provider}-{contract}-contract"),
-        },
+        }),
         spec: SandboxSpec {
             image,
             resources: Default::default(),

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -24,37 +24,7 @@ use uuid::Uuid;
 
 use crate::{DurableFileSystem, SandboxAttachment};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum SandboxKey {
-    StandaloneSandbox {
-        sandbox_id: String,
-    },
-    AgentSandbox {
-        agent_id: String,
-        sandbox_id: String,
-    },
-    ConversationSandbox {
-        #[serde(alias = "conversation_id")]
-        thread_id: String,
-        sandbox_id: String,
-    },
-}
-
-impl fmt::Display for SandboxKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::StandaloneSandbox { sandbox_id } => write!(f, "sandbox:{sandbox_id}"),
-            Self::AgentSandbox {
-                agent_id,
-                sandbox_id,
-            } => write!(f, "agent:{agent_id}:{sandbox_id}"),
-            Self::ConversationSandbox {
-                thread_id,
-                sandbox_id,
-            } => write!(f, "thread:{thread_id}:{sandbox_id}"),
-        }
-    }
-}
+pub type SandboxKey = String;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SandboxLifecycleConfig {
@@ -2301,35 +2271,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn conversation_sandbox_key_uses_thread_id_and_reads_conversation_id() {
-        let key = SandboxKey::ConversationSandbox {
-            thread_id: "thread-1".to_string(),
-            sandbox_id: "sandbox-1".to_string(),
-        };
-
-        assert_eq!(
-            serde_json::to_value(&key).unwrap(),
-            serde_json::json!({
-                "ConversationSandbox": {
-                    "thread_id": "thread-1",
-                    "sandbox_id": "sandbox-1"
-                }
-            })
-        );
-        assert_eq!(
-            serde_json::from_value::<SandboxKey>(serde_json::json!({
-                "ConversationSandbox": {
-                    "conversation_id": "thread-1",
-                    "sandbox_id": "sandbox-1"
-                }
-            }))
-            .unwrap(),
-            key
-        );
-        assert_eq!(key.to_string(), "thread:thread-1:sandbox-1");
-    }
-
-    #[test]
     fn apple_container_list_item_reads_current_status_shape() {
         let container: ContainerListItem = serde_json::from_value(serde_json::json!({
             "configuration": {
@@ -2440,10 +2381,7 @@ mod tests {
         fs::set_permissions(&script_path, permissions).expect("chmod fake docker");
 
         let request = SandboxRequest {
-            key: SandboxKey::ConversationSandbox {
-                thread_id: "thread".to_string(),
-                sandbox_id: "sandbox".to_string(),
-            },
+            key: "sandbox".to_string(),
             spec: SandboxSpec {
                 image: "docker.io/library/ubuntu:24.04".to_string(),
                 resources: Default::default(),
@@ -2517,10 +2455,7 @@ mod tests {
             warm_sandboxes: Arc::new(Mutex::new(HashMap::new())),
         };
         let request = SandboxRequest {
-            key: SandboxKey::ConversationSandbox {
-                thread_id: "thread".to_string(),
-                sandbox_id: "sandbox".to_string(),
-            },
+            key: "sandbox".to_string(),
             spec: SandboxSpec {
                 image: "docker.io/library/ubuntu:24.04".to_string(),
                 resources: Default::default(),
@@ -2610,10 +2545,7 @@ esac
             warm_sandboxes: Arc::new(Mutex::new(HashMap::new())),
         };
         let request = SandboxRequest {
-            key: SandboxKey::ConversationSandbox {
-                thread_id: "thread".to_string(),
-                sandbox_id: "sandbox".to_string(),
-            },
+            key: "sandbox".to_string(),
             spec: SandboxSpec {
                 image: "docker.io/library/ubuntu:24.04".to_string(),
                 resources: Default::default(),
@@ -2722,10 +2654,7 @@ esac
             warm_sandboxes: Arc::new(Mutex::new(HashMap::new())),
         };
         let request = SandboxRequest {
-            key: SandboxKey::ConversationSandbox {
-                thread_id: "thread".to_string(),
-                sandbox_id: "sandbox".to_string(),
-            },
+            key: "sandbox".to_string(),
             spec: SandboxSpec {
                 image: "task-image".to_string(),
                 resources: Default::default(),

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -26,6 +26,9 @@ use crate::{DurableFileSystem, SandboxAttachment};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum SandboxKey {
+    StandaloneSandbox {
+        sandbox_id: String,
+    },
     AgentSandbox {
         agent_id: String,
         sandbox_id: String,
@@ -40,6 +43,7 @@ pub enum SandboxKey {
 impl fmt::Display for SandboxKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::StandaloneSandbox { sandbox_id } => write!(f, "sandbox:{sandbox_id}"),
             Self::AgentSandbox {
                 agent_id,
                 sandbox_id,

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -22,7 +22,7 @@ use tokio::time;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use uuid::Uuid;
 
-use crate::{DurableFileSystem, SandboxAttachment};
+use crate::{DurableFileSystem, SandboxAttachment, SandboxId};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum SandboxScope {
@@ -73,7 +73,7 @@ pub struct SandboxSpec {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SandboxRequest {
-    pub sandbox_id: String,
+    pub sandbox_id: SandboxId,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scope: Option<SandboxScope>,
     pub spec: SandboxSpec,
@@ -468,7 +468,7 @@ pub struct CliContainerSandboxBackend {
     durable_file_system_root: Option<PathBuf>,
     system_started: Mutex<bool>,
     network_created: Mutex<bool>,
-    warm_sandboxes: Arc<Mutex<HashMap<String, WarmSandboxEntry>>>,
+    warm_sandboxes: Arc<Mutex<HashMap<SandboxId, WarmSandboxEntry>>>,
 }
 
 static DOCKER_CONSUMABLE_SNAPSHOT_FORMATS: [SnapshotFormat; 1] = [SnapshotFormat::DockerImageTar];
@@ -910,7 +910,7 @@ struct WarmSandboxHandle {
     cli: ContainerCliFlavor,
     container_bin: PathBuf,
     request: SandboxRequest,
-    warm_sandboxes: Arc<Mutex<HashMap<String, WarmSandboxEntry>>>,
+    warm_sandboxes: Arc<Mutex<HashMap<SandboxId, WarmSandboxEntry>>>,
 }
 
 #[async_trait]
@@ -1276,7 +1276,7 @@ pub(crate) fn stable_fnv1a_hex(input: &str) -> String {
 }
 
 async fn touch_warm_sandbox(
-    warm_sandboxes: &Arc<Mutex<HashMap<String, WarmSandboxEntry>>>,
+    warm_sandboxes: &Arc<Mutex<HashMap<SandboxId, WarmSandboxEntry>>>,
     key: &str,
 ) {
     let mut warm_sandboxes = warm_sandboxes.lock().await;
@@ -1504,7 +1504,7 @@ async fn ensure_warm_sandbox_ready(
     container_bin: &Path,
     cli: ContainerCliFlavor,
     request: &SandboxRequest,
-    warm_sandboxes: &Arc<Mutex<HashMap<String, WarmSandboxEntry>>>,
+    warm_sandboxes: &Arc<Mutex<HashMap<SandboxId, WarmSandboxEntry>>>,
 ) -> Result<String> {
     let healthcheck = SandboxCommand {
         argv: vec!["/bin/true".to_string()],

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -25,45 +25,14 @@ use uuid::Uuid;
 use crate::{DurableFileSystem, SandboxAttachment};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum SandboxKey {
-    StandaloneSandbox {
-        sandbox_id: String,
-    },
-    AgentSandbox {
+pub enum SandboxScope {
+    Agent {
         agent_id: String,
-        sandbox_id: String,
     },
-    ConversationSandbox {
+    Conversation {
         #[serde(alias = "conversation_id")]
         thread_id: String,
-        sandbox_id: String,
     },
-}
-
-impl SandboxKey {
-    pub fn sandbox_id(&self) -> &str {
-        match self {
-            Self::StandaloneSandbox { sandbox_id }
-            | Self::AgentSandbox { sandbox_id, .. }
-            | Self::ConversationSandbox { sandbox_id, .. } => sandbox_id,
-        }
-    }
-}
-
-impl fmt::Display for SandboxKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::StandaloneSandbox { sandbox_id } => write!(f, "sandbox:{sandbox_id}"),
-            Self::AgentSandbox {
-                agent_id,
-                sandbox_id,
-            } => write!(f, "agent:{agent_id}:{sandbox_id}"),
-            Self::ConversationSandbox {
-                thread_id,
-                sandbox_id,
-            } => write!(f, "thread:{thread_id}:{sandbox_id}"),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -104,7 +73,9 @@ pub struct SandboxSpec {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SandboxRequest {
-    pub key: SandboxKey,
+    pub sandbox_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<SandboxScope>,
     pub spec: SandboxSpec,
     pub lifecycle: SandboxLifecycleConfig,
     pub provider_state: Option<Value>,
@@ -618,13 +589,14 @@ impl CliContainerSandboxBackend {
             })
             .collect::<Result<Vec<_>>>()?;
         mounts.extend(materialize_durable_file_systems(
-            request.key.sandbox_id(),
+            request.sandbox_id.as_str(),
             &request.spec.durable_file_systems,
             self.durable_file_system_root.as_deref(),
         )?);
 
         Ok(SandboxRequest {
-            key: request.key,
+            sandbox_id: request.sandbox_id,
+            scope: request.scope,
             spec: SandboxSpec {
                 image: if request.spec.image.trim().is_empty() {
                     DEFAULT_SANDBOX_IMAGE.to_string()
@@ -692,7 +664,7 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
 
         if request.lifecycle.idle_ttl.is_none() {
             return Ok(Arc::new(OneShotSandboxHandle {
-                id: format!("oneshot:{}", request.key.sandbox_id()),
+                id: format!("oneshot:{}", request.sandbox_id.as_str()),
                 container_bin: self.container_bin.clone(),
                 request,
             }));
@@ -702,17 +674,17 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
 
         let replaced = {
             let mut warm_sandboxes = self.warm_sandboxes.lock().await;
-            match warm_sandboxes.get(request.key.sandbox_id()) {
+            match warm_sandboxes.get(request.sandbox_id.as_str()) {
                 Some(entry) if entry.request.spec == request.spec => {
                     return Ok(Arc::new(WarmSandboxHandle {
-                        id: format!("warm:{}", request.key.sandbox_id()),
+                        id: format!("warm:{}", request.sandbox_id.as_str()),
                         cli: self.cli,
                         container_bin: self.container_bin.clone(),
                         request,
                         warm_sandboxes: Arc::clone(&self.warm_sandboxes),
                     }));
                 }
-                Some(_) => warm_sandboxes.remove(request.key.sandbox_id()),
+                Some(_) => warm_sandboxes.remove(request.sandbox_id.as_str()),
                 None => None,
             }
         };
@@ -734,7 +706,7 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
         {
             let mut warm_sandboxes = self.warm_sandboxes.lock().await;
             warm_sandboxes.insert(
-                request.key.sandbox_id().to_string(),
+                request.sandbox_id.clone(),
                 WarmSandboxEntry {
                     name: name.clone(),
                     request: request.clone(),
@@ -745,7 +717,7 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
         }
 
         Ok(Arc::new(WarmSandboxHandle {
-            id: format!("warm:{}", request.key.sandbox_id()),
+            id: format!("warm:{}", request.sandbox_id.as_str()),
             cli: self.cli,
             container_bin: self.container_bin.clone(),
             request,
@@ -797,7 +769,7 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
         // whatever was running before.
         let replaced = {
             let mut warm_sandboxes = self.warm_sandboxes.lock().await;
-            warm_sandboxes.remove(request.key.sandbox_id())
+            warm_sandboxes.remove(request.sandbox_id.as_str())
         };
         if let Some(entry) = replaced {
             schedule_cleanup_named_container(self.container_bin.clone(), self.cli, entry.name);
@@ -807,7 +779,7 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
         {
             let mut warm_sandboxes = self.warm_sandboxes.lock().await;
             warm_sandboxes.insert(
-                request.key.sandbox_id().to_string(),
+                request.sandbox_id.clone(),
                 WarmSandboxEntry {
                     name: name.clone(),
                     request: request.clone(),
@@ -818,7 +790,7 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
         }
 
         Ok(Arc::new(WarmSandboxHandle {
-            id: format!("warm:{}", request.key.sandbox_id()),
+            id: format!("warm:{}", request.sandbox_id.as_str()),
             cli: self.cli,
             container_bin: self.container_bin.clone(),
             request,
@@ -831,13 +803,16 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
             .warm_sandboxes
             .lock()
             .await
-            .remove(request.key.sandbox_id())
+            .remove(request.sandbox_id.as_str())
         {
             cleanup_named_container(&self.container_bin, self.cli, &entry.name).await?;
         }
-        for container in
-            find_sandbox_containers_for_key(&self.container_bin, self.cli, request.key.sandbox_id())
-                .await?
+        for container in find_sandbox_containers_for_key(
+            &self.container_bin,
+            self.cli,
+            request.sandbox_id.as_str(),
+        )
+        .await?
         {
             cleanup_named_container(&self.container_bin, self.cli, &container).await?;
         }
@@ -956,9 +931,9 @@ impl ManagedSandboxHandle for WarmSandboxHandle {
             &self.warm_sandboxes,
         )
         .await?;
-        touch_warm_sandbox(&self.warm_sandboxes, self.request.key.sandbox_id()).await;
+        touch_warm_sandbox(&self.warm_sandboxes, self.request.sandbox_id.as_str()).await;
         let output = exec_warm(&self.container_bin, &name, &self.request.spec, command).await;
-        touch_warm_sandbox(&self.warm_sandboxes, self.request.key.sandbox_id()).await;
+        touch_warm_sandbox(&self.warm_sandboxes, self.request.sandbox_id.as_str()).await;
         output
     }
 
@@ -970,14 +945,14 @@ impl ManagedSandboxHandle for WarmSandboxHandle {
             &self.warm_sandboxes,
         )
         .await?;
-        touch_warm_sandbox(&self.warm_sandboxes, self.request.key.sandbox_id()).await;
+        touch_warm_sandbox(&self.warm_sandboxes, self.request.sandbox_id.as_str()).await;
         start_warm_process(&self.container_bin, &name, &self.request.spec, command).await
     }
 
     async fn stop(&self) -> Result<()> {
         let removed = {
             let mut warm_sandboxes = self.warm_sandboxes.lock().await;
-            warm_sandboxes.remove(self.request.key.sandbox_id())
+            warm_sandboxes.remove(self.request.sandbox_id.as_str())
         };
 
         if let Some(entry) = removed
@@ -1003,7 +978,7 @@ impl ManagedSandboxHandle for WarmSandboxHandle {
         let container_id = inspect_running_docker_container(&self.container_bin, &name).await?;
         let mut warm_sandboxes = self.warm_sandboxes.lock().await;
         let entry = warm_sandboxes
-            .get_mut(self.request.key.sandbox_id())
+            .get_mut(self.request.sandbox_id.as_str())
             .ok_or_else(|| anyhow!("warm sandbox disappeared while detaching"))?;
         entry.owned = false;
         Ok(SandboxAttachment::DockerContainer { container_id })
@@ -1019,7 +994,7 @@ impl ManagedSandboxHandle for WarmSandboxHandle {
                     &self.warm_sandboxes,
                 )
                 .await?;
-                touch_warm_sandbox(&self.warm_sandboxes, self.request.key.sandbox_id()).await;
+                touch_warm_sandbox(&self.warm_sandboxes, self.request.sandbox_id.as_str()).await;
                 docker_snapshot_container(&self.container_bin, &name).await
             }
             // The Apple `container` CLI exposes `container image save` and a
@@ -1060,7 +1035,7 @@ impl ManagedSandboxBackend for LocalProcessSandboxBackend {
             bail!("local-process sandbox backend does not support durable file systems");
         }
         Ok(Arc::new(LocalProcessSandboxHandle {
-            id: format!("local:{}", request.key.sandbox_id()),
+            id: format!("local:{}", request.sandbox_id.as_str()),
             request,
         }))
     }
@@ -1324,7 +1299,7 @@ async fn create_named_warm_sandbox(
         .arg("--label")
         .arg(format!(
             "{WARM_SANDBOX_KEY_LABEL}={}",
-            request.key.sandbox_id()
+            request.sandbox_id.as_str()
         ))
         .arg("--label")
         .arg(format!(
@@ -1364,7 +1339,7 @@ async fn create_unique_warm_sandbox(
     request: &SandboxRequest,
 ) -> Result<String> {
     for _ in 0..4 {
-        let name = new_warm_container_name(request.key.sandbox_id());
+        let name = new_warm_container_name(request.sandbox_id.as_str());
         match create_named_warm_sandbox(container_bin, request, &name).await {
             Ok(()) => return Ok(name),
             Err(err) if is_already_exists_error(&err.to_string()) => continue,
@@ -1374,7 +1349,7 @@ async fn create_unique_warm_sandbox(
 
     Err(anyhow!(
         "failed to allocate a unique warm sandbox name for {}",
-        request.key.sandbox_id()
+        request.sandbox_id.as_str()
     ))
 }
 
@@ -1477,7 +1452,7 @@ async fn find_running_apple_container_warm_sandbox(
         let labels = &container.configuration.labels;
         let key_matches = labels
             .get(WARM_SANDBOX_KEY_LABEL)
-            .is_some_and(|value| value == request.key.sandbox_id());
+            .is_some_and(|value| value == request.sandbox_id.as_str());
         let spec_matches = labels
             .get(WARM_SANDBOX_SPEC_HASH_LABEL)
             .is_some_and(|value| value == &spec_hash);
@@ -1492,7 +1467,7 @@ async fn find_running_docker_warm_sandbox(
     let spec_hash = sandbox_spec_hash(&request.spec);
     let key_filter = format!(
         "label={WARM_SANDBOX_KEY_LABEL}={}",
-        request.key.sandbox_id()
+        request.sandbox_id.as_str()
     );
     let spec_filter = format!("label={WARM_SANDBOX_SPEC_HASH_LABEL}={spec_hash}");
     let output = run_container_admin_command(
@@ -1540,14 +1515,14 @@ async fn ensure_warm_sandbox_ready(
     };
 
     let mut warm_sandboxes = warm_sandboxes.lock().await;
-    let (current_name, current_owned) = match warm_sandboxes.get_mut(request.key.sandbox_id()) {
+    let (current_name, current_owned) = match warm_sandboxes.get_mut(request.sandbox_id.as_str()) {
         Some(entry) if entry.request.spec == request.spec => {
             entry.last_used_at = Instant::now();
             (entry.name.clone(), entry.owned)
         }
         Some(_) => {
             let stale = warm_sandboxes
-                .remove(request.key.sandbox_id())
+                .remove(request.sandbox_id.as_str())
                 .expect("entry disappeared while locked");
             if stale.owned {
                 schedule_cleanup_named_container(container_bin.to_path_buf(), cli, stale.name);
@@ -1561,7 +1536,7 @@ async fn ensure_warm_sandbox_ready(
                 ),
             };
             warm_sandboxes.insert(
-                request.key.sandbox_id().to_string(),
+                request.sandbox_id.clone(),
                 WarmSandboxEntry {
                     name: name.clone(),
                     request: request.clone(),
@@ -1581,7 +1556,7 @@ async fn ensure_warm_sandbox_ready(
                 ),
             };
             warm_sandboxes.insert(
-                request.key.sandbox_id().to_string(),
+                request.sandbox_id.clone(),
                 WarmSandboxEntry {
                     name: name.clone(),
                     request: request.clone(),
@@ -1610,7 +1585,7 @@ async fn ensure_warm_sandbox_ready(
             ),
         };
     warm_sandboxes.insert(
-        request.key.sandbox_id().to_string(),
+        request.sandbox_id.clone(),
         WarmSandboxEntry {
             name: replacement_name.clone(),
             request: request.clone(),
@@ -2327,32 +2302,46 @@ mod tests {
     use super::*;
 
     #[test]
-    fn conversation_sandbox_key_uses_thread_id_and_reads_conversation_id() {
-        let key = SandboxKey::ConversationSandbox {
+    fn conversation_scope_uses_thread_id_and_reads_conversation_id() {
+        let scope = SandboxScope::Conversation {
             thread_id: "thread-1".to_string(),
-            sandbox_id: "sandbox-1".to_string(),
         };
-
         assert_eq!(
-            serde_json::to_value(&key).unwrap(),
+            serde_json::to_value(&scope).unwrap(),
             serde_json::json!({
-                "ConversationSandbox": {
-                    "thread_id": "thread-1",
-                    "sandbox_id": "sandbox-1"
-                }
+                "Conversation": { "thread_id": "thread-1" }
             })
         );
         assert_eq!(
-            serde_json::from_value::<SandboxKey>(serde_json::json!({
-                "ConversationSandbox": {
-                    "conversation_id": "thread-1",
-                    "sandbox_id": "sandbox-1"
-                }
+            serde_json::from_value::<SandboxScope>(serde_json::json!({
+                "Conversation": { "conversation_id": "thread-1" }
             }))
             .unwrap(),
-            key
+            scope
         );
-        assert_eq!(key.to_string(), "thread:thread-1:sandbox-1");
+    }
+
+    #[test]
+    fn raw_sandbox_requests_do_not_require_scope() {
+        let request: SandboxRequest = serde_json::from_value(serde_json::json!({
+            "sandbox_id": "sandbox-1",
+            "spec": {
+                "image": "alpine",
+                "mounts": [],
+                "durable_file_systems": [],
+                "network": "Disabled",
+                "default_workdir": "/"
+            },
+            "lifecycle": {},
+            "provider_state": null
+        }))
+        .unwrap();
+        assert_eq!(request.sandbox_id, "sandbox-1");
+        assert_eq!(request.scope, None);
+        let mut serialized = serde_json::to_value(&request).unwrap();
+        assert!(serialized.get("scope").is_none());
+        serialized.as_object_mut().unwrap().remove("sandbox_id");
+        assert!(serde_json::from_value::<SandboxRequest>(serialized).is_err());
     }
 
     #[test]
@@ -2466,10 +2455,10 @@ mod tests {
         fs::set_permissions(&script_path, permissions).expect("chmod fake docker");
 
         let request = SandboxRequest {
-            key: SandboxKey::ConversationSandbox {
+            sandbox_id: "sandbox".to_string(),
+            scope: Some(SandboxScope::Conversation {
                 thread_id: "thread".to_string(),
-                sandbox_id: "sandbox".to_string(),
-            },
+            }),
             spec: SandboxSpec {
                 image: "docker.io/library/ubuntu:24.04".to_string(),
                 resources: Default::default(),
@@ -2492,7 +2481,7 @@ mod tests {
 
         let key_filter = format!(
             "label={WARM_SANDBOX_KEY_LABEL}={}",
-            request.key.sandbox_id()
+            request.sandbox_id.as_str()
         );
         let spec_filter = format!("label={WARM_SANDBOX_SPEC_HASH_LABEL}={spec_hash}");
         let args = fs::read_to_string(&args_path).expect("read fake docker args");
@@ -2546,10 +2535,10 @@ mod tests {
             warm_sandboxes: Arc::new(Mutex::new(HashMap::new())),
         };
         let request = SandboxRequest {
-            key: SandboxKey::ConversationSandbox {
+            sandbox_id: "sandbox".to_string(),
+            scope: Some(SandboxScope::Conversation {
                 thread_id: "thread".to_string(),
-                sandbox_id: "sandbox".to_string(),
-            },
+            }),
             spec: SandboxSpec {
                 image: "docker.io/library/ubuntu:24.04".to_string(),
                 resources: Default::default(),
@@ -2639,10 +2628,10 @@ esac
             warm_sandboxes: Arc::new(Mutex::new(HashMap::new())),
         };
         let request = SandboxRequest {
-            key: SandboxKey::ConversationSandbox {
+            sandbox_id: "sandbox".to_string(),
+            scope: Some(SandboxScope::Conversation {
                 thread_id: "thread".to_string(),
-                sandbox_id: "sandbox".to_string(),
-            },
+            }),
             spec: SandboxSpec {
                 image: "docker.io/library/ubuntu:24.04".to_string(),
                 resources: Default::default(),
@@ -2751,10 +2740,10 @@ esac
             warm_sandboxes: Arc::new(Mutex::new(HashMap::new())),
         };
         let request = SandboxRequest {
-            key: SandboxKey::ConversationSandbox {
+            sandbox_id: "sandbox".to_string(),
+            scope: Some(SandboxScope::Conversation {
                 thread_id: "thread".to_string(),
-                sandbox_id: "sandbox".to_string(),
-            },
+            }),
             spec: SandboxSpec {
                 image: "task-image".to_string(),
                 resources: Default::default(),

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -24,7 +24,47 @@ use uuid::Uuid;
 
 use crate::{DurableFileSystem, SandboxAttachment};
 
-pub type SandboxKey = String;
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum SandboxKey {
+    StandaloneSandbox {
+        sandbox_id: String,
+    },
+    AgentSandbox {
+        agent_id: String,
+        sandbox_id: String,
+    },
+    ConversationSandbox {
+        #[serde(alias = "conversation_id")]
+        thread_id: String,
+        sandbox_id: String,
+    },
+}
+
+impl SandboxKey {
+    pub fn sandbox_id(&self) -> &str {
+        match self {
+            Self::StandaloneSandbox { sandbox_id }
+            | Self::AgentSandbox { sandbox_id, .. }
+            | Self::ConversationSandbox { sandbox_id, .. } => sandbox_id,
+        }
+    }
+}
+
+impl fmt::Display for SandboxKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::StandaloneSandbox { sandbox_id } => write!(f, "sandbox:{sandbox_id}"),
+            Self::AgentSandbox {
+                agent_id,
+                sandbox_id,
+            } => write!(f, "agent:{agent_id}:{sandbox_id}"),
+            Self::ConversationSandbox {
+                thread_id,
+                sandbox_id,
+            } => write!(f, "thread:{thread_id}:{sandbox_id}"),
+        }
+    }
+}
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SandboxLifecycleConfig {
@@ -457,7 +497,7 @@ pub struct CliContainerSandboxBackend {
     durable_file_system_root: Option<PathBuf>,
     system_started: Mutex<bool>,
     network_created: Mutex<bool>,
-    warm_sandboxes: Arc<Mutex<HashMap<SandboxKey, WarmSandboxEntry>>>,
+    warm_sandboxes: Arc<Mutex<HashMap<String, WarmSandboxEntry>>>,
 }
 
 static DOCKER_CONSUMABLE_SNAPSHOT_FORMATS: [SnapshotFormat; 1] = [SnapshotFormat::DockerImageTar];
@@ -578,7 +618,7 @@ impl CliContainerSandboxBackend {
             })
             .collect::<Result<Vec<_>>>()?;
         mounts.extend(materialize_durable_file_systems(
-            &request.key,
+            request.key.sandbox_id(),
             &request.spec.durable_file_systems,
             self.durable_file_system_root.as_deref(),
         )?);
@@ -652,7 +692,7 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
 
         if request.lifecycle.idle_ttl.is_none() {
             return Ok(Arc::new(OneShotSandboxHandle {
-                id: format!("oneshot:{}", request.key),
+                id: format!("oneshot:{}", request.key.sandbox_id()),
                 container_bin: self.container_bin.clone(),
                 request,
             }));
@@ -662,17 +702,17 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
 
         let replaced = {
             let mut warm_sandboxes = self.warm_sandboxes.lock().await;
-            match warm_sandboxes.get(&request.key) {
+            match warm_sandboxes.get(request.key.sandbox_id()) {
                 Some(entry) if entry.request.spec == request.spec => {
                     return Ok(Arc::new(WarmSandboxHandle {
-                        id: format!("warm:{}", request.key),
+                        id: format!("warm:{}", request.key.sandbox_id()),
                         cli: self.cli,
                         container_bin: self.container_bin.clone(),
                         request,
                         warm_sandboxes: Arc::clone(&self.warm_sandboxes),
                     }));
                 }
-                Some(_) => warm_sandboxes.remove(&request.key),
+                Some(_) => warm_sandboxes.remove(request.key.sandbox_id()),
                 None => None,
             }
         };
@@ -694,7 +734,7 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
         {
             let mut warm_sandboxes = self.warm_sandboxes.lock().await;
             warm_sandboxes.insert(
-                request.key.clone(),
+                request.key.sandbox_id().to_string(),
                 WarmSandboxEntry {
                     name: name.clone(),
                     request: request.clone(),
@@ -705,7 +745,7 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
         }
 
         Ok(Arc::new(WarmSandboxHandle {
-            id: format!("warm:{}", request.key),
+            id: format!("warm:{}", request.key.sandbox_id()),
             cli: self.cli,
             container_bin: self.container_bin.clone(),
             request,
@@ -757,7 +797,7 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
         // whatever was running before.
         let replaced = {
             let mut warm_sandboxes = self.warm_sandboxes.lock().await;
-            warm_sandboxes.remove(&request.key)
+            warm_sandboxes.remove(request.key.sandbox_id())
         };
         if let Some(entry) = replaced {
             schedule_cleanup_named_container(self.container_bin.clone(), self.cli, entry.name);
@@ -767,7 +807,7 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
         {
             let mut warm_sandboxes = self.warm_sandboxes.lock().await;
             warm_sandboxes.insert(
-                request.key.clone(),
+                request.key.sandbox_id().to_string(),
                 WarmSandboxEntry {
                     name: name.clone(),
                     request: request.clone(),
@@ -778,7 +818,7 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
         }
 
         Ok(Arc::new(WarmSandboxHandle {
-            id: format!("warm:{}", request.key),
+            id: format!("warm:{}", request.key.sandbox_id()),
             cli: self.cli,
             container_bin: self.container_bin.clone(),
             request,
@@ -787,11 +827,17 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
     }
 
     async fn terminate(&self, request: SandboxRequest) -> Result<()> {
-        if let Some(entry) = self.warm_sandboxes.lock().await.remove(&request.key) {
+        if let Some(entry) = self
+            .warm_sandboxes
+            .lock()
+            .await
+            .remove(request.key.sandbox_id())
+        {
             cleanup_named_container(&self.container_bin, self.cli, &entry.name).await?;
         }
         for container in
-            find_sandbox_containers_for_key(&self.container_bin, self.cli, &request.key).await?
+            find_sandbox_containers_for_key(&self.container_bin, self.cli, request.key.sandbox_id())
+                .await?
         {
             cleanup_named_container(&self.container_bin, self.cli, &container).await?;
         }
@@ -889,7 +935,7 @@ struct WarmSandboxHandle {
     cli: ContainerCliFlavor,
     container_bin: PathBuf,
     request: SandboxRequest,
-    warm_sandboxes: Arc<Mutex<HashMap<SandboxKey, WarmSandboxEntry>>>,
+    warm_sandboxes: Arc<Mutex<HashMap<String, WarmSandboxEntry>>>,
 }
 
 #[async_trait]
@@ -910,9 +956,9 @@ impl ManagedSandboxHandle for WarmSandboxHandle {
             &self.warm_sandboxes,
         )
         .await?;
-        touch_warm_sandbox(&self.warm_sandboxes, &self.request.key).await;
+        touch_warm_sandbox(&self.warm_sandboxes, self.request.key.sandbox_id()).await;
         let output = exec_warm(&self.container_bin, &name, &self.request.spec, command).await;
-        touch_warm_sandbox(&self.warm_sandboxes, &self.request.key).await;
+        touch_warm_sandbox(&self.warm_sandboxes, self.request.key.sandbox_id()).await;
         output
     }
 
@@ -924,14 +970,14 @@ impl ManagedSandboxHandle for WarmSandboxHandle {
             &self.warm_sandboxes,
         )
         .await?;
-        touch_warm_sandbox(&self.warm_sandboxes, &self.request.key).await;
+        touch_warm_sandbox(&self.warm_sandboxes, self.request.key.sandbox_id()).await;
         start_warm_process(&self.container_bin, &name, &self.request.spec, command).await
     }
 
     async fn stop(&self) -> Result<()> {
         let removed = {
             let mut warm_sandboxes = self.warm_sandboxes.lock().await;
-            warm_sandboxes.remove(&self.request.key)
+            warm_sandboxes.remove(self.request.key.sandbox_id())
         };
 
         if let Some(entry) = removed
@@ -957,7 +1003,7 @@ impl ManagedSandboxHandle for WarmSandboxHandle {
         let container_id = inspect_running_docker_container(&self.container_bin, &name).await?;
         let mut warm_sandboxes = self.warm_sandboxes.lock().await;
         let entry = warm_sandboxes
-            .get_mut(&self.request.key)
+            .get_mut(self.request.key.sandbox_id())
             .ok_or_else(|| anyhow!("warm sandbox disappeared while detaching"))?;
         entry.owned = false;
         Ok(SandboxAttachment::DockerContainer { container_id })
@@ -973,7 +1019,7 @@ impl ManagedSandboxHandle for WarmSandboxHandle {
                     &self.warm_sandboxes,
                 )
                 .await?;
-                touch_warm_sandbox(&self.warm_sandboxes, &self.request.key).await;
+                touch_warm_sandbox(&self.warm_sandboxes, self.request.key.sandbox_id()).await;
                 docker_snapshot_container(&self.container_bin, &name).await
             }
             // The Apple `container` CLI exposes `container image save` and a
@@ -1014,7 +1060,7 @@ impl ManagedSandboxBackend for LocalProcessSandboxBackend {
             bail!("local-process sandbox backend does not support durable file systems");
         }
         Ok(Arc::new(LocalProcessSandboxHandle {
-            id: format!("local:{}", request.key),
+            id: format!("local:{}", request.key.sandbox_id()),
             request,
         }))
     }
@@ -1122,7 +1168,7 @@ fn resolve_local_workdir(spec: &SandboxSpec, cwd: &str) -> Option<PathBuf> {
 }
 
 fn materialize_durable_file_systems(
-    key: &SandboxKey,
+    key: &str,
     file_systems: &[DurableFileSystem],
     configured_root: Option<&Path>,
 ) -> Result<Vec<SandboxMount>> {
@@ -1255,8 +1301,8 @@ pub(crate) fn stable_fnv1a_hex(input: &str) -> String {
 }
 
 async fn touch_warm_sandbox(
-    warm_sandboxes: &Arc<Mutex<HashMap<SandboxKey, WarmSandboxEntry>>>,
-    key: &SandboxKey,
+    warm_sandboxes: &Arc<Mutex<HashMap<String, WarmSandboxEntry>>>,
+    key: &str,
 ) {
     let mut warm_sandboxes = warm_sandboxes.lock().await;
     if let Some(entry) = warm_sandboxes.get_mut(key) {
@@ -1276,7 +1322,10 @@ async fn create_named_warm_sandbox(
         .arg("--name")
         .arg(name)
         .arg("--label")
-        .arg(format!("{WARM_SANDBOX_KEY_LABEL}={}", request.key))
+        .arg(format!(
+            "{WARM_SANDBOX_KEY_LABEL}={}",
+            request.key.sandbox_id()
+        ))
         .arg("--label")
         .arg(format!(
             "{WARM_SANDBOX_SPEC_HASH_LABEL}={}",
@@ -1315,7 +1364,7 @@ async fn create_unique_warm_sandbox(
     request: &SandboxRequest,
 ) -> Result<String> {
     for _ in 0..4 {
-        let name = new_warm_container_name(&request.key);
+        let name = new_warm_container_name(request.key.sandbox_id());
         match create_named_warm_sandbox(container_bin, request, &name).await {
             Ok(()) => return Ok(name),
             Err(err) if is_already_exists_error(&err.to_string()) => continue,
@@ -1325,7 +1374,7 @@ async fn create_unique_warm_sandbox(
 
     Err(anyhow!(
         "failed to allocate a unique warm sandbox name for {}",
-        request.key
+        request.key.sandbox_id()
     ))
 }
 
@@ -1349,7 +1398,7 @@ async fn find_running_warm_sandbox(
 async fn find_sandbox_containers_for_key(
     container_bin: &Path,
     cli: ContainerCliFlavor,
-    key: &SandboxKey,
+    key: &str,
 ) -> Result<Vec<String>> {
     match cli {
         ContainerCliFlavor::AppleContainer => {
@@ -1428,7 +1477,7 @@ async fn find_running_apple_container_warm_sandbox(
         let labels = &container.configuration.labels;
         let key_matches = labels
             .get(WARM_SANDBOX_KEY_LABEL)
-            .is_some_and(|value| value == &request.key.to_string());
+            .is_some_and(|value| value == request.key.sandbox_id());
         let spec_matches = labels
             .get(WARM_SANDBOX_SPEC_HASH_LABEL)
             .is_some_and(|value| value == &spec_hash);
@@ -1441,7 +1490,10 @@ async fn find_running_docker_warm_sandbox(
     request: &SandboxRequest,
 ) -> Result<Option<String>> {
     let spec_hash = sandbox_spec_hash(&request.spec);
-    let key_filter = format!("label={WARM_SANDBOX_KEY_LABEL}={}", request.key);
+    let key_filter = format!(
+        "label={WARM_SANDBOX_KEY_LABEL}={}",
+        request.key.sandbox_id()
+    );
     let spec_filter = format!("label={WARM_SANDBOX_SPEC_HASH_LABEL}={spec_hash}");
     let output = run_container_admin_command(
         container_bin,
@@ -1477,7 +1529,7 @@ async fn ensure_warm_sandbox_ready(
     container_bin: &Path,
     cli: ContainerCliFlavor,
     request: &SandboxRequest,
-    warm_sandboxes: &Arc<Mutex<HashMap<SandboxKey, WarmSandboxEntry>>>,
+    warm_sandboxes: &Arc<Mutex<HashMap<String, WarmSandboxEntry>>>,
 ) -> Result<String> {
     let healthcheck = SandboxCommand {
         argv: vec!["/bin/true".to_string()],
@@ -1488,14 +1540,14 @@ async fn ensure_warm_sandbox_ready(
     };
 
     let mut warm_sandboxes = warm_sandboxes.lock().await;
-    let (current_name, current_owned) = match warm_sandboxes.get_mut(&request.key) {
+    let (current_name, current_owned) = match warm_sandboxes.get_mut(request.key.sandbox_id()) {
         Some(entry) if entry.request.spec == request.spec => {
             entry.last_used_at = Instant::now();
             (entry.name.clone(), entry.owned)
         }
         Some(_) => {
             let stale = warm_sandboxes
-                .remove(&request.key)
+                .remove(request.key.sandbox_id())
                 .expect("entry disappeared while locked");
             if stale.owned {
                 schedule_cleanup_named_container(container_bin.to_path_buf(), cli, stale.name);
@@ -1509,7 +1561,7 @@ async fn ensure_warm_sandbox_ready(
                 ),
             };
             warm_sandboxes.insert(
-                request.key.clone(),
+                request.key.sandbox_id().to_string(),
                 WarmSandboxEntry {
                     name: name.clone(),
                     request: request.clone(),
@@ -1529,7 +1581,7 @@ async fn ensure_warm_sandbox_ready(
                 ),
             };
             warm_sandboxes.insert(
-                request.key.clone(),
+                request.key.sandbox_id().to_string(),
                 WarmSandboxEntry {
                     name: name.clone(),
                     request: request.clone(),
@@ -1558,7 +1610,7 @@ async fn ensure_warm_sandbox_ready(
             ),
         };
     warm_sandboxes.insert(
-        request.key.clone(),
+        request.key.sandbox_id().to_string(),
         WarmSandboxEntry {
             name: replacement_name.clone(),
             request: request.clone(),
@@ -2127,7 +2179,7 @@ fn network_name_for_policy(policy: SandboxNetworkPolicy) -> Option<&'static str>
     matches!(policy, SandboxNetworkPolicy::Enabled).then_some(DEFAULT_ENABLED_NETWORK_NAME)
 }
 
-fn new_warm_container_name(key: &SandboxKey) -> String {
+fn new_warm_container_name(key: &str) -> String {
     let mut hasher = DefaultHasher::new();
     key.hash(&mut hasher);
     let hash = hasher.finish();
@@ -2275,6 +2327,35 @@ mod tests {
     use super::*;
 
     #[test]
+    fn conversation_sandbox_key_uses_thread_id_and_reads_conversation_id() {
+        let key = SandboxKey::ConversationSandbox {
+            thread_id: "thread-1".to_string(),
+            sandbox_id: "sandbox-1".to_string(),
+        };
+
+        assert_eq!(
+            serde_json::to_value(&key).unwrap(),
+            serde_json::json!({
+                "ConversationSandbox": {
+                    "thread_id": "thread-1",
+                    "sandbox_id": "sandbox-1"
+                }
+            })
+        );
+        assert_eq!(
+            serde_json::from_value::<SandboxKey>(serde_json::json!({
+                "ConversationSandbox": {
+                    "conversation_id": "thread-1",
+                    "sandbox_id": "sandbox-1"
+                }
+            }))
+            .unwrap(),
+            key
+        );
+        assert_eq!(key.to_string(), "thread:thread-1:sandbox-1");
+    }
+
+    #[test]
     fn apple_container_list_item_reads_current_status_shape() {
         let container: ContainerListItem = serde_json::from_value(serde_json::json!({
             "configuration": {
@@ -2385,7 +2466,10 @@ mod tests {
         fs::set_permissions(&script_path, permissions).expect("chmod fake docker");
 
         let request = SandboxRequest {
-            key: "sandbox".to_string(),
+            key: SandboxKey::ConversationSandbox {
+                thread_id: "thread".to_string(),
+                sandbox_id: "sandbox".to_string(),
+            },
             spec: SandboxSpec {
                 image: "docker.io/library/ubuntu:24.04".to_string(),
                 resources: Default::default(),
@@ -2406,7 +2490,10 @@ mod tests {
             .expect("find warm sandbox");
         assert_eq!(name.as_deref(), Some("warm-name"));
 
-        let key_filter = format!("label={WARM_SANDBOX_KEY_LABEL}={}", request.key);
+        let key_filter = format!(
+            "label={WARM_SANDBOX_KEY_LABEL}={}",
+            request.key.sandbox_id()
+        );
         let spec_filter = format!("label={WARM_SANDBOX_SPEC_HASH_LABEL}={spec_hash}");
         let args = fs::read_to_string(&args_path).expect("read fake docker args");
         assert_eq!(
@@ -2459,7 +2546,10 @@ mod tests {
             warm_sandboxes: Arc::new(Mutex::new(HashMap::new())),
         };
         let request = SandboxRequest {
-            key: "sandbox".to_string(),
+            key: SandboxKey::ConversationSandbox {
+                thread_id: "thread".to_string(),
+                sandbox_id: "sandbox".to_string(),
+            },
             spec: SandboxSpec {
                 image: "docker.io/library/ubuntu:24.04".to_string(),
                 resources: Default::default(),
@@ -2549,7 +2639,10 @@ esac
             warm_sandboxes: Arc::new(Mutex::new(HashMap::new())),
         };
         let request = SandboxRequest {
-            key: "sandbox".to_string(),
+            key: SandboxKey::ConversationSandbox {
+                thread_id: "thread".to_string(),
+                sandbox_id: "sandbox".to_string(),
+            },
             spec: SandboxSpec {
                 image: "docker.io/library/ubuntu:24.04".to_string(),
                 resources: Default::default(),
@@ -2658,7 +2751,10 @@ esac
             warm_sandboxes: Arc::new(Mutex::new(HashMap::new())),
         };
         let request = SandboxRequest {
-            key: "sandbox".to_string(),
+            key: SandboxKey::ConversationSandbox {
+                thread_id: "thread".to_string(),
+                sandbox_id: "sandbox".to_string(),
+            },
             spec: SandboxSpec {
                 image: "task-image".to_string(),
                 resources: Default::default(),

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -807,7 +807,7 @@ impl ManagedSandboxBackend for CliContainerSandboxBackend {
         {
             cleanup_named_container(&self.container_bin, self.cli, &entry.name).await?;
         }
-        for container in find_sandbox_containers_for_key(
+        for container in find_sandbox_containers_for_id(
             &self.container_bin,
             self.cli,
             request.sandbox_id.as_str(),
@@ -1143,7 +1143,7 @@ fn resolve_local_workdir(spec: &SandboxSpec, cwd: &str) -> Option<PathBuf> {
 }
 
 fn materialize_durable_file_systems(
-    key: &str,
+    sandbox_id: &str,
     file_systems: &[DurableFileSystem],
     configured_root: Option<&Path>,
 ) -> Result<Vec<SandboxMount>> {
@@ -1154,7 +1154,10 @@ fn materialize_durable_file_systems(
     file_systems
         .iter()
         .map(|file_system| {
-            let host_path = root.join(stable_fnv1a_hex(&format!("{}\n{}", key, file_system.name)));
+            let host_path = root.join(stable_fnv1a_hex(&format!(
+                "{}\n{}",
+                sandbox_id, file_system.name
+            )));
             std::fs::create_dir_all(&host_path).with_context(|| {
                 format!(
                     "creating durable file system {} at {}",
@@ -1277,10 +1280,10 @@ pub(crate) fn stable_fnv1a_hex(input: &str) -> String {
 
 async fn touch_warm_sandbox(
     warm_sandboxes: &Arc<Mutex<HashMap<SandboxId, WarmSandboxEntry>>>,
-    key: &str,
+    sandbox_id: &str,
 ) {
     let mut warm_sandboxes = warm_sandboxes.lock().await;
-    if let Some(entry) = warm_sandboxes.get_mut(key) {
+    if let Some(entry) = warm_sandboxes.get_mut(sandbox_id) {
         entry.last_used_at = Instant::now();
     }
 }
@@ -1368,12 +1371,12 @@ async fn find_running_warm_sandbox(
     }
 }
 
-/// Every container labelled for `key`, running or not, so termination also
+/// Every container labelled for `sandbox_id`, running or not, so termination also
 /// clears records left behind by an earlier process.
-async fn find_sandbox_containers_for_key(
+async fn find_sandbox_containers_for_id(
     container_bin: &Path,
     cli: ContainerCliFlavor,
-    key: &str,
+    sandbox_id: &str,
 ) -> Result<Vec<String>> {
     match cli {
         ContainerCliFlavor::AppleContainer => {
@@ -1397,17 +1400,17 @@ async fn find_sandbox_containers_for_key(
                         .configuration
                         .labels
                         .get(WARM_SANDBOX_KEY_LABEL)
-                        .is_some_and(|value| value == &key.to_string())
+                        .is_some_and(|value| value == &sandbox_id.to_string())
                 })
                 .map(|container| container.configuration.id)
                 .collect())
         }
         ContainerCliFlavor::Docker => {
-            let key_filter = format!("label={WARM_SANDBOX_KEY_LABEL}={key}");
+            let id_filter = format!("label={WARM_SANDBOX_KEY_LABEL}={sandbox_id}");
             let output = run_container_admin_command(
                 container_bin,
                 WARM_SANDBOX_CLEANUP_TIMEOUT,
-                ["ps", "-aq", "--no-trunc", "--filter", key_filter.as_str()],
+                ["ps", "-aq", "--no-trunc", "--filter", id_filter.as_str()],
             )
             .await?;
             if !output.status.success() {
@@ -2154,9 +2157,9 @@ fn network_name_for_policy(policy: SandboxNetworkPolicy) -> Option<&'static str>
     matches!(policy, SandboxNetworkPolicy::Enabled).then_some(DEFAULT_ENABLED_NETWORK_NAME)
 }
 
-fn new_warm_container_name(key: &str) -> String {
+fn new_warm_container_name(sandbox_id: &str) -> String {
     let mut hasher = DefaultHasher::new();
-    key.hash(&mut hasher);
+    sandbox_id.hash(&mut hasher);
     let hash = hasher.finish();
     let generation = Uuid::new_v4().simple().to_string();
     format!("exo-{hash:016x}-{}", &generation[..8])

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -194,6 +194,10 @@ pub trait ManagedSandboxHandle: Send + Sync {
         None
     }
 
+    async fn is_running(&self) -> Result<Option<bool>> {
+        Ok(None)
+    }
+
     async fn exec(&self, command: &SandboxCommand) -> Result<SandboxCommandOutput>;
 
     async fn start_process(&self, command: &SandboxCommand) -> Result<crate::SandboxProcessParts>;

--- a/crates/exoharness/src/sandbox.rs
+++ b/crates/exoharness/src/sandbox.rs
@@ -29,7 +29,7 @@ pub enum SandboxScope {
     Agent {
         agent_id: String,
     },
-    Conversation {
+    Thread {
         #[serde(alias = "conversation_id")]
         thread_id: String,
     },
@@ -2302,19 +2302,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn conversation_scope_uses_thread_id_and_reads_conversation_id() {
-        let scope = SandboxScope::Conversation {
+    fn thread_scope_uses_thread_id_and_reads_conversation_id() {
+        let scope = SandboxScope::Thread {
             thread_id: "thread-1".to_string(),
         };
         assert_eq!(
             serde_json::to_value(&scope).unwrap(),
             serde_json::json!({
-                "Conversation": { "thread_id": "thread-1" }
+                "Thread": { "thread_id": "thread-1" }
             })
         );
         assert_eq!(
             serde_json::from_value::<SandboxScope>(serde_json::json!({
-                "Conversation": { "conversation_id": "thread-1" }
+                "Thread": { "conversation_id": "thread-1" }
             }))
             .unwrap(),
             scope
@@ -2456,7 +2456,7 @@ mod tests {
 
         let request = SandboxRequest {
             sandbox_id: "sandbox".to_string(),
-            scope: Some(SandboxScope::Conversation {
+            scope: Some(SandboxScope::Thread {
                 thread_id: "thread".to_string(),
             }),
             spec: SandboxSpec {
@@ -2536,7 +2536,7 @@ mod tests {
         };
         let request = SandboxRequest {
             sandbox_id: "sandbox".to_string(),
-            scope: Some(SandboxScope::Conversation {
+            scope: Some(SandboxScope::Thread {
                 thread_id: "thread".to_string(),
             }),
             spec: SandboxSpec {
@@ -2629,7 +2629,7 @@ esac
         };
         let request = SandboxRequest {
             sandbox_id: "sandbox".to_string(),
-            scope: Some(SandboxScope::Conversation {
+            scope: Some(SandboxScope::Thread {
                 thread_id: "thread".to_string(),
             }),
             spec: SandboxSpec {
@@ -2741,7 +2741,7 @@ esac
         };
         let request = SandboxRequest {
             sandbox_id: "sandbox".to_string(),
-            scope: Some(SandboxScope::Conversation {
+            scope: Some(SandboxScope::Thread {
                 thread_id: "thread".to_string(),
             }),
             spec: SandboxSpec {

--- a/crates/exoharness/src/sandbox_provider/aws_agentcore.rs
+++ b/crates/exoharness/src/sandbox_provider/aws_agentcore.rs
@@ -511,8 +511,8 @@ struct AgentCoreExecResponse {
 mod tests {
     use super::*;
     use crate::{
-        DurableFileSystem, FileSystemMountMode, SandboxKey, SandboxLifecycleConfig,
-        SandboxNetworkPolicy, SandboxSpec,
+        DurableFileSystem, FileSystemMountMode, SandboxLifecycleConfig, SandboxNetworkPolicy,
+        SandboxSpec,
     };
 
     #[test]
@@ -554,10 +554,7 @@ mod tests {
 
     fn durable_request(mount_path: &str, mode: FileSystemMountMode) -> SandboxRequest {
         SandboxRequest {
-            key: SandboxKey::ConversationSandbox {
-                thread_id: "thread".to_string(),
-                sandbox_id: "sandbox".to_string(),
-            },
+            key: "sandbox".to_string(),
             spec: SandboxSpec {
                 image: "agentcore".to_string(),
                 resources: Default::default(),

--- a/crates/exoharness/src/sandbox_provider/aws_agentcore.rs
+++ b/crates/exoharness/src/sandbox_provider/aws_agentcore.rs
@@ -441,7 +441,7 @@ fn normalize_agentcore_session_storage_mount_path(path: &str) -> Result<String> 
 }
 
 fn agentcore_runtime_session_id(request: &SandboxRequest, spec_hash: &str) -> String {
-    let input = format!("{}\n{spec_hash}", request.key);
+    let input = format!("{}\n{spec_hash}", request.key.sandbox_id());
     format!("exo-{}-session-0000000000", stable_fnv1a_hex(&input))
 }
 
@@ -511,8 +511,8 @@ struct AgentCoreExecResponse {
 mod tests {
     use super::*;
     use crate::{
-        DurableFileSystem, FileSystemMountMode, SandboxLifecycleConfig, SandboxNetworkPolicy,
-        SandboxSpec,
+        DurableFileSystem, FileSystemMountMode, SandboxKey, SandboxLifecycleConfig,
+        SandboxNetworkPolicy, SandboxSpec,
     };
 
     #[test]
@@ -554,7 +554,10 @@ mod tests {
 
     fn durable_request(mount_path: &str, mode: FileSystemMountMode) -> SandboxRequest {
         SandboxRequest {
-            key: "sandbox".to_string(),
+            key: SandboxKey::ConversationSandbox {
+                thread_id: "thread".to_string(),
+                sandbox_id: "sandbox".to_string(),
+            },
             spec: SandboxSpec {
                 image: "agentcore".to_string(),
                 resources: Default::default(),

--- a/crates/exoharness/src/sandbox_provider/aws_agentcore.rs
+++ b/crates/exoharness/src/sandbox_provider/aws_agentcore.rs
@@ -441,7 +441,7 @@ fn normalize_agentcore_session_storage_mount_path(path: &str) -> Result<String> 
 }
 
 fn agentcore_runtime_session_id(request: &SandboxRequest, spec_hash: &str) -> String {
-    let input = format!("{}\n{spec_hash}", request.key.sandbox_id());
+    let input = format!("{}\n{spec_hash}", request.sandbox_id.as_str());
     format!("exo-{}-session-0000000000", stable_fnv1a_hex(&input))
 }
 
@@ -511,8 +511,8 @@ struct AgentCoreExecResponse {
 mod tests {
     use super::*;
     use crate::{
-        DurableFileSystem, FileSystemMountMode, SandboxKey, SandboxLifecycleConfig,
-        SandboxNetworkPolicy, SandboxSpec,
+        DurableFileSystem, FileSystemMountMode, SandboxLifecycleConfig, SandboxNetworkPolicy,
+        SandboxScope, SandboxSpec,
     };
 
     #[test]
@@ -554,10 +554,10 @@ mod tests {
 
     fn durable_request(mount_path: &str, mode: FileSystemMountMode) -> SandboxRequest {
         SandboxRequest {
-            key: SandboxKey::ConversationSandbox {
+            sandbox_id: "sandbox".to_string(),
+            scope: Some(SandboxScope::Conversation {
                 thread_id: "thread".to_string(),
-                sandbox_id: "sandbox".to_string(),
-            },
+            }),
             spec: SandboxSpec {
                 image: "agentcore".to_string(),
                 resources: Default::default(),

--- a/crates/exoharness/src/sandbox_provider/aws_agentcore.rs
+++ b/crates/exoharness/src/sandbox_provider/aws_agentcore.rs
@@ -555,7 +555,7 @@ mod tests {
     fn durable_request(mount_path: &str, mode: FileSystemMountMode) -> SandboxRequest {
         SandboxRequest {
             sandbox_id: "sandbox".to_string(),
-            scope: Some(SandboxScope::Conversation {
+            scope: Some(SandboxScope::Thread {
                 thread_id: "thread".to_string(),
             }),
             spec: SandboxSpec {

--- a/crates/exoharness/src/sandbox_provider/daytona.rs
+++ b/crates/exoharness/src/sandbox_provider/daytona.rs
@@ -142,7 +142,10 @@ impl DaytonaSandboxBackend {
         snapshot_name: Option<&str>,
     ) -> Result<DaytonaSandbox> {
         let mut labels = HashMap::new();
-        labels.insert(WARM_SANDBOX_KEY_LABEL.to_string(), request.key.to_string());
+        labels.insert(
+            WARM_SANDBOX_KEY_LABEL.to_string(),
+            request.key.sandbox_id().to_string(),
+        );
         labels.insert(
             WARM_SANDBOX_SPEC_HASH_LABEL.to_string(),
             spec_hash.to_string(),
@@ -262,7 +265,7 @@ impl ManagedSandboxBackend for DaytonaSandboxBackend {
         // Reuse a matching sandbox if one exists (also how we recover across exo
         // restarts); Daytona keeps its filesystem across stop.
         let sandbox = match self
-            .find_sandbox_by_labels(&request.key.to_string(), &spec_hash)
+            .find_sandbox_by_labels(request.key.sandbox_id(), &spec_hash)
             .await?
         {
             // Replace a terminal/error sandbox; start only durably-stopped ones
@@ -278,7 +281,7 @@ impl ManagedSandboxBackend for DaytonaSandboxBackend {
 
         self.wait_until_started(&sandbox.id).await?;
         Ok(Arc::new(DaytonaSandboxHandle {
-            id: format!("daytona:{}", request.key),
+            id: format!("daytona:{}", request.key.sandbox_id()),
             sandbox_id: sandbox.id,
             request,
             backend: self.handle_backend(),
@@ -317,7 +320,7 @@ impl ManagedSandboxBackend for DaytonaSandboxBackend {
             .await?;
         self.wait_until_started(&sandbox.id).await?;
         Ok(Arc::new(DaytonaSandboxHandle {
-            id: format!("daytona:{}", request.key),
+            id: format!("daytona:{}", request.key.sandbox_id()),
             sandbox_id: sandbox.id,
             request,
             backend: self.handle_backend(),

--- a/crates/exoharness/src/sandbox_provider/daytona.rs
+++ b/crates/exoharness/src/sandbox_provider/daytona.rs
@@ -144,7 +144,7 @@ impl DaytonaSandboxBackend {
         let mut labels = HashMap::new();
         labels.insert(
             WARM_SANDBOX_KEY_LABEL.to_string(),
-            request.key.sandbox_id().to_string(),
+            request.sandbox_id.clone(),
         );
         labels.insert(
             WARM_SANDBOX_SPEC_HASH_LABEL.to_string(),
@@ -265,7 +265,7 @@ impl ManagedSandboxBackend for DaytonaSandboxBackend {
         // Reuse a matching sandbox if one exists (also how we recover across exo
         // restarts); Daytona keeps its filesystem across stop.
         let sandbox = match self
-            .find_sandbox_by_labels(request.key.sandbox_id(), &spec_hash)
+            .find_sandbox_by_labels(request.sandbox_id.as_str(), &spec_hash)
             .await?
         {
             // Replace a terminal/error sandbox; start only durably-stopped ones
@@ -281,7 +281,7 @@ impl ManagedSandboxBackend for DaytonaSandboxBackend {
 
         self.wait_until_started(&sandbox.id).await?;
         Ok(Arc::new(DaytonaSandboxHandle {
-            id: format!("daytona:{}", request.key.sandbox_id()),
+            id: format!("daytona:{}", request.sandbox_id.as_str()),
             sandbox_id: sandbox.id,
             request,
             backend: self.handle_backend(),
@@ -320,7 +320,7 @@ impl ManagedSandboxBackend for DaytonaSandboxBackend {
             .await?;
         self.wait_until_started(&sandbox.id).await?;
         Ok(Arc::new(DaytonaSandboxHandle {
-            id: format!("daytona:{}", request.key.sandbox_id()),
+            id: format!("daytona:{}", request.sandbox_id.as_str()),
             sandbox_id: sandbox.id,
             request,
             backend: self.handle_backend(),

--- a/crates/exoharness/src/sandbox_provider/e2b.rs
+++ b/crates/exoharness/src/sandbox_provider/e2b.rs
@@ -145,7 +145,7 @@ impl E2bSandboxBackend {
         let mut metadata = HashMap::new();
         metadata.insert(
             WARM_SANDBOX_KEY_LABEL.to_string(),
-            request.key.sandbox_id().to_string(),
+            request.sandbox_id.clone(),
         );
         metadata.insert(
             WARM_SANDBOX_SPEC_HASH_LABEL.to_string(),
@@ -233,7 +233,7 @@ impl ManagedSandboxBackend for E2bSandboxBackend {
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
         reject_host_mounts(&request)?;
         let spec_hash = sandbox_spec_hash(&request.spec);
-        let key_label = request.key.sandbox_id().to_string();
+        let key_label = request.sandbox_id.clone();
         let template_id = resolve_template_id(&request.spec, &self.template_id);
 
         if let Some(existing) = self
@@ -249,7 +249,7 @@ impl ManagedSandboxBackend for E2bSandboxBackend {
                 envd_access_token = connected.envd_access_token;
             }
             return Ok(Arc::new(E2bSandboxHandle {
-                id: format!("e2b:{}", request.key.sandbox_id()),
+                id: format!("e2b:{}", request.sandbox_id.as_str()),
                 sandbox_id: existing.sandbox_id,
                 envd_access_token,
                 request,
@@ -261,7 +261,7 @@ impl ManagedSandboxBackend for E2bSandboxBackend {
             .create_sandbox(&request, &spec_hash, &template_id)
             .await?;
         Ok(Arc::new(E2bSandboxHandle {
-            id: format!("e2b:{}", request.key.sandbox_id()),
+            id: format!("e2b:{}", request.sandbox_id.as_str()),
             sandbox_id: sandbox.sandbox_id,
             envd_access_token: sandbox.envd_access_token,
             request,
@@ -297,7 +297,7 @@ impl ManagedSandboxBackend for E2bSandboxBackend {
             .create_sandbox(&request, &spec_hash, &manifest.snapshot_id)
             .await?;
         Ok(Arc::new(E2bSandboxHandle {
-            id: format!("e2b-restored:{}", request.key.sandbox_id()),
+            id: format!("e2b-restored:{}", request.sandbox_id.as_str()),
             sandbox_id: sandbox.sandbox_id,
             envd_access_token: sandbox.envd_access_token,
             request,

--- a/crates/exoharness/src/sandbox_provider/e2b.rs
+++ b/crates/exoharness/src/sandbox_provider/e2b.rs
@@ -143,7 +143,10 @@ impl E2bSandboxBackend {
         template_id: &str,
     ) -> Result<E2bSandboxCreated> {
         let mut metadata = HashMap::new();
-        metadata.insert(WARM_SANDBOX_KEY_LABEL.to_string(), request.key.to_string());
+        metadata.insert(
+            WARM_SANDBOX_KEY_LABEL.to_string(),
+            request.key.sandbox_id().to_string(),
+        );
         metadata.insert(
             WARM_SANDBOX_SPEC_HASH_LABEL.to_string(),
             spec_hash.to_string(),
@@ -230,7 +233,7 @@ impl ManagedSandboxBackend for E2bSandboxBackend {
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
         reject_host_mounts(&request)?;
         let spec_hash = sandbox_spec_hash(&request.spec);
-        let key_label = request.key.to_string();
+        let key_label = request.key.sandbox_id().to_string();
         let template_id = resolve_template_id(&request.spec, &self.template_id);
 
         if let Some(existing) = self
@@ -246,7 +249,7 @@ impl ManagedSandboxBackend for E2bSandboxBackend {
                 envd_access_token = connected.envd_access_token;
             }
             return Ok(Arc::new(E2bSandboxHandle {
-                id: format!("e2b:{}", request.key),
+                id: format!("e2b:{}", request.key.sandbox_id()),
                 sandbox_id: existing.sandbox_id,
                 envd_access_token,
                 request,
@@ -258,7 +261,7 @@ impl ManagedSandboxBackend for E2bSandboxBackend {
             .create_sandbox(&request, &spec_hash, &template_id)
             .await?;
         Ok(Arc::new(E2bSandboxHandle {
-            id: format!("e2b:{}", request.key),
+            id: format!("e2b:{}", request.key.sandbox_id()),
             sandbox_id: sandbox.sandbox_id,
             envd_access_token: sandbox.envd_access_token,
             request,
@@ -294,7 +297,7 @@ impl ManagedSandboxBackend for E2bSandboxBackend {
             .create_sandbox(&request, &spec_hash, &manifest.snapshot_id)
             .await?;
         Ok(Arc::new(E2bSandboxHandle {
-            id: format!("e2b-restored:{}", request.key),
+            id: format!("e2b-restored:{}", request.key.sandbox_id()),
             sandbox_id: sandbox.sandbox_id,
             envd_access_token: sandbox.envd_access_token,
             request,

--- a/crates/exoharness/src/sandbox_provider/firecracker.rs
+++ b/crates/exoharness/src/sandbox_provider/firecracker.rs
@@ -796,6 +796,7 @@ impl FirecrackerSandboxBackend {
 
     // The caller holds the source machine's lifecycle lock until capture has
     // resumed the VM and published the immutable template.
+    #[tracing::instrument(name = "firecracker.snapshot_capture", skip_all)]
     async fn capture_snapshot_locked(
         shared: &Arc<Shared>,
         request: &SandboxRequest,
@@ -840,7 +841,9 @@ impl FirecrackerSandboxBackend {
         let config = shared.config.clone();
         let source_for_snapshot = source.clone();
         let key_for_snapshot = template_key.clone();
+        let span = tracing::Span::current();
         let lease = tokio::task::spawn_blocking(move || {
+            let _entered = span.enter();
             capture_snapshot_template(&config, &source_for_snapshot, &key_for_snapshot, lifecycle)
         })
         .await
@@ -1104,6 +1107,7 @@ impl ManagedSandboxBackend for FirecrackerSandboxBackend {
         &CONSUMABLE_SNAPSHOT_FORMATS
     }
 
+    #[tracing::instrument(name = "firecracker.acquire", skip_all)]
     async fn acquire(&self, request: SandboxRequest) -> Result<Arc<dyn ManagedSandboxHandle>> {
         self.reap_stale_machines().await?;
         self.reap_expired_machines().await?;
@@ -1124,6 +1128,7 @@ impl ManagedSandboxBackend for FirecrackerSandboxBackend {
         self.shared.delete_snapshot(payload).await
     }
 
+    #[tracing::instrument(name = "firecracker.terminate", skip_all)]
     async fn terminate(&self, request: SandboxRequest) -> Result<()> {
         let persisted_machine_id = request
             .provider_state
@@ -1212,6 +1217,7 @@ impl ManagedSandboxBackend for FirecrackerSandboxBackend {
         .await
     }
 
+    #[tracing::instrument(name = "firecracker.restore", skip_all)]
     async fn acquire_from_snapshot(
         &self,
         request: SandboxRequest,
@@ -1350,6 +1356,7 @@ impl ManagedSandboxHandle for FirecrackerSandboxHandle {
         true
     }
 
+    #[tracing::instrument(name = "firecracker.connect_tcp", skip_all)]
     async fn connect_tcp(&self, port: u16) -> Result<Option<BoxSandboxTcpStream>> {
         if !self.machine.record.network_enabled {
             bail!("Firecracker sandbox does not have networking enabled");
@@ -1358,6 +1365,7 @@ impl ManagedSandboxHandle for FirecrackerSandboxHandle {
         Ok(Some(Box::pin(TcpStream::connect(address).await?)))
     }
 
+    #[tracing::instrument(name = "firecracker.stop", skip_all)]
     async fn stop(&self) -> Result<()> {
         let _lifecycle_guard = self
             .shared
@@ -1466,6 +1474,7 @@ impl Shared {
         }
     }
 
+    #[tracing::instrument(name = "firecracker.capacity", skip_all)]
     async fn reserve_machine_capacity(
         &self,
         machine_id: &str,
@@ -1523,6 +1532,7 @@ impl Shared {
         Ok(())
     }
 
+    #[tracing::instrument(name = "firecracker.ensure_machine", skip_all)]
     async fn ensure_machine(
         self: &Arc<Self>,
         request: &SandboxRequest,
@@ -1604,6 +1614,7 @@ impl Shared {
         Ok(machine)
     }
 
+    #[tracing::instrument(name = "firecracker.restore_network", skip_all)]
     async fn reconfigure_restored_network(self: &Arc<Self>, machine: &Machine) -> Result<()> {
         // Snapshot memory contains the source guest's configured IP, while each
         // clone gets a distinct host TAP/resource slot. Reset the address before
@@ -1640,6 +1651,7 @@ impl Shared {
             .context("joining Firecracker lease update")?
     }
 
+    #[tracing::instrument(name = "firecracker.allocate_machine", skip_all)]
     async fn new_machine_record(
         &self,
         request: &SandboxRequest,
@@ -1707,6 +1719,7 @@ impl Shared {
         .context("joining Firecracker machine allocation")?
     }
 
+    #[tracing::instrument(name = "firecracker.prepare_launch", skip_all)]
     async fn prepare_and_launch(
         &self,
         request: &SandboxRequest,
@@ -1715,7 +1728,9 @@ impl Shared {
         let config = self.config.clone();
         let request = request.clone();
         let record = record.clone();
+        let span = tracing::Span::current();
         tokio::task::spawn_blocking(move || {
+            let _entered = span.enter();
             let network = record.network();
             let result = (|| {
                 if record.network_enabled {
@@ -1737,6 +1752,7 @@ impl Shared {
         .context("joining Firecracker launch task")?
     }
 
+    #[tracing::instrument(name = "firecracker.stop_process", skip_all)]
     async fn stop_machine_process(&self, machine_id: &str) -> Result<()> {
         let pid_path = self.pid_path(machine_id);
         let machine_id = machine_id.to_string();
@@ -1745,6 +1761,7 @@ impl Shared {
             .context("joining Firecracker stop task")?
     }
 
+    #[tracing::instrument(name = "firecracker.cleanup_network", skip_all)]
     async fn cleanup_network(&self, network: &NetworkConfig) {
         let network = network.clone();
         if let Err(error) =
@@ -1754,6 +1771,7 @@ impl Shared {
         }
     }
 
+    #[tracing::instrument(name = "firecracker.cleanup", skip_all)]
     async fn cleanup_machine(&self, machine_id: &str, delete_rootfs: bool) -> Result<()> {
         if !valid_machine_id(machine_id) {
             bail!("invalid Firecracker machine id: {machine_id}");
@@ -2187,6 +2205,7 @@ pub(super) fn copy_sparse_full(source: &Path, destination: &Path) -> Result<()> 
     copy_sparse_with_mode(source, destination, SparseCopyMode::Full)
 }
 
+#[tracing::instrument(name = "firecracker.copy_snapshot_file", skip_all)]
 fn copy_sparse_reflink(source: &Path, destination: &Path) -> Result<()> {
     copy_sparse_with_mode(source, destination, SparseCopyMode::ReflinkRequired)
 }
@@ -2624,6 +2643,7 @@ fn ipv4_add(address: Ipv4Addr, offset: u32) -> Ipv4Addr {
     Ipv4Addr::from(u32::from(address) + offset)
 }
 
+#[tracing::instrument(name = "firecracker.network_setup", skip_all)]
 fn prepare_network(
     config: &FirecrackerConfig,
     network: &NetworkConfig,
@@ -3049,6 +3069,7 @@ fn remove_firecracker_cgroup(path: &Path) -> Result<()> {
     }
 }
 
+#[tracing::instrument(name = "firecracker.prepare_vm", skip_all)]
 fn prepare_and_launch_blocking(
     config: &FirecrackerConfig,
     request: &SandboxRequest,
@@ -3165,6 +3186,7 @@ fn prepare_and_launch_blocking(
     Ok(GuestReadiness::Signal(ready_listener))
 }
 
+#[tracing::instrument(name = "firecracker.launch_vmm", skip_all)]
 fn spawn_jailed_firecracker(
     config: &FirecrackerConfig,
     record: &MachineRecord,
@@ -3524,6 +3546,7 @@ fn replace_hard_link(source: &Path, destination: &Path) -> Result<()> {
     })
 }
 
+#[tracing::instrument(name = "firecracker.prepare_snapshot_files", skip_all)]
 fn prepare_snapshot_jail_files(
     config: &FirecrackerConfig,
     request: &SandboxRequest,
@@ -3596,6 +3619,7 @@ fn firecracker_api_patch<T: Serialize>(socket: &Path, path: &str, body: &T) -> R
     firecracker_api_request(socket, "PATCH", path, body, FIRECRACKER_API_TIMEOUT)
 }
 
+#[tracing::instrument(name = "firecracker.api", skip_all, fields(method, path))]
 fn firecracker_api_request<T: Serialize>(
     socket: &Path,
     method: &str,
@@ -3771,6 +3795,7 @@ fn enforce_snapshot_budget(config: &FirecrackerConfig, capture_bytes: u64) -> Re
     Ok(())
 }
 
+#[tracing::instrument(name = "firecracker.capture_template", skip_all)]
 fn capture_snapshot_template(
     config: &FirecrackerConfig,
     source: &MachineRecord,
@@ -3926,6 +3951,7 @@ fn capture_snapshot_template(
     open_snapshot_template_lease(config, template_key)
 }
 
+#[tracing::instrument(name = "firecracker.prepare_snapshot_overlay", skip_all)]
 fn prepare_snapshot_overlay(
     config: &FirecrackerConfig,
     record: &MachineRecord,
@@ -4517,6 +4543,7 @@ impl Drop for ProcessWait {
     }
 }
 
+#[tracing::instrument(name = "firecracker.guest_ready", skip_all)]
 async fn wait_for_guest(
     shared: &Shared,
     machine_id: &str,
@@ -4529,6 +4556,7 @@ async fn wait_for_guest(
         .context("joining Firecracker guest-ready wait")?
 }
 
+#[tracing::instrument(name = "firecracker.restored_guest_ready", skip_all)]
 async fn wait_for_restored_guest(shared: &Arc<Shared>, machine: &Machine) -> Result<()> {
     let started = Instant::now();
     let pid_path = shared.pid_path(&machine.record.machine_id);

--- a/crates/exoharness/src/sandbox_provider/firecracker.rs
+++ b/crates/exoharness/src/sandbox_provider/firecracker.rs
@@ -49,7 +49,7 @@ use crate::sandbox::{
 };
 use crate::sandbox_provider::process_bridge;
 use crate::{
-    FileSystemMountMode, SandboxAttachment, SandboxProcessParts, SandboxResourceShape,
+    FileSystemMountMode, SandboxAttachment, SandboxId, SandboxProcessParts, SandboxResourceShape,
     SandboxTerminalParts, SandboxTerminalSize,
 };
 
@@ -577,7 +577,7 @@ struct Shared {
     // matching machines after the prior controller releases this lock; the
     // lock prevents concurrent controllers from racing that reconciliation.
     _state_lock: File,
-    warm_machines: Mutex<HashMap<String, WarmMachineEntry>>,
+    warm_machines: Mutex<HashMap<SandboxId, WarmMachineEntry>>,
     lifecycle_locks: MachineLifecycleLocks,
     capacity_gate: Mutex<()>,
     starting_machines: Arc<StdMutex<HashSet<String>>>,
@@ -4685,7 +4685,7 @@ fn wait_for_guest_blocking(
 
 async fn touch_machine(
     shared: &Shared,
-    machines: &Mutex<HashMap<String, WarmMachineEntry>>,
+    machines: &Mutex<HashMap<SandboxId, WarmMachineEntry>>,
     key: &str,
     machine_id: &str,
 ) -> Result<()> {

--- a/crates/exoharness/src/sandbox_provider/firecracker.rs
+++ b/crates/exoharness/src/sandbox_provider/firecracker.rs
@@ -499,8 +499,8 @@ impl MachineLifecycleLocks {
         self.lock_key(machine_lifecycle_key(machine_id)).await
     }
 
-    async fn lock_sandbox(&self, key: &str) -> OwnedMutexGuard<()> {
-        self.lock_key(sandbox_lifecycle_key(key)).await
+    async fn lock_sandbox(&self, sandbox_id: &str) -> OwnedMutexGuard<()> {
+        self.lock_key(sandbox_lifecycle_key(sandbox_id)).await
     }
 
     async fn lock_sandbox_pair(
@@ -2256,20 +2256,20 @@ fn binary_version(path: &Path) -> Result<String> {
         .ok_or_else(|| anyhow!("could not parse version from {}", path.display()))
 }
 
-fn machine_id(key: &str, spec_hash: &str) -> String {
-    format!("fc-{}-{}", stable_id(key), &spec_hash[..8])
+fn machine_id(sandbox_id: &str, spec_hash: &str) -> String {
+    format!("fc-{}-{}", stable_id(sandbox_id), &spec_hash[..8])
 }
 
-fn one_shot_machine_id(key: &str, spec_hash: &str, sequence: u64) -> String {
+fn one_shot_machine_id(sandbox_id: &str, spec_hash: &str, sequence: u64) -> String {
     format!(
         "fc-{}-{}",
-        stable_id(&format!("{key}\n{}\n{sequence}", std::process::id())),
+        stable_id(&format!("{sandbox_id}\n{}\n{sequence}", std::process::id())),
         &spec_hash[..8]
     )
 }
 
-fn sandbox_lifecycle_key(key: &str) -> String {
-    format!("fc-{}", stable_id(key))
+fn sandbox_lifecycle_key(sandbox_id: &str) -> String {
+    format!("fc-{}", stable_id(sandbox_id))
 }
 
 fn machine_lifecycle_key(machine_id: &str) -> String {
@@ -4686,12 +4686,12 @@ fn wait_for_guest_blocking(
 async fn touch_machine(
     shared: &Shared,
     machines: &Mutex<HashMap<SandboxId, WarmMachineEntry>>,
-    key: &str,
+    sandbox_id: &str,
     machine_id: &str,
 ) -> Result<()> {
     let touched = {
         let mut machines = machines.lock().await;
-        if let Some(entry) = machines.get_mut(key)
+        if let Some(entry) = machines.get_mut(sandbox_id)
             && entry.machine_id == machine_id
         {
             entry.last_used_at = Instant::now();

--- a/crates/exoharness/src/sandbox_provider/firecracker.rs
+++ b/crates/exoharness/src/sandbox_provider/firecracker.rs
@@ -44,8 +44,8 @@ use uuid::Uuid;
 
 use crate::sandbox::{
     BoxSandboxTcpStream, ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand,
-    SandboxCommandOutput, SandboxKey, SandboxNetworkPolicy, SandboxRequest, SandboxSpec,
-    SnapshotFormat, SnapshotPayload, sandbox_spec_hash,
+    SandboxCommandOutput, SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotFormat,
+    SnapshotPayload, sandbox_spec_hash,
 };
 use crate::sandbox_provider::process_bridge;
 use crate::{
@@ -499,14 +499,14 @@ impl MachineLifecycleLocks {
         self.lock_key(machine_lifecycle_key(machine_id)).await
     }
 
-    async fn lock_sandbox(&self, key: &SandboxKey) -> OwnedMutexGuard<()> {
+    async fn lock_sandbox(&self, key: &str) -> OwnedMutexGuard<()> {
         self.lock_key(sandbox_lifecycle_key(key)).await
     }
 
     async fn lock_sandbox_pair(
         &self,
-        first: &SandboxKey,
-        second: &SandboxKey,
+        first: &str,
+        second: &str,
     ) -> (OwnedMutexGuard<()>, Option<OwnedMutexGuard<()>>) {
         let first = sandbox_lifecycle_key(first);
         let second = sandbox_lifecycle_key(second);
@@ -577,7 +577,7 @@ struct Shared {
     // matching machines after the prior controller releases this lock; the
     // lock prevents concurrent controllers from racing that reconciliation.
     _state_lock: File,
-    warm_machines: Mutex<HashMap<SandboxKey, WarmMachineEntry>>,
+    warm_machines: Mutex<HashMap<String, WarmMachineEntry>>,
     lifecycle_locks: MachineLifecycleLocks,
     capacity_gate: Mutex<()>,
     starting_machines: Arc<StdMutex<HashSet<String>>>,
@@ -869,8 +869,12 @@ impl FirecrackerSandboxBackend {
         captured_lease: Option<File>,
     ) -> Result<Arc<dyn ManagedSandboxHandle>> {
         let spec_hash = sandbox_spec_hash(&request.spec);
-        let machine_id = machine_id(&request.key, &spec_hash);
-        let _lifecycle_guard = self.shared.lifecycle_locks.lock_sandbox(&request.key).await;
+        let machine_id = machine_id(request.key.sandbox_id(), &spec_hash);
+        let _lifecycle_guard = self
+            .shared
+            .lifecycle_locks
+            .lock_sandbox(request.key.sandbox_id())
+            .await;
         self.restore_snapshot_locked(
             request,
             manifest,
@@ -1004,11 +1008,15 @@ impl FirecrackerSandboxBackend {
         let one_shot = request.lifecycle.idle_ttl.is_none();
         let machine_id = if one_shot {
             let sequence = ONE_SHOT_SEQUENCE.fetch_add(1, Ordering::Relaxed);
-            one_shot_machine_id(&request.key, &spec_hash, sequence)
+            one_shot_machine_id(request.key.sandbox_id(), &spec_hash, sequence)
         } else {
-            machine_id(&request.key, &spec_hash)
+            machine_id(request.key.sandbox_id(), &spec_hash)
         };
-        let _lifecycle_guard = self.shared.lifecycle_locks.lock_sandbox(&request.key).await;
+        let _lifecycle_guard = self
+            .shared
+            .lifecycle_locks
+            .lock_sandbox(request.key.sandbox_id())
+            .await;
         self.acquire_resolved_locked(request, spec_hash, machine_id, one_shot, None)
             .await
     }
@@ -1024,8 +1032,8 @@ impl FirecrackerSandboxBackend {
         one_shot: bool,
         capacity_reservation: Option<MachineCapacityReservation>,
     ) -> Result<Arc<dyn ManagedSandboxHandle>> {
-        let stable_machine_id = machine_id(&request.key, &spec_hash);
-        let machine_key_prefix = format!("fc-{}-", stable_id(&request.key.to_string()));
+        let stable_machine_id = machine_id(request.key.sandbox_id(), &spec_hash);
+        let machine_key_prefix = format!("fc-{}-", stable_id(request.key.sandbox_id()));
 
         if let Some(state) = request
             .provider_state
@@ -1045,9 +1053,9 @@ impl FirecrackerSandboxBackend {
         if !one_shot {
             let replaced = {
                 let mut machines = self.shared.warm_machines.lock().await;
-                match machines.get(&request.key) {
+                match machines.get(request.key.sandbox_id()) {
                     Some(entry) if entry.spec_hash == spec_hash => None,
-                    Some(_) => machines.remove(&request.key),
+                    Some(_) => machines.remove(request.key.sandbox_id()),
                     None => None,
                 }
             };
@@ -1071,7 +1079,7 @@ impl FirecrackerSandboxBackend {
         if !one_shot {
             self.shared.touch_machine_lease(&target_machine_id).await?;
             self.shared.warm_machines.lock().await.insert(
-                request.key.clone(),
+                request.key.sandbox_id().to_string(),
                 WarmMachineEntry {
                     machine_id: target_machine_id.clone(),
                     spec_hash: spec_hash.clone(),
@@ -1137,23 +1145,27 @@ impl ManagedSandboxBackend for FirecrackerSandboxBackend {
             .transpose()?
             .map(|state| state.machine_id);
         if let Some(machine_id) = persisted_machine_id.as_deref() {
-            let machine_key_prefix = format!("fc-{}-", stable_id(&request.key.to_string()));
+            let machine_key_prefix = format!("fc-{}-", stable_id(request.key.sandbox_id()));
             if !valid_machine_id(machine_id) || !machine_id.starts_with(&machine_key_prefix) {
                 bail!("Firecracker provider state does not match the terminated sandbox key");
             }
         }
-        let _lifecycle_guard = self.shared.lifecycle_locks.lock_sandbox(&request.key).await;
+        let _lifecycle_guard = self
+            .shared
+            .lifecycle_locks
+            .lock_sandbox(request.key.sandbox_id())
+            .await;
         let machine_id = self
             .shared
             .warm_machines
             .lock()
             .await
-            .remove(&request.key)
+            .remove(request.key.sandbox_id())
             .map(|entry| entry.machine_id)
             .or(persisted_machine_id)
             .unwrap_or_else(|| {
                 let spec_hash = sandbox_spec_hash(&request.spec);
-                machine_id(&request.key, &spec_hash)
+                machine_id(request.key.sandbox_id(), &spec_hash)
             });
         self.shared.cleanup_machine(&machine_id, true).await
     }
@@ -1165,22 +1177,22 @@ impl ManagedSandboxBackend for FirecrackerSandboxBackend {
     ) -> Result<Arc<dyn ManagedSandboxHandle>> {
         let mut source = prepare_request(source)?;
         let target = self.resolve_request(target).await?;
-        if source.key == target.key {
+        if source.key.sandbox_id() == target.key.sandbox_id() {
             bail!("Firecracker fork source and target must be different sandboxes")
         }
         let target_spec_hash = sandbox_spec_hash(&target.spec);
-        let target_machine_id = machine_id(&target.key, &target_spec_hash);
+        let target_machine_id = machine_id(target.key.sandbox_id(), &target_spec_hash);
         let (_first_lifecycle_guard, _second_lifecycle_guard) = self
             .shared
             .lifecycle_locks
-            .lock_sandbox_pair(&source.key, &target.key)
+            .lock_sandbox_pair(source.key.sandbox_id(), target.key.sandbox_id())
             .await;
         let source_entry = self
             .shared
             .warm_machines
             .lock()
             .await
-            .get(&source.key)
+            .get(source.key.sandbox_id())
             .cloned()
             .context("Firecracker fork source is not active")?;
         let source_record = self
@@ -1299,7 +1311,7 @@ impl ManagedSandboxHandle for FirecrackerSandboxHandle {
             touch_machine(
                 &self.shared,
                 &self.shared.warm_machines,
-                &self.request.key,
+                self.request.key.sandbox_id(),
                 &self.machine.record.machine_id,
             )
             .await?;
@@ -1323,7 +1335,7 @@ impl ManagedSandboxHandle for FirecrackerSandboxHandle {
             touch_machine(
                 &self.shared,
                 &self.shared.warm_machines,
-                &self.request.key,
+                self.request.key.sandbox_id(),
                 &self.machine.record.machine_id,
             )
             .await?;
@@ -1351,7 +1363,7 @@ impl ManagedSandboxHandle for FirecrackerSandboxHandle {
             touch_machine(
                 &self.shared,
                 &self.shared.warm_machines,
-                &self.request.key,
+                self.request.key.sandbox_id(),
                 &self.machine.record.machine_id,
             )
             .await?;
@@ -1676,7 +1688,13 @@ impl Shared {
                 .spec
                 .durable_file_systems
                 .first()
-                .map(|file_system| stable_id(&format!("{}\n{}", request.key, file_system.name)))
+                .map(|file_system| {
+                    stable_id(&format!(
+                        "{}\n{}",
+                        request.key.sandbox_id(),
+                        file_system.name
+                    ))
+                })
         } else {
             None
         };
@@ -2238,11 +2256,11 @@ fn binary_version(path: &Path) -> Result<String> {
         .ok_or_else(|| anyhow!("could not parse version from {}", path.display()))
 }
 
-fn machine_id(key: &SandboxKey, spec_hash: &str) -> String {
-    format!("fc-{}-{}", stable_id(&key.to_string()), &spec_hash[..8])
+fn machine_id(key: &str, spec_hash: &str) -> String {
+    format!("fc-{}-{}", stable_id(key), &spec_hash[..8])
 }
 
-fn one_shot_machine_id(key: &SandboxKey, spec_hash: &str, sequence: u64) -> String {
+fn one_shot_machine_id(key: &str, spec_hash: &str, sequence: u64) -> String {
     format!(
         "fc-{}-{}",
         stable_id(&format!("{key}\n{}\n{sequence}", std::process::id())),
@@ -2250,8 +2268,8 @@ fn one_shot_machine_id(key: &SandboxKey, spec_hash: &str, sequence: u64) -> Stri
     )
 }
 
-fn sandbox_lifecycle_key(key: &SandboxKey) -> String {
-    format!("fc-{}", stable_id(&key.to_string()))
+fn sandbox_lifecycle_key(key: &str) -> String {
+    format!("fc-{}", stable_id(key))
 }
 
 fn machine_lifecycle_key(machine_id: &str) -> String {
@@ -4667,8 +4685,8 @@ fn wait_for_guest_blocking(
 
 async fn touch_machine(
     shared: &Shared,
-    machines: &Mutex<HashMap<SandboxKey, WarmMachineEntry>>,
-    key: &SandboxKey,
+    machines: &Mutex<HashMap<String, WarmMachineEntry>>,
+    key: &str,
     machine_id: &str,
 ) -> Result<()> {
     let touched = {

--- a/crates/exoharness/src/sandbox_provider/firecracker.rs
+++ b/crates/exoharness/src/sandbox_provider/firecracker.rs
@@ -869,11 +869,11 @@ impl FirecrackerSandboxBackend {
         captured_lease: Option<File>,
     ) -> Result<Arc<dyn ManagedSandboxHandle>> {
         let spec_hash = sandbox_spec_hash(&request.spec);
-        let machine_id = machine_id(request.key.sandbox_id(), &spec_hash);
+        let machine_id = machine_id(request.sandbox_id.as_str(), &spec_hash);
         let _lifecycle_guard = self
             .shared
             .lifecycle_locks
-            .lock_sandbox(request.key.sandbox_id())
+            .lock_sandbox(request.sandbox_id.as_str())
             .await;
         self.restore_snapshot_locked(
             request,
@@ -1008,14 +1008,14 @@ impl FirecrackerSandboxBackend {
         let one_shot = request.lifecycle.idle_ttl.is_none();
         let machine_id = if one_shot {
             let sequence = ONE_SHOT_SEQUENCE.fetch_add(1, Ordering::Relaxed);
-            one_shot_machine_id(request.key.sandbox_id(), &spec_hash, sequence)
+            one_shot_machine_id(request.sandbox_id.as_str(), &spec_hash, sequence)
         } else {
-            machine_id(request.key.sandbox_id(), &spec_hash)
+            machine_id(request.sandbox_id.as_str(), &spec_hash)
         };
         let _lifecycle_guard = self
             .shared
             .lifecycle_locks
-            .lock_sandbox(request.key.sandbox_id())
+            .lock_sandbox(request.sandbox_id.as_str())
             .await;
         self.acquire_resolved_locked(request, spec_hash, machine_id, one_shot, None)
             .await
@@ -1032,8 +1032,8 @@ impl FirecrackerSandboxBackend {
         one_shot: bool,
         capacity_reservation: Option<MachineCapacityReservation>,
     ) -> Result<Arc<dyn ManagedSandboxHandle>> {
-        let stable_machine_id = machine_id(request.key.sandbox_id(), &spec_hash);
-        let machine_key_prefix = format!("fc-{}-", stable_id(request.key.sandbox_id()));
+        let stable_machine_id = machine_id(request.sandbox_id.as_str(), &spec_hash);
+        let machine_key_prefix = format!("fc-{}-", stable_id(request.sandbox_id.as_str()));
 
         if let Some(state) = request
             .provider_state
@@ -1053,9 +1053,9 @@ impl FirecrackerSandboxBackend {
         if !one_shot {
             let replaced = {
                 let mut machines = self.shared.warm_machines.lock().await;
-                match machines.get(request.key.sandbox_id()) {
+                match machines.get(request.sandbox_id.as_str()) {
                     Some(entry) if entry.spec_hash == spec_hash => None,
-                    Some(_) => machines.remove(request.key.sandbox_id()),
+                    Some(_) => machines.remove(request.sandbox_id.as_str()),
                     None => None,
                 }
             };
@@ -1079,7 +1079,7 @@ impl FirecrackerSandboxBackend {
         if !one_shot {
             self.shared.touch_machine_lease(&target_machine_id).await?;
             self.shared.warm_machines.lock().await.insert(
-                request.key.sandbox_id().to_string(),
+                request.sandbox_id.clone(),
                 WarmMachineEntry {
                     machine_id: target_machine_id.clone(),
                     spec_hash: spec_hash.clone(),
@@ -1145,7 +1145,7 @@ impl ManagedSandboxBackend for FirecrackerSandboxBackend {
             .transpose()?
             .map(|state| state.machine_id);
         if let Some(machine_id) = persisted_machine_id.as_deref() {
-            let machine_key_prefix = format!("fc-{}-", stable_id(request.key.sandbox_id()));
+            let machine_key_prefix = format!("fc-{}-", stable_id(request.sandbox_id.as_str()));
             if !valid_machine_id(machine_id) || !machine_id.starts_with(&machine_key_prefix) {
                 bail!("Firecracker provider state does not match the terminated sandbox key");
             }
@@ -1153,19 +1153,19 @@ impl ManagedSandboxBackend for FirecrackerSandboxBackend {
         let _lifecycle_guard = self
             .shared
             .lifecycle_locks
-            .lock_sandbox(request.key.sandbox_id())
+            .lock_sandbox(request.sandbox_id.as_str())
             .await;
         let machine_id = self
             .shared
             .warm_machines
             .lock()
             .await
-            .remove(request.key.sandbox_id())
+            .remove(request.sandbox_id.as_str())
             .map(|entry| entry.machine_id)
             .or(persisted_machine_id)
             .unwrap_or_else(|| {
                 let spec_hash = sandbox_spec_hash(&request.spec);
-                machine_id(request.key.sandbox_id(), &spec_hash)
+                machine_id(request.sandbox_id.as_str(), &spec_hash)
             });
         self.shared.cleanup_machine(&machine_id, true).await
     }
@@ -1177,22 +1177,22 @@ impl ManagedSandboxBackend for FirecrackerSandboxBackend {
     ) -> Result<Arc<dyn ManagedSandboxHandle>> {
         let mut source = prepare_request(source)?;
         let target = self.resolve_request(target).await?;
-        if source.key.sandbox_id() == target.key.sandbox_id() {
+        if source.sandbox_id == target.sandbox_id {
             bail!("Firecracker fork source and target must be different sandboxes")
         }
         let target_spec_hash = sandbox_spec_hash(&target.spec);
-        let target_machine_id = machine_id(target.key.sandbox_id(), &target_spec_hash);
+        let target_machine_id = machine_id(&target.sandbox_id, &target_spec_hash);
         let (_first_lifecycle_guard, _second_lifecycle_guard) = self
             .shared
             .lifecycle_locks
-            .lock_sandbox_pair(source.key.sandbox_id(), target.key.sandbox_id())
+            .lock_sandbox_pair(&source.sandbox_id, &target.sandbox_id)
             .await;
         let source_entry = self
             .shared
             .warm_machines
             .lock()
             .await
-            .get(source.key.sandbox_id())
+            .get(&source.sandbox_id)
             .cloned()
             .context("Firecracker fork source is not active")?;
         let source_record = self
@@ -1311,7 +1311,7 @@ impl ManagedSandboxHandle for FirecrackerSandboxHandle {
             touch_machine(
                 &self.shared,
                 &self.shared.warm_machines,
-                self.request.key.sandbox_id(),
+                self.request.sandbox_id.as_str(),
                 &self.machine.record.machine_id,
             )
             .await?;
@@ -1335,7 +1335,7 @@ impl ManagedSandboxHandle for FirecrackerSandboxHandle {
             touch_machine(
                 &self.shared,
                 &self.shared.warm_machines,
-                self.request.key.sandbox_id(),
+                self.request.sandbox_id.as_str(),
                 &self.machine.record.machine_id,
             )
             .await?;
@@ -1363,7 +1363,7 @@ impl ManagedSandboxHandle for FirecrackerSandboxHandle {
             touch_machine(
                 &self.shared,
                 &self.shared.warm_machines,
-                self.request.key.sandbox_id(),
+                self.request.sandbox_id.as_str(),
                 &self.machine.record.machine_id,
             )
             .await?;
@@ -1691,7 +1691,7 @@ impl Shared {
                 .map(|file_system| {
                     stable_id(&format!(
                         "{}\n{}",
-                        request.key.sandbox_id(),
+                        request.sandbox_id.as_str(),
                         file_system.name
                     ))
                 })

--- a/crates/exoharness/src/sandbox_provider/firecracker.rs
+++ b/crates/exoharness/src/sandbox_provider/firecracker.rs
@@ -1264,6 +1264,13 @@ impl ManagedSandboxHandle for FirecrackerSandboxHandle {
         Some(self.request.spec.image.clone())
     }
 
+    async fn is_running(&self) -> Result<Option<bool>> {
+        let pid_path = self.shared.pid_path(&self.machine.record.machine_id);
+        tokio::task::spawn_blocking(move || observe_machine_process(&pid_path))
+            .await
+            .context("joining Firecracker liveness observation")?
+    }
+
     async fn exec(&self, command: &SandboxCommand) -> Result<SandboxCommandOutput> {
         let output = GuestClient::new(Arc::clone(&self.shared), self.machine.vsock_path.clone())
             .exec(&self.request.spec, command)
@@ -4046,6 +4053,28 @@ fn process_running(pid_path: &Path) -> bool {
         return false;
     };
     PathBuf::from(format!("/proc/{pid}")).exists()
+}
+
+#[cfg(target_os = "linux")]
+fn observe_machine_process(pid_path: &Path) -> Result<Option<bool>> {
+    let pid = match fs::read_to_string(pid_path) {
+        Ok(pid) => pid,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Some(false)),
+        Err(error) => return Err(error).context("reading Firecracker pid"),
+    };
+    let pid = Pid::from_raw(pid.trim().parse().context("invalid Firecracker pid")?)
+        .context("invalid Firecracker pid")?;
+    let pidfd = match pidfd_open(pid, PidfdFlags::empty()) {
+        Ok(pidfd) => pidfd,
+        Err(rustix::io::Errno::SRCH) => return Ok(Some(false)),
+        Err(error) => return Err(error).context("opening Firecracker pidfd"),
+    };
+    Ok(Some(!wait_for_pidfd(&pidfd, Duration::ZERO)?))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn observe_machine_process(_pid_path: &Path) -> Result<Option<bool>> {
+    Ok(None)
 }
 
 #[cfg(target_os = "linux")]

--- a/crates/exoharness/src/sandbox_provider/firecracker_image.rs
+++ b/crates/exoharness/src/sandbox_provider/firecracker_image.rs
@@ -28,6 +28,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tempfile::{Builder as TempBuilder, NamedTempFile};
 use tokio::io::AsyncWriteExt;
+use tracing::Instrument;
 
 const MATERIALIZER_VERSION: u32 = 4;
 const EXT4_MAGIC_OFFSET: u64 = 1024 + 0x38;
@@ -84,6 +85,11 @@ enum Whiteout {
     Opaque(PathBuf),
 }
 
+#[tracing::instrument(
+    name = "firecracker.resolve_image",
+    skip_all,
+    fields(cache_hit = tracing::field::Empty, registry_lookup = false)
+)]
 pub(super) async fn resolve_image(
     state_root: &Path,
     source: &str,
@@ -124,10 +130,13 @@ pub(super) async fn resolve_image(
     if let Some(source_digest) = immutable_reference_digest(&reference)? {
         let cache_dir = cache_image_dir(&cache_root, &platform, source_digest)?;
         if cache_dir.try_exists()? {
+            tracing::Span::current().record("cache_hit", true);
             return validate_cache_entry(&cache_dir, source_digest, None, &platform);
         }
     }
 
+    tracing::Span::current().record("cache_hit", false);
+    tracing::Span::current().record("registry_lookup", true);
     let auth = registry_auth(&reference)?;
 
     let client = Client::default();
@@ -151,6 +160,7 @@ pub(super) async fn resolve_image(
     // LimitedAsyncWriter under declared-size and cumulative budgets.
     let (manifest, manifest_digest, config_json, list_digest) = client
         .pull_manifest_and_config_and_list_digest(&reference, &auth)
+        .instrument(tracing::info_span!("firecracker.registry_manifest"))
         .await
         .with_context(|| format!("resolving OCI image manifest for {source}"))?;
     let source_digest = list_digest.unwrap_or_else(|| manifest_digest.clone());
@@ -160,6 +170,7 @@ pub(super) async fn resolve_image(
     validate_platform(&image_config)?;
     let cache_dir = cache_image_dir(&cache_root, &platform, &source_digest)?;
     if cache_dir.try_exists()? {
+        tracing::Span::current().record("cache_hit", true);
         return validate_cache_entry(
             &cache_dir,
             &source_digest,

--- a/crates/exoharness/src/sandbox_provider/firecracker_tests.rs
+++ b/crates/exoharness/src/sandbox_provider/firecracker_tests.rs
@@ -113,14 +113,7 @@ fn resource_names_and_addresses_are_distinct() {
 fn validates_machine_ids() {
     assert!(valid_machine_id("fc-0123456789abcdef-01234567"));
     assert!(!valid_machine_id("../firecracker"));
-    let one_shot = one_shot_machine_id(
-        &SandboxKey::AgentSandbox {
-            agent_id: "agent".to_string(),
-            sandbox_id: "sandbox".to_string(),
-        },
-        "0123456789abcdef",
-        u64::MAX,
-    );
+    let one_shot = one_shot_machine_id(&"sandbox".to_string(), "0123456789abcdef", u64::MAX);
     assert!(valid_machine_id(&one_shot));
     assert_eq!(one_shot.len(), MAX_MACHINE_ID.len());
 }
@@ -154,10 +147,7 @@ async fn lifecycle_locks_serialize_a_machine_family_but_not_other_machines() {
     .await
     .expect("the machine-family lock must be released with its guard");
 
-    let key = SandboxKey::AgentSandbox {
-        agent_id: "agent".to_string(),
-        sandbox_id: "sandbox".to_string(),
-    };
+    let key = "sandbox".to_string();
     let machine_id = machine_id(&key, "0123456789abcdef");
     let sandbox_guard = locks.lock_sandbox(&key).await;
     assert!(
@@ -167,10 +157,7 @@ async fn lifecycle_locks_serialize_a_machine_family_but_not_other_machines() {
     );
     drop(sandbox_guard);
 
-    let other_key = SandboxKey::AgentSandbox {
-        agent_id: "agent".to_string(),
-        sandbox_id: "other".to_string(),
-    };
+    let other_key = "other".to_string();
     let (first_pair_guard, second_pair_guard) = locks.lock_sandbox_pair(&key, &other_key).await;
     assert!(second_pair_guard.is_some());
     assert!(

--- a/crates/exoharness/src/sandbox_provider/firecracker_tests.rs
+++ b/crates/exoharness/src/sandbox_provider/firecracker_tests.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::SandboxKey;
 use tokio::net::UnixListener;
 
 fn test_host_runtime() -> FirecrackerHostFingerprint {
@@ -119,39 +118,6 @@ fn validates_machine_ids() {
     assert_eq!(one_shot.len(), MAX_MACHINE_ID.len());
 }
 
-#[test]
-fn machine_identity_uses_sandbox_id_without_owner_scope() {
-    let agent = SandboxKey::AgentSandbox {
-        agent_id: "agent".to_string(),
-        sandbox_id: "sandbox".to_string(),
-    };
-    let conversation = SandboxKey::ConversationSandbox {
-        thread_id: "thread".to_string(),
-        sandbox_id: "sandbox".to_string(),
-    };
-    let standalone = SandboxKey::StandaloneSandbox {
-        sandbox_id: "sandbox".to_string(),
-    };
-    let spec_hash = "0123456789abcdef";
-    assert_ne!(agent, conversation);
-    assert_eq!(
-        machine_id(agent.sandbox_id(), spec_hash),
-        machine_id(conversation.sandbox_id(), spec_hash)
-    );
-    assert_eq!(
-        machine_id(agent.sandbox_id(), spec_hash),
-        machine_id(standalone.sandbox_id(), spec_hash)
-    );
-    assert_ne!(
-        machine_id(agent.sandbox_id(), spec_hash),
-        machine_id("another-sandbox", spec_hash)
-    );
-    assert_eq!(
-        sandbox_lifecycle_key(agent.sandbox_id()),
-        sandbox_lifecycle_key(conversation.sandbox_id())
-    );
-}
-
 #[tokio::test]
 async fn lifecycle_locks_serialize_a_machine_family_but_not_other_machines() {
     let locks = MachineLifecycleLocks::default();
@@ -181,12 +147,9 @@ async fn lifecycle_locks_serialize_a_machine_family_but_not_other_machines() {
     .await
     .expect("the machine-family lock must be released with its guard");
 
-    let key = SandboxKey::AgentSandbox {
-        agent_id: "agent".to_string(),
-        sandbox_id: "sandbox".to_string(),
-    };
-    let machine_id = machine_id(key.sandbox_id(), "0123456789abcdef");
-    let sandbox_guard = locks.lock_sandbox(key.sandbox_id()).await;
+    let key = "sandbox";
+    let machine_id = machine_id(key, "0123456789abcdef");
+    let sandbox_guard = locks.lock_sandbox(key).await;
     assert!(
         tokio::time::timeout(Duration::from_millis(20), locks.lock_machine(&machine_id))
             .await
@@ -194,29 +157,18 @@ async fn lifecycle_locks_serialize_a_machine_family_but_not_other_machines() {
     );
     drop(sandbox_guard);
 
-    let other_key = SandboxKey::AgentSandbox {
-        agent_id: "agent".to_string(),
-        sandbox_id: "other".to_string(),
-    };
-    let (first_pair_guard, second_pair_guard) = locks
-        .lock_sandbox_pair(key.sandbox_id(), other_key.sandbox_id())
-        .await;
+    let other_key = "other";
+    let (first_pair_guard, second_pair_guard) = locks.lock_sandbox_pair(key, other_key).await;
     assert!(second_pair_guard.is_some());
     assert!(
-        tokio::time::timeout(
-            Duration::from_millis(20),
-            locks.lock_sandbox(key.sandbox_id())
-        )
-        .await
-        .is_err()
+        tokio::time::timeout(Duration::from_millis(20), locks.lock_sandbox(key))
+            .await
+            .is_err()
     );
     assert!(
-        tokio::time::timeout(
-            Duration::from_millis(20),
-            locks.lock_sandbox(other_key.sandbox_id())
-        )
-        .await
-        .is_err()
+        tokio::time::timeout(Duration::from_millis(20), locks.lock_sandbox(other_key))
+            .await
+            .is_err()
     );
     drop(first_pair_guard);
     drop(second_pair_guard);

--- a/crates/exoharness/src/sandbox_provider/firecracker_tests.rs
+++ b/crates/exoharness/src/sandbox_provider/firecracker_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::SandboxKey;
 use tokio::net::UnixListener;
 
 fn test_host_runtime() -> FirecrackerHostFingerprint {
@@ -113,9 +114,42 @@ fn resource_names_and_addresses_are_distinct() {
 fn validates_machine_ids() {
     assert!(valid_machine_id("fc-0123456789abcdef-01234567"));
     assert!(!valid_machine_id("../firecracker"));
-    let one_shot = one_shot_machine_id(&"sandbox".to_string(), "0123456789abcdef", u64::MAX);
+    let one_shot = one_shot_machine_id("sandbox", "0123456789abcdef", u64::MAX);
     assert!(valid_machine_id(&one_shot));
     assert_eq!(one_shot.len(), MAX_MACHINE_ID.len());
+}
+
+#[test]
+fn machine_identity_uses_sandbox_id_without_owner_scope() {
+    let agent = SandboxKey::AgentSandbox {
+        agent_id: "agent".to_string(),
+        sandbox_id: "sandbox".to_string(),
+    };
+    let conversation = SandboxKey::ConversationSandbox {
+        thread_id: "thread".to_string(),
+        sandbox_id: "sandbox".to_string(),
+    };
+    let standalone = SandboxKey::StandaloneSandbox {
+        sandbox_id: "sandbox".to_string(),
+    };
+    let spec_hash = "0123456789abcdef";
+    assert_ne!(agent, conversation);
+    assert_eq!(
+        machine_id(agent.sandbox_id(), spec_hash),
+        machine_id(conversation.sandbox_id(), spec_hash)
+    );
+    assert_eq!(
+        machine_id(agent.sandbox_id(), spec_hash),
+        machine_id(standalone.sandbox_id(), spec_hash)
+    );
+    assert_ne!(
+        machine_id(agent.sandbox_id(), spec_hash),
+        machine_id("another-sandbox", spec_hash)
+    );
+    assert_eq!(
+        sandbox_lifecycle_key(agent.sandbox_id()),
+        sandbox_lifecycle_key(conversation.sandbox_id())
+    );
 }
 
 #[tokio::test]
@@ -147,9 +181,12 @@ async fn lifecycle_locks_serialize_a_machine_family_but_not_other_machines() {
     .await
     .expect("the machine-family lock must be released with its guard");
 
-    let key = "sandbox".to_string();
-    let machine_id = machine_id(&key, "0123456789abcdef");
-    let sandbox_guard = locks.lock_sandbox(&key).await;
+    let key = SandboxKey::AgentSandbox {
+        agent_id: "agent".to_string(),
+        sandbox_id: "sandbox".to_string(),
+    };
+    let machine_id = machine_id(key.sandbox_id(), "0123456789abcdef");
+    let sandbox_guard = locks.lock_sandbox(key.sandbox_id()).await;
     assert!(
         tokio::time::timeout(Duration::from_millis(20), locks.lock_machine(&machine_id))
             .await
@@ -157,18 +194,29 @@ async fn lifecycle_locks_serialize_a_machine_family_but_not_other_machines() {
     );
     drop(sandbox_guard);
 
-    let other_key = "other".to_string();
-    let (first_pair_guard, second_pair_guard) = locks.lock_sandbox_pair(&key, &other_key).await;
+    let other_key = SandboxKey::AgentSandbox {
+        agent_id: "agent".to_string(),
+        sandbox_id: "other".to_string(),
+    };
+    let (first_pair_guard, second_pair_guard) = locks
+        .lock_sandbox_pair(key.sandbox_id(), other_key.sandbox_id())
+        .await;
     assert!(second_pair_guard.is_some());
     assert!(
-        tokio::time::timeout(Duration::from_millis(20), locks.lock_sandbox(&key))
-            .await
-            .is_err()
+        tokio::time::timeout(
+            Duration::from_millis(20),
+            locks.lock_sandbox(key.sandbox_id())
+        )
+        .await
+        .is_err()
     );
     assert!(
-        tokio::time::timeout(Duration::from_millis(20), locks.lock_sandbox(&other_key))
-            .await
-            .is_err()
+        tokio::time::timeout(
+            Duration::from_millis(20),
+            locks.lock_sandbox(other_key.sandbox_id())
+        )
+        .await
+        .is_err()
     );
     drop(first_pair_guard);
     drop(second_pair_guard);

--- a/crates/exoharness/src/sandbox_provider/smolvm.rs
+++ b/crates/exoharness/src/sandbox_provider/smolvm.rs
@@ -1135,7 +1135,7 @@ mod tests {
     #[test]
     fn machine_name_is_stable_and_key_specific() {
         let a = "sandbox-1".into();
-        let b = "sandbox-1".into();
+        let b = "sandbox-2".into();
         assert_eq!(machine_name(&a), machine_name(&a));
         assert_ne!(machine_name(&a), machine_name(&b));
         assert!(machine_name(&a).starts_with("exo-"));

--- a/crates/exoharness/src/sandbox_provider/smolvm.rs
+++ b/crates/exoharness/src/sandbox_provider/smolvm.rs
@@ -1016,10 +1016,7 @@ mod tests {
 
     fn test_request(idle_ttl: Option<Duration>) -> SandboxRequest {
         SandboxRequest {
-            key: SandboxKey::AgentSandbox {
-                agent_id: "a".into(),
-                sandbox_id: "s".into(),
-            },
+            key: "s".into(),
             spec: SandboxSpec {
                 image: "alpine".into(),
                 resources: Default::default(),
@@ -1137,14 +1134,8 @@ mod tests {
 
     #[test]
     fn machine_name_is_stable_and_key_specific() {
-        let a = SandboxKey::AgentSandbox {
-            agent_id: "agent-1".into(),
-            sandbox_id: "sandbox-1".into(),
-        };
-        let b = SandboxKey::ConversationSandbox {
-            thread_id: "agent-1".into(),
-            sandbox_id: "sandbox-1".into(),
-        };
+        let a = "sandbox-1".into();
+        let b = "sandbox-1".into();
         assert_eq!(machine_name(&a), machine_name(&a));
         assert_ne!(machine_name(&a), machine_name(&b));
         assert!(machine_name(&a).starts_with("exo-"));

--- a/crates/exoharness/src/sandbox_provider/smolvm.rs
+++ b/crates/exoharness/src/sandbox_provider/smolvm.rs
@@ -424,8 +424,8 @@ impl ManagedSandboxBackend for SmolvmSandboxBackend {
         reject_unsupported_spec(&request.spec)?;
         match self.resolve_mode(&request).await {
             SmolvmExecutionMode::Warm => {
-                let machine = machine_name(request.key.sandbox_id());
-                self.ensure_machine_started(&machine, &request.spec, request.key.sandbox_id())
+                let machine = machine_name(request.sandbox_id.as_str());
+                self.ensure_machine_started(&machine, &request.spec, request.sandbox_id.as_str())
                     .await?;
                 self.reap_idle_machines(&request, &machine).await;
                 if self.labels_supported().await {
@@ -440,7 +440,7 @@ impl ManagedSandboxBackend for SmolvmSandboxBackend {
             }
             // `Auto` is resolved by `resolve_mode`, so it never reaches here.
             _ => Ok(Arc::new(SmolvmOneShotHandle {
-                id: format!("smolvm-oneshot:{}", request.key.sandbox_id()),
+                id: format!("smolvm-oneshot:{}", request.sandbox_id.as_str()),
                 binary: self.binary.clone(),
                 boot_binary: self.boot_binary().await.clone(),
                 request,
@@ -485,7 +485,7 @@ impl ManagedSandboxBackend for SmolvmSandboxBackend {
             );
         }
 
-        let machine = machine_name(request.key.sandbox_id());
+        let machine = machine_name(request.sandbox_id.as_str());
         // Unconditional: delete already tolerates "not found".
         self.delete_machine_if_present(&machine).await?;
 
@@ -498,7 +498,7 @@ impl ManagedSandboxBackend for SmolvmSandboxBackend {
             .arg("--from")
             .arg(&manifest.pack_path);
         // A restored machine is ours too, or reaping would never see it.
-        self.stamp_labels(&mut create, request.key.sandbox_id())
+        self.stamp_labels(&mut create, request.sandbox_id.as_str())
             .await;
         configure_spec_args(&mut create, &request.spec);
         run_checked(create, "smolvm machine create --from").await?;
@@ -938,7 +938,7 @@ async fn run_checked(mut process: Command, what: &str) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::SandboxKey;
+    use crate::SandboxScope;
     use crate::sandbox::SandboxLifecycleConfig;
 
     /// A configured boot binary is used as given. The point is what does *not*
@@ -1018,10 +1018,10 @@ mod tests {
 
     fn test_request(idle_ttl: Option<Duration>) -> SandboxRequest {
         SandboxRequest {
-            key: SandboxKey::AgentSandbox {
+            sandbox_id: "s".into(),
+            scope: Some(SandboxScope::Agent {
                 agent_id: "a".into(),
-                sandbox_id: "s".into(),
-            },
+            }),
             spec: SandboxSpec {
                 image: "alpine".into(),
                 resources: Default::default(),
@@ -1139,24 +1139,19 @@ mod tests {
 
     #[test]
     fn machine_name_uses_sandbox_id_without_owner_scope() {
-        let a = SandboxKey::AgentSandbox {
-            agent_id: "agent-1".into(),
-            sandbox_id: "sandbox-1".into(),
-        };
-        let b = SandboxKey::ConversationSandbox {
-            thread_id: "agent-1".into(),
-            sandbox_id: "sandbox-1".into(),
-        };
-        assert_eq!(machine_name(a.sandbox_id()), machine_name(a.sandbox_id()));
-        assert_eq!(machine_name(a.sandbox_id()), machine_name(b.sandbox_id()));
-        assert_ne!(machine_name(a.sandbox_id()), machine_name("sandbox-2"));
-        assert!(machine_name(a.sandbox_id()).starts_with("exo-"));
+        let mut request = test_request(None);
+        let name = machine_name(&request.sandbox_id);
+        request.scope = Some(SandboxScope::Conversation {
+            thread_id: "thread".into(),
+        });
+        assert_eq!(name, machine_name(&request.sandbox_id));
+        request.scope = None;
+        assert_eq!(name, machine_name(&request.sandbox_id));
+        request.sandbox_id = "sandbox-2".into();
+        assert_ne!(name, machine_name(&request.sandbox_id));
+        assert!(name.starts_with("exo-"));
         // These go on the CLI and into paths: keep them boring.
-        assert!(
-            machine_name(a.sandbox_id())
-                .chars()
-                .all(|c| c.is_ascii_alphanumeric() || c == '-')
-        );
+        assert!(name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'));
     }
 
     #[test]

--- a/crates/exoharness/src/sandbox_provider/smolvm.rs
+++ b/crates/exoharness/src/sandbox_provider/smolvm.rs
@@ -28,7 +28,7 @@ use tokio::sync::OnceCell;
 
 use crate::SandboxAttachment;
 use crate::sandbox::{
-    ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand, SandboxCommandOutput, SandboxKey,
+    ManagedSandboxBackend, ManagedSandboxHandle, SandboxCommand, SandboxCommandOutput,
     SandboxMountAccess, SandboxNetworkPolicy, SandboxRequest, SandboxSpec, SnapshotFormat,
     SnapshotPayload, WARM_SANDBOX_KEY_LABEL, WARM_SANDBOX_OWNER_PID_LABEL, owner_pid_is_alive,
     run_command, spawn_sandbox_process,
@@ -235,7 +235,7 @@ impl SmolvmSandboxBackend {
         &self,
         name: &str,
         spec: &SandboxSpec,
-        key: &SandboxKey,
+        key: &str,
     ) -> Result<()> {
         let mut create = Command::new(&self.binary);
         create.arg("machine").arg("create").arg("--name").arg(name);
@@ -308,7 +308,7 @@ impl SmolvmSandboxBackend {
 
     /// Record which sandbox a machine serves and which process owns it, under the
     /// same keys the Docker backend uses. A no-op without `--label`.
-    async fn stamp_labels(&self, command: &mut Command, key: &SandboxKey) {
+    async fn stamp_labels(&self, command: &mut Command, key: &str) {
         if !self.labels_supported().await {
             return;
         }
@@ -424,8 +424,8 @@ impl ManagedSandboxBackend for SmolvmSandboxBackend {
         reject_unsupported_spec(&request.spec)?;
         match self.resolve_mode(&request).await {
             SmolvmExecutionMode::Warm => {
-                let machine = machine_name(&request.key);
-                self.ensure_machine_started(&machine, &request.spec, &request.key)
+                let machine = machine_name(request.key.sandbox_id());
+                self.ensure_machine_started(&machine, &request.spec, request.key.sandbox_id())
                     .await?;
                 self.reap_idle_machines(&request, &machine).await;
                 if self.labels_supported().await {
@@ -440,7 +440,7 @@ impl ManagedSandboxBackend for SmolvmSandboxBackend {
             }
             // `Auto` is resolved by `resolve_mode`, so it never reaches here.
             _ => Ok(Arc::new(SmolvmOneShotHandle {
-                id: format!("smolvm-oneshot:{}", request.key),
+                id: format!("smolvm-oneshot:{}", request.key.sandbox_id()),
                 binary: self.binary.clone(),
                 boot_binary: self.boot_binary().await.clone(),
                 request,
@@ -485,7 +485,7 @@ impl ManagedSandboxBackend for SmolvmSandboxBackend {
             );
         }
 
-        let machine = machine_name(&request.key);
+        let machine = machine_name(request.key.sandbox_id());
         // Unconditional: delete already tolerates "not found".
         self.delete_machine_if_present(&machine).await?;
 
@@ -498,7 +498,8 @@ impl ManagedSandboxBackend for SmolvmSandboxBackend {
             .arg("--from")
             .arg(&manifest.pack_path);
         // A restored machine is ours too, or reaping would never see it.
-        self.stamp_labels(&mut create, &request.key).await;
+        self.stamp_labels(&mut create, request.key.sandbox_id())
+            .await;
         configure_spec_args(&mut create, &request.spec);
         run_checked(create, "smolvm machine create --from").await?;
 
@@ -911,9 +912,9 @@ fn is_local_image_ref(image: &str) -> bool {
 
 /// Stable, filesystem-safe machine name for a sandbox key. FNV-1a rather than
 /// `DefaultHasher`, whose output is not stable across processes or releases.
-fn machine_name(key: &SandboxKey) -> String {
+fn machine_name(key: &str) -> String {
     let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
-    for byte in key.to_string().as_bytes() {
+    for byte in key.as_bytes() {
         hash ^= *byte as u64;
         hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
     }
@@ -937,6 +938,7 @@ async fn run_checked(mut process: Command, what: &str) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::SandboxKey;
     use crate::sandbox::SandboxLifecycleConfig;
 
     /// A configured boot binary is used as given. The point is what does *not*
@@ -1016,7 +1018,10 @@ mod tests {
 
     fn test_request(idle_ttl: Option<Duration>) -> SandboxRequest {
         SandboxRequest {
-            key: "s".into(),
+            key: SandboxKey::AgentSandbox {
+                agent_id: "a".into(),
+                sandbox_id: "s".into(),
+            },
             spec: SandboxSpec {
                 image: "alpine".into(),
                 resources: Default::default(),
@@ -1133,15 +1138,22 @@ mod tests {
     }
 
     #[test]
-    fn machine_name_is_stable_and_key_specific() {
-        let a = "sandbox-1".into();
-        let b = "sandbox-2".into();
-        assert_eq!(machine_name(&a), machine_name(&a));
-        assert_ne!(machine_name(&a), machine_name(&b));
-        assert!(machine_name(&a).starts_with("exo-"));
+    fn machine_name_uses_sandbox_id_without_owner_scope() {
+        let a = SandboxKey::AgentSandbox {
+            agent_id: "agent-1".into(),
+            sandbox_id: "sandbox-1".into(),
+        };
+        let b = SandboxKey::ConversationSandbox {
+            thread_id: "agent-1".into(),
+            sandbox_id: "sandbox-1".into(),
+        };
+        assert_eq!(machine_name(a.sandbox_id()), machine_name(a.sandbox_id()));
+        assert_eq!(machine_name(a.sandbox_id()), machine_name(b.sandbox_id()));
+        assert_ne!(machine_name(a.sandbox_id()), machine_name("sandbox-2"));
+        assert!(machine_name(a.sandbox_id()).starts_with("exo-"));
         // These go on the CLI and into paths: keep them boring.
         assert!(
-            machine_name(&a)
+            machine_name(a.sandbox_id())
                 .chars()
                 .all(|c| c.is_ascii_alphanumeric() || c == '-')
         );

--- a/crates/exoharness/src/sandbox_provider/smolvm.rs
+++ b/crates/exoharness/src/sandbox_provider/smolvm.rs
@@ -1141,7 +1141,7 @@ mod tests {
     fn machine_name_uses_sandbox_id_without_owner_scope() {
         let mut request = test_request(None);
         let name = machine_name(&request.sandbox_id);
-        request.scope = Some(SandboxScope::Conversation {
+        request.scope = Some(SandboxScope::Thread {
             thread_id: "thread".into(),
         });
         assert_eq!(name, machine_name(&request.sandbox_id));

--- a/crates/exoharness/src/sandbox_provider/sprites.rs
+++ b/crates/exoharness/src/sandbox_provider/sprites.rs
@@ -3,7 +3,7 @@
 //! Uses the Sprites platform REST API (`api.sprites.dev`) for lifecycle, HTTP
 //! exec for one-shot commands, WebSocket exec for streaming processes, and
 //! checkpoint/restore snapshots. Cross-process resume uses a
-//! deterministic sprite name derived from [`SandboxKey`] + spec hash (same role
+//! deterministic sprite name derived from the sandbox ID + spec hash (same role
 //! as Docker labels / E2B metadata). Snapshots are bytes-by-reference via
 //! [`SnapshotFormat::SpritesRef`] manifests pointing at a checkpoint id.
 
@@ -182,7 +182,7 @@ impl ManagedSandboxBackend for SpritesSandboxBackend {
         let sprite_name = sprite_name_for_request(&request);
         self.ensure_sprite(&sprite_name, &request).await?;
         Ok(Arc::new(SpritesSandboxHandle {
-            id: format!("sprites:{}", request.key.sandbox_id()),
+            id: format!("sprites:{}", request.sandbox_id.as_str()),
             sprite_name,
             request,
             backend: self.handle_backend(),
@@ -228,7 +228,7 @@ impl ManagedSandboxBackend for SpritesSandboxBackend {
         )
         .await?;
         Ok(Arc::new(SpritesSandboxHandle {
-            id: format!("sprites-restored:{}", request.key.sandbox_id()),
+            id: format!("sprites-restored:{}", request.sandbox_id.as_str()),
             sprite_name,
             request,
             backend: self.handle_backend(),
@@ -746,7 +746,7 @@ fn parse_checkpoint_id_from_stream(body: &str) -> Result<String> {
 fn sprite_name_for_request(request: &SandboxRequest) -> String {
     let spec_hash = sandbox_spec_hash(&request.spec);
     let mut hasher = DefaultHasher::new();
-    request.key.sandbox_id().hash(&mut hasher);
+    request.sandbox_id.as_str().hash(&mut hasher);
     spec_hash.hash(&mut hasher);
     format!("exo-{:016x}", hasher.finish())
 }
@@ -780,7 +780,7 @@ fn sprite_labels_for_request(
     let mut labels = Vec::with_capacity(extra_labels.len() + 2);
     labels.push(sprite_label(
         WARM_SANDBOX_KEY_LABEL,
-        request.key.sandbox_id(),
+        request.sandbox_id.as_str(),
     ));
     labels.push(sprite_label(WARM_SANDBOX_SPEC_HASH_LABEL, spec_hash));
     labels.extend(extra_labels.iter().cloned());

--- a/crates/exoharness/src/sandbox_provider/sprites.rs
+++ b/crates/exoharness/src/sandbox_provider/sprites.rs
@@ -182,7 +182,7 @@ impl ManagedSandboxBackend for SpritesSandboxBackend {
         let sprite_name = sprite_name_for_request(&request);
         self.ensure_sprite(&sprite_name, &request).await?;
         Ok(Arc::new(SpritesSandboxHandle {
-            id: format!("sprites:{}", request.key),
+            id: format!("sprites:{}", request.key.sandbox_id()),
             sprite_name,
             request,
             backend: self.handle_backend(),
@@ -228,7 +228,7 @@ impl ManagedSandboxBackend for SpritesSandboxBackend {
         )
         .await?;
         Ok(Arc::new(SpritesSandboxHandle {
-            id: format!("sprites-restored:{}", request.key),
+            id: format!("sprites-restored:{}", request.key.sandbox_id()),
             sprite_name,
             request,
             backend: self.handle_backend(),
@@ -746,7 +746,7 @@ fn parse_checkpoint_id_from_stream(body: &str) -> Result<String> {
 fn sprite_name_for_request(request: &SandboxRequest) -> String {
     let spec_hash = sandbox_spec_hash(&request.spec);
     let mut hasher = DefaultHasher::new();
-    request.key.hash(&mut hasher);
+    request.key.sandbox_id().hash(&mut hasher);
     spec_hash.hash(&mut hasher);
     format!("exo-{:016x}", hasher.finish())
 }
@@ -780,7 +780,7 @@ fn sprite_labels_for_request(
     let mut labels = Vec::with_capacity(extra_labels.len() + 2);
     labels.push(sprite_label(
         WARM_SANDBOX_KEY_LABEL,
-        &request.key.to_string(),
+        request.key.sandbox_id(),
     ));
     labels.push(sprite_label(WARM_SANDBOX_SPEC_HASH_LABEL, spec_hash));
     labels.extend(extra_labels.iter().cloned());

--- a/crates/exoharness/src/sandbox_provider/vercel.rs
+++ b/crates/exoharness/src/sandbox_provider/vercel.rs
@@ -103,7 +103,10 @@ impl VercelSandboxBackend {
         spec_hash: &str,
     ) -> Result<VercelSandboxSessionResponse> {
         let mut tags = HashMap::new();
-        tags.insert(WARM_SANDBOX_KEY_LABEL.to_string(), request.key.to_string());
+        tags.insert(
+            WARM_SANDBOX_KEY_LABEL.to_string(),
+            request.key.sandbox_id().to_string(),
+        );
         tags.insert(
             WARM_SANDBOX_SPEC_HASH_LABEL.to_string(),
             spec_hash.to_string(),
@@ -635,7 +638,7 @@ fn parse_log_stream(text: &str) -> Result<VercelCommandLogs> {
 }
 
 fn vercel_sandbox_name(request: &SandboxRequest, spec_hash: &str) -> String {
-    let key = format!("{}\n{spec_hash}", request.key);
+    let key = format!("{}\n{spec_hash}", request.key.sandbox_id());
     format!("exo-{}", stable_fnv1a_hex(&key))
 }
 

--- a/crates/exoharness/src/sandbox_provider/vercel.rs
+++ b/crates/exoharness/src/sandbox_provider/vercel.rs
@@ -105,7 +105,7 @@ impl VercelSandboxBackend {
         let mut tags = HashMap::new();
         tags.insert(
             WARM_SANDBOX_KEY_LABEL.to_string(),
-            request.key.sandbox_id().to_string(),
+            request.sandbox_id.clone(),
         );
         tags.insert(
             WARM_SANDBOX_SPEC_HASH_LABEL.to_string(),
@@ -638,7 +638,7 @@ fn parse_log_stream(text: &str) -> Result<VercelCommandLogs> {
 }
 
 fn vercel_sandbox_name(request: &SandboxRequest, spec_hash: &str) -> String {
-    let key = format!("{}\n{spec_hash}", request.key.sandbox_id());
+    let key = format!("{}\n{spec_hash}", request.sandbox_id.as_str());
     format!("exo-{}", stable_fnv1a_hex(&key))
 }
 

--- a/exoharness/docs/sandbox-snapshots.md
+++ b/exoharness/docs/sandbox-snapshots.md
@@ -111,7 +111,7 @@ format name includes a version when its wire representation can evolve.
 `ManagedSandboxHandle::snapshot` (Docker):
 
 1. `ensure_warm_sandbox_ready` — make sure the container exists and is the
-   one in the warm cache for this `SandboxKey`.
+   one in the warm cache for this sandbox ID.
 2. `docker commit -p <container> exo-snap-<uuid>` — pause the container
    during commit for a consistent filesystem capture, then create a new
    image from its layers.
@@ -129,7 +129,7 @@ format name includes a version when its wire representation can evolve.
    `Loaded image: <ref>`).
 3. Build a fresh `SandboxRequest` with `spec.image` swapped for the loaded
    reference. Mounts, network policy, default workdir, lifecycle, and
-   `SandboxKey` are preserved from the original request.
+   sandbox ID and optional scope are preserved from the original request.
 4. Evict any pre-existing warm container for this key (we want a fresh
    container booted from the restored image, not a reuse of whatever was
    running before).


### PR DESCRIPTION
Sandbox requests now carry a required `sandbox_id` and an optional `SandboxScope` (`Agent` or `Thread`). Scope contains only the owner ID. Raw allocation needs no scope; harness requests retain their owner context. Provider lookup, warm caches, lifecycle locks, and machine names use the sandbox ID independently of scope.

Firecracker operations gain standard tracing spans, including propagation across blocking launch and snapshot tasks. The optional `ManagedSandboxHandle::is_running` observation checks VMM process exit through a host pidfd without contacting the guest; unsupported backends report no observation. Request arguments and payloads are excluded from spans.

Validation: workspace tests and workspace Clippy with warnings denied pass locally, along with the focused Firecracker tests. Coverage checks scope-free request serialization, required sandbox identity, harness routing, and provider naming independent of scope.
