### PR TITLE
Keep background service logs out of the Exo REPL

### DIFF
--- a/exo.sh
+++ b/exo.sh
@@ -46,7 +46,6 @@ SKIP_BUILD="${EXO_SKIP_BUILD:-false}"
 TEMPLATE="${EXO_TEMPLATE:-canonical}"
 PROFILE="${EXO_PROFILE:-practical}"
 PROVIDER_EXPLICIT=false
-declare -a CONTROL_PIDS=()
 SETUP_ADAPTER="${EXO_SETUP_ADAPTER:-}"
 declare -a SETUP_ADAPTERS=()
 if [[ -n "$SETUP_ADAPTER" ]]; then
@@ -65,6 +64,7 @@ usage() {
 Usage:
   ./exo.sh [options]
   ./exo.sh list
+  ./exo.sh logs
   ./exo.sh delall all
   ./exo.sh fresh
   ./exo.sh stop-all
@@ -76,12 +76,13 @@ Usage:
 
 Default behavior starts the canonical stack: it creates or reuses an Exo
 agent and conversation with a Docker sandbox, repo self-map mount, ExoChat
-setup, guardian config, and control logs, starts the local scheduler and
+setup and guardian config, starts the local scheduler and
 adapter loops, then starts a REPL. It reads .env by default if present.
 Choose a different template with --template.
 
 Subcommands:
   list             List agents and conversations
+  logs             Follow scheduler and adapter logs in this terminal
   delall all       Delete all agents and conversations
   fresh            Rebuild, delete all state, and start a clean REPL
   stop-all         Stop the scheduler and adapter runners, preserving .exo state
@@ -111,7 +112,7 @@ Options:
   --module <path>              Exo TypeScript harness module
   --template <name>            Launch template (default: canonical):
                                  canonical  Docker sandbox, repo self-map mount, ExoChat
-                                            setup, control logs, and guardian config
+                                            setup and guardian restart supervision
                                  dev        Same as canonical but with IRC+Discord
                                             instead of ExoChat
                                  minimal    No Docker defaults, adapter setup prompts,
@@ -132,7 +133,7 @@ Options:
   --no-adapters                Do not start the local adapter runner
   --adapters                   Start the local adapter runner
   --adapter-limit <n>          Max adapters supervised by the runner (default: 50)
-  --control                    Show live scheduler and adapter logs beside the REPL
+  --control                    Restart the REPL after guardian rebuild requests
   --setup-profile              Prompt once and write the ignored local profile prompt
   --local-prompt-file <path>    Local profile prompt path (default: .exo/exo-profile.md)
   --setup <adapter>            Send adapters/<adapter>/setup-prompt.md.
@@ -873,8 +874,6 @@ run_repl() {
   ensure_self_repo_mount
   ensure_agent_cli_mount
   configure_guardian_for_current_launch
-  local scheduler_log_start_line
-  scheduler_log_start_line="$(scheduler_log_line_count)"
   ensure_scheduler
   local adapter_log_start_line
   adapter_log_start_line="$(adapter_log_line_count)"
@@ -884,7 +883,7 @@ run_repl() {
   show_signal_qr_if_needed "$adapter_log_start_line"
   show_whatsapp_qr_if_needed "$adapter_log_start_line"
   if [[ "$CONTROL" == true ]]; then
-    run_control_repl "$scheduler_log_start_line" "$adapter_log_start_line"
+    run_control_repl
   else
     EXO_GLOBAL_ARGS=()
     append_exo_global_args
@@ -904,42 +903,27 @@ adapter_log_line_count() {
   fi
 }
 
-scheduler_log_line_count() {
-  local log_file
-  log_file="$(scheduler_log_file)"
-  if [[ -f "$log_file" ]]; then
-    wc -l <"$log_file" | tr -d '[:space:]'
-  else
-    echo 0
-  fi
+follow_service_logs() {
+  mkdir -p "$ROOT_DIR/.exo"
+  touch "$(scheduler_log_file)" "$(adapters_log_file)"
+  exec tail -n 20 -F "$(scheduler_log_file)" "$(adapters_log_file)"
 }
 
 run_control_repl() {
-  local scheduler_start_line="$1"
-  local adapter_start_line="$2"
-  local repl_pid=""
   local restart_watcher_pid=""
 
-  cleanup_control_logs() {
-    local pid
-    for pid in "${CONTROL_PIDS[@]:-}"; do
-      kill "$pid" >/dev/null 2>&1 || true
-    done
+  cleanup_control_repl() {
     if [[ -n "${restart_watcher_pid:-}" ]]; then
       kill "$restart_watcher_pid" >/dev/null 2>&1 || true
     fi
     kill_repl_children "$$"
   }
-  trap cleanup_control_logs EXIT INT TERM
+  trap cleanup_control_repl EXIT
+  trap 'exit 130' INT
+  trap 'exit 143' TERM
 
-  echo "Control console enabled. Streaming scheduler and adapter logs beside the REPL."
+  printf 'Service logs: run %q logs in another terminal.\n' "$ROOT_DIR/exo.sh"
   echo "The control wrapper will restart the REPL child when $(repl_restart_file) appears."
-  if [[ "$START_SCHEDULER" == true ]]; then
-    start_control_log_tail "scheduler" "$(scheduler_log_file)" "$scheduler_start_line"
-  fi
-  if [[ "$START_ADAPTERS" == true ]]; then
-    start_control_log_tail "adapters" "$(adapters_log_file)" "$adapter_start_line"
-  fi
 
   EXO_GLOBAL_ARGS=()
   append_exo_global_args
@@ -995,26 +979,11 @@ watch_repl_restart_request() {
   marker="$(repl_restart_file)"
   while true; do
     if [[ -f "$marker" ]]; then
-      echo "Guardian requested REPL child restart; stopping current child..."
       kill_repl_children "$control_pid"
       return
     fi
     sleep 2
   done
-}
-
-start_control_log_tail() {
-  local label="$1"
-  local log_file="$2"
-  local start_line="$3"
-  local tail_start=$((start_line + 1))
-
-  mkdir -p "$(dirname "$log_file")"
-  touch "$log_file"
-  echo "[$label] tailing $log_file"
-  tail -n +"$tail_start" -F "$log_file" 2>/dev/null \
-    | awk -v label="$label" '{ print "[" label "] " $0; fflush(); }' &
-  CONTROL_PIDS+=("$!")
 }
 
 startup_prompt_file() {
@@ -1237,6 +1206,11 @@ while [[ $# -gt 0 ]]; do
       shift
       [[ $# -eq 0 ]] || die "list does not accept additional arguments"
       COMMAND="list"
+      ;;
+    logs)
+      shift
+      [[ $# -eq 0 ]] || die "logs does not accept additional arguments"
+      COMMAND="logs"
       ;;
     delall|delete-all)
       shift
@@ -1508,6 +1482,9 @@ case "$COMMAND" in
     ;;
   list)
     list_agents_and_conversations
+    ;;
+  logs)
+    follow_service_logs
     ;;
   delall)
     delete_all_agents_and_conversations

--- a/exo/adapters/whatsapp/README.md
+++ b/exo/adapters/whatsapp/README.md
@@ -18,6 +18,11 @@ Use the Exo setup flow:
 
 The script watches `.exo/exo-adapters.log`, prints the QR code if it appears, and pauses while you scan it. Scan from WhatsApp using the linked-device flow.
 
+Background logs do not stream into the REPL. Run `./exo.sh logs` in another
+terminal to follow pairing updates and service errors. The worker logs each
+distinct QR code once; newly rotated codes remain available there if the code
+shown during setup expires.
+
 The setup prompt at `setup-prompt.md` asks Exo to create a library adapter similar to:
 
 ```json

--- a/exo/adapters/whatsapp/worker.test.ts
+++ b/exo/adapters/whatsapp/worker.test.ts
@@ -1,0 +1,82 @@
+import { EventEmitter } from "node:events";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  emit: vi.fn(),
+  socket: vi.fn(),
+  render: vi.fn(
+    (qr: string, _options: unknown, callback: (text: string) => void) =>
+      callback(`rendered:${qr}`),
+  ),
+}));
+
+vi.mock("node:fs/promises", () => ({ default: { mkdir: vi.fn() } }));
+vi.mock("node:readline/promises", () => ({
+  default: { createInterface: () => [] },
+}));
+vi.mock("@whiskeysockets/baileys", () => ({
+  default: mocks.socket,
+  DisconnectReason: { loggedOut: 401 },
+  fetchLatestBaileysVersion: async () => ({ version: [1, 0, 0] }),
+  useMultiFileAuthState: async () => ({
+    state: { creds: { registered: true } },
+    saveCreds: vi.fn(),
+  }),
+}));
+vi.mock("qrcode-terminal", () => ({ default: { generate: mocks.render } }));
+vi.mock("../protocol", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../protocol")>()),
+  writeWorkerEvent: mocks.emit,
+}));
+
+let events: EventEmitter;
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  vi.stubEnv("EXO_ADAPTER_CONFIG", "{}");
+  vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  events = new EventEmitter();
+  mocks.socket.mockReturnValue({ ev: events, user: { id: "test-user" } });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+});
+
+it("suppresses repeated codes but logs and emits fresh replacement codes", async () => {
+  await import("./worker");
+  events.emit("connection.update", { qr: "first" });
+  events.emit("connection.update", { qr: "first" });
+  events.emit("connection.update", { qr: "replacement" });
+  expect(mocks.render.mock.calls.map(([qr]) => qr)).toEqual([
+    "first",
+    "replacement",
+  ]);
+  expect(mocks.emit.mock.calls.map(([event]) => event)).toEqual([
+    { type: "lifecycle", name: "qr", metadata: { qr: "first" } },
+    { type: "lifecycle", name: "qr", metadata: { qr: "replacement" } },
+  ]);
+  expect(process.stderr.write).toHaveBeenCalledTimes(2);
+});
+
+it("allows a new pairing session after connecting", async () => {
+  await import("./worker");
+  events.emit("connection.update", { qr: "code" });
+  events.emit("connection.update", { connection: "open" });
+  events.emit("connection.update", { qr: "code" });
+  expect(mocks.render).toHaveBeenCalledTimes(2);
+  expect(mocks.emit).toHaveBeenCalledWith({
+    type: "connected",
+    subject: "test-user",
+  });
+});
+
+it("does not print QR updates for pairing-code linking", async () => {
+  vi.stubEnv("EXO_ADAPTER_CONFIG", '{"linkMethod":"pairing-code"}');
+  await import("./worker");
+  events.emit("connection.update", { qr: "code" });
+  expect(mocks.render).not.toHaveBeenCalled();
+  expect(mocks.emit).not.toHaveBeenCalled();
+});

--- a/exo/adapters/whatsapp/worker.ts
+++ b/exo/adapters/whatsapp/worker.ts
@@ -66,8 +66,11 @@ const socket = makeWASocket({
 
 socket.ev.on("creds.update", saveCreds);
 
+let lastQr: string | undefined;
 socket.ev.on("connection.update", (update) => {
-  if (update.qr && linkMethod === "qr") {
+  // Baileys can repeat an update; rotated codes must still reach the pairing log.
+  if (update.qr && linkMethod === "qr" && update.qr !== lastQr) {
+    lastQr = update.qr;
     qrcodeTerminal.generate(update.qr, { small: true }, (qr) => {
       process.stderr.write(
         `\n[whatsapp-adapter] Scan this QR with WhatsApp:\n${qr}\n`,
@@ -80,6 +83,7 @@ socket.ev.on("connection.update", (update) => {
     });
   }
   if (update.connection === "open") {
+    lastQr = undefined;
     writeWorkerEvent({
       type: "connected",
       subject: socket.user?.id ?? null,

--- a/scripts/fixtures/quiet-repl-exo.sh
+++ b/scripts/fixtures/quiet-repl-exo.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "--env-file-if-exists" ]]; then
+  shift 2
+fi
+
+case " $* " in
+  *" repl "*)
+    echo "$$" >> "$TEST_ROOT/repl-pids"
+    echo "adapter-output-during-repl" >> "$TEST_ROOT/.exo/exo-adapters.log"
+    echo "scheduler-output-during-repl" >> "$TEST_ROOT/.exo/exo-scheduler.log"
+    echo "repl-ready"
+    while read -r command; do
+      case "$command" in
+        restart)
+          touch "$TEST_ROOT/.exo/exo-control.restart"
+          ;;
+        finish)
+          # Give a competing log tail time to expose output interference.
+          sleep 2
+          exit 7
+          ;;
+      esac
+    done
+    ;;
+  *" adapters run "*|*" run --watch "*)
+    echo "service-started"
+    ;;
+esac

--- a/scripts/quiet-repl.test.ts
+++ b/scripts/quiet-repl.test.ts
@@ -1,0 +1,130 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { once } from "node:events";
+import {
+  appendFile,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  chmod,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, expect, it } from "vitest";
+
+let root: string;
+let child: ChildProcessWithoutNullStreams | undefined;
+let output: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "exo quiet logs "));
+  output = "";
+  await mkdir(join(root, ".exo"));
+  await copyFile(new URL("../exo.sh", import.meta.url), join(root, "exo.sh"));
+  for (const name of ["exo", "exo-scheduler-runner"]) {
+    await copyFile(
+      new URL("./fixtures/quiet-repl-exo.sh", import.meta.url),
+      join(root, name),
+    );
+    await chmod(join(root, name), 0o755);
+  }
+});
+
+afterEach(async () => {
+  if (child && child.exitCode === null && child.signalCode === null) {
+    const closed = once(child, "close");
+    // Kill the isolated process group, including fixture children on failures.
+    process.kill(-child.pid!, "SIGKILL");
+    await closed;
+  }
+  child = undefined;
+  await rm(root, { recursive: true, force: true });
+});
+
+function launch(args: string[]) {
+  child = spawn("/bin/bash", [join(root, "exo.sh"), ...args], {
+    cwd: tmpdir(),
+    detached: true,
+    env: {
+      PATH: process.env.PATH,
+      HOME: process.env.HOME,
+      TEST_ROOT: root,
+      EXO_BIN: join(root, "exo"),
+      EXO_SCHEDULER_BIN: join(root, "exo-scheduler-runner"),
+    },
+  });
+  child.stdout.on("data", (data: Buffer) => {
+    output += data.toString();
+  });
+  child.stderr.on("data", (data: Buffer) => {
+    output += data.toString();
+  });
+  return child;
+}
+
+const replArgs = ["--template", "minimal", "--no-sandbox", "--control"];
+
+it("keeps service output out of the REPL while retaining it in the logs", async () => {
+  const repl = launch(replArgs);
+  const closed = once(repl, "close");
+  await expect.poll(() => output).toContain("repl-ready");
+  repl.stdin.write("finish\n");
+  expect(await closed).toEqual([7, null]);
+  expect(output).not.toContain("output-during-repl");
+  for (const service of ["adapters", "scheduler"]) {
+    expect(
+      await readFile(join(root, `.exo/exo-${service}.log`), "utf8"),
+    ).toContain("output-during-repl");
+  }
+}, 10_000);
+
+it("restarts the REPL on a guardian request and preserves its exit status", async () => {
+  const repl = launch(replArgs);
+  const closed = once(repl, "close");
+  await expect.poll(() => output).toContain("repl-ready");
+  repl.stdin.write("restart\n");
+  await expect
+    .poll(() => output, { timeout: 5_000 })
+    .toMatch(/repl-ready[\s\S]*repl-ready/);
+  const pids = (await readFile(join(root, "repl-pids"), "utf8"))
+    .trim()
+    .split("\n");
+  expect(() => process.kill(Number(pids[0]), 0)).toThrow();
+  repl.stdin.write("finish\n");
+  expect(await closed).toEqual([7, null]);
+  expect(() => process.kill(Number(pids[1]), 0)).toThrow();
+  expect(output).not.toContain("output-during-repl");
+}, 10_000);
+
+it("follows both service logs without starting a REPL or requiring a binary", async () => {
+  await rm(join(root, "exo"));
+  const logs = launch(["logs"]);
+  await expect.poll(() => output).toContain("exo-adapters.log");
+  await appendFile(join(root, ".exo/exo-adapters.log"), "adapter-warning\n");
+  await appendFile(join(root, ".exo/exo-scheduler.log"), "scheduler-warning\n");
+  await expect.poll(() => output).toContain("adapter-warning");
+  await expect.poll(() => output).toContain("scheduler-warning");
+  expect(output).not.toContain("repl-ready");
+  const closed = once(logs, "close");
+  logs.kill("SIGTERM");
+  expect(await closed).toEqual([null, "SIGTERM"]);
+});
+
+it("rejects extra arguments to logs", async () => {
+  const logs = launch(["logs", "unexpected"]);
+  expect((await once(logs, "close"))[0]).toBe(1);
+  expect(output).toContain("logs does not accept additional arguments");
+});
+
+it("exits on terminal shutdown without restarting the REPL", async () => {
+  const repl = launch(replArgs);
+  const closed = once(repl, "close");
+  await expect.poll(() => output).toContain("repl-ready");
+  const pid = Number((await readFile(join(root, "repl-pids"), "utf8")).trim());
+  process.kill(-repl.pid!, "SIGTERM");
+  expect(await closed).toEqual([143, null]);
+  expect(() => process.kill(pid, 0)).toThrow();
+  expect(output.match(/repl-ready/g)).toHaveLength(1);
+});

--- a/website/docs-src/concepts/lifecycles.md
+++ b/website/docs-src/concepts/lifecycles.md
@@ -409,8 +409,10 @@ exo adapters list
 ```
 
 Health signals: `last_connected_at_ms`, `last_error` on each record;
-runner and worker logs under the paths `./exo.sh` / guardian use for
-control logs.
+runner and worker logs are in `.exo/exo-scheduler.log` and
+`.exo/exo-adapters.log`. Run `./exo.sh logs` in another terminal to follow
+both. The control wrapper supervises REPL restarts without streaming
+background logs into the interactive terminal.
 
 ---
 


### PR DESCRIPTION
Fixes #183.

## Summary

Background service log tails currently write over the terminal UI while a user types. Stop streaming adapter and scheduler logs into the REPL, and add `./exo.sh logs` to follow both logs from a separate terminal. Guardian-triggered REPL restarts remain intact.

Deduplicate identical WhatsApp QR notifications while preserving rotated QR codes and new pairing sessions. Update launcher and pairing documentation.

This complements #254, which skips redundant adapter setup prompts. The focused regression tests also pass with that patch applied.

[download (1).webm](https://github.com/user-attachments/assets/febd1a15-a6ae-41be-8e9e-5440746642f5)

## Validation

- `pnpm check`: lint, typechecking, and all 162 tests pass.
- `pnpm format:check` and `pnpm docs:build` pass.
- Bash syntax checks pass.
- `cargo clippy --workspace --all-targets -- -D warnings` passes.
- Regression coverage includes log isolation and viewing, guardian restarts, exit status and shutdown, and QR deduplication and rotation.
- Verified the before/after behavior using the real Exo terminal UI, injected service logs, and isolated demo state with stubbed background services. No model calls or live WhatsApp pairing were performed.
