### PR TITLE
scheduler: prevent deleted task resurrection with conditional updates (#276)

### DIFF
--- a/crates/executor/src/scheduler_runtime.rs
+++ b/crates/executor/src/scheduler_runtime.rs
@@ -107,9 +107,21 @@ pub async fn run_task(
     mut task: ScheduledTaskRecord,
 ) -> Result<Vec<ScheduledTaskRunRecord>> {
     let plan = task.plan_missed_fires(now_ms())?;
+    let lease_id = task.lease.as_ref().map(|lease| lease.id.clone());
     let mut runs = Vec::with_capacity(plan.fire_slots.len());
     for slot_ms in &plan.fire_slots {
-        runs.push(fire_once(Arc::clone(&harness), store, &mut task, *slot_ms).await?);
+        let Some(run) = fire_once(
+            Arc::clone(&harness),
+            store,
+            &mut task,
+            *slot_ms,
+            lease_id.as_deref(),
+        )
+        .await?
+        else {
+            break;
+        };
+        runs.push(run);
         if !task.enabled {
             // The agent or conversation is gone; the rest of the backlog would
             // fail identically.
@@ -117,7 +129,11 @@ pub async fn run_task(
         }
     }
     task.resume_after_fires(&plan, now_ms());
-    store.put_task(&task).await?;
+    if let Some(lease_id) = lease_id {
+        let _ = store.put_task_if_lease(&task, &lease_id).await?;
+    } else {
+        let _ = store.put_task_if_present(&task).await?;
+    }
     Ok(runs)
 }
 
@@ -126,7 +142,8 @@ async fn fire_once(
     store: &SchedulerStore,
     task: &mut ScheduledTaskRecord,
     slot_ms: u64,
-) -> Result<ScheduledTaskRunRecord> {
+    lease_id: Option<&str>,
+) -> Result<Option<ScheduledTaskRunRecord>> {
     let started_at_ms = now_ms();
     let run_id = Uuid7::now().to_string();
     let run_result = run_task_inner(Arc::clone(&harness), store, task, &run_id, slot_ms).await;
@@ -180,8 +197,11 @@ async fn fire_once(
     }
     run.task_id = task.id.clone();
     store.put_run(&run).await?;
-    store.put_task(task).await?;
-    Ok(run)
+    let updated = match lease_id {
+        Some(lease_id) => store.put_task_if_lease(task, lease_id).await?,
+        None => store.put_task_if_present(task).await?,
+    };
+    Ok(updated.then_some(run))
 }
 
 fn is_missing_task_owner_error(error: &str) -> bool {

--- a/crates/executor/src/scheduler_store.rs
+++ b/crates/executor/src/scheduler_store.rs
@@ -1,9 +1,11 @@
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use exoharness::Uuid7;
 use serde::Serialize;
 use tokio::fs;
+use tokio::sync::Mutex;
 
 use crate::scheduler_types::{
     NewScheduledTask, ScheduledFireRecord, ScheduledTaskRecord, ScheduledTaskRunRecord,
@@ -13,11 +15,15 @@ use crate::scheduler_types::{
 #[derive(Debug, Clone)]
 pub struct SchedulerStore {
     root: PathBuf,
+    task_lock: Arc<Mutex<()>>,
 }
 
 impl SchedulerStore {
     pub fn new(root: impl Into<PathBuf>) -> Self {
-        Self { root: root.into() }
+        Self {
+            root: root.into(),
+            task_lock: Arc::new(Mutex::new(())),
+        }
     }
 
     pub fn root(&self) -> &Path {
@@ -81,24 +87,23 @@ impl SchedulerStore {
             .collect())
     }
 
-    /// Reads, leases, and writes back without a conditional put, so two
-    /// runners racing the same due task can both win. The PID lockfile in the
-    /// runner is the real guard today. The fix is a claim keyed by
-    /// `(task, slot)` written conditionally, which is deferred pending the
-    /// conditional puts in upstream PR #113 rather than raced against it.
+    /// Reads and leases due tasks while holding the same store lock used by
+    /// deletion and conditional completion updates. This prevents a delete
+    /// from being followed by a stale claim write in this scheduler process.
     pub async fn claim_due_tasks(
         &self,
         now_ms: u64,
         limit: usize,
         lease_ms: u64,
     ) -> Result<Vec<ScheduledTaskRecord>> {
+        let _guard = self.task_lock.lock().await;
         let mut due = self.due_tasks(now_ms).await?;
         due.sort_by_key(|task| task.next_run_at_ms);
         due.truncate(limit);
         let mut claimed = Vec::new();
         for mut task in due {
             task.claim(now_ms, lease_ms);
-            self.put_task(&task).await?;
+            self.put_task_locked(&task).await?;
             claimed.push(task);
         }
         Ok(claimed)
@@ -115,6 +120,11 @@ impl SchedulerStore {
     }
 
     pub async fn put_task(&self, task: &ScheduledTaskRecord) -> Result<()> {
+        let _guard = self.task_lock.lock().await;
+        self.put_task_locked(task).await
+    }
+
+    async fn put_task_locked(&self, task: &ScheduledTaskRecord) -> Result<()> {
         fs::create_dir_all(self.tasks_dir()).await?;
         let path = self.task_path(&task.id);
         write_json_file(&path, task)
@@ -122,17 +132,60 @@ impl SchedulerStore {
             .with_context(|| format!("failed to write scheduled task {}", path.display()))
     }
 
+    /// Updates a leased task only while the same lease is still present.
+    ///
+    /// The conditional check and replacement share the store lock with
+    /// deletion, so a task removed while its command is running cannot be
+    /// recreated by the stale in-memory record when the command finishes.
+    pub async fn put_task_if_lease(
+        &self,
+        task: &ScheduledTaskRecord,
+        lease_id: &str,
+    ) -> Result<bool> {
+        let _guard = self.task_lock.lock().await;
+        let path = self.task_path(&task.id);
+        let current = match fs::read(&path).await {
+            Ok(bytes) => decode_task(&bytes)?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("failed to read scheduled task {}", path.display()));
+            }
+        };
+        if current.lease.as_ref().map(|lease| lease.id.as_str()) != Some(lease_id) {
+            return Ok(false);
+        }
+        self.put_task_locked(task).await?;
+        Ok(true)
+    }
+
+    /// Replaces a task only while its record still exists. This is used by
+    /// unleased compatibility callers; the existence check and write are
+    /// serialized with deletion by the same store lock.
+    pub async fn put_task_if_present(&self, task: &ScheduledTaskRecord) -> Result<bool> {
+        let _guard = self.task_lock.lock().await;
+        match fs::metadata(self.task_path(&task.id)).await {
+            Ok(_) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(error) => return Err(error.into()),
+        }
+        self.put_task_locked(task).await?;
+        Ok(true)
+    }
+
     pub async fn disable_task(&self, task_id: &str) -> Result<Option<ScheduledTaskRecord>> {
+        let _guard = self.task_lock.lock().await;
         let Some(mut task) = self.get_task(task_id).await? else {
             return Ok(None);
         };
         task.enabled = false;
         task.updated_at_ms = now_ms();
-        self.put_task(&task).await?;
+        self.put_task_locked(&task).await?;
         Ok(Some(task))
     }
 
     pub async fn delete_task(&self, task_id: &str) -> Result<Option<ScheduledTaskRecord>> {
+        let _guard = self.task_lock.lock().await;
         let Some(task) = self.get_task(task_id).await? else {
             return Ok(None);
         };
@@ -530,6 +583,36 @@ mod tests {
         assert_eq!(claimed.len(), 1);
         assert!(store.claim_due_tasks(3, 10, 100).await.unwrap().is_empty());
         assert_eq!(store.claim_due_tasks(103, 10, 100).await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn deleted_task_racing_stale_lease_update_is_not_resurrected() {
+        let tempdir = TempDir::new().unwrap();
+        let store = SchedulerStore::new(tempdir.path());
+        let mut task = store
+            .create_task(NewScheduledTask {
+                agent_id: "agent".to_string(),
+                conversation_id: "conversation".to_string(),
+                name: "check".to_string(),
+                schedule: "@every 1m".to_string(),
+                sandbox_mode: None,
+                setup_command: None,
+                command: vec!["true".to_string()],
+                report_prompt: "Report.".to_string(),
+                max_output_bytes: None,
+                missed: None,
+            })
+            .await
+            .unwrap();
+        task.claim(2, 100);
+        let lease_id = task.lease.as_ref().unwrap().id.clone();
+        store.put_task(&task).await.unwrap();
+
+        let stale = task.clone();
+        let update = async { store.put_task_if_lease(&stale, &lease_id).await.unwrap() };
+        let delete = async { store.delete_task(&task.id).await.unwrap() };
+        let (_updated, _deleted) = tokio::join!(update, delete);
+        assert!(store.get_task(&task.id).await.unwrap().is_none());
     }
 
     fn fire(task_id: &str, slot_ms: u64) -> ScheduledFireRecord {


### PR DESCRIPTION
## 问题现象与最小复现

`run_task` 会在一次完整的模型 turn 结束后，把运行期间持有的任务副本写回调度存储。若此期间调用 `delete_scheduled_task` 删除任务文件，旧实现会在 `fire_once` 或 `run_task` 完成时无条件 `put_task`，导致任务记录被重新创建并在下一轮继续触发。

复现步骤：

1. 创建一个 `@every 1m` 任务，并让其执行一个较慢的模型 turn。
2. 在 turn 仍运行时调用 `delete_scheduled_task`。
3. 等待当前 turn 完成并重新读取任务列表。
4. 观察到删除成功但任务记录重新出现。

## 影响范围

删除操作无法可靠停止正在运行的任务，可能造成重复模型调用和 credits 消耗。任务仍存在时，正常 lease、完成记录和下一次调度网格行为保持不变。

## 根因分析

运行器只持有从 store 读取的内存副本，写回时没有验证该副本对应的 lease 是否仍然有效。删除操作与 stale writer 之间也没有 store 层的条件关系，因此旧副本可以重新创建已经删除的 JSON 文件。`claim_due_tasks` 还存在同一类读、删除、写回窗口。

## 具体代码改动

- `SchedulerStore` 增加共享异步任务锁，覆盖 claim、写入、禁用和删除；同一 store 实例及其 clone 的检查与替换在一个临界区内完成。
- 新增 `put_task_if_lease`：只有当任务文件仍存在且当前 lease id 与运行开始时的 lease id 相同，才允许替换；文件不存在或 lease 已改变时返回 `false`，绝不创建任务。
- 新增 `put_task_if_present`，让无 lease 的兼容调用也不会在删除后重新创建任务。
- `run_task` / `fire_once` 保存 claim lease，并在每次 fire 完成及最终恢复调度网格时使用条件写；条件失败后停止剩余 backlog fire。
- `claim_due_tasks` 在同一 store 锁内完成 due 扫描与 claim 写入，关闭 claim 阶段的删除竞态。
- 添加异步并发回归测试，令删除与 stale lease 更新同时发生，并断言任务最终仍不存在。

## 回归测试与完整验证

本分支已运行：

```text
cargo fmt --all -- --check
cargo test -p executor scheduler_store -- --nocapture
# 12 passed; 0 failed
cargo test -p executor
# 115 passed; 0 failed; doc-tests: 0 passed
cargo check -p executor
# Finished `dev` profile

git diff --check
# passed
```

## 兼容性与边界说明

- 生产 scheduler 通过 `claim_due_tasks` 获得 lease，因此删除后的 stale completion 不会复活任务，也不会继续执行 backlog。
- 直接调用 `run_task` 且没有 lease 的路径改为“仅在记录仍存在时写回”，保持接口可用并避免同类复活。
- 锁在同一 `SchedulerStore` 实例及其 clones 之间共享。若未来支持多个独立进程同时写同一目录，应进一步使用跨进程文件锁或数据库 CAS。
- 当前 `put_run` 仍可能在删除后留下孤立的 run 目录；任务 JSON 不会被重新创建，这一清理边界可在后续独立改进。

## 与 Issue #276 的对应关系

Fixes #276。该实现直接修复 Issue 指出的 `scheduler_runtime.rs` 无条件 `store.put_task(&task)` 路径，并将保护下沉到 scheduler store 的条件更新层。Issue 页面目前已有 [PR #277](https://github.com/exoharness/exo/pull/277)，其方案是先读后写，仍保留读写之间的竞态；本 PR 提供带 store 锁和 lease 条件的完整路径，供维护者比较或合并其中更合适的实现。

## 未覆盖内容与后续建议

本 PR 不改变公开工具返回值或任务记录 schema。建议后续在多进程 scheduler 部署场景增加跨进程 CAS/文件锁，并补充真实长模型 turn 的端到端删除测试。

验证提交：`6332e9a fix(executor): prevent deleted task resurrection`
