### PR TITLE
scheduler: wall-clock cron schedules with a seconds field (#264)

### DIFF
--- a/crates/executor/src/scheduler_types.rs
+++ b/crates/executor/src/scheduler_types.rs
@@ -1,7 +1,8 @@
+use std::collections::VecDeque;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Result, anyhow, bail};
-use chrono::DateTime;
+use chrono::{DateTime, Datelike, Duration, Timelike};
 use exoharness::Uuid7;
 use serde::{Deserialize, Serialize};
 
@@ -185,6 +186,213 @@ pub enum ParsedSchedule {
     Every { interval_ms: u64 },
     /// One-shot: fires once at `at_ms`, then the task is done.
     At { at_ms: u64 },
+    /// Wall-clock cron (`sec min hour day-of-month month day-of-week`),
+    /// evaluated in UTC. Unlike [`ParsedSchedule::Every`] the grid is the
+    /// calendar rather than task creation, so a `*/10` seconds field fires at
+    /// :00, :10, :20, … of every minute no matter when the task was created.
+    Cron { schedule: CronSchedule },
+}
+
+/// A single field of a wall-clock cron expression. A field is either one
+/// literal value (`step == 0`) or the arithmetic progression
+/// `first, first + step, …` up to `max`; the `*` wildcard is the progression
+/// that covers the whole range (`first == min, step == 1`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CronField {
+    min: u32,
+    max: u32,
+    first: u32,
+    step: u32,
+}
+
+impl CronField {
+    fn matches(&self, value: u32) -> bool {
+        if value < self.min || value > self.max {
+            return false;
+        }
+        if self.step == 0 {
+            return value == self.first;
+        }
+        value >= self.first && (value - self.first) % self.step == 0
+    }
+
+    /// True when the field accepts every value in its range (`*` or `*/1`).
+    fn is_wildcard(&self) -> bool {
+        self.step == 1 && self.first == self.min
+    }
+
+    /// The values this field accepts, ascending. Fields have at most 12
+    /// (months), so collecting is cheap and only happens at parse time.
+    fn values(&self) -> Vec<u32> {
+        if self.step == 0 {
+            return vec![self.first];
+        }
+        let mut values = Vec::new();
+        let mut value = self.first;
+        while value <= self.max {
+            values.push(value);
+            value = value.saturating_add(self.step);
+        }
+        values
+    }
+}
+
+/// A parsed 5- or 6-field cron expression: `sec min hour day-of-month month
+/// day-of-week`, evaluated in UTC. A 5-field expression is standard cron with
+/// no seconds field (seconds fixed at 0).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CronSchedule {
+    sec: CronField,
+    min: CronField,
+    hour: CronField,
+    dom: CronField,
+    month: CronField,
+    dow: CronField,
+}
+
+impl CronSchedule {
+    /// Cron's day rule: when both day-of-month and day-of-week are restricted,
+    /// a day matches either field. When only one is restricted it governs on
+    /// its own — a wildcard means "matches every day", not "ignore the field".
+    fn day_matches(&self, day: u32, weekday: u32) -> bool {
+        let dom_restricted = !self.dom.is_wildcard();
+        let dow_restricted = !self.dow.is_wildcard();
+        let dom_ok = self.dom.matches(day);
+        let dow_ok = self.dow.matches(weekday);
+        match (dom_restricted, dow_restricted) {
+            (true, true) => dom_ok || dow_ok,
+            (true, false) => dom_ok,
+            (false, true) => dow_ok,
+            (false, false) => true,
+        }
+    }
+
+    /// Next fire strictly after `after_ms`, in UTC epoch milliseconds.
+    ///
+    /// Search is minute-by-minute: every minute contains every possible
+    /// second, so the first minute whose month/day/hour/minute match — with
+    /// the earliest allowed second at or after the lower bound — is the
+    /// earliest fire. The horizon is wider than the widest legitimate gap
+    /// between fires (eight years for a Feb 29 schedule that skips a leap
+    /// year), so every schedule that passes [`ensure_cron_can_fire`] resolves;
+    /// `None` exists only as a safety net.
+    fn next_fire_after_ms(&self, after_ms: u64) -> Option<u64> {
+        let after = DateTime::from_timestamp_millis(i64::try_from(after_ms).ok()?)?;
+        let horizon = after + Duration::seconds(9 * 366 * 86_400);
+        let start_minute_ms = after_ms - after_ms % 60_000;
+        let mut minute = DateTime::from_timestamp_millis(i64::try_from(start_minute_ms).ok()?)?;
+        let mut at_start_minute = true;
+        loop {
+            if minute > horizon {
+                return None;
+            }
+            if self.month.matches(minute.month())
+                && self.day_matches(minute.day(), minute.weekday().num_days_from_sunday())
+                && self.hour.matches(minute.hour())
+                && self.min.matches(minute.minute())
+            {
+                // Inside the starting minute, seconds at or below the second we
+                // started from have already passed; later minutes start over.
+                let lower = if at_start_minute { after.second() + 1 } else { 0 };
+                if let Some(sec) = self.seconds_at_or_after(lower) {
+                    return Some((minute.timestamp_millis() as u64) + u64::from(sec) * 1_000);
+                }
+            }
+            at_start_minute = false;
+            minute = minute + Duration::seconds(60);
+        }
+    }
+
+    fn seconds_at_or_after(&self, lower: u32) -> Option<u32> {
+        if self.sec.step == 0 {
+            return (self.sec.first >= lower).then_some(self.sec.first);
+        }
+        let first = if self.sec.first >= lower {
+            self.sec.first
+        } else {
+            let steps = (lower - self.sec.first).div_ceil(self.sec.step);
+            self.sec.first + steps * self.sec.step
+        };
+        (first <= self.sec.max).then_some(first)
+    }
+}
+
+fn parse_cron_field(raw: &str, min: u32, max: u32, name: &str) -> Result<CronField> {
+    if raw == "*" {
+        return Ok(CronField {
+            min,
+            max,
+            first: min,
+            step: 1,
+        });
+    }
+    if let Some(step) = raw.strip_prefix("*/") {
+        let step: u32 = step.parse().map_err(|_| {
+            anyhow!("cron {name} step must be a positive integer, e.g. '*/{step}'")
+        })?;
+        if step == 0 {
+            bail!("cron {name} step must be greater than zero");
+        }
+        return Ok(CronField {
+            min,
+            max,
+            first: min,
+            step,
+        });
+    }
+    let value: u32 = raw.parse().map_err(|_| {
+        anyhow!("cron {name} must be '*', '*/<step>', or an integer between {min} and {max}")
+    })?;
+    if value < min || value > max {
+        bail!("cron {name} must be between {min} and {max}, got {value}");
+    }
+    Ok(CronField {
+        min,
+        max,
+        first: value,
+        step: 0,
+    })
+}
+
+fn parse_cron_dow(raw: &str) -> Result<CronField> {
+    let mut field = parse_cron_field(raw, 0, 7, "day-of-week")?;
+    // 7 is a common alias for Sunday (0); a week has no day 7.
+    if field.step == 0 && field.first == 7 {
+        field.first = 0;
+    }
+    field.max = 6;
+    Ok(field)
+}
+
+/// Rejects cron expressions that can never fire. A restricted day-of-week
+/// matches some day in every month, so the only impossible schedules pair a
+/// restricted day-of-month with months too short for any of its days (e.g.
+/// Feb 30). Feb 29 is allowed: it is a real fire every leap year.
+fn ensure_cron_can_fire(schedule: &CronSchedule) -> Result<()> {
+    // A restricted day-of-week matches some day in every month, so only a
+    // wildcard day-of-week can leave day-of-month in sole charge.
+    if !schedule.dow.is_wildcard() || schedule.dom.is_wildcard() {
+        return Ok(());
+    }
+    let max_days = |month: u32| match month {
+        2 => 29, // leap-agnostic: Feb 29 fires every four years
+        4 | 6 | 9 | 11 => 30,
+        _ => 31,
+    };
+    // `dom.first` is the smallest allowed day, so if it fits in any allowed
+    // month the schedule fires.
+    let can_fire = schedule
+        .month
+        .values()
+        .iter()
+        .any(|month| schedule.dom.first <= max_days(*month));
+    if can_fire {
+        return Ok(());
+    }
+    bail!(
+        "cron day-of-month {} never occurs in the allowed month(s)",
+        schedule.dom.first
+    );
 }
 
 impl ScheduledTaskRecord {
@@ -289,8 +497,15 @@ impl ScheduledTaskRecord {
     pub fn plan_missed_fires(&self, now_ms: u64) -> Result<MissedFirePlan> {
         let schedule = parse_schedule(&self.schedule)?;
         let due_slot_ms = self.next_run_at_ms;
-        let interval_ms = match schedule {
-            ParsedSchedule::Every { interval_ms } => interval_ms,
+        let (fire_slots, backlog, truncated) = match schedule {
+            ParsedSchedule::Every { interval_ms } => {
+                self.owed_grid_plan(due_slot_ms, now_ms, |slot| {
+                    Some(slot.saturating_add(interval_ms))
+                })
+            }
+            ParsedSchedule::Cron { schedule } => self.owed_grid_plan(due_slot_ms, now_ms, |slot| {
+                schedule.next_fire_after_ms(slot)
+            }),
             // A one-shot has no grid and so no backlog: it fires once whenever
             // the runner reaches it, late or not, and is then terminal.
             ParsedSchedule::At { at_ms } => {
@@ -315,26 +530,6 @@ impl ScheduledTaskRecord {
                 });
             }
         };
-        let elapsed_ms = now_ms.saturating_sub(due_slot_ms);
-        // Slots that came and went behind the due one.
-        let overdue = elapsed_ms / interval_ms;
-        let backlog = overdue.saturating_add(1);
-
-        let mut truncated = false;
-        let fire_slots: Vec<u64> = match self.missed {
-            MissedPolicy::Skip if overdue > 0 => Vec::new(),
-            MissedPolicy::All if overdue > 0 => {
-                let cap = u64::from(MAX_MISSED_FIRE_CATCHUP);
-                truncated = backlog > cap;
-                // Keep the newest slots when capped: their results are the ones
-                // still worth reporting.
-                let first = backlog.saturating_sub(cap.min(backlog));
-                (first..backlog)
-                    .map(|slot| due_slot_ms.saturating_add(slot.saturating_mul(interval_ms)))
-                    .collect()
-            }
-            _ => vec![due_slot_ms],
-        };
 
         let fired_slots = u32::try_from(fire_slots.len()).unwrap_or(u32::MAX);
         let skipped_slots =
@@ -352,6 +547,49 @@ impl ScheduledTaskRecord {
                 truncated,
             },
         })
+    }
+
+    /// Enumerates the grid slots a due task owes at `now_ms`: the stored due
+    /// slot plus every later slot that has come and gone, walking the grid with
+    /// `next_slot`. Both grid schedules (interval and wall-clock cron) share
+    /// this — they differ only in what "the next slot" is — so the missed-fire
+    /// policy is applied once here. Returns the slots that fire under the
+    /// policy (oldest-first, capped at the newest
+    /// [`MAX_MISSED_FIRE_CATCHUP`] when truncated), the total backlog, and
+    /// whether it was truncated.
+    fn owed_grid_plan(
+        &self,
+        due_slot_ms: u64,
+        now_ms: u64,
+        next_slot: impl Fn(u64) -> Option<u64>,
+    ) -> (Vec<u64>, u64, bool) {
+        let cap = u64::from(MAX_MISSED_FIRE_CATCHUP);
+        // Keep a sliding window of the newest slots so an unbounded backlog
+        // never materializes in memory.
+        let mut newest = VecDeque::with_capacity(cap as usize);
+        let mut backlog: u64 = 0;
+        let mut slot = due_slot_ms;
+        loop {
+            backlog = backlog.saturating_add(1);
+            newest.push_back(slot);
+            if newest.len() as u64 > cap {
+                newest.pop_front();
+            }
+            match next_slot(slot) {
+                Some(next) if next <= now_ms => slot = next,
+                _ => break,
+            }
+        }
+        let fire_slots = match self.missed {
+            // One slot behind is the normal polling case and fires under every
+            // policy; only a deeper backlog is a policy decision.
+            MissedPolicy::Skip if backlog > 1 => Vec::new(),
+            // Keep the newest slots when capped: their results are the ones
+            // still worth reporting.
+            MissedPolicy::All if backlog > 1 => newest.into_iter().collect(),
+            _ => vec![due_slot_ms],
+        };
+        (fire_slots, backlog, backlog > cap)
     }
 
     /// Applies a plan once its fires are done: back onto the grid, lease
@@ -374,7 +612,8 @@ impl ParsedSchedule {
     /// First slot strictly after `after_ms` on the grid anchored at
     /// `anchor_ms`. The anchor itself is not a slot: the first fire of a new
     /// task is one interval after it was created. A one-shot has no grid, so
-    /// its only slot is its timestamp.
+    /// its only slot is its timestamp. Wall-clock cron ignores the anchor — its
+    /// grid is the calendar — and resolves against the calendar instead.
     pub fn next_slot_after_ms(&self, anchor_ms: u64, after_ms: u64) -> u64 {
         match self {
             Self::Every { interval_ms } => {
@@ -383,6 +622,7 @@ impl ParsedSchedule {
                 anchor_ms.saturating_add(slots.saturating_mul(*interval_ms))
             }
             Self::At { at_ms } => *at_ms,
+            Self::Cron { schedule } => schedule.next_fire_after_ms(after_ms).unwrap_or(u64::MAX),
         }
     }
 }
@@ -434,12 +674,14 @@ pub fn parse_schedule(raw: &str) -> Result<ParsedSchedule> {
     }
 
     let parts = schedule.split_whitespace().collect::<Vec<_>>();
+    // `*/N * * * *` — the pre-existing minute-interval grid, anchored to task
+    // creation. It is intentionally checked first and kept exactly as it was:
+    // reinterpreting an accepted schedule would silently shift every task that
+    // already uses it. Wall-clock cron below is a new grammar for strings that
+    // previously errored.
     if parts.len() == 5
         && parts[0].starts_with("*/")
-        && parts[1] == "*"
-        && parts[2] == "*"
-        && parts[3] == "*"
-        && parts[4] == "*"
+        && parts[1..].iter().all(|part| *part == "*")
     {
         let minutes = parts[0]
             .trim_start_matches("*/")
@@ -453,7 +695,29 @@ pub fn parse_schedule(raw: &str) -> Result<ParsedSchedule> {
         });
     }
 
-    bail!("schedule must be '@every <duration>', '@at <rfc3339>', or '*/N * * * *'");
+    if parts.len() == 5 || parts.len() == 6 {
+        // Wall-clock cron. Six fields are `sec min hour day month weekday`;
+        // five fields are standard cron with no seconds field (seconds = 0).
+        let (seconds, min, hour, dom, month, dow) = if parts.len() == 6 {
+            (parts[0], parts[1], parts[2], parts[3], parts[4], parts[5])
+        } else {
+            ("0", parts[0], parts[1], parts[2], parts[3], parts[4])
+        };
+        let schedule = CronSchedule {
+            sec: parse_cron_field(seconds, 0, 59, "second")?,
+            min: parse_cron_field(min, 0, 59, "minute")?,
+            hour: parse_cron_field(hour, 0, 23, "hour")?,
+            dom: parse_cron_field(dom, 1, 31, "day-of-month")?,
+            month: parse_cron_field(month, 1, 12, "month")?,
+            dow: parse_cron_dow(dow)?,
+        };
+        ensure_cron_can_fire(&schedule)?;
+        return Ok(ParsedSchedule::Cron { schedule });
+    }
+
+    bail!(
+        "schedule must be '@every <duration>', '@at <rfc3339>', '*/N * * * *' (every N minutes), or 5/6-field cron like '*/10 * * * * *' (sec min hour day month weekday, UTC)"
+    );
 }
 
 fn parse_interval(raw: &str) -> Result<ParsedSchedule> {
@@ -524,6 +788,14 @@ fn non_empty(field: &str, value: String) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // `Utc.with_ymd_and_hms` needs the `TimeZone` trait in scope.
+    use chrono::{TimeZone, Utc};
+
+    fn utc_ms(y: i32, mo: u32, d: u32, h: u32, mi: u32, s: u32) -> u64 {
+        Utc.with_ymd_and_hms(y, mo, d, h, mi, s)
+            .unwrap()
+            .timestamp_millis() as u64
+    }
 
     #[test]
     fn parses_every_interval() {
@@ -547,7 +819,137 @@ mod tests {
 
     #[test]
     fn rejects_invalid_schedule() {
-        assert!(parse_schedule("* * * * *").is_err());
+        // Second-level cron fields are range-checked on both ends.
+        assert!(parse_schedule("60 * * * * *").is_err());
+        assert!(parse_schedule("0 0 24 * * *").is_err());
+        assert!(parse_schedule("0 0 0 0 * *").is_err());
+        assert!(parse_schedule("0 0 0 32 * *").is_err());
+        assert!(parse_schedule("0 0 0 1 13 *").is_err());
+        assert!(parse_schedule("0 0 0 * * 8").is_err());
+        // Cron supports steps, wildcards, and single values — nothing else.
+        assert!(parse_schedule("1,2 * * * * *").is_err());
+        assert!(parse_schedule("1-5 * * * * *").is_err());
+        assert!(parse_schedule("@mon * * * * *").is_err());
+        // Neither 4 fields nor 7 fields are cron.
+        assert!(parse_schedule("* * * *").is_err());
+        assert!(parse_schedule("* * * * * * *").is_err());
+        // A Feb 30 schedule can never fire.
+        assert!(parse_schedule("0 0 0 30 2 *").is_err());
+        assert!(parse_schedule("0 0 0 31 2 *").is_err());
+    }
+
+    #[test]
+    fn parses_wall_clock_cron_schedules() {
+        // Every second.
+        let every_second = parse_schedule("* * * * * *").unwrap();
+        assert_eq!(
+            every_second.next_slot_after_ms(0, utc_ms(2026, 1, 1, 0, 0, 0)),
+            utc_ms(2026, 1, 1, 0, 0, 1)
+        );
+        // Seconds steps are anchored to the wall clock.
+        let ten_seconds = parse_schedule("*/10 * * * * *").unwrap();
+        assert_eq!(
+            ten_seconds.next_slot_after_ms(0, utc_ms(2026, 1, 1, 0, 0, 5)),
+            utc_ms(2026, 1, 1, 0, 0, 10)
+        );
+        // Strictly after: landing exactly on a fire moves to the next one.
+        assert_eq!(
+            ten_seconds.next_slot_after_ms(0, utc_ms(2026, 1, 1, 0, 0, 10)),
+            utc_ms(2026, 1, 1, 0, 0, 20)
+        );
+        // 5-field cron is standard cron: no seconds field, seconds = 0.
+        let daily = parse_schedule("30 6 * * *").unwrap();
+        assert_eq!(
+            daily.next_slot_after_ms(0, utc_ms(2026, 1, 1, 6, 29, 59)),
+            utc_ms(2026, 1, 1, 6, 30, 0)
+        );
+        assert_eq!(
+            daily.next_slot_after_ms(0, utc_ms(2026, 1, 1, 6, 30, 0)),
+            utc_ms(2026, 1, 2, 6, 30, 0),
+            "exactly on the fire, the next one is a day later"
+        );
+    }
+
+    #[test]
+    fn cron_carries_across_minute_and_day_boundaries() {
+        let ten_seconds = parse_schedule("*/10 * * * * *").unwrap();
+        // :55 rolls into the next minute at :00 of the next minute.
+        assert_eq!(
+            ten_seconds.next_slot_after_ms(0, utc_ms(2026, 1, 1, 0, 0, 55)),
+            utc_ms(2026, 1, 1, 0, 1, 0)
+        );
+        let midnight = parse_schedule("0 0 * * *").unwrap();
+        assert_eq!(
+            midnight.next_slot_after_ms(0, utc_ms(2026, 1, 1, 23, 59, 59)),
+            utc_ms(2026, 1, 2, 0, 0, 0)
+        );
+        let last_second = parse_schedule("59 59 23 * * *").unwrap();
+        assert_eq!(
+            last_second.next_slot_after_ms(0, utc_ms(2026, 1, 1, 23, 59, 59)),
+            utc_ms(2026, 1, 2, 23, 59, 59)
+        );
+    }
+
+    #[test]
+    fn cron_matches_day_of_week_and_month() {
+        // 2026-01-01 is a Thursday; the next Sunday is the 4th, and 7 is an
+        // alias for Sunday.
+        let sunday = parse_schedule("0 0 0 * * 0").unwrap();
+        let sunday_as_seven = parse_schedule("0 0 0 * * 7").unwrap();
+        let want = utc_ms(2026, 1, 4, 0, 0, 0);
+        assert_eq!(sunday.next_slot_after_ms(0, utc_ms(2026, 1, 1, 0, 0, 0)), want);
+        assert_eq!(
+            sunday_as_seven.next_slot_after_ms(0, utc_ms(2026, 1, 1, 0, 0, 0)),
+            want
+        );
+        // Mondays in January only (month and day-of-week both restricted).
+        let mondays_in_january = parse_schedule("0 0 0 * 1 1").unwrap();
+        assert_eq!(
+            mondays_in_january.next_slot_after_ms(0, utc_ms(2026, 1, 1, 0, 0, 0)),
+            utc_ms(2026, 1, 5, 0, 0, 0)
+        );
+        assert_eq!(
+            mondays_in_january.next_slot_after_ms(0, utc_ms(2026, 2, 1, 0, 0, 0)),
+            utc_ms(2027, 1, 4, 0, 0, 0),
+            "February has no fire; the next January Monday is 2027-01-04"
+        );
+        // A year boundary: Jan 1 only.
+        let new_years = parse_schedule("0 0 0 1 1 *").unwrap();
+        assert_eq!(
+            new_years.next_slot_after_ms(0, utc_ms(2026, 6, 1, 0, 0, 0)),
+            utc_ms(2027, 1, 1, 0, 0, 0)
+        );
+    }
+
+    #[test]
+    fn cron_matches_day_of_month_or_day_of_week() {
+        // The 13th, or any Friday: 2026-02-01 is a Sunday, so the next fire is
+        // Friday the 6th (day-of-week match), not the 13th.
+        let thirteenth_or_friday = parse_schedule("0 0 0 13 * 5").unwrap();
+        assert_eq!(
+            thirteenth_or_friday.next_slot_after_ms(0, utc_ms(2026, 2, 1, 0, 0, 0)),
+            utc_ms(2026, 2, 6, 0, 0, 0)
+        );
+        // The day-of-month half still fires: February 2026 has a Friday the
+        // 13th, but the 6th already matched, so walk past it.
+        assert_eq!(
+            thirteenth_or_friday.next_slot_after_ms(0, utc_ms(2026, 2, 6, 0, 0, 0)),
+            utc_ms(2026, 2, 13, 0, 0, 0)
+        );
+    }
+
+    #[test]
+    fn cron_leap_day_fires_in_leap_years_only() {
+        let feb_29 = parse_schedule("0 0 0 29 2 *").unwrap();
+        assert_eq!(
+            feb_29.next_slot_after_ms(0, utc_ms(2027, 6, 1, 0, 0, 0)),
+            utc_ms(2028, 2, 29, 0, 0, 0)
+        );
+        // Right after a leap day, the next one is four years out.
+        assert_eq!(
+            feb_29.next_slot_after_ms(0, utc_ms(2028, 2, 29, 0, 0, 0)),
+            utc_ms(2032, 2, 29, 0, 0, 0)
+        );
     }
 
     /// Every test below drives time by hand — the scheduler's clock is a `u64`
@@ -811,6 +1213,127 @@ mod tests {
         task.resume_after_fires(&plan, 1_000);
         assert_eq!(task.completed_at_ms, None);
         assert!(task.is_due(2_000));
+    }
+
+    /// A cron task record created at `now_ms`; `new` schedules its first fire
+    /// on the wall clock, strictly after creation.
+    fn cron_task(schedule: &str, now_ms: u64, missed: MissedPolicy) -> ScheduledTaskRecord {
+        ScheduledTaskRecord::new(
+            NewScheduledTask {
+                agent_id: "agent".to_string(),
+                conversation_id: "conversation".to_string(),
+                name: "cron".to_string(),
+                schedule: schedule.to_string(),
+                sandbox_mode: None,
+                setup_command: None,
+                command: vec!["true".to_string()],
+                report_prompt: "Report.".to_string(),
+                max_output_bytes: None,
+                missed: Some(missed),
+            },
+            now_ms,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn cron_task_schedules_its_first_fire_on_the_wall_clock() {
+        // Created at :07, the first */10s fire is :10 — the grid is the
+        // calendar, not "seven seconds after creation".
+        let task = cron_task("*/10 * * * * *", utc_ms(2026, 1, 1, 0, 0, 7), MissedPolicy::Once);
+        assert_eq!(task.next_run_at_ms, utc_ms(2026, 1, 1, 0, 0, 10));
+        assert!(!task.is_due(utc_ms(2026, 1, 1, 0, 0, 9)));
+        assert!(task.is_due(utc_ms(2026, 1, 1, 0, 0, 10)));
+    }
+
+    #[test]
+    fn cron_missed_fires_follow_the_policy() {
+        let t0 = utc_ms(2026, 1, 1, 0, 0, 0);
+        let now = t0 + 2_500;
+        for (policy, want_fires, want_skipped) in [
+            (MissedPolicy::Skip, 0, 3),
+            (MissedPolicy::Once, 1, 2),
+            (MissedPolicy::All, 3, 0),
+        ] {
+            let mut task = cron_task("* * * * * *", t0, policy);
+            task.next_run_at_ms = t0;
+            let plan = task.plan_missed_fires(now).unwrap();
+            assert_eq!(plan.fire_slots.len(), want_fires, "policy {policy:?}");
+            assert_eq!(plan.outcome.skipped_slots, want_skipped, "policy {policy:?}");
+            assert_eq!(
+                plan.next_run_at_ms,
+                t0 + 3_000,
+                "policy {policy:?} resumes on the next future second"
+            );
+            assert!(!plan.completes, "policy {policy:?}");
+        }
+        // A task noticed exactly when it comes due (the normal polling case)
+        // fires once under every policy, even Skip.
+        let mut task = cron_task("* * * * * *", t0, MissedPolicy::Skip);
+        task.next_run_at_ms = t0;
+        let plan = task.plan_missed_fires(t0 + 1).unwrap();
+        assert_eq!(plan.fire_slots, vec![t0]);
+        assert_eq!(plan.outcome.skipped_slots, 0);
+    }
+
+    #[test]
+    fn cron_all_policy_caps_the_backlog_and_keeps_the_newest() {
+        let t0 = utc_ms(2026, 1, 1, 0, 0, 0);
+        let mut task = cron_task("* * * * * *", t0, MissedPolicy::All);
+        task.next_run_at_ms = t0;
+        // 151 seconds of downtime on a 1s grid.
+        let plan = task.plan_missed_fires(t0 + 150_000).unwrap();
+        assert_eq!(plan.fire_slots.len(), MAX_MISSED_FIRE_CATCHUP as usize);
+        assert_eq!(
+            plan.fire_slots.last().copied(),
+            Some(t0 + 150_000),
+            "the freshest owed slot must be one of the ones we fire"
+        );
+        assert_eq!(plan.fire_slots.first().copied(), Some(t0 + 51_000));
+        assert!(plan.outcome.truncated);
+        assert_eq!(plan.outcome.fired_slots, MAX_MISSED_FIRE_CATCHUP);
+        assert_eq!(plan.outcome.skipped_slots, 51);
+        assert_eq!(plan.next_run_at_ms, t0 + 151_000);
+    }
+
+    #[test]
+    fn cron_resume_after_fires_stays_on_the_wall_clock_grid() {
+        let mut task = cron_task("*/10 * * * * *", utc_ms(2026, 1, 1, 0, 0, 0), MissedPolicy::Once);
+        task.next_run_at_ms = utc_ms(2026, 1, 1, 0, 0, 10);
+
+        let plan = task
+            .plan_missed_fires(utc_ms(2026, 1, 1, 0, 0, 12))
+            .unwrap();
+        assert_eq!(plan.fire_slots, vec![utc_ms(2026, 1, 1, 0, 0, 10)]);
+
+        task.resume_after_fires(&plan, utc_ms(2026, 1, 1, 0, 0, 12));
+        assert_eq!(task.next_run_at_ms, utc_ms(2026, 1, 1, 0, 0, 20));
+        assert!(!task.is_due(utc_ms(2026, 1, 1, 0, 0, 19)));
+        assert!(task.is_due(utc_ms(2026, 1, 1, 0, 0, 20)));
+    }
+
+    #[test]
+    #[ignore = "uses the real wall clock; run explicitly with --ignored"]
+    fn cron_every_second_grid_keeps_firing_against_the_real_clock() {
+        let schedule = parse_schedule("* * * * * *").unwrap();
+        let mut task = cron_task("* * * * * *", now_ms(), MissedPolicy::Once);
+        let started = now_ms();
+
+        // The runner claims the first due slot, then resumes onto the next
+        // wall-clock second — twice — without sleeping in the test.
+        for _ in 0..2 {
+            std::thread::sleep(std::time::Duration::from_millis(
+                task.next_run_at_ms.saturating_sub(now_ms()) + 50,
+            ));
+            assert!(task.is_due(now_ms()), "task should be due on the wall clock");
+            let plan = task.plan_missed_fires(now_ms()).unwrap();
+            assert_eq!(plan.fire_slots.len(), 1);
+            task.resume_after_fires(&plan, now_ms());
+        }
+        assert!(task.next_run_at_ms > started);
+        // The very next scheduled fire is one second after the resume.
+        let next = schedule.next_slot_after_ms(0, task.next_run_at_ms);
+        assert_eq!(next - task.next_run_at_ms, 1_000);
     }
 
     #[test]

--- a/exo/harness.ts
+++ b/exo/harness.ts
@@ -79,7 +79,7 @@ export async function exoInstructions(
 
 ## Scheduled tasks
 You can schedule recurring sandbox work with schedule_sandbox_task, inspect active tasks with list_scheduled_tasks, cancel tasks with cancel_scheduled_task, and permanently delete tasks with delete_scheduled_task.
-Schedules are '@every <duration>', '*/N * * * *', or '@at <rfc3339>' for a one-shot; a one-shot fires once and is then completed, and completed tasks stay listed but never run again.
+Schedules are '@every <duration>', '*/N * * * *' (every N minutes from creation), wall-clock cron like '0 0 5 * * *' or '*/10 * * * * *' (sec min hour day month weekday, evaluated in UTC; five fields leave seconds at 0), or '@at <rfc3339>' for a one-shot; a one-shot fires once and is then completed, and completed tasks stay listed but never run again.
 Fires land on the schedule's own grid, not on when the previous run finished, so a slow run does not drift the schedule.
 Use missed to say what a host that was down owes a task: 'skip' drops the missed slots, 'once' fires one catch-up and resumes (the default), 'all' fires every missed slot up to 100. Prefer 'skip' when a stale run is worse than no run.
 

--- a/exo/tools/scheduler-tools.ts
+++ b/exo/tools/scheduler-tools.ts
@@ -55,7 +55,7 @@ function createScheduleSandboxTaskTool(): ToolInstance {
           schedule: {
             type: "string",
             description:
-              "Schedule as '@every 10m', '@every 1h', a simple cron interval like '*/30 * * * *', or '@at 2026-07-26T17:00:00Z' for a one-shot. Recurring fires land on the schedule's own grid rather than on when the last run finished, so a slow run does not push later fires later. A one-shot fires once, is then marked completed, and stays listed without ever running again.",
+              "Schedule as '@every 10m', '@every 1h', a simple cron interval like '*/30 * * * *', wall-clock cron like '0 0 5 * * *' (5 fields) or '*/10 * * * * *' (6 fields; sec min hour day month weekday, UTC), or '@at 2026-07-26T17:00:00Z' for a one-shot. Recurring fires land on the schedule's own grid rather than on when the last run finished, so a slow run does not push later fires later. A one-shot fires once, is then marked completed, and stays listed without ever running again.",
           },
           missed: {
             anyOf: [


### PR DESCRIPTION
Adds 5/6-field wall-clock cron to scheduled tasks, fixing #264: today the only 'cron' form is '*/N * * * *', which is a minute-resolution interval grid anchored to task creation, so it neither supports seconds nor syncs with the wall clock.

## Change

- parse_schedule accepts 5-field (standard cron, seconds = 0) and 6-field 'sec min hour day month weekday' expressions. Fields are '*', '*/N', or a literal; ranges and lists are rejected with a clear message.
- New ParsedSchedule::Cron variant with its own next-fire computation, walked minute-by-minute in UTC (chrono is already a dependency). Cron honors the standard day rule (dom OR dow when both are restricted) and 0/7 both mean Sunday. Expressions that can never fire (Feb 30) are rejected at parse time; Feb 29 is a valid leap-year schedule.
- Missed-fire planning is shared between interval and cron grids via one enumerator, so skip/once/all, the 100-slot cap, and the newest-slot truncation behave identically for both.
- The model-facing grammar text in harness.ts and the schedule_sandbox_task schema description now document the cron forms.

## Semantics

- Existing schedules are untouched: '@every', '@at', and '*/N * * * *' keep their exact current meaning (the minute-interval form is still anchored to creation). Cron is a new grammar for strings that previously errored, evaluated in UTC.
- No schema bump: schedules are stored as raw strings and re-parsed per evaluation, so nothing on disk changes.
- Cron precision is bounded by the runner's polling interval (exo.sh defaults to --interval-seconds 10), so sub-minute cron lands within one poll of its wall-clock second.

Tests drive time by hand through the u64 clock, as the rest of the module does. Calendar expectations (weekdays, leap years, month lengths) were cross-checked against an independent UTC oracle.