### PR TITLE
scheduler: don't resurrect a task deleted mid-run (#276)

### DIFF
--- a/crates/executor/src/scheduler_store.rs
+++ b/crates/executor/src/scheduler_store.rs
@@ -26,7 +26,7 @@ impl SchedulerStore {
 
     pub async fn create_task(&self, request: NewScheduledTask) -> Result<ScheduledTaskRecord> {
         let task = ScheduledTaskRecord::new(request, now_ms())?;
-        self.put_task(&task).await?;
+        self.write_task(&task, Write::Create).await?;
         Ok(task)
     }
 
@@ -114,12 +114,31 @@ impl SchedulerStore {
         }
     }
 
+    /// Updates an existing task record.
+    ///
+    /// A fire runs a model turn, so a task can be deleted while a run holds a
+    /// copy of its record. Writing that copy back must not recreate the task,
+    /// so this replaces an existing record and is a no-op once the task is
+    /// gone. The check and the write happen under the tasks lock, so a delete
+    /// cannot land between them. Use `create_task` to add a task.
     pub async fn put_task(&self, task: &ScheduledTaskRecord) -> Result<()> {
+        self.write_task(task, Write::Replace).await
+    }
+
+    async fn write_task(&self, task: &ScheduledTaskRecord, mode: Write) -> Result<()> {
         fs::create_dir_all(self.tasks_dir()).await?;
+        let root = self.root.clone();
         let path = self.task_path(&task.id);
-        write_json_file(&path, task)
-            .await
-            .with_context(|| format!("failed to write scheduled task {}", path.display()))
+        let bytes = serde_json::to_vec_pretty(task)?;
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let _lock = TasksLock::acquire(&root)?;
+            if mode == Write::Replace && !path.exists() {
+                return Ok(());
+            }
+            write_json_file_blocking(&path, &bytes)
+                .with_context(|| format!("failed to write scheduled task {}", path.display()))
+        })
+        .await?
     }
 
     pub async fn disable_task(&self, task_id: &str) -> Result<Option<ScheduledTaskRecord>> {
@@ -136,7 +155,13 @@ impl SchedulerStore {
         let Some(task) = self.get_task(task_id).await? else {
             return Ok(None);
         };
-        remove_file_if_exists(self.task_path(task_id)).await?;
+        let root = self.root.clone();
+        let path = self.task_path(task_id);
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            let _lock = TasksLock::acquire(&root)?;
+            remove_file_if_exists_blocking(&path)
+        })
+        .await??;
         remove_dir_if_exists(self.runs_dir(task_id)).await?;
         Ok(Some(task))
     }
@@ -264,11 +289,16 @@ fn decode_task(bytes: &[u8]) -> Result<ScheduledTaskRecord> {
 /// record intact instead of a half-written one. Same shape as the adapter
 /// store's writer.
 async fn write_json_file<T: Serialize>(path: &Path, value: &T) -> Result<()> {
+    let bytes = serde_json::to_vec_pretty(value)?;
+    let path = path.to_path_buf();
+    tokio::task::spawn_blocking(move || write_json_file_blocking(&path, &bytes)).await?
+}
+
+fn write_json_file_blocking(path: &Path, bytes: &[u8]) -> Result<()> {
     let temp_path = path.with_extension(format!("json.{}.tmp", Uuid7::now()));
-    fs::write(&temp_path, serde_json::to_vec_pretty(value)?)
-        .await
+    std::fs::write(&temp_path, bytes)
         .with_context(|| format!("failed to write temp file {}", temp_path.display()))?;
-    fs::rename(&temp_path, path).await.with_context(|| {
+    std::fs::rename(&temp_path, path).with_context(|| {
         format!(
             "failed to replace {} with temp file {}",
             path.display(),
@@ -277,8 +307,44 @@ async fn write_json_file<T: Serialize>(path: &Path, value: &T) -> Result<()> {
     })
 }
 
-async fn remove_file_if_exists(path: PathBuf) -> Result<()> {
-    match fs::remove_file(&path).await {
+/// Whether a task file may be created, or only replaced if it still exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Write {
+    Create,
+    Replace,
+}
+
+/// Serializes task-file writes against deletes across processes: the runner,
+/// the CLI, and the harness all touch the same directory. Held around the file
+/// operations only, never across a run, and released by the OS if a holder
+/// dies.
+struct TasksLock(std::fs::File);
+
+impl TasksLock {
+    fn acquire(root: &Path) -> Result<Self> {
+        let path = root.join("tasks.lock");
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&path)
+            .with_context(|| format!("failed to open tasks lock {}", path.display()))?;
+        file.lock()
+            .with_context(|| format!("failed to lock tasks lock {}", path.display()))?;
+        Ok(Self(file))
+    }
+}
+
+impl Drop for TasksLock {
+    fn drop(&mut self) {
+        if let Err(error) = self.0.unlock() {
+            tracing::error!(%error, "failed to release scheduler tasks lock");
+        }
+    }
+}
+
+fn remove_file_if_exists_blocking(path: &Path) -> Result<()> {
+    match std::fs::remove_file(path) {
         Ok(()) => Ok(()),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(error) => {
@@ -367,6 +433,40 @@ mod tests {
         let deleted = store.delete_task(&task.id).await.unwrap().unwrap();
         assert_eq!(deleted.id, task.id);
         assert!(store.get_task(&task.id).await.unwrap().is_none());
+    }
+
+    /// A run holds a task record across a fire, and a delete lands while it is
+    /// away. Writing that stale record back must not bring the task back.
+    #[tokio::test]
+    async fn a_task_deleted_during_a_run_stays_deleted() {
+        let tempdir = TempDir::new().unwrap();
+        let store = SchedulerStore::new(tempdir.path());
+        let task = store
+            .create_task(NewScheduledTask {
+                agent_id: "agent".to_string(),
+                conversation_id: "conversation".to_string(),
+                name: "check".to_string(),
+                schedule: "@every 1m".to_string(),
+                sandbox_mode: None,
+                setup_command: None,
+                command: vec!["true".to_string()],
+                report_prompt: "Report.".to_string(),
+                max_output_bytes: None,
+                missed: None,
+            })
+            .await
+            .unwrap();
+
+        // The runner reads the task and starts firing.
+        let mut in_flight = store.get_task(&task.id).await.unwrap().unwrap();
+        // delete_scheduled_task lands mid-run.
+        store.delete_task(&task.id).await.unwrap();
+        // The run finishes and puts the task back on the grid.
+        in_flight.next_run_at_ms = in_flight.next_run_at_ms.saturating_add(60_000);
+        store.put_task(&in_flight).await.unwrap();
+
+        assert!(store.get_task(&task.id).await.unwrap().is_none());
+        assert!(store.list_tasks().await.unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/crates/executor/src/scheduler_store.rs
+++ b/crates/executor/src/scheduler_store.rs
@@ -26,7 +26,7 @@ impl SchedulerStore {
 
     pub async fn create_task(&self, request: NewScheduledTask) -> Result<ScheduledTaskRecord> {
         let task = ScheduledTaskRecord::new(request, now_ms())?;
-        self.write_task(&task, Write::Create).await?;
+        self.write_task(&task, Write::CreateOrReplace).await?;
         Ok(task)
     }
 
@@ -114,15 +114,15 @@ impl SchedulerStore {
         }
     }
 
-    /// Updates an existing task record.
+    /// Replaces an existing task record, and does nothing if the task is gone.
     ///
     /// A fire runs a model turn, so a task can be deleted while a run holds a
-    /// copy of its record. Writing that copy back must not recreate the task,
-    /// so this replaces an existing record and is a no-op once the task is
-    /// gone. The check and the write happen under the tasks lock, so a delete
-    /// cannot land between them. Use `create_task` to add a task.
+    /// copy of its record. Writing that copy back must not bring the task
+    /// back, so this never creates the file. The existence check and the write
+    /// happen under the tasks lock, so a delete cannot land between them. Use
+    /// `create_task` to add a task.
     pub async fn put_task(&self, task: &ScheduledTaskRecord) -> Result<()> {
-        self.write_task(task, Write::Replace).await
+        self.write_task(task, Write::ReplaceIfExists).await
     }
 
     async fn write_task(&self, task: &ScheduledTaskRecord, mode: Write) -> Result<()> {
@@ -132,7 +132,7 @@ impl SchedulerStore {
         let bytes = serde_json::to_vec_pretty(task)?;
         tokio::task::spawn_blocking(move || -> Result<()> {
             let _lock = TasksLock::acquire(&root)?;
-            if mode == Write::Replace && !path.exists() {
+            if mode == Write::ReplaceIfExists && !path.exists() {
                 return Ok(());
             }
             write_json_file_blocking(&path, &bytes)
@@ -307,11 +307,14 @@ fn write_json_file_blocking(path: &Path, bytes: &[u8]) -> Result<()> {
     })
 }
 
-/// Whether a task file may be created, or only replaced if it still exists.
+/// Whether a task file write may bring the record into existence.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Write {
-    Create,
-    Replace,
+    /// Write unconditionally: the record is created, and a file already at
+    /// that path is overwritten.
+    CreateOrReplace,
+    /// Write only if the file is still there; a no-op once it is gone.
+    ReplaceIfExists,
 }
 
 /// Serializes task-file writes against deletes across processes: the runner,


### PR DESCRIPTION
Fixes #276.

A fire runs a model turn, so a task can be deleted while a run holds a copy of its record. `run_task` then wrote that stale copy back, and because `put_task` created the file when it was missing, the delete was undone and the task kept firing. `delete_scheduled_task` and `cancel_scheduled_task` are model-facing tools, so a delete naturally arrives during a run — that is how this was hit.

`create_task` is the only creator, so `put_task` becomes replace-only: a no-op once the task is gone. The existence check and the write happen under an exclusive lock on the tasks directory, taken by `delete_task` as well, so a delete cannot land between them. The lock is held around the file operations only, never across a run, and the OS releases it if a holder dies (`std::fs::File::lock`, stable since 1.89 — no new dependency).

Deletion is therefore terminal: an in-flight fire still finishes, and the task is simply never scheduled again.

The whole change is in `scheduler_store.rs`. **No call sites change** — `run_task` is untouched.

Includes a test that reproduces the original failure: a run holds a record, a delete lands mid-run, and the stale write-back must not recreate the task. It fails if `put_task` is allowed to create.

<details>
<summary>Related, if useful</summary>

The doc comment on `claim_due_tasks` notes its read-lease-write is unconditional pending "the conditional puts in upstream PR #113". Replace-only `put_task` also covers that call site.

Worth flagging: #113 as it stands keeps the unconditional `put_task` at the end of `run_task`, so this bug survives it — and #113 removes `claim_due_tasks` entirely. Happy to rebase onto #113 or #232 in whatever order suits.

</details>

`cargo test -p executor` (115 passed), `cargo clippy --all-targets -D warnings`, `cargo fmt`, and `cargo check --workspace --all-targets` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhK4EoQJsbjEaqGR3VJ7g5