### PR TITLE
secrets: resolve a stored id to the live secret for its name (#279)

### DIFF
--- a/crates/exoharness/src/basic.rs
+++ b/crates/exoharness/src/basic.rs
@@ -1166,18 +1166,13 @@ impl ExoHarness for BasicExoHarness {
     }
 
     async fn get_secret(&self, id: &SecretId) -> Result<Option<Secret>> {
-        let path = self.secrets_dir().join(format!("{id}.json"));
-        let Some(record) = self
-            .inner
-            .storage
-            .get_json_if_exists::<StoredSecret>(&path)
-            .await?
-        else {
-            return Ok(None);
-        };
-        Ok(Some(
-            self.inner.secret_cipher.decrypt_secret(&record.secret)?,
-        ))
+        resolve_effective_secret(
+            &self.inner.storage,
+            &self.inner.secret_cipher,
+            &[self.secrets_dir()],
+            id,
+        )
+        .await
     }
 }
 
@@ -1553,22 +1548,13 @@ impl AgentHandle for BasicAgentHandle {
     }
 
     async fn get_secret(&self, id: &SecretId) -> Result<Option<Secret>> {
-        let path = self.secrets_dir().join(format!("{id}.json"));
-        let Some(record) = self
-            .harness
-            .inner
-            .storage
-            .get_json_if_exists::<StoredSecret>(&path)
-            .await?
-        else {
-            return self.harness.get_secret(id).await;
-        };
-        Ok(Some(
-            self.harness
-                .inner
-                .secret_cipher
-                .decrypt_secret(&record.secret)?,
-        ))
+        resolve_effective_secret(
+            &self.harness.inner.storage,
+            &self.harness.inner.secret_cipher,
+            &[self.harness.secrets_dir(), self.secrets_dir()],
+            id,
+        )
+        .await
     }
 
     async fn write_artifact(&self, request: WriteArtifactRequest) -> Result<ArtifactVersion> {
@@ -3103,37 +3089,17 @@ impl ConversationHandle for BasicConversationHandle {
     }
 
     async fn get_secret(&self, id: &SecretId) -> Result<Option<Secret>> {
-        let local_path = self.secrets_dir().join(format!("{id}.json"));
-        if let Some(record) = self
-            .harness
-            .inner
-            .storage
-            .get_json_if_exists::<StoredSecret>(&local_path)
-            .await?
-        {
-            return Ok(Some(
-                self.harness
-                    .inner
-                    .secret_cipher
-                    .decrypt_secret(&record.secret)?,
-            ));
-        }
-        let agent_path = agent_secrets_dir(&self.harness, self.agent_id).join(format!("{id}.json"));
-        let Some(record) = self
-            .harness
-            .inner
-            .storage
-            .get_json_if_exists::<StoredSecret>(&agent_path)
-            .await?
-        else {
-            return self.harness.get_secret(id).await;
-        };
-        Ok(Some(
-            self.harness
-                .inner
-                .secret_cipher
-                .decrypt_secret(&record.secret)?,
-        ))
+        resolve_effective_secret(
+            &self.harness.inner.storage,
+            &self.harness.inner.secret_cipher,
+            &[
+                self.harness.secrets_dir(),
+                agent_secrets_dir(&self.harness, self.agent_id),
+                self.secrets_dir(),
+            ],
+            id,
+        )
+        .await
     }
 }
 
@@ -4703,6 +4669,46 @@ fn stored_binding(id: BindingId, binding: Binding) -> StoredBinding {
             binding,
         },
     }
+}
+
+/// Reads the secret a stored id refers to, following rotations of its name.
+///
+/// `put_secret` stores a rotated key as a new record rather than overwriting
+/// the old one, so anything holding an id — a model binding, an adapter — would
+/// otherwise stay pinned to a superseded value. Resolving through the name
+/// applies the precedence `list_secrets` already reports: the narrowest scope
+/// wins, and within a scope the newest record wins. `scopes` runs widest to
+/// narrowest.
+async fn resolve_effective_secret(
+    storage: &BasicObjectStore,
+    cipher: &SecretCipher,
+    scopes: &[PathBuf],
+    id: &SecretId,
+) -> Result<Option<Secret>> {
+    let mut per_scope = Vec::with_capacity(scopes.len());
+    for dir in scopes {
+        per_scope.push(list_secret_metadata(storage, dir).await?);
+    }
+    let Some(name) = per_scope
+        .iter()
+        .flatten()
+        .find(|metadata| &metadata.id == id)
+        .map(|metadata| metadata.name.clone())
+    else {
+        return Ok(None);
+    };
+    let effective = merge_secret_metadata(per_scope)
+        .into_iter()
+        .find(|metadata| metadata.name == name)
+        .map_or(*id, |metadata| metadata.id);
+
+    for dir in scopes.iter().rev() {
+        let path = dir.join(format!("{effective}.json"));
+        if let Some(record) = storage.get_json_if_exists::<StoredSecret>(&path).await? {
+            return Ok(Some(cipher.decrypt_secret(&record.secret)?));
+        }
+    }
+    Ok(None)
 }
 
 async fn list_secret_metadata(

--- a/crates/exoharness/src/basic_tests.rs
+++ b/crates/exoharness/src/basic_tests.rs
@@ -1186,6 +1186,95 @@ async fn legacy_json_artifacts_are_still_readable() {
     assert_eq!(loaded.contents, br#"{"model":"gpt-5.4"}"#);
 }
 
+/// Rotating a key is `secret set <name>` with the new value. The model binding
+/// must then send the new key: a binding keeps working across a rotation.
+#[tokio::test(flavor = "current_thread")]
+async fn a_model_binding_uses_the_latest_secret_stored_under_its_name() {
+    let tempdir = TempDir::new().expect("tempdir");
+    let harness = BasicExoHarness::new(local_test_config(tempdir.path()))
+        .await
+        .expect("harness should initialize");
+    let agent = harness
+        .new_agent(NewAgentRequest {
+            slug: "agent".to_string(),
+            name: "Agent".to_string(),
+        })
+        .await
+        .expect("agent");
+    let conversation = agent
+        .new_conversation(NewConversationRequest {
+            slug: Some("dev".to_string()),
+            name: Some("Dev".to_string()),
+        })
+        .await
+        .expect("conversation");
+
+    // The key in use, then a model bound to it.
+    let stale_secret_id = conversation
+        .put_secret(PutSecretRequest {
+            name: "openrouter".to_string(),
+            secret: Secret::Key {
+                value: "stale-key".to_string(),
+            },
+        })
+        .await
+        .expect("stale secret");
+    conversation
+        .put_binding(Binding::Llm {
+            name: "model".to_string(),
+            model: "some/model".to_string(),
+            base_url: None,
+            secret_id: Some(stale_secret_id),
+        })
+        .await
+        .expect("binding");
+    assert_eq!(
+        resolved_model_key(conversation.as_ref()).await,
+        "stale-key",
+        "the binding should start out on the key it was registered with"
+    );
+
+    // The key is rotated: `secret set openrouter` with the new value.
+    conversation
+        .put_secret(PutSecretRequest {
+            name: "openrouter".to_string(),
+            secret: Secret::Key {
+                value: "rotated-key".to_string(),
+            },
+        })
+        .await
+        .expect("rotated secret");
+
+    assert_eq!(
+        resolved_model_key(conversation.as_ref()).await,
+        "rotated-key",
+        "the binding should send the rotated key without being re-registered"
+    );
+}
+
+/// Mirrors how a model call resolves its API key from the named binding.
+async fn resolved_model_key(conversation: &dyn crate::ConversationHandle) -> String {
+    let binding = conversation
+        .list_bindings()
+        .await
+        .expect("list bindings")
+        .into_iter()
+        .find(|record| matches!(&record.binding, Binding::Llm { name, .. } if name == "model"))
+        .expect("model binding");
+    let Binding::Llm { secret_id, .. } = binding.binding else {
+        panic!("expected an llm binding");
+    };
+    let secret = conversation
+        .get_secret(&secret_id.expect("secret id"))
+        .await
+        .expect("get secret")
+        .expect("secret should exist");
+    match secret {
+        Secret::Key { value } => value,
+        Secret::Oauth { .. } => panic!("expected a key secret"),
+    }
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn conversation_scope_overrides_agent_scope_and_fork_copies_local_state() {
     let tempdir = TempDir::new().expect("tempdir");


### PR DESCRIPTION
Fixes #279.

## Problem

`exo secret set <name>` stores a new record rather than overwriting the old one, and bindings pin a `secret_id`. After rotating a key, a model binding keeps sending the old value and re-registering the model is the only way out. Adapters hold ids the same way.

## Solution

`get_secret` resolves the id to its name and returns the effective secret for that name, applying the precedence `list_secrets` already reports: narrowest scope wins, newest record within a scope wins.

`list_secrets` was already doing this; `get_secret` was the one path that bypassed it, and it is the path bindings use. The three scope-walking implementations collapse into one shared resolver, so the change is close to net-neutral.

Stored history is untouched and no binding or adapter record changes.

Test covers the rotation flow: register a binding, resolve it, rotate the secret, resolve again. It fails without the fix.

## Alternatives considered

- **`put_secret` overwrites in place** for an existing name in the same scope. Smaller, but changes what `set` means and discards prior key records.
- **Explicit versioning** — an `active`/`supersedes` field, ids in `secret list`, `secret delete`, and a way to re-point a binding. The right shape if credential history is wanted; much larger.

Related: #95 / #211 cover missing-model errors, not stale credentials. #152 also touches `basic.rs` and `secrets.rs`.

`cargo test --workspace --all-targets`, `cargo clippy --all-targets -D warnings`, `cargo fmt`, and `pnpm check` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QhK4EoQJsbjEaqGR3VJ7g5